### PR TITLE
Benchmark harness: reproducible fork-exec and exec round-trip latency

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -490,6 +490,151 @@ jobs:
           echo "  Fork-correctness checks passed"
           echo "================================"
 
+      # Benchmark phase: run the reproducible cmd/bench harness against the real
+      # KVM-backed engine and publish the latency distributions to the run page.
+      #
+      # IMPORTANT: these are SHARED-CI-CLASS numbers. ubuntu-latest is a noisy,
+      # oversubscribed, shared runner (often itself nested-virt), so the absolute
+      # values are NOT representative of bare metal. They exist to prove the
+      # harness runs end to end and to give a reproducible, regenerated-every-run
+      # distribution, not to be quoted as the product's latency. Bare-metal
+      # reference numbers are tracked in BENCHMARKS.md / issue #15.
+      #
+      # This phase GATES on the bench running successfully (a crash or zero
+      # samples fails the job, because cmd/bench exits non-zero on any fork/exec
+      # error and Summarize over zero samples cannot happen without an error
+      # first). It does NOT gate on any latency threshold.
+      - name: Bench harness, fork-exec and exec round-trip on the KVM runner
+        timeout-minutes: 10
+        run: |
+          set -e
+          BENCH_DATA=/tmp/agent-run-test/bench-data
+          TPL=bench
+          TPL_DIR=$BENCH_DATA/templates/$TPL
+          WORKDIR=/tmp/agent-run-test/bench-build
+          mkdir -p $WORKDIR $TPL_DIR/snapshot
+
+          sudo chmod 666 /dev/kvm
+
+          # Build a rootfs with the guest agent as /init plus the busybox tools
+          # the agent's exec path needs. The bench execs "/bin/true" through the
+          # agent's "/bin/sh -c" wrapper, so sh and true must resolve.
+          dd if=/dev/zero of=$WORKDIR/rootfs.ext4 bs=1M count=256 status=none
+          mkfs.ext4 -q -F $WORKDIR/rootfs.ext4
+          mkdir -p $WORKDIR/mnt
+          sudo mount -o loop $WORKDIR/rootfs.ext4 $WORKDIR/mnt
+          sudo mkdir -p $WORKDIR/mnt/{bin,dev,proc,sys,tmp,workspace,etc,run}
+          sudo cp /tmp/agent-run-test/agent $WORKDIR/mnt/init
+          sudo chmod +x $WORKDIR/mnt/init
+          sudo curl -fsSL -o $WORKDIR/mnt/bin/busybox \
+            "https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox"
+          sudo chmod +x $WORKDIR/mnt/bin/busybox
+          for cmd in sh true echo cat ls mkdir rm cp head date base64 tr; do
+            sudo ln -sf /bin/busybox $WORKDIR/mnt/bin/$cmd
+          done
+          echo "sandbox" | sudo tee $WORKDIR/mnt/etc/hostname > /dev/null
+          sudo umount $WORKDIR/mnt
+
+          # The engine's Fork loads the snapshot from a RELATIVE vsock uds_path
+          # baked at snapshot time (firecracker.VsockRelPath = "vsock.sock"),
+          # resolved against each fork's per-sandbox working directory. The
+          # source VM is therefore booted in its own cwd with uds_path
+          # "vsock.sock" so the snapshot bakes the relative path the engine
+          # expects.
+          mkdir -p $WORKDIR/src
+          SOCK=$WORKDIR/source.sock
+          ( cd $WORKDIR/src && exec /usr/local/bin/firecracker --api-sock $SOCK ) > $WORKDIR/source-serial.log 2>&1 &
+          SRC_PID=$!
+          sleep 1
+          curl --unix-socket $SOCK -X PUT 'http://localhost/boot-source' \
+            -H 'Content-Type: application/json' \
+            -d "{\"kernel_image_path\": \"/tmp/agent-run-test/vmlinux\", \"boot_args\": \"console=ttyS0 reboot=k panic=1 pci=off init=/init\"}"
+          curl --unix-socket $SOCK -X PUT 'http://localhost/drives/rootfs' \
+            -H 'Content-Type: application/json' \
+            -d "{\"drive_id\": \"rootfs\", \"path_on_host\": \"$WORKDIR/rootfs.ext4\", \"is_root_device\": true, \"is_read_only\": false}"
+          curl --unix-socket $SOCK -X PUT 'http://localhost/machine-config' \
+            -H 'Content-Type: application/json' \
+            -d '{"vcpu_count": 1, "mem_size_mib": 256}'
+          curl --unix-socket $SOCK -X PUT 'http://localhost/vsock' \
+            -H 'Content-Type: application/json' \
+            -d "{\"guest_cid\": 3, \"uds_path\": \"vsock.sock\"}"
+          curl --unix-socket $SOCK -X PUT 'http://localhost/actions' \
+            -H 'Content-Type: application/json' \
+            -d '{"action_type": "InstanceStart"}'
+
+          echo "Bench source VM booted, waiting for agent..."
+          sleep 8
+
+          # Pause and snapshot directly into the template layout the engine
+          # loads from: <dataDir>/templates/<id>/snapshot/{mem,vmstate} plus the
+          # template rootfs at <dataDir>/templates/<id>/rootfs.ext4.
+          curl --unix-socket $SOCK -X PATCH 'http://localhost/vm' \
+            -H 'Content-Type: application/json' \
+            -d '{"state": "Paused"}'
+          curl --unix-socket $SOCK -X PUT 'http://localhost/snapshot/create' \
+            -H 'Content-Type: application/json' \
+            -d "{\"snapshot_type\": \"Full\", \"snapshot_path\": \"$TPL_DIR/snapshot/vmstate\", \"mem_file_path\": \"$TPL_DIR/snapshot/mem\"}"
+          kill $SRC_PID 2>/dev/null || true
+          sleep 1
+          cp $WORKDIR/rootfs.ext4 $TPL_DIR/rootfs.ext4
+
+          # The engine refuses to fork an unverified snapshot unless the cheap
+          # "verified" marker is present (internal/fork/verify.go isVerified is a
+          # single stat). This snapshot was built by the workflow directly (not
+          # via CreateTemplate, so no CAS digest is recorded); writing the marker
+          # is the supported way to tell the engine the template is trusted for
+          # this in-CI bench run. The engine's Fork-time gate then short-circuits
+          # on the marker without re-hashing.
+          touch $TPL_DIR/verified
+          echo "Bench template laid out:"
+          ls -lhR $TPL_DIR
+
+          go build -o /tmp/bench ./cmd/bench/
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## KVM bench harness (shared-CI-class, NOT bare metal)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Runner: \`ubuntu-latest\` (noisy shared GitHub runner). Firecracker v1.15.0. CI kernel + busybox/agent rootfs. These numbers are reproducible per run but are NOT representative of bare metal; see BENCHMARKS.md and issue #15." >> $GITHUB_STEP_SUMMARY
+
+          run_mode() {
+            local mode=$1 json=$2
+            echo "================================"
+            echo "  bench --mode $mode"
+            echo "================================"
+            /tmp/bench \
+              --mode $mode \
+              --template $TPL \
+              --data-dir $BENCH_DATA \
+              --firecracker /usr/local/bin/firecracker \
+              --kernel /tmp/agent-run-test/vmlinux \
+              --iterations 30 --warmup 5 \
+              --summary --json $json | tee /tmp/bench-$mode.out
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### \`$mode\`" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat /tmp/bench-$mode.out >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          }
+
+          run_mode fork-exec /tmp/bench-fork.json
+          run_mode exec-rt /tmp/bench-execrt.json
+
+          echo "================================"
+          echo "  Bench harness ran (shared-CI-class numbers above)"
+          echo "================================"
+
+      # Publish the raw bench JSON so BENCHMARKS.md can point at a concrete
+      # artifact for the regenerated-every-run distributions.
+      - name: Upload bench JSON artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: |
+            /tmp/bench-fork.json
+            /tmp/bench-execrt.json
+          if-no-files-found: warn
+
       # Install the host networking tools the egress phases need. nftables and
       # iproute2 are what the real internal/network Linux Manager shells out to
       # (nft, ip); a stock ubuntu-latest runner has iproute2 but may lack nft.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -19,7 +19,10 @@ Two modes:
   of a fork to the first successful exec result returned through the guest
   agent. Each iteration forks a fresh sandbox from the template snapshot,
   connects to the fork's Firecracker vsock UDS, execs a trivial command, and
-  terminates the sandbox. This is the cold-claim-shaped number: snapshot restore
+  terminates the sandbox. The clock stops the instant the first exec result is
+  in; teardown (SIGKILL of Firecracker, process wait, and removal of the
+  sandbox/jailer chroot) runs after the timer has stopped and is excluded from
+  the measured duration. This is the cold-claim-shaped number: snapshot restore
   plus the time for the guest agent to service the first exec.
 - **`exec-rt`** (`exec_round_trip`): forks one sandbox once, warms the
   connection and the guest exec path, then measures a stream of trivial exec

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,86 @@
+# Benchmarks
+
+Every latency number this project publishes must come from a benchmark anyone
+can rerun. This file documents the methodology behind the reproducible harness
+and records where the current (shared-CI-class) numbers come from. It is
+deliberately honest about what is measured and what is still open.
+
+## What is measured today
+
+The harness is `cmd/bench`. It imports `internal/fork` and drives the real
+KVM-backed engine in-process (no forkd, no gRPC, no HTTP API in the path), so
+the timing reflects the fork + vsock + guest-agent data path and nothing else.
+The percentile statistics are computed by `internal/benchstat` (count, min, p50,
+p90, p99, max, mean; nearest-rank percentiles).
+
+Two modes:
+
+- **`fork-exec`** (`fork_to_first_exec`): measures the wall time from the start
+  of a fork to the first successful exec result returned through the guest
+  agent. Each iteration forks a fresh sandbox from the template snapshot,
+  connects to the fork's Firecracker vsock UDS, execs a trivial command, and
+  terminates the sandbox. This is the cold-claim-shaped number: snapshot restore
+  plus the time for the guest agent to service the first exec.
+- **`exec-rt`** (`exec_round_trip`): forks one sandbox once, warms the
+  connection and the guest exec path, then measures a stream of trivial exec
+  round-trips against the already-warm agent. This isolates the warm exec
+  hot-path (vsock round-trip + `/bin/sh -c` spawn in the guest) from the
+  one-time restore cost.
+
+Warmup iterations are discarded; they pay the page-cache and snapshot-load costs
+that should not skew the measured samples.
+
+## Hardware and configuration (CI run)
+
+- **Runner:** GitHub Actions `ubuntu-latest` (a shared, oversubscribed runner,
+  frequently itself nested-virt). This is NOT bare metal.
+- **VMM:** Firecracker v1.15.0.
+- **Kernel:** the Firecracker CI kernel (`vmlinux-*`) pulled from
+  `spec.ccfc.min` for the v1.15 CI series.
+- **Rootfs:** a minimal ext4 image with the project's guest agent as `/init`
+  plus a static busybox (`/bin/sh`, `/bin/true`, and the small tool set the
+  agent's exec path needs).
+- **Iterations:** 30 measured, 5 warmup, per mode (modest on purpose; the runner
+  is noisy).
+- **VM size:** 1 vCPU, 256 MiB.
+
+## Results
+
+The numbers are produced by the `KVM Integration Test` workflow on every run of
+the bench phase and are **SHARED-CI-CLASS**: noisy, oversubscribed, and not
+representative of bare metal. They exist to prove the harness runs end to end and
+to give a reproducible distribution that is regenerated every run, not to be
+quoted as the product's latency.
+
+> Populated from the CI artifact. The latency tables for `fork_to_first_exec`
+> and `exec_round_trip` are printed to the step log AND appended to the run's
+> job summary by the bench phase, and the raw JSON is uploaded as the
+> `bench-results` workflow artifact. See the most recent `KVM Integration Test`
+> workflow run summary for the current shared-CI-class distribution. (We do not
+> paste numbers here: this file is committed before the post-merge CI run that
+> produces them, and a hand-copied number would be exactly the kind of
+> unverifiable claim this harness exists to eliminate.)
+
+To regenerate the numbers on your own hardware, see [`bench/README.md`](bench/README.md).
+
+## Open (not yet measured)
+
+These are explicitly out of scope for the current harness and tracked in
+[#15](https://github.com/paperclipinc/sandbox/issues/15) / roadmap section 4:
+
+- **Bare-metal reference numbers** on the Hetzner + Talos reference node. The
+  CI numbers above are shared-runner-class; the representative numbers need the
+  reference hardware to exist.
+- **Claim to first-exec end to end through the controller** on a real cluster
+  (claim a `Sandbox` CRD, wait for the pool to hand back a forked VM, exec):
+  the current harness measures the engine data path, not the controller +
+  scheduler + pool path.
+- **Sustained claims/sec** and **density curves** (how many forks per node
+  before p99 degrades, unique-vs-shared memory at density).
+- **Pool-rebuild propagation**: time from a new template snapshot landing to it
+  being claimable across the pool.
+- **Head-to-head competitor comparison** against E2B (self-hosted), Daytona
+  (OSS), and Agent Sandbox + Kata, on identical hardware, regenerated from
+  in-repo scripts so anyone can reproduce or refute it.
+- **Latency regression gating**: deliberately not done on shared CI, which is
+  too noisy to threshold without flaking.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Two ways to run it:
 ## Features
 
 **Fast**
-- Sandbox claims fork from pre-built memory snapshots via Firecracker CoW restore; the mechanism targets sub-10ms forks, and the reproducible benchmark program that backs every public number is in progress ([#15](https://github.com/paperclipinc/sandbox/issues/15))
+- Sandbox claims fork from pre-built memory snapshots via Firecracker CoW restore; fork->first-exec is now measured reproducibly in CI (shared-runner-class, see [BENCHMARKS.md](BENCHMARKS.md)), and bare-metal reference numbers are pending the reference hardware ([#15](https://github.com/paperclipinc/sandbox/issues/15))
 - Pre-snapshotted pools: no cold start on claim
 - CoW memory sharing across forks: you pay for unique pages, not for copies
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -215,16 +215,24 @@ or spoof.
 
 ## 4. Benchmark program + honest comparison
 
-- ⬜ `bench/` harness: claim→first-exec P50/P99, fork→first-exec P50/P99
-  (end-to-end, not just the KVM restore syscall), exec round-trip, sustained
-  claims/sec, density curves, pool-rebuild propagation
-- ⬜ CI runs on pinned bare-metal hardware per release → `BENCHMARKS.md`
-  with methodology
+- ✅ `bench/` harness (`cmd/bench` + `internal/benchstat`): drives the real
+  fork engine in-process and measures fork->first-exec and warm exec
+  round-trip distributions (count/min/p50/p90/p99/max/mean). Reproducible in
+  CI: the KVM workflow runs it every run and publishes the tables to the job
+  summary plus a JSON artifact. Methodology in `BENCHMARKS.md`,
+  reproduction in `bench/README.md`.
+- ⬜ claim->first-exec end to end through the controller on a real cluster
+  (the harness measures the engine data path, not the controller + pool path)
+- ⬜ sustained claims/sec, density curves, pool-rebuild propagation
+- ⬜ Bare-metal reference numbers on the Hetzner + Talos reference node; CI
+  runs on pinned bare-metal hardware per release → `BENCHMARKS.md` results
+  section (current CI numbers are shared-runner-class, not representative)
 - ⬜ Comparison table regenerated from in-repo scripts against E2B
   self-hosted, Daytona OSS, Agent Sandbox + Kata warm pools on the same
   hardware; reproducible by anyone
-- ⬜ Track exec hot-path latency (gRPC → vsock → spawn) with the same rigor
-  as fork latency; it dominates agent tokens-to-completion
+- ✅ Exec hot-path latency (vsock round-trip + guest spawn) is measured by the
+  `exec-rt` mode with the same percentile rigor as fork latency; end-to-end
+  gRPC->vsock->spawn through the API remains open
 
 ## 5. Talos + Hetzner reference platform
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,96 @@
+# Running the benchmark harness
+
+`cmd/bench` is the reproducible source behind every latency number the project
+publishes. It drives the real KVM-backed fork engine in-process and measures the
+fork + vsock + guest-agent data path directly. This page is how to run it on a
+real KVM host to reproduce the CI numbers or capture reference-hardware numbers.
+
+For methodology and the meaning of each mode, see
+[`../BENCHMARKS.md`](../BENCHMARKS.md).
+
+## Requirements
+
+- A Linux host with `/dev/kvm` (bare metal, or a VM with nested virt). The
+  engine validates `/dev/kvm` at construction, so the tool builds and parses
+  flags everywhere but only runs the timing path on a KVM host.
+- A Firecracker binary (the CI pins v1.15.0).
+- A guest kernel (`vmlinux`) and a template snapshot already laid out under the
+  data dir (see below).
+
+## Template layout the engine loads from
+
+`cmd/bench --template <id> --data-dir <dir>` forks from a snapshot the engine
+expects at:
+
+```
+<data-dir>/templates/<id>/snapshot/mem
+<data-dir>/templates/<id>/snapshot/vmstate
+<data-dir>/templates/<id>/rootfs.ext4      # the backing rootfs
+<data-dir>/templates/<id>/verified         # cheap "trusted" marker (see below)
+```
+
+The snapshot must have been created with a **relative** vsock `uds_path`
+(`vsock.sock`); the engine resolves it against each fork's own working
+directory, so a relative path is required for forks not to collide on one host
+socket. The rootfs must contain the guest agent as `/init` and a shell, so the
+bench's exec (`/bin/sh -c /bin/true` inside the guest) resolves.
+
+The cleanest way to produce this layout is to build the template through the
+engine itself (`forkd`'s `CreateTemplate`, which boots the VM, snapshots it,
+content-addresses it into the CAS store, and writes the `verified` marker). If
+you instead lay out the snapshot files by hand (as the CI bench phase does),
+the engine will refuse to fork an unverified snapshot; `touch
+<data-dir>/templates/<id>/verified` tells the Fork-time gate the template is
+trusted for that run. The full snapshot-create + layout sequence the CI uses is
+in the "Bench harness" step of `.github/workflows/kvm-test.yaml`.
+
+## Run it
+
+```sh
+go build -o /tmp/bench ./cmd/bench/
+
+# fork -> first exec (cold-claim-shaped)
+/tmp/bench \
+  --mode fork-exec \
+  --template <id> \
+  --data-dir <data-dir> \
+  --firecracker /usr/local/bin/firecracker \
+  --kernel <data-dir>/vmlinux \
+  --iterations 100 --warmup 10 \
+  --summary --json fork.json
+
+# warm exec round-trip (hot path)
+/tmp/bench \
+  --mode exec-rt \
+  --template <id> \
+  --data-dir <data-dir> \
+  --firecracker /usr/local/bin/firecracker \
+  --kernel <data-dir>/vmlinux \
+  --iterations 100 --warmup 10 \
+  --summary --json execrt.json
+```
+
+`--summary` prints the count/min/p50/p90/p99/max/mean table to stdout. `--json`
+writes the same distribution as machine-readable JSON (durations in
+nanoseconds) so results can be archived or diffed across hardware.
+
+## Flags
+
+| flag | meaning |
+| --- | --- |
+| `--mode` | `fork-exec` or `exec-rt` |
+| `--iterations` | measured iterations (default 50) |
+| `--warmup` | warmup iterations, discarded (default 5) |
+| `--template` | template (snapshot) id under the data dir (required) |
+| `--data-dir` | data directory holding template snapshots |
+| `--firecracker` | Firecracker binary path |
+| `--kernel` | guest kernel path |
+| `--json` | optional path to write results JSON |
+| `--summary` | print the summary table to stdout |
+
+## Capturing reference-hardware numbers
+
+To capture bare-metal reference numbers (roadmap section 4 / issue #15), run the
+two modes on the reference node with a higher iteration count (the runs above
+use 100), archive both JSON files, and record the host (CPU, kernel, Firecracker
+version, rootfs) alongside them so the numbers are reproducible and auditable.

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -52,7 +52,7 @@ func parseConfig(args []string) (config, error) {
 	var cfg config
 	fs.StringVar(&cfg.mode, "mode", modeForkExec, "benchmark mode: fork-exec|exec-rt")
 	fs.IntVar(&cfg.iterations, "iterations", 50, "measured iterations")
-	fs.IntVar(&cfg.warmup, "warmup", 5, "warmup iterations (discarded)")
+	fs.IntVar(&cfg.warmup, "warmup", 5, "discarded warmup iterations; in exec-rt mode one mandatory connection-establishment exec always runs in addition to these, even at --warmup=0")
 	fs.StringVar(&cfg.template, "template", "", "template (snapshot) id to fork from")
 	fs.StringVar(&cfg.dataDir, "data-dir", "/var/lib/agent-run", "data directory holding template snapshots")
 	fs.StringVar(&cfg.firecracker, "firecracker", "/usr/local/bin/firecracker", "Firecracker binary path")
@@ -139,7 +139,7 @@ func benchForkExec(engine *fork.Engine, cfg config) (benchstat.Result, error) {
 	// snapshot-load costs that should not skew the measured samples.
 	for i := 0; i < cfg.warmup; i++ {
 		id := fmt.Sprintf("bench-warm-%d", i)
-		if err := oneForkExec(engine, cfg.template, id); err != nil {
+		if _, err := oneForkExec(engine, cfg.template, id); err != nil {
 			return benchstat.Result{}, fmt.Errorf("warmup iteration %d: %w", i, err)
 		}
 	}
@@ -147,35 +147,52 @@ func benchForkExec(engine *fork.Engine, cfg config) (benchstat.Result, error) {
 	samples := make([]time.Duration, 0, cfg.iterations)
 	for i := 0; i < cfg.iterations; i++ {
 		id := fmt.Sprintf("bench-fe-%d", i)
-		t0 := time.Now()
-		if err := oneForkExec(engine, cfg.template, id); err != nil {
+		elapsed, err := oneForkExec(engine, cfg.template, id)
+		if err != nil {
 			return benchstat.Result{}, fmt.Errorf("iteration %d: %w", i, err)
 		}
-		samples = append(samples, time.Since(t0))
+		samples = append(samples, elapsed)
 	}
 
 	return benchstat.Result{Name: "fork_to_first_exec", Unit: "ms", Summary: benchstat.Summarize(samples)}, nil
 }
 
 // oneForkExec forks one sandbox, execs a trivial command over its vsock, and
-// terminates it. The timer in the caller spans this whole call.
-func oneForkExec(engine *fork.Engine, template, sandboxID string) error {
+// terminates it, returning the measured fork-to-first-exec elapsed time.
+//
+// Measurement boundary (do not regress): the clock starts immediately before
+// Fork and stops the instant the first exec result is in. Teardown (client
+// close and engine.Terminate, which SIGKILLs Firecracker, waits on the
+// process, and removes the sandbox/jailer chroot) runs AFTER the elapsed value
+// is captured and is therefore NOT counted in the returned duration. The
+// directive is fork -> first successful exec, not fork -> teardown.
+func oneForkExec(engine *fork.Engine, template, sandboxID string) (time.Duration, error) {
+	t0 := time.Now()
 	res, err := engine.Fork(template, sandboxID, fork.ForkOpts{})
 	if err != nil {
-		return fmt.Errorf("fork: %w", err)
+		return 0, fmt.Errorf("fork: %w", err)
 	}
-	defer func() { _ = engine.Terminate(sandboxID) }()
+	// From here every path must tear the sandbox down so a failed iteration
+	// does not leak a VM. cleanup is invoked explicitly (never deferred on the
+	// success path) so that it runs only AFTER elapsed is computed.
+	cleanup := func() { _ = engine.Terminate(sandboxID) }
 
 	client, err := connectWithRetry(res.VsockPath)
 	if err != nil {
-		return err
+		cleanup()
+		return 0, fmt.Errorf("connect: %w", err)
 	}
-	defer client.Close()
 
 	if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {
-		return fmt.Errorf("exec: %w", err)
+		client.Close()
+		cleanup()
+		return 0, fmt.Errorf("exec: %w", err)
 	}
-	return nil
+
+	elapsed := time.Since(t0) // clock stops here, before any teardown
+	client.Close()
+	cleanup() // teardown is NOT part of elapsed
+	return elapsed, nil
 }
 
 // benchExecRT forks one sandbox, warms it, then measures M trivial exec
@@ -194,9 +211,15 @@ func benchExecRT(engine *fork.Engine, cfg config) (benchstat.Result, error) {
 	}
 	defer client.Close()
 
-	// Warm the connection and the guest exec path with one discarded exec.
+	// Connection establishment: one mandatory discarded exec that pays the
+	// first-exec costs (guest exec path cold start, any lazy connection
+	// setup) which must happen once before the agent can serve execs at all.
+	// This is distinct from and always runs in addition to the --warmup execs
+	// below; it is not counted by --warmup. With --warmup=0 the agent still
+	// gets this single connection-establishing exec, but zero discretionary
+	// warmup iterations on top of it.
 	if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {
-		return benchstat.Result{}, fmt.Errorf("warmup exec: %w", err)
+		return benchstat.Result{}, fmt.Errorf("connection-establishment exec: %w", err)
 	}
 	for i := 0; i < cfg.warmup; i++ {
 		if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -1,0 +1,233 @@
+// Command bench measures the sandbox fork and exec data path directly against
+// the real KVM-backed engine. It is the reproducible source behind every
+// latency number the project publishes (CLAUDE.md operating principle 1).
+//
+// Driver path: bench imports internal/fork and internal/vsock and drives the
+// engine in-process. This is the most direct measurement of the data path: it
+// forks from a template snapshot already present under --data-dir (the CI
+// builds it), connects to the fork's Firecracker vsock UDS, and execs a
+// trivial command. There is no forkd, no gRPC, and no HTTP API in the path, so
+// the timing reflects fork + vsock + guest agent and nothing else.
+//
+// The engine validates /dev/kvm at construction, so the timing path runs only
+// on a Linux KVM host; on any other platform the tool builds and parses flags
+// but exits non-zero at engine construction with a clear message.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/paperclipinc/sandbox/internal/benchstat"
+	"github.com/paperclipinc/sandbox/internal/firecracker"
+	"github.com/paperclipinc/sandbox/internal/fork"
+	"github.com/paperclipinc/sandbox/internal/vsock"
+)
+
+const (
+	modeForkExec = "fork-exec"
+	modeExecRT   = "exec-rt"
+)
+
+// config holds the parsed, validated flags. Parsing is split out so it can be
+// unit-tested without touching the KVM-only timing path.
+type config struct {
+	mode        string
+	iterations  int
+	warmup      int
+	template    string
+	dataDir     string
+	firecracker string
+	kernel      string
+	jsonPath    string
+	summary     bool
+}
+
+// parseConfig parses args (excluding the program name) into a validated config.
+func parseConfig(args []string) (config, error) {
+	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
+
+	var cfg config
+	fs.StringVar(&cfg.mode, "mode", modeForkExec, "benchmark mode: fork-exec|exec-rt")
+	fs.IntVar(&cfg.iterations, "iterations", 50, "measured iterations")
+	fs.IntVar(&cfg.warmup, "warmup", 5, "warmup iterations (discarded)")
+	fs.StringVar(&cfg.template, "template", "", "template (snapshot) id to fork from")
+	fs.StringVar(&cfg.dataDir, "data-dir", "/var/lib/agent-run", "data directory holding template snapshots")
+	fs.StringVar(&cfg.firecracker, "firecracker", "/usr/local/bin/firecracker", "Firecracker binary path")
+	fs.StringVar(&cfg.kernel, "kernel", "/var/lib/agent-run/vmlinux", "guest kernel path")
+	fs.StringVar(&cfg.jsonPath, "json", "", "optional path to write results JSON")
+	fs.BoolVar(&cfg.summary, "summary", false, "print the summary table to stdout")
+
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+
+	if cfg.mode != modeForkExec && cfg.mode != modeExecRT {
+		return config{}, fmt.Errorf("invalid --mode %q: want %s or %s", cfg.mode, modeForkExec, modeExecRT)
+	}
+	if cfg.template == "" {
+		return config{}, fmt.Errorf("--template is required")
+	}
+	if cfg.iterations < 1 {
+		return config{}, fmt.Errorf("--iterations must be at least 1, got %d", cfg.iterations)
+	}
+	if cfg.warmup < 0 {
+		return config{}, fmt.Errorf("--warmup must not be negative, got %d", cfg.warmup)
+	}
+	return cfg, nil
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bench: %v\n", err)
+		os.Exit(2)
+	}
+
+	if err := run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "bench: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg config) error {
+	// Mirror cmd/forkd construction with a zero jailer config (jailer
+	// disabled) and networking/CAS opts left at their defaults: the bench
+	// measures the bare fork + exec path, so no per-fork network is set up.
+	engine, err := fork.NewEngine(cfg.dataDir, cfg.firecracker, cfg.kernel, firecracker.JailerConfig{}, fork.EngineOpts{})
+	if err != nil {
+		return fmt.Errorf("init engine (needs Linux + /dev/kvm + template under --data-dir): %w", err)
+	}
+
+	var result benchstat.Result
+	switch cfg.mode {
+	case modeForkExec:
+		result, err = benchForkExec(engine, cfg)
+	case modeExecRT:
+		result, err = benchExecRT(engine, cfg)
+	default:
+		return fmt.Errorf("invalid mode %q", cfg.mode)
+	}
+	if err != nil {
+		return err
+	}
+
+	results := []benchstat.Result{result}
+
+	if cfg.summary {
+		fmt.Printf("%s (%s)\n%s", result.Name, result.Unit, result.Summary.Table())
+	}
+	if cfg.jsonPath != "" {
+		f, err := os.Create(cfg.jsonPath)
+		if err != nil {
+			return fmt.Errorf("create json output: %w", err)
+		}
+		defer f.Close()
+		if err := benchstat.WriteJSON(f, results); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// benchForkExec measures the time from fork start to the first successful exec
+// result, terminating the sandbox each iteration.
+func benchForkExec(engine *fork.Engine, cfg config) (benchstat.Result, error) {
+	// Warmup iterations are discarded; they pay the page-cache and
+	// snapshot-load costs that should not skew the measured samples.
+	for i := 0; i < cfg.warmup; i++ {
+		id := fmt.Sprintf("bench-warm-%d", i)
+		if err := oneForkExec(engine, cfg.template, id); err != nil {
+			return benchstat.Result{}, fmt.Errorf("warmup iteration %d: %w", i, err)
+		}
+	}
+
+	samples := make([]time.Duration, 0, cfg.iterations)
+	for i := 0; i < cfg.iterations; i++ {
+		id := fmt.Sprintf("bench-fe-%d", i)
+		t0 := time.Now()
+		if err := oneForkExec(engine, cfg.template, id); err != nil {
+			return benchstat.Result{}, fmt.Errorf("iteration %d: %w", i, err)
+		}
+		samples = append(samples, time.Since(t0))
+	}
+
+	return benchstat.Result{Name: "fork_to_first_exec", Unit: "ms", Summary: benchstat.Summarize(samples)}, nil
+}
+
+// oneForkExec forks one sandbox, execs a trivial command over its vsock, and
+// terminates it. The timer in the caller spans this whole call.
+func oneForkExec(engine *fork.Engine, template, sandboxID string) error {
+	res, err := engine.Fork(template, sandboxID, fork.ForkOpts{})
+	if err != nil {
+		return fmt.Errorf("fork: %w", err)
+	}
+	defer func() { _ = engine.Terminate(sandboxID) }()
+
+	client, err := connectWithRetry(res.VsockPath)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {
+		return fmt.Errorf("exec: %w", err)
+	}
+	return nil
+}
+
+// benchExecRT forks one sandbox, warms it, then measures M trivial exec
+// round-trips against the live agent.
+func benchExecRT(engine *fork.Engine, cfg config) (benchstat.Result, error) {
+	const sandboxID = "bench-execrt"
+	res, err := engine.Fork(cfg.template, sandboxID, fork.ForkOpts{})
+	if err != nil {
+		return benchstat.Result{}, fmt.Errorf("fork: %w", err)
+	}
+	defer func() { _ = engine.Terminate(sandboxID) }()
+
+	client, err := connectWithRetry(res.VsockPath)
+	if err != nil {
+		return benchstat.Result{}, err
+	}
+	defer client.Close()
+
+	// Warm the connection and the guest exec path with one discarded exec.
+	if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {
+		return benchstat.Result{}, fmt.Errorf("warmup exec: %w", err)
+	}
+	for i := 0; i < cfg.warmup; i++ {
+		if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {
+			return benchstat.Result{}, fmt.Errorf("warmup exec %d: %w", i, err)
+		}
+	}
+
+	samples := make([]time.Duration, 0, cfg.iterations)
+	for i := 0; i < cfg.iterations; i++ {
+		t0 := time.Now()
+		if _, err := client.Exec("/bin/true", "/", nil, 10); err != nil {
+			return benchstat.Result{}, fmt.Errorf("exec iteration %d: %w", i, err)
+		}
+		samples = append(samples, time.Since(t0))
+	}
+
+	return benchstat.Result{Name: "exec_round_trip", Unit: "ms", Summary: benchstat.Summarize(samples)}, nil
+}
+
+// connectWithRetry dials the fork's vsock UDS, retrying briefly because the
+// guest agent needs a moment to accept connections after a restore.
+func connectWithRetry(vsockPath string) (*vsock.Client, error) {
+	const attempts = 50
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		client, err := vsock.Connect(vsockPath, vsock.AgentPort)
+		if err == nil {
+			return client, nil
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("connect vsock %s after %d attempts: %w", vsockPath, attempts, lastErr)
+}

--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import "testing"
+
+func TestParseConfigDefaults(t *testing.T) {
+	cfg, err := parseConfig([]string{"--template", "default"})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.mode != modeForkExec {
+		t.Errorf("mode = %q, want %q", cfg.mode, modeForkExec)
+	}
+	if cfg.iterations != 50 {
+		t.Errorf("iterations = %d, want 50", cfg.iterations)
+	}
+	if cfg.warmup != 5 {
+		t.Errorf("warmup = %d, want 5", cfg.warmup)
+	}
+	if cfg.template != "default" {
+		t.Errorf("template = %q, want default", cfg.template)
+	}
+}
+
+func TestParseConfigInvalidMode(t *testing.T) {
+	_, err := parseConfig([]string{"--mode", "bogus", "--template", "default"})
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+}
+
+func TestParseConfigMissingTemplate(t *testing.T) {
+	_, err := parseConfig([]string{"--mode", "fork-exec"})
+	if err == nil {
+		t.Fatal("expected error for missing template")
+	}
+}
+
+func TestParseConfigExecRT(t *testing.T) {
+	cfg, err := parseConfig([]string{"--mode", "exec-rt", "--template", "t", "--iterations", "10", "--warmup", "2"})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.mode != modeExecRT {
+		t.Errorf("mode = %q, want %q", cfg.mode, modeExecRT)
+	}
+	if cfg.iterations != 10 {
+		t.Errorf("iterations = %d, want 10", cfg.iterations)
+	}
+}

--- a/docs/superpowers/plans/2026-06-11-benchmark-program.md
+++ b/docs/superpowers/plans/2026-06-11-benchmark-program.md
@@ -1,0 +1,59 @@
+# Benchmark Program Implementation Plan (issue #15)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A reproducible `bench/` harness that measures the latencies that matter, run in CI on the KVM runner, with results written to a `BENCHMARKS.md` that states the methodology and hardware honestly. This is the no-unverified-claims principle made concrete: instead of target numbers, the repo carries measured fork->first-exec and exec-round-trip latencies that anyone can reproduce, clearly labeled as shared-CI-class (not bare metal). The bare-metal reference numbers and the head-to-head competitor comparison remain explicitly open (they need the reference hardware and the competitors installed on the same machine).
+
+**Honesty constraint (the whole point):** every number in BENCHMARKS.md and the README is produced by the in-repo harness on documented hardware. The harness measures end-to-end fork->first-successful-exec (snapshot restore plus the first command actually completing through the guest agent), not just the restore syscall. Numbers measured on GitHub Actions shared runners are labeled as such with a loud disclaimer that they are noisy and not representative of bare metal; the README does not state a single latency number that the harness did not produce.
+
+**Architecture:** A `cmd/bench` tool drives the real fork data path against a running forkd (or directly the engine on a KVM host): build/load a template, then over N iterations fork a sandbox and exec a trivial command, timing restore-start to exec-result; separately, on one warm sandbox, measure exec round-trip over M iterations. It computes P50/P90/P99 and emits JSON plus a human table. The KVM CI workflow runs it after building a template and appends the numbers to the GitHub step summary and to a committed BENCHMARKS.md template via a documented manual-update step (CI prints; a human or a follow-up automation commits, to avoid CI committing to main). Pure statistics (percentile computation, result formatting) are unit-tested on any platform; the real timing runs only on the KVM runner.
+
+**Context for the implementer:**
+- The KVM CI (`.github/workflows/kvm-test.yaml`) already: installs Firecracker v1.15 + jailer, downloads a kernel and rootfs, builds the guest agent into a rootfs, boots a VM, snapshots it, restores it, and execs via the guest agent over vsock (`cmd/test-agent`). Reuse this machinery: the bench needs a template snapshot and the vsock exec path.
+- Fork data path: `internal/fork/engine.go` Fork (restore snapshot into a fresh Firecracker process) and the vsock exec via `internal/vsock` + the guest agent. `cmd/test-agent` shows how to connect and exec over the Firecracker vsock UDS.
+- For a representative end-to-end measurement WITHOUT a full k8s cluster, drive the engine or forkd directly on the KVM host: fork from a prepared template snapshot, connect to the new sandbox's vsock, exec `true` or `echo`, measure. The standalone `cmd/sandbox-server` (no k8s) already wires the engine + the HTTP exec path and may be the simplest driver; or call the engine directly from `cmd/bench`.
+- Conventions: CLAUDE.md authoritative. No em/en dashes. TDD for the pure stats. Explicit-path git add. Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Lint darwin + GOOS=linux.
+
+---
+
+### Task 1: `internal/benchstat` percentile + result formatting (pure, unit-tested)
+
+**Files:** Create `internal/benchstat/stats.go`, `internal/benchstat/stats_test.go`.
+
+- [ ] `type Sample float64` (milliseconds) or use `time.Duration`. `type Summary{ Count int; Min, P50, P90, P99, Max, Mean Duration }`. `func Summarize(samples []time.Duration) Summary` (sort, nearest-rank percentiles, handle empty and single-sample). `func (s Summary) Table() string` (human-readable aligned table) and a JSON-serializable struct `type Result{ Name string; Unit string; Summary Summary }` with a `func WriteJSON(w io.Writer, results []Result) error`. TDD: known input yields known P50/P99 (nearest-rank, deterministic), empty input is safe, single sample, monotonic ordering; JSON round-trips.
+- [ ] Commit `feat: benchstat percentile summarization and result formatting`.
+
+### Task 2: `cmd/bench` driver
+
+**Files:** Create `cmd/bench/main.go` (+ a `main_other.go` stub if the timing path is Linux-only; keep the arg parsing and the benchstat usage cross-platform).
+
+- [ ] Flags: `--mode fork-exec|exec-rt`, `--iterations N` (default 50), `--warmup W` (default 5, discarded), `--template <id>`, `--data-dir`, `--firecracker`, `--kernel`, and the engine/forkd connection params, plus `--json <path>` and `--summary` (print the table). 
+- [ ] `fork-exec` mode: for each iteration (after warmup), fork a sandbox from the template, connect to its vsock, exec a trivial command (`/bin/true` or `echo x`), record the duration from fork-start to exec-result, terminate the sandbox. Report the Summary as `fork_to_first_exec_ms`.
+- [ ] `exec-rt` mode: fork one sandbox, warm it, then exec a trivial command M times recording each round-trip; report `exec_round_trip_ms`.
+- [ ] Drive the REAL engine (import internal/fork + internal/vsock) on a KVM host, OR drive a running forkd/sandbox-server over its API; choose the path that most directly measures the data path with the least orchestration. Document the choice. Keep the tool dependency-light and scriptable; nonzero exit on setup failure, clear stderr.
+- [ ] No unit test of the timing path (KVM-only); a smoke build test and the benchstat tests cover the logic. Ensure `go build ./cmd/bench` works on darwin (guard the Linux-only engine calls behind a build tag if needed, with a clear not-supported message on non-Linux).
+- [ ] Commit `feat: cmd/bench fork-exec and exec round-trip latency driver`.
+
+### Task 3: KVM CI benchmark phase + BENCHMARKS.md
+
+**Files:** `.github/workflows/kvm-test.yaml`, `BENCHMARKS.md` (new), `bench/README.md` (new, how to run it locally/on bare metal).
+
+- [ ] KVM CI phase (after a template snapshot is available): build `cmd/bench`, run `fork-exec` mode with a modest iteration count (e.g. 30 plus 5 warmup) and `exec-rt` mode, print the tables to the step log AND append them to `$GITHUB_STEP_SUMMARY` so the numbers are visible on the run page. Save the JSON as a workflow artifact. This phase is allowed to be non-gating on the NUMBERS (shared runners are noisy; do not fail on a latency threshold) but MUST gate on the bench running successfully (a crash or zero samples fails the job). Add a comment stating the numbers are shared-CI-class.
+- [ ] `BENCHMARKS.md`: the methodology (what fork->first-exec measures: restore start to first exec result through the guest agent; what exec-round-trip measures), the hardware (GitHub Actions runner class, Firecracker v1.15, kernel/rootfs versions, iteration counts), a results section that says the current numbers are produced by the CI run and are shared-CI-class (noisy, not bare metal), and an explicit OPEN section: bare-metal reference numbers on the Hetzner+Talos reference node (pending that hardware), claim->first-exec end-to-end through the controller (pending a bench cluster), density curves, pool-rebuild propagation, and the head-to-head competitor comparison (E2B self-hosted, Daytona OSS, Agent Sandbox + Kata) on the same hardware. Do NOT paste fabricated numbers; if you cannot capture the CI numbers into the file in this PR (CI runs after merge), put a clearly-marked placeholder line that says the numbers are populated from the CI artifact and link the workflow, and have the README point at BENCHMARKS.md rather than stating numbers inline.
+- [ ] `bench/README.md`: how to run `cmd/bench` on a real KVM host (bare metal) to reproduce or extend, so the reference-hardware numbers can be captured when that hardware exists.
+- [ ] Commit `ci: run the bench harness on the KVM runner, publish to step summary`.
+
+### Task 4: README + ROADMAP honesty pass
+
+**Files:** `README.md` (CAUTION: this is the one place the session has historically been careful; make ONLY the performance-section change described), `ROADMAP.md`.
+
+- [ ] README performance section: ensure it states no latency number that the harness did not produce. Point to BENCHMARKS.md for measured (CI-class) numbers and state that bare-metal reference numbers are pending the reference hardware. The mechanism description (Firecracker CoW snapshot restore) stays; the specific millisecond claims must either be the harness-measured CI numbers (clearly labeled) or remain qualitative with a pointer to BENCHMARKS.md. If the README already avoids inline numbers (it was rewritten this way earlier), just add the BENCHMARKS.md pointer.
+- [ ] ROADMAP section 4 (benchmark program): flip the harness + fork->exec/exec-rt measurement to done (reproducible in CI); leave bare-metal reference numbers, claim->exec end-to-end, density curves, propagation, and the competitor comparison open with notes.
+- [ ] Commit `docs: point performance claims at the reproducible bench harness`.
+
+### Task 5: verification + PR
+
+- [ ] Full verification: build darwin + GOOS=linux, vet, lint both, all Go suites with envtest, Python suite, gofmt zero, dash grep zero, YAML parse, `go build ./cmd/bench` on darwin.
+- [ ] Push `feat/benchmark-program`, PR `Benchmark harness: reproducible fork-exec and exec round-trip latency` body references #15, states what is measured (CI-class) and what is open (bare-metal, claim->exec, competitor comparison), watch CI (confirm the bench phase runs and prints numbers), merge when green.
+
+**Out of scope (remain open in #15 / roadmap section 4):** bare-metal reference numbers on Hetzner+Talos (needs the hardware); claim->first-exec end-to-end through the controller on a real cluster; sustained claims/sec, density curves, pool-rebuild propagation; the reproducible head-to-head comparison table against E2B/Daytona/Agent-Sandbox on identical hardware; regression-gating on latency (too noisy on shared CI).

--- a/internal/benchstat/stats.go
+++ b/internal/benchstat/stats.go
@@ -1,0 +1,179 @@
+// Package benchstat provides pure latency statistics for the bench driver:
+// nearest-rank percentile summarization, a human-readable table, and a
+// JSON-serializable result view. It has no runtime dependencies and is fully
+// unit-tested so the timing path in cmd/bench carries no statistical logic.
+package benchstat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Summary is the distribution of a set of latency samples. Percentiles use the
+// nearest-rank method (see Summarize).
+type Summary struct {
+	Count int
+	Min   time.Duration
+	P50   time.Duration
+	P90   time.Duration
+	P99   time.Duration
+	Max   time.Duration
+	Mean  time.Duration
+}
+
+// Summarize computes a Summary over samples. The input slice is not mutated; a
+// sorted copy is taken internally.
+//
+// Percentiles use the nearest-rank method: for the P-th percentile of n sorted
+// samples the chosen index is ceil(P/100 * n) - 1, clamped to [0, n-1]. An
+// empty input yields the zero Summary. A single sample yields a Summary whose
+// Min, percentiles, Max, and Mean are all that sample.
+func Summarize(samples []time.Duration) Summary {
+	n := len(samples)
+	if n == 0 {
+		return Summary{}
+	}
+
+	sorted := make([]time.Duration, n)
+	copy(sorted, samples)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	var total time.Duration
+	for _, s := range sorted {
+		total += s
+	}
+
+	return Summary{
+		Count: n,
+		Min:   sorted[0],
+		P50:   percentile(sorted, 50),
+		P90:   percentile(sorted, 90),
+		P99:   percentile(sorted, 99),
+		Max:   sorted[n-1],
+		Mean:  total / time.Duration(n),
+	}
+}
+
+// percentile returns the p-th percentile of the already-sorted slice using the
+// nearest-rank method. sorted must be non-empty.
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	n := len(sorted)
+	idx := int(math.Ceil(p/100*float64(n))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > n-1 {
+		idx = n - 1
+	}
+	return sorted[idx]
+}
+
+// Table renders the Summary as an aligned human-readable table with values in
+// milliseconds.
+func (s Summary) Table() string {
+	rows := []struct {
+		label string
+		value string
+	}{
+		{"count", fmt.Sprintf("%d", s.Count)},
+		{"min", ms(s.Min)},
+		{"p50", ms(s.P50)},
+		{"p90", ms(s.P90)},
+		{"p99", ms(s.P99)},
+		{"max", ms(s.Max)},
+		{"mean", ms(s.Mean)},
+	}
+
+	var b strings.Builder
+	for _, r := range rows {
+		fmt.Fprintf(&b, "%-6s %10s\n", r.label, r.value)
+	}
+	return b.String()
+}
+
+// ms formats a duration as milliseconds with three decimal places.
+func ms(d time.Duration) string {
+	return fmt.Sprintf("%.3f ms", float64(d)/float64(time.Millisecond))
+}
+
+// Result names a measured Summary and its unit (for example "ms").
+type Result struct {
+	Name    string
+	Unit    string
+	Summary Summary
+}
+
+// jsonSummary is the wire view of a Summary. Durations are exported as
+// integer nanoseconds (the native time.Duration unit) so the JSON round-trips
+// losslessly back into a time.Duration.
+type jsonSummary struct {
+	Count  int   `json:"count"`
+	MinNs  int64 `json:"min_ns"`
+	P50Ns  int64 `json:"p50_ns"`
+	P90Ns  int64 `json:"p90_ns"`
+	P99Ns  int64 `json:"p99_ns"`
+	MaxNs  int64 `json:"max_ns"`
+	MeanNs int64 `json:"mean_ns"`
+}
+
+type jsonResult struct {
+	Name    string      `json:"name"`
+	Unit    string      `json:"unit"`
+	Summary jsonSummary `json:"summary"`
+}
+
+func toJSON(s Summary) jsonSummary {
+	return jsonSummary{
+		Count:  s.Count,
+		MinNs:  s.Min.Nanoseconds(),
+		P50Ns:  s.P50.Nanoseconds(),
+		P90Ns:  s.P90.Nanoseconds(),
+		P99Ns:  s.P99.Nanoseconds(),
+		MaxNs:  s.Max.Nanoseconds(),
+		MeanNs: s.Mean.Nanoseconds(),
+	}
+}
+
+func fromJSON(j jsonSummary) Summary {
+	return Summary{
+		Count: j.Count,
+		Min:   time.Duration(j.MinNs),
+		P50:   time.Duration(j.P50Ns),
+		P90:   time.Duration(j.P90Ns),
+		P99:   time.Duration(j.P99Ns),
+		Max:   time.Duration(j.MaxNs),
+		Mean:  time.Duration(j.MeanNs),
+	}
+}
+
+// MarshalJSON encodes the Result via its nanosecond wire view.
+func (r Result) MarshalJSON() ([]byte, error) {
+	return json.Marshal(jsonResult{Name: r.Name, Unit: r.Unit, Summary: toJSON(r.Summary)})
+}
+
+// UnmarshalJSON decodes a Result from its nanosecond wire view.
+func (r *Result) UnmarshalJSON(data []byte) error {
+	var j jsonResult
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	r.Name = j.Name
+	r.Unit = j.Unit
+	r.Summary = fromJSON(j.Summary)
+	return nil
+}
+
+// WriteJSON writes results as indented JSON to w.
+func WriteJSON(w io.Writer, results []Result) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		return fmt.Errorf("encode results: %w", err)
+	}
+	return nil
+}

--- a/internal/benchstat/stats_test.go
+++ b/internal/benchstat/stats_test.go
@@ -1,0 +1,141 @@
+package benchstat
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// makeSamples returns n samples with values 1ms, 2ms, ..., n*ms in order.
+func makeSamples(n int) []time.Duration {
+	out := make([]time.Duration, n)
+	for i := 0; i < n; i++ {
+		out[i] = time.Duration(i+1) * time.Millisecond
+	}
+	return out
+}
+
+func TestSummarizeKnownPercentiles(t *testing.T) {
+	// 100 samples valued 1ms..100ms. Nearest-rank index = ceil(P/100*n)-1.
+	// P50 -> ceil(50)-1 = 49 -> 50ms; P90 -> ceil(90)-1 = 89 -> 90ms;
+	// P99 -> ceil(99)-1 = 98 -> 99ms.
+	s := Summarize(makeSamples(100))
+
+	if s.Count != 100 {
+		t.Errorf("Count = %d, want 100", s.Count)
+	}
+	if s.Min != 1*time.Millisecond {
+		t.Errorf("Min = %v, want 1ms", s.Min)
+	}
+	if s.Max != 100*time.Millisecond {
+		t.Errorf("Max = %v, want 100ms", s.Max)
+	}
+	if s.P50 != 50*time.Millisecond {
+		t.Errorf("P50 = %v, want 50ms", s.P50)
+	}
+	if s.P90 != 90*time.Millisecond {
+		t.Errorf("P90 = %v, want 90ms", s.P90)
+	}
+	if s.P99 != 99*time.Millisecond {
+		t.Errorf("P99 = %v, want 99ms", s.P99)
+	}
+	// Mean of 1..100 ms = 50.5ms.
+	wantMean := 50500 * time.Microsecond
+	if s.Mean != wantMean {
+		t.Errorf("Mean = %v, want %v", s.Mean, wantMean)
+	}
+}
+
+func TestSummarizeEmpty(t *testing.T) {
+	s := Summarize(nil)
+	if s != (Summary{}) {
+		t.Errorf("Summarize(nil) = %+v, want zero Summary", s)
+	}
+	s2 := Summarize([]time.Duration{})
+	if s2 != (Summary{}) {
+		t.Errorf("Summarize(empty) = %+v, want zero Summary", s2)
+	}
+}
+
+func TestSummarizeSingle(t *testing.T) {
+	s := Summarize([]time.Duration{42 * time.Millisecond})
+	v := 42 * time.Millisecond
+	if s.Count != 1 {
+		t.Errorf("Count = %d, want 1", s.Count)
+	}
+	for name, got := range map[string]time.Duration{
+		"Min": s.Min, "P50": s.P50, "P90": s.P90,
+		"P99": s.P99, "Max": s.Max, "Mean": s.Mean,
+	} {
+		if got != v {
+			t.Errorf("%s = %v, want %v", name, got, v)
+		}
+	}
+}
+
+func TestSummarizeOrderingInvariant(t *testing.T) {
+	ordered := makeSamples(100)
+	shuffled := make([]time.Duration, len(ordered))
+	copy(shuffled, ordered)
+	r := rand.New(rand.NewSource(1))
+	r.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+
+	a := Summarize(ordered)
+	b := Summarize(shuffled)
+	if a != b {
+		t.Errorf("shuffled summary differs: %+v vs %+v", a, b)
+	}
+}
+
+func TestSummarizeDoesNotMutateInput(t *testing.T) {
+	in := []time.Duration{3 * time.Millisecond, 1 * time.Millisecond, 2 * time.Millisecond}
+	_ = Summarize(in)
+	if in[0] != 3*time.Millisecond || in[1] != 1*time.Millisecond || in[2] != 2*time.Millisecond {
+		t.Errorf("input was mutated: %v", in)
+	}
+}
+
+func TestTableContainsValues(t *testing.T) {
+	s := Summarize(makeSamples(100))
+	tbl := s.Table()
+	for _, want := range []string{"count", "min", "p50", "p90", "p99", "max", "mean", "100"} {
+		if !bytes.Contains([]byte(tbl), []byte(want)) {
+			t.Errorf("Table() missing %q:\n%s", want, tbl)
+		}
+	}
+}
+
+func TestWriteJSONRoundTrip(t *testing.T) {
+	results := []Result{
+		{Name: "fork_to_first_exec", Unit: "ms", Summary: Summarize(makeSamples(100))},
+		{Name: "exec_round_trip", Unit: "ms", Summary: Summarize(makeSamples(50))},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, results); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got []Result
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(got) != len(results) {
+		t.Fatalf("len = %d, want %d", len(got), len(results))
+	}
+	for i := range results {
+		if got[i].Name != results[i].Name {
+			t.Errorf("[%d].Name = %q, want %q", i, got[i].Name, results[i].Name)
+		}
+		if got[i].Unit != results[i].Unit {
+			t.Errorf("[%d].Unit = %q, want %q", i, got[i].Unit, results[i].Unit)
+		}
+		if got[i].Summary != results[i].Summary {
+			t.Errorf("[%d].Summary = %+v, want %+v", i, got[i].Summary, results[i].Summary)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/benchstat` computes percentile latency statistics (count, min, p50, p90, p99, max, mean; nearest-rank) and emits both a table and machine-readable JSON.
- `cmd/bench` drives the real KVM-backed fork engine in-process (no forkd, no gRPC, no HTTP in the path) and measures two distributions: `fork_to_first_exec` (fork start to first exec result through the guest agent) and `exec_round_trip` (a warm exec round trip against the live agent).
- The KVM integration workflow runs the harness every run: it lays out a template snapshot in the layout the engine loads from (`<dataDir>/templates/<id>/snapshot/{mem,vmstate}` + `rootfs.ext4`), writes the cheap `verified` marker so the Fork-time gate trusts it, runs both modes, prints the tables to the step log AND the job summary, and uploads the raw JSON as the `bench-results` artifact. The phase gates on the bench running successfully (a crash or zero samples fails the job) but NOT on any latency threshold; the numbers are shared-CI-class (noisy shared runner, not bare metal).
- `BENCHMARKS.md` documents methodology, CI hardware, a results pointer (populated from the CI artifact, not fabricated), and an explicit OPEN section. `bench/README.md` documents how to run `cmd/bench` on a real KVM host.
- README performance bullet points at `BENCHMARKS.md` for the measured (CI-class) numbers and states bare-metal reference numbers are pending; the Firecracker CoW mechanism description is unchanged. ROADMAP section 4 flips the harness + fork/exec measurement to done.
- References #15. Bare-metal reference numbers, claim->first-exec end to end through the controller, sustained claims/sec, density curves, pool-rebuild propagation, and the head-to-head competitor comparison remain explicitly open.

## Test plan

- [x] `go build ./...` and `GOOS=linux go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` (darwin) and `GOOS=linux golangci-lint run`
- [x] `go test ./internal/... -count=1 -race` with envtest (all packages pass)
- [x] Python SDK suite (`pytest tests/`, 34 passed)
- [x] `go build ./cmd/bench/`
- [x] `gofmt -l` clean, no em/en dashes, `kvm-test.yaml` parses
- [ ] CI: KVM workflow bench phase runs and publishes shared-CI-class numbers to the run summary (verified on the PR run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)