### PR TITLE
MCP server: expose sandboxes as tools for any MCP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ spec:
 
 ## SDKs
 
-Python today (`sdk/python`, pre-PyPI: `pip install -e .`), TypeScript planned, MCP server planned so any MCP-speaking agent can use sandboxes with zero SDK integration ([#27](https://github.com/paperclipinc/sandbox/issues/27)). The target developer surface (three-line common path, git-shaped workspace verbs, capability-budgeted self-service for agents) is specified in [docs/api/v2-spec.md](docs/api/v2-spec.md).
+Python today (`sdk/python`, pre-PyPI: `pip install -e .`), TypeScript planned, and an MCP server (`agentrun-mcp`) that exposes sandboxes as MCP tools so any MCP-speaking agent can use them with zero SDK integration ([#27](https://github.com/paperclipinc/sandbox/issues/27)); see [docs/mcp.md](docs/mcp.md). The target developer surface (three-line common path, git-shaped workspace verbs, capability-budgeted self-service for agents) is specified in [docs/api/v2-spec.md](docs/api/v2-spec.md).
 
 ## Comparison
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -270,10 +270,12 @@ or spoof.
 The DX gap against E2B/Daytona is the adoption bottleneck once the core is
 verified. In rough order of leverage:
 
-- ⬜ **MCP server interface**: expose sandboxes as an MCP tool server
-  (create/exec/files/fork as tools); every MCP-speaking agent becomes a user
-  with zero SDK integration. Candidate to pull forward as soon as the exec
-  path is verified end-to-end.
+- ✅ **MCP server interface**: `agentrun-mcp` exposes sandboxes as an MCP tool
+  server (create/exec/read/write/fork/terminate as tools with versioned JSON
+  schemas) over stdio JSON-RPC; every MCP-speaking agent becomes a user with
+  zero SDK integration. A conformance test drives the server as a real MCP
+  client in standard CI; see docs/mcp.md. Open: workspace tools (#21) and
+  capability-budget advertisement (#24).
 - ⬜ Streaming exec (stdout/stderr), stdin, **PTY mode**, file transfer,
   port forwarding, the daily-driver agent-harness needs
 - ⬜ Code-interpreter-compatible API shim (drop-in for LangChain/LlamaIndex

--- a/cmd/agentrun-mcp/main.go
+++ b/cmd/agentrun-mcp/main.go
@@ -1,0 +1,63 @@
+// Command agentrun-mcp exposes the agentrun sandbox lifecycle (create, exec,
+// file IO, fork, terminate) as Model Context Protocol tools over a stdio
+// JSON-RPC transport. Any MCP-speaking agent can drive sandboxes through it
+// without an SDK integration.
+//
+// It speaks MCP on stdin/stdout: stdout is the JSON-RPC channel and carries
+// nothing else. ALL logging goes to stderr. The launch-time bearer token
+// (--token / AGENTRUN_TOKEN) scopes what the server can do on the backend and
+// is NEVER logged.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/paperclipinc/sandbox/internal/mcp"
+)
+
+func main() {
+	defaultServer := envOr("AGENTRUN_SERVER", "http://localhost:8080")
+	defaultToken := os.Getenv("AGENTRUN_TOKEN")
+
+	server := flag.String("server", defaultServer, "Base URL of the sandbox-server (env AGENTRUN_SERVER).")
+	token := flag.String("token", defaultToken, "Bearer token; scopes what this server may do (env AGENTRUN_TOKEN). Never logged.")
+	enableWorkspace := flag.Bool("enable-workspace-tools", false, "Advertise the workspace tools in tools/list (dispatch deferred, issue #21).")
+	flag.Parse()
+
+	// Log to stderr only: stdout is the MCP JSON-RPC channel. Never log the token.
+	logger := log.New(os.Stderr, "agentrun-mcp ", log.LstdFlags)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	backend := mcp.NewHTTPBackend(*server, *token, nil)
+	srv := mcp.New(backend, mcp.Options{EnableWorkspaceTools: *enableWorkspace})
+
+	logger.Printf("starting: server=%s workspace_tools=%v token=%s", *server, *enableWorkspace, tokenState(*token))
+
+	if err := srv.Run(ctx, os.Stdin, os.Stdout); err != nil {
+		logger.Printf("server stopped: %v", err)
+		os.Exit(1)
+	}
+}
+
+// envOr returns the environment variable value or a fallback default.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// tokenState reports whether a token is configured without ever revealing it.
+func tokenState(token string) string {
+	if token == "" {
+		return "unset"
+	}
+	return "set"
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,139 @@
+# MCP server (`agentrun-mcp`)
+
+`agentrun-mcp` exposes the agentrun sandbox lifecycle as [Model Context
+Protocol](https://modelcontextprotocol.io) tools. Any MCP-speaking agent
+(Claude Desktop, an MCP client library, an agent framework with MCP support)
+can create sandboxes, run commands, read and write files, fork, and terminate,
+with no SDK integration.
+
+It speaks MCP over a stdio JSON-RPC 2.0 transport: stdin and stdout are the
+protocol channel, and all logging goes to stderr. The protocol subset
+(`initialize`, `tools/list`, `tools/call` over newline-delimited JSON-RPC) is
+implemented directly and is dependency free, so the binary stays on go 1.24.
+
+## Tools
+
+The server advertises six always-on tools. The tool input-schema contract is
+versioned by `ToolSchemaVersion` (currently `1.0.0`); it is bumped whenever a
+tool name, required field, or property semantic changes in a way clients must
+observe.
+
+| Tool | Required arguments | Optional arguments | Returns |
+| --- | --- | --- | --- |
+| `sandbox_create` | `pool` (string) | | The new sandbox id. |
+| `sandbox_exec` | `sandbox` (string), `command` (string) | `timeout_seconds` (integer) | JSON `{exit_code, stdout, stderr}`. |
+| `sandbox_read_file` | `sandbox` (string), `path` (string) | | The file contents. |
+| `sandbox_write_file` | `sandbox` (string), `path` (string), `content` (string) | | A confirmation of bytes written. |
+| `sandbox_fork` | `sandbox` (string) | `replicas` (integer) | JSON array of new sandbox ids. |
+| `sandbox_terminate` | `sandbox` (string) | | A termination confirmation. |
+
+`pool` maps to a sandbox-server template id in the HTTP backend (see below).
+
+Tool failures are returned as LLM-legible tool results, not bare codes: each
+carries a `code`, a one-sentence `cause`, and an actionable `remediation`
+(the API v2 error rule, issue #28), with `isError` set so the client can
+distinguish a tool failure from a transport error.
+
+Workspace tools (`workspace_create`, `workspace_list`, `workspace_attach`,
+`workspace_delete`) are advertised only when `--enable-workspace-tools` is set
+and are not yet dispatched (issue #21).
+
+## Launching it
+
+The HTTP backend talks to a running [sandbox-server](../cmd/sandbox-server)
+over its REST API.
+
+```bash
+agentrun-mcp \
+  --server https://sandbox.example.internal \
+  --token "$AGENTRUN_TOKEN" \
+  --enable-workspace-tools=false
+```
+
+Flags and environment:
+
+| Flag | Environment | Default | Meaning |
+| --- | --- | --- | --- |
+| `--server` | `AGENTRUN_SERVER` | `http://localhost:8080` | Base URL of the sandbox-server. |
+| `--token` | `AGENTRUN_TOKEN` | empty | Bearer token sent on every backend request. |
+| `--enable-workspace-tools` | | `false` | Advertise the deferred workspace tools. |
+
+### Token scoping
+
+The launch-time token is the server's only credential. Every backend request
+carries it as `Authorization: Bearer <token>`, so `agentrun-mcp` can do exactly
+what that token authorizes on the sandbox-server and nothing more. Scope the
+token to scope the agent.
+
+The token is never logged and never placed in an error message. The backend
+does not log at all; on a non-2xx response it surfaces the response body as
+error context, but redacts any echo of the token first, so the secret cannot
+escape through an error string. The startup log line reports only whether a
+token is `set` or `unset`.
+
+### Backend mapping and caveats
+
+`agentrun-mcp` ships with the HTTP backend, the simplest real backend: one
+sandbox-server process, plain HTTP, one token.
+
+- `sandbox_create` issues `POST /v1/fork {template: <pool>, id: <generated>}`.
+  The sandbox-server has no pools; it forks from a named template, so the
+  HTTP backend treats `pool` as the template id. On a real Kubernetes
+  deployment a pool is a `SandboxPool`; that mapping belongs to the future
+  k8s-claim backend.
+- `sandbox_fork` issues one `POST /v1/fork` per replica. The sandbox-server
+  fork endpoint has no replicas parameter and its `template` field is a
+  template lookup, so the source id must resolve there. True
+  fork-of-a-running-sandbox is the k8s `SandboxFork` path and is a follow-up.
+- `sandbox_exec` and the file tools require the bearer token on the
+  sandbox-server (its exec/files routes are token-guarded); `fork` does not.
+
+Sandbox ids are generated client-side with `crypto/rand`.
+
+## Example MCP client config
+
+A generic MCP client that launches servers as subprocesses points a command at
+the binary and passes the backend URL and token through the environment:
+
+```json
+{
+  "mcpServers": {
+    "agentrun": {
+      "command": "/usr/local/bin/agentrun-mcp",
+      "env": {
+        "AGENTRUN_SERVER": "https://sandbox.example.internal",
+        "AGENTRUN_TOKEN": "your-scoped-token"
+      }
+    }
+  }
+}
+```
+
+## What is proven vs open
+
+Proven:
+
+- The MCP protocol handshake (`initialize`), `tools/list` schema advertisement,
+  and `tools/call` dispatch, driven by a conformance test that acts as a real
+  MCP client over the same wire framing, in the standard `go-test` CI job (no
+  KVM required).
+- LLM-legible tool errors (code, cause, remediation) on bad arguments,
+  unknown tools, and backend failures, asserted by the same test.
+- The token-scoped HTTP backend: each method sends the bearer token and the
+  correct method, path, and body, parses the response, turns a non-2xx into an
+  error, and never leaks the token, asserted against an `httptest` server.
+- The underlying exec/fork against a real microVM via the existing KVM CI job
+  (`firecracker-test`), which exercises the sandbox-server data path the HTTP
+  backend wraps.
+
+Open:
+
+- Workspace tools (log/diff/revert/attach) pending Workspace (issue #21);
+  advertised but not dispatched.
+- The Kubernetes claim backend (create a `SandboxClaim`, read its token
+  Secret, exec via forkd); the HTTP backend is the v1 path.
+- Capability-budget advertisement pending issue #24.
+- Streaming exec and PTY over MCP pending the Connect runtime protocol
+  (issue #23).
+- Transport: stdio only in v1; no SSE or HTTP MCP transport yet.
+- MCP primitives: tools only in v1; no resources or prompts yet.

--- a/docs/superpowers/plans/2026-06-11-mcp-server.md
+++ b/docs/superpowers/plans/2026-06-11-mcp-server.md
@@ -1,0 +1,58 @@
+# MCP Server Implementation Plan (issue #27)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issue #27. Ship `agentrun-mcp`, a Model Context Protocol server that exposes sandboxes as tools (`sandbox_create`, `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_fork`, `sandbox_terminate`), so any MCP-speaking agent (Claude, and any MCP client) can drive sandboxes with zero SDK integration. Tools are scoped by the credentials the server is launched with, schemas are published and versioned, errors are LLM-legible (code, cause, remediation), and the protocol/dispatch is proven by a conformance test in standard CI (no KVM): a real MCP client drives the server over stdio against a fake backend.
+
+**Honesty constraint:** the MCP server is a thin adapter over the existing sandbox data path (the forkd HTTP sandbox API and the CRD claim path), both already CI-proven. This PR proves the MCP layer (protocol handshake, tool schemas, dispatch, token scoping, error shape) against a fake backend; the underlying exec/fork against a real VM is already proven by the KVM CI. The docs say exactly that. Workspace tools (log/diff/revert) are deferred behind a flag because the Workspace primitive (#21) is not built; they are advertised only when explicitly enabled, and the README/docs say so.
+
+**Architecture:** A new `internal/mcp` package implements the MCP server over stdio JSON-RPC 2.0 (initialize, tools/list, tools/call), defining the tool set and their JSON schemas, and dispatching each tool to a `SandboxBackend` interface (Create, Exec, ReadFile, WriteFile, Fork, Terminate). A real backend talks to the sandbox system (the standalone sandbox-server HTTP API for the simplest path, or the k8s CRD + forkd HTTP path), carrying the per-sandbox bearer token. A fake backend (in tests) returns canned results so the conformance test exercises the full protocol without a cluster. `cmd/agentrun-mcp` wires the real backend and runs the server on stdio.
+
+**MCP library decision (Task 1, investigate):** prefer the official Go MCP SDK `github.com/modelcontextprotocol/go-sdk` IF its go.mod directive is <= 1.24 and it does not drag in a fragile dependency tree (we just pinned the toolchain to go 1.24; do not regress it). If the official SDK forces a higher Go version or heavy deps, implement the minimal MCP subset directly (JSON-RPC 2.0 over stdio: initialize, tools/list, tools/call, plus the standard error envelope). The subset is small and well-specified; implementing it avoids dependency risk and is fully testable. State the decision and confidence in the report.
+
+**Context for the implementer:**
+- The sandbox data path the backend wraps: the standalone `cmd/sandbox-server` HTTP API (POST /v1/exec, /v1/files/read|write, /v1/fork, etc., no k8s, supports --mock) is the simplest backend target; OR the k8s path (create a SandboxClaim, wait Ready, exec via the forkd HTTP API with the claim-owned bearer token, like the Python SDK `sdk/python/agent_run/sandbox.py`). Pick one for the real backend (sandbox-server HTTP is simpler; document the choice and note k8s backend as a follow-up if you pick HTTP).
+- Per-sandbox bearer tokens: the HTTP sandbox API requires `Authorization: Bearer <token>` (PR #41); the backend must carry it.
+- LLM-legible errors: issue #28 specifies code/cause/remediation; apply that shape to tool errors (an error result with a machine code, a one-sentence cause, and an actionable remediation).
+- Conventions: CLAUDE.md authoritative. No em/en dashes. TDD. Explicit-path git add. Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Lint darwin + GOOS=linux. Do not regress go 1.24. No secrets/tokens logged.
+
+---
+
+### Task 1: `internal/mcp` server core + tool definitions + SandboxBackend
+
+**Files:** Create `internal/mcp/server.go`, `internal/mcp/tools.go`, `internal/mcp/backend.go`, `internal/mcp/jsonrpc.go` (if implementing the subset), and `_test.go`.
+
+- [ ] Decide the MCP library (see the decision note above) and add the dep only if it passes the go-1.24 + clean-deps bar; else implement the JSON-RPC 2.0 stdio subset in `jsonrpc.go` (Request{jsonrpc,id,method,params}, Response{jsonrpc,id,result|error}, the initialize/tools-list/tools-call methods, stdio framing per the MCP spec which uses newline-delimited or Content-Length framing; implement the framing the spec mandates for stdio, which is newline-delimited JSON-RPC messages).
+- [ ] `backend.go`: `type SandboxBackend interface { Create(ctx, pool string) (sandboxID string, err error); Exec(ctx, sandboxID, command string, timeoutSec int) (ExecResult, error); ReadFile(ctx, sandboxID, path string) (string, error); WriteFile(ctx, sandboxID, path, content string) error; Fork(ctx, sandboxID string, replicas int) (forkIDs []string, err error); Terminate(ctx, sandboxID string) error }` with `ExecResult{ExitCode int; Stdout, Stderr string}`. A `FakeBackend` recording calls and returning canned results (for tests).
+- [ ] `tools.go`: define the six tools with names, descriptions, and JSON-Schema input schemas: `sandbox_create{pool}`, `sandbox_exec{sandbox, command, timeout_seconds?}`, `sandbox_read_file{sandbox, path}`, `sandbox_write_file{sandbox, path, content}`, `sandbox_fork{sandbox, replicas?}`, `sandbox_terminate{sandbox}`. A `ToolSchemaVersion` constant. Workspace tools defined but only registered when an `EnableWorkspaceTools` option is set (deferred, #21).
+- [ ] `server.go`: `Server{backend SandboxBackend; opts}`. Handles initialize (returns serverInfo + capabilities advertising tools), tools/list (returns the tool schemas), tools/call (validates the arguments against the tool, dispatches to the backend, returns a tool result or an LLM-legible error: a structured error with code/cause/remediation in the tool result content). `Run(ctx, in io.Reader, out io.Writer)` drives the stdio loop. Errors from the backend map to tool-call error results (isError:true) with the code/cause/remediation tri(never a bare code); a malformed request maps to a JSON-RPC error.
+- [ ] Tests: unit-test tool schema validity (each tool has a name, description, valid JSON schema), the tools/list output contains all six, and tools/call dispatches to the backend (FakeBackend records the call and the server returns its result). A bad tool name returns a tool error; a missing required arg returns an LLM-legible validation error.
+- [ ] Commit `feat: internal/mcp server, tool definitions, SandboxBackend interface`.
+
+### Task 2: conformance test driving the server as a real MCP client
+
+**Files:** `internal/mcp/conformance_test.go`.
+
+- [ ] A test that runs `Server.Run` against an in-process pipe (io.Pipe) with a FakeBackend, and on the other end speaks the MCP protocol as a CLIENT: send initialize, assert the server response (protocol version, capabilities, tools advertised); send tools/list, assert all six tools with their schemas; send tools/call for each tool (create, exec, read, write, fork, terminate) and assert the result matches the FakeBackend canned output and the backend recorded the right arguments; send a tools/call with an unknown tool and a tools/call with a missing required argument and assert LLM-legible errors (code/cause/remediation present). This proves the full protocol handshake + dispatch + error shape without a cluster or KVM, and runs in the standard go test suite (and thus go-test CI).
+- [ ] Commit `test: MCP conformance, client drives the server end to end`.
+
+### Task 3: real backend + `cmd/agentrun-mcp`
+
+**Files:** Create `internal/mcp/httpbackend.go` (real backend over the sandbox-server HTTP API, or k8s), `cmd/agentrun-mcp/main.go`, tests.
+
+- [ ] `httpbackend.go`: a `SandboxBackend` talking to the chosen real path. If the sandbox-server HTTP API: a client hitting POST /v1/fork (create a sandbox from a template), /v1/exec, /v1/files/read|write, /v1/sandboxes/{id} DELETE, carrying the bearer token from a launch-time credential. Token scoping: the server is launched with a token (env AGENTRUN_TOKEN or a flag) and a base URL (AGENTRUN_SERVER); all backend calls carry that token, so the MCP server can only do what the token authorizes. Document the scoping. (If k8s path chosen: create a SandboxClaim, read its `<claim>-sandbox-token` Secret, exec via forkd HTTP; more moving parts; note the choice.)
+- [ ] Unit-test the HTTP backend against an httptest.Server asserting it sends the bearer token and the right request bodies and parses responses (no real cluster).
+- [ ] `cmd/agentrun-mcp/main.go`: parse flags/env (server URL, token, --enable-workspace-tools off by default), construct the real backend, run `mcp.Server.Run(ctx, os.Stdin, os.Stdout)`. Log to stderr only (stdout is the MCP channel); never log the token.
+- [ ] Commit `feat: agentrun-mcp binary with an HTTP sandbox backend`.
+
+### Task 4: docs + README + ROADMAP + PR
+
+**Files:** `docs/mcp.md` (new), `README.md` (MCP section pointer), `ROADMAP.md`, full verification.
+
+- [ ] `docs/mcp.md`: what agentrun-mcp is, the tool set + schemas + the schema version, how to launch it (the credential/token scoping, the backend URL), an example MCP client config (Claude Desktop / a generic MCP client stanza pointing at the agentrun-mcp binary), what is PROVEN (protocol + dispatch + schemas + token scoping via the conformance test; underlying exec/fork via the KVM CI), and what is OPEN (workspace tools pending #21; the k8s-claim backend if HTTP was chosen; capability-budget advertisement pending #24; streaming exec pending the Connect protocol #23).
+- [ ] README: add a short MCP section (or a bullet under SDKs) stating sandboxes are exposed as MCP tools via agentrun-mcp, pointing at docs/mcp.md. No unverified claims.
+- [ ] ROADMAP section 7 (ergonomics): flip the MCP server line to done (tools + conformance test), noting workspace-tools and capability-budget advertisement as open.
+- [ ] Full verification (build darwin + GOOS=linux, vet, lint both, all Go suites with envtest, Python suite, gofmt zero, dash grep zero, go 1.24 directive preserved, any new dep clean).
+- [ ] Push `feat/mcp-server`, PR `MCP server: expose sandboxes as tools for any MCP agent` body Closes #27 (tools + conformance proven, workspace tools and capability budgets open), watch CI, dismiss guarded CodeQL alerts with justification if any, merge when green.
+
+**Out of scope (follow-ups):** workspace tools (log/diff/revert) pending Workspace #21; capability-budget advertisement pending #24; streaming exec / PTY over MCP pending the Connect runtime protocol #23; the k8s-claim backend (if the HTTP backend was chosen for v1); resource/prompt MCP primitives (only tools in v1); SSE/HTTP MCP transport (stdio only in v1).

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -1,0 +1,155 @@
+// Package mcp implements a Model Context Protocol (MCP) server that exposes
+// the sandbox lifecycle (create, exec, file IO, fork, terminate) as MCP tools
+// over a JSON-RPC 2.0 stdio transport.
+//
+// The MCP protocol surface is implemented directly (see jsonrpc.go) rather than
+// via the official Go SDK: that SDK requires go 1.25 and pulls in oauth2, jwt,
+// and x/tools, while this repo is pinned to go 1.24. The subset we need
+// (initialize, tools/list, tools/call over newline-delimited JSON-RPC) is small,
+// fully specified, and dependency free.
+package mcp
+
+import (
+	"context"
+	"sync"
+)
+
+// ExecResult is the outcome of running a command inside a sandbox.
+type ExecResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+// SandboxBackend is the lifecycle surface the MCP server dispatches tool calls
+// to. It is intentionally narrow so tests can supply a fake and the real
+// implementation (Task 3) can wrap forkd or sandbox-server.
+type SandboxBackend interface {
+	// Create provisions a new sandbox from the named pool and returns its id.
+	Create(ctx context.Context, pool string) (sandboxID string, err error)
+	// Exec runs command inside the sandbox. A timeoutSec of 0 means the
+	// backend default applies.
+	Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error)
+	// ReadFile returns the contents of path inside the sandbox.
+	ReadFile(ctx context.Context, sandboxID, path string) (string, error)
+	// WriteFile writes content to path inside the sandbox.
+	WriteFile(ctx context.Context, sandboxID, path, content string) error
+	// Fork forks the sandbox into replicas copies and returns their ids.
+	Fork(ctx context.Context, sandboxID string, replicas int) (forkIDs []string, err error)
+	// Terminate destroys the sandbox.
+	Terminate(ctx context.Context, sandboxID string) error
+}
+
+// FakeCall records a single backend invocation for assertions in tests.
+type FakeCall struct {
+	Method     string
+	Pool       string
+	SandboxID  string
+	Command    string
+	TimeoutSec int
+	Path       string
+	Content    string
+	Replicas   int
+}
+
+// FakeBackend is a test double that records every call and returns canned
+// responses. Responses are settable; an error can be injected per method via
+// Errors so the LLM-legible error path can be exercised.
+type FakeBackend struct {
+	mu    sync.Mutex
+	Calls []FakeCall
+
+	// Canned responses.
+	CreateID    string
+	ExecResultV ExecResult
+	ReadContent string
+	ForkIDs     []string
+
+	// Errors injects an error for the named method ("create", "exec",
+	// "read_file", "write_file", "fork", "terminate"). When set for a method,
+	// that method returns the error instead of its canned response.
+	Errors map[string]error
+}
+
+// NewFakeBackend returns a FakeBackend with sensible default canned responses.
+func NewFakeBackend() *FakeBackend {
+	return &FakeBackend{
+		CreateID:    "sbx-fake-1",
+		ExecResultV: ExecResult{ExitCode: 0, Stdout: "ok", Stderr: ""},
+		ReadContent: "file-contents",
+		ForkIDs:     []string{"sbx-fork-1", "sbx-fork-2"},
+		Errors:      map[string]error{},
+	}
+}
+
+func (f *FakeBackend) record(c FakeCall) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, c)
+}
+
+func (f *FakeBackend) err(method string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.Errors == nil {
+		return nil
+	}
+	return f.Errors[method]
+}
+
+// RecordedCalls returns a copy of the recorded calls.
+func (f *FakeBackend) RecordedCalls() []FakeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]FakeCall, len(f.Calls))
+	copy(out, f.Calls)
+	return out
+}
+
+// Create implements SandboxBackend.
+func (f *FakeBackend) Create(_ context.Context, pool string) (string, error) {
+	f.record(FakeCall{Method: "create", Pool: pool})
+	if e := f.err("create"); e != nil {
+		return "", e
+	}
+	return f.CreateID, nil
+}
+
+// Exec implements SandboxBackend.
+func (f *FakeBackend) Exec(_ context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error) {
+	f.record(FakeCall{Method: "exec", SandboxID: sandboxID, Command: command, TimeoutSec: timeoutSec})
+	if e := f.err("exec"); e != nil {
+		return ExecResult{}, e
+	}
+	return f.ExecResultV, nil
+}
+
+// ReadFile implements SandboxBackend.
+func (f *FakeBackend) ReadFile(_ context.Context, sandboxID, path string) (string, error) {
+	f.record(FakeCall{Method: "read_file", SandboxID: sandboxID, Path: path})
+	if e := f.err("read_file"); e != nil {
+		return "", e
+	}
+	return f.ReadContent, nil
+}
+
+// WriteFile implements SandboxBackend.
+func (f *FakeBackend) WriteFile(_ context.Context, sandboxID, path, content string) error {
+	f.record(FakeCall{Method: "write_file", SandboxID: sandboxID, Path: path, Content: content})
+	return f.err("write_file")
+}
+
+// Fork implements SandboxBackend.
+func (f *FakeBackend) Fork(_ context.Context, sandboxID string, replicas int) ([]string, error) {
+	f.record(FakeCall{Method: "fork", SandboxID: sandboxID, Replicas: replicas})
+	if e := f.err("fork"); e != nil {
+		return nil, e
+	}
+	return f.ForkIDs, nil
+}
+
+// Terminate implements SandboxBackend.
+func (f *FakeBackend) Terminate(_ context.Context, sandboxID string) error {
+	f.record(FakeCall{Method: "terminate", SandboxID: sandboxID})
+	return f.err("terminate")
+}

--- a/internal/mcp/conformance_test.go
+++ b/internal/mcp/conformance_test.go
@@ -1,0 +1,299 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+)
+
+// mcpClient speaks the MCP protocol over a pair of pipes as a real client would:
+// it writes newline-delimited JSON-RPC requests to the server and reads the
+// server's newline-delimited responses back. It uses the same framing the
+// server uses (frameReader/frameWriter) to prove wire compatibility.
+type mcpClient struct {
+	t      *testing.T
+	w      *frameWriter
+	r      *frameReader
+	nextID int
+}
+
+func (c *mcpClient) call(method string, params any) Response {
+	c.t.Helper()
+	c.nextID++
+	var rawParams json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			c.t.Fatalf("marshal params: %v", err)
+		}
+		rawParams = b
+	}
+	id, _ := json.Marshal(c.nextID)
+	req := Request{JSONRPC: jsonrpcVersion, ID: id, Method: method, Params: rawParams}
+	if err := c.w.Write(req); err != nil {
+		c.t.Fatalf("client write %s: %v", method, err)
+	}
+	raw, err := c.r.Read()
+	if err != nil {
+		c.t.Fatalf("client read response to %s: %v", method, err)
+	}
+	var resp Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		c.t.Fatalf("client decode response to %s: %v", method, err)
+	}
+	return resp
+}
+
+// notify sends a notification (no id, no response expected).
+func (c *mcpClient) notify(method string) {
+	c.t.Helper()
+	req := Request{JSONRPC: jsonrpcVersion, Method: method}
+	if err := c.w.Write(req); err != nil {
+		c.t.Fatalf("client notify %s: %v", method, err)
+	}
+}
+
+// TestConformanceClientDrivesServer runs Server.Run in a goroutine against an
+// io.Pipe pair and exercises the full protocol handshake, tool listing, dispatch
+// for all six tools, and the two LLM-legible error paths, end to end.
+func TestConformanceClientDrivesServer(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.CreateID = "sbx-conf-1"
+	fb.ExecResultV = ExecResult{ExitCode: 3, Stdout: "hello", Stderr: "warn"}
+	fb.ReadContent = "the file body"
+	fb.ForkIDs = []string{"sbx-a", "sbx-b", "sbx-c"}
+
+	srv := New(fb, Options{})
+
+	// clientToServer: client writes, server reads. serverToClient: server
+	// writes, client reads.
+	csr, csw := io.Pipe()
+	scr, scw := io.Pipe()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var runErr error
+	go func() {
+		defer wg.Done()
+		runErr = srv.Run(context.Background(), csr, scw)
+	}()
+
+	client := &mcpClient{
+		t: t,
+		w: newFrameWriter(csw),
+		r: newFrameReader(scr),
+	}
+
+	// initialize
+	initResp := client.call("initialize", map[string]any{
+		"protocolVersion": protocolVersion,
+		"capabilities":    map[string]any{},
+	})
+	if initResp.Error != nil {
+		t.Fatalf("initialize returned error: %+v", initResp.Error)
+	}
+	var init initializeResult
+	if err := json.Unmarshal(initResp.Result, &init); err != nil {
+		t.Fatalf("decode initialize: %v", err)
+	}
+	if init.ProtocolVersion == "" {
+		t.Error("initialize: protocolVersion missing")
+	}
+	if init.Capabilities.Tools == nil {
+		t.Error("initialize: capabilities.tools not advertised")
+	}
+	if init.ServerInfo.Name == "" || init.ServerInfo.Version == "" {
+		t.Errorf("initialize: serverInfo incomplete: %+v", init.ServerInfo)
+	}
+
+	client.notify("notifications/initialized")
+
+	// tools/list
+	listResp := client.call("tools/list", nil)
+	if listResp.Error != nil {
+		t.Fatalf("tools/list returned error: %+v", listResp.Error)
+	}
+	var list toolsListResult
+	if err := json.Unmarshal(listResp.Result, &list); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	if len(list.Tools) != 6 {
+		t.Fatalf("tools/list: expected 6 tools, got %d", len(list.Tools))
+	}
+	for _, tool := range list.Tools {
+		if tool.Name == "" || tool.Description == "" {
+			t.Errorf("tool with empty name/description: %+v", tool)
+		}
+		if tool.InputSchema.Type != "object" {
+			t.Errorf("tool %q schema type %q != object", tool.Name, tool.InputSchema.Type)
+		}
+	}
+
+	// tools/call for each of the six, asserting result and recorded args.
+	t.Run("create", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxCreate, map[string]any{"pool": "default"})
+		assertNoError(t, tr)
+		if tr.Content[0].Text != "Created sandbox sbx-conf-1" {
+			t.Errorf("unexpected text: %q", tr.Content[0].Text)
+		}
+	})
+
+	t.Run("exec", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxExec, map[string]any{
+			"sandbox": "sbx-conf-1", "command": "echo hi", "timeout_seconds": 9,
+		})
+		assertNoError(t, tr)
+		var res ExecResult
+		if err := json.Unmarshal([]byte(tr.Content[0].Text), &res); err != nil {
+			t.Fatalf("decode exec result: %v", err)
+		}
+		if res != fb.ExecResultV {
+			t.Errorf("exec result %+v != canned %+v", res, fb.ExecResultV)
+		}
+	})
+
+	t.Run("read_file", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxReadFile, map[string]any{
+			"sandbox": "sbx-conf-1", "path": "/etc/hosts",
+		})
+		assertNoError(t, tr)
+		if tr.Content[0].Text != fb.ReadContent {
+			t.Errorf("read result %q != canned %q", tr.Content[0].Text, fb.ReadContent)
+		}
+	})
+
+	t.Run("write_file", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxWriteFile, map[string]any{
+			"sandbox": "sbx-conf-1", "path": "/tmp/x", "content": "data",
+		})
+		assertNoError(t, tr)
+	})
+
+	t.Run("fork", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxFork, map[string]any{
+			"sandbox": "sbx-conf-1", "replicas": 3,
+		})
+		assertNoError(t, tr)
+		var ids []string
+		if err := json.Unmarshal([]byte(tr.Content[0].Text), &ids); err != nil {
+			t.Fatalf("decode fork ids: %v", err)
+		}
+		if len(ids) != len(fb.ForkIDs) {
+			t.Errorf("fork ids %v != canned %v", ids, fb.ForkIDs)
+		}
+	})
+
+	t.Run("terminate", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxTerminate, map[string]any{"sandbox": "sbx-conf-1"})
+		assertNoError(t, tr)
+	})
+
+	// Unknown tool: LLM-legible error.
+	t.Run("unknown_tool", func(t *testing.T) {
+		tr := conformCall(t, client, "bogus_tool", map[string]any{})
+		assertLLMError(t, tr, "unknown_tool")
+	})
+
+	// Missing required argument: LLM-legible error.
+	t.Run("missing_required_arg", func(t *testing.T) {
+		tr := conformCall(t, client, ToolSandboxExec, map[string]any{"sandbox": "sbx-conf-1"})
+		assertLLMError(t, tr, "missing_required_argument")
+	})
+
+	// Assert the backend recorded the right arguments for the dispatched tools.
+	calls := fb.RecordedCalls()
+	wantOrder := []struct {
+		method string
+		check  func(FakeCall) bool
+	}{
+		{"create", func(c FakeCall) bool { return c.Pool == "default" }},
+		{"exec", func(c FakeCall) bool {
+			return c.SandboxID == "sbx-conf-1" && c.Command == "echo hi" && c.TimeoutSec == 9
+		}},
+		{"read_file", func(c FakeCall) bool { return c.SandboxID == "sbx-conf-1" && c.Path == "/etc/hosts" }},
+		{"write_file", func(c FakeCall) bool {
+			return c.SandboxID == "sbx-conf-1" && c.Path == "/tmp/x" && c.Content == "data"
+		}},
+		{"fork", func(c FakeCall) bool { return c.SandboxID == "sbx-conf-1" && c.Replicas == 3 }},
+		{"terminate", func(c FakeCall) bool { return c.SandboxID == "sbx-conf-1" }},
+	}
+	if len(calls) != len(wantOrder) {
+		t.Fatalf("expected %d backend calls, got %d: %+v", len(wantOrder), len(calls), calls)
+	}
+	for i, w := range wantOrder {
+		if calls[i].Method != w.method {
+			t.Errorf("call %d method = %q, want %q", i, calls[i].Method, w.method)
+		}
+		if !w.check(calls[i]) {
+			t.Errorf("call %d (%s) recorded wrong args: %+v", i, w.method, calls[i])
+		}
+	}
+
+	// Close the client->server pipe so Run sees EOF and exits.
+	if err := csw.Close(); err != nil {
+		t.Fatalf("close client writer: %v", err)
+	}
+	wg.Wait()
+	if runErr != nil {
+		t.Errorf("Server.Run returned error: %v", runErr)
+	}
+	// Drain anything pending and close the server->client side.
+	_ = scr.Close()
+}
+
+func conformCall(t *testing.T, c *mcpClient, name string, args map[string]any) toolResult {
+	t.Helper()
+	resp := c.call("tools/call", toolsCallParams{
+		Name:      name,
+		Arguments: mustMarshal(t, args),
+	})
+	if resp.Error != nil {
+		t.Fatalf("tools/call %s jsonrpc error: %+v", name, resp.Error)
+	}
+	var tr toolResult
+	if err := json.Unmarshal(resp.Result, &tr); err != nil {
+		t.Fatalf("decode tool result for %s: %v", name, err)
+	}
+	return tr
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func assertNoError(t *testing.T, tr toolResult) {
+	t.Helper()
+	if tr.IsError {
+		t.Fatalf("unexpected error result: %+v", tr)
+	}
+	if len(tr.Content) == 0 {
+		t.Fatalf("result has no content")
+	}
+}
+
+func assertLLMError(t *testing.T, tr toolResult, wantCode string) {
+	t.Helper()
+	if !tr.IsError {
+		t.Fatalf("expected error result, got %+v", tr)
+	}
+	if len(tr.Content) == 0 {
+		t.Fatalf("error result has no content")
+	}
+	var e llmError
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &e); err != nil {
+		t.Fatalf("decode llmError: %v", err)
+	}
+	if e.Code != wantCode {
+		t.Errorf("error code = %q, want %q", e.Code, wantCode)
+	}
+	if e.Cause == "" || e.Remediation == "" {
+		t.Errorf("LLM-legible error missing cause/remediation: %+v", e)
+	}
+}

--- a/internal/mcp/httpbackend.go
+++ b/internal/mcp/httpbackend.go
@@ -1,0 +1,221 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// HTTPBackend implements SandboxBackend over the standalone sandbox-server REST
+// API (cmd/sandbox-server). It is the simplest real backend: one process, plain
+// HTTP, a single launch-time bearer token. A Kubernetes claim backend (create a
+// SandboxClaim, read its token Secret, exec via forkd) is a planned follow-up
+// and is intentionally not implemented here.
+//
+// Token scoping: every request carries the launch-time bearer token, so the MCP
+// server can do exactly what that token authorizes on the sandbox-server and
+// nothing more. The token is never logged and never placed in an error message;
+// see do, which redacts any echo of the token from a response body before using
+// it as error context.
+//
+// Pool-to-template mapping: the MCP sandbox_create tool takes a "pool" name. The
+// sandbox-server has no pools; it forks a sandbox from a named template. The
+// HTTP backend therefore treats the pool argument as the template id and forks
+// from it (POST /v1/fork {template, id}). On a real k8s deployment a pool maps
+// to a SandboxPool; that mapping belongs to the future k8s backend.
+type HTTPBackend struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+// NewHTTPBackend builds a backend against the sandbox-server at baseURL. When
+// token is non-empty it is sent as "Authorization: Bearer <token>" on every
+// request. A nil client defaults to http.DefaultClient.
+func NewHTTPBackend(baseURL, token string, client *http.Client) *HTTPBackend {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &HTTPBackend{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		client:  client,
+	}
+}
+
+// newSandboxID returns a random hex id for a sandbox or fork. crypto/rand makes
+// collisions across concurrent callers negligible without a uuid dependency.
+func newSandboxID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read never fails on supported platforms; degrade rather than panic.
+		return "sbx-fallback"
+	}
+	return "sbx-" + hex.EncodeToString(b[:])
+}
+
+// do issues an HTTP request to path with an optional JSON body and decodes a
+// 2xx JSON response into out (when out is non-nil). A non-2xx status becomes an
+// error carrying the response body as context, with any echo of the bearer
+// token redacted first so the secret never reaches a caller, a log, or an LLM.
+func (b *HTTPBackend) do(ctx context.Context, method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal %s request: %w", path, err)
+		}
+		reader = bytes.NewReader(raw)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, b.baseURL+path, reader)
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if b.token != "" {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, b.redact(string(respBody)))
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("decode %s response: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// redact removes any occurrence of the bearer token from s. A hostile or
+// misconfigured server might echo the Authorization header into its error body;
+// this guarantees the token never escapes through an error string.
+func (b *HTTPBackend) redact(s string) string {
+	if b.token == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, b.token, "[REDACTED]")
+}
+
+type forkResponse struct {
+	ID         string `json:"id"`
+	TemplateID string `json:"template_id"`
+}
+
+// Create forks a new sandbox from the pool, treating pool as the sandbox-server
+// template id. It generates the sandbox id client-side and returns it.
+func (b *HTTPBackend) Create(ctx context.Context, pool string) (string, error) {
+	id := newSandboxID()
+	var resp forkResponse
+	if err := b.do(ctx, http.MethodPost, "/v1/fork", map[string]any{
+		"template": pool,
+		"id":       id,
+	}, &resp); err != nil {
+		return "", err
+	}
+	if resp.ID != "" {
+		return resp.ID, nil
+	}
+	return id, nil
+}
+
+type execResponse struct {
+	ExitCode int    `json:"exit_code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+}
+
+// Exec runs command in the sandbox via POST /v1/exec. A timeoutSec of 0 omits
+// the field so the server default applies.
+func (b *HTTPBackend) Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error) {
+	reqBody := map[string]any{
+		"sandbox": sandboxID,
+		"command": command,
+	}
+	if timeoutSec > 0 {
+		reqBody["timeout"] = timeoutSec
+	}
+	var resp execResponse
+	if err := b.do(ctx, http.MethodPost, "/v1/exec", reqBody, &resp); err != nil {
+		return ExecResult{}, err
+	}
+	return ExecResult(resp), nil
+}
+
+type readFileResponse struct {
+	Content string `json:"content"`
+}
+
+// ReadFile reads path from the sandbox via POST /v1/files/read.
+func (b *HTTPBackend) ReadFile(ctx context.Context, sandboxID, path string) (string, error) {
+	var resp readFileResponse
+	if err := b.do(ctx, http.MethodPost, "/v1/files/read", map[string]any{
+		"sandbox": sandboxID,
+		"path":    path,
+	}, &resp); err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+// WriteFile writes content to path in the sandbox via POST /v1/files/write.
+func (b *HTTPBackend) WriteFile(ctx context.Context, sandboxID, path, content string) error {
+	return b.do(ctx, http.MethodPost, "/v1/files/write", map[string]any{
+		"sandbox": sandboxID,
+		"path":    path,
+		"content": content,
+	}, nil)
+}
+
+// Fork forks the sandbox replicas times. The sandbox-server fork endpoint has
+// no replicas parameter, so this issues one POST /v1/fork per replica. Caveat:
+// the sandbox-server /v1/fork "template" field is a template lookup, so this
+// passes the source sandbox id as the template key; on the standalone server a
+// fork-of-a-fork therefore requires that key to resolve to a known template.
+// The richer k8s SandboxFork path (true fork-of-a-running-sandbox) belongs to
+// the future k8s backend. A replicas value below 1 is treated as 1.
+func (b *HTTPBackend) Fork(ctx context.Context, sandboxID string, replicas int) ([]string, error) {
+	if replicas < 1 {
+		replicas = 1
+	}
+	ids := make([]string, 0, replicas)
+	for i := 0; i < replicas; i++ {
+		id := newSandboxID()
+		var resp forkResponse
+		if err := b.do(ctx, http.MethodPost, "/v1/fork", map[string]any{
+			"template": sandboxID,
+			"id":       id,
+		}, &resp); err != nil {
+			return ids, err
+		}
+		if resp.ID != "" {
+			ids = append(ids, resp.ID)
+		} else {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// Terminate destroys the sandbox via DELETE /v1/sandboxes/{id}.
+func (b *HTTPBackend) Terminate(ctx context.Context, sandboxID string) error {
+	return b.do(ctx, http.MethodDelete, "/v1/sandboxes/"+sandboxID, nil, nil)
+}

--- a/internal/mcp/httpbackend.go
+++ b/internal/mcp/httpbackend.go
@@ -9,8 +9,23 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 )
+
+// sandboxIDRe is the allowlist for sandbox ids received from tool arguments
+// (LLM-controlled). It matches the same pattern used by daemon/validate.go and
+// firecracker/validate.go: start with alphanumeric, then up to 63 alphanumeric,
+// underscore, or hyphen characters.
+var sandboxIDRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`)
+
+// validSandboxID reports whether id is an acceptable sandbox id to embed in a
+// URL path. An empty string, any id containing "/" or "..", or any id that does
+// not match the allowlist pattern is rejected.
+func validSandboxID(id string) bool {
+	return sandboxIDRe.MatchString(id)
+}
 
 // HTTPBackend implements SandboxBackend over the standalone sandbox-server REST
 // API (cmd/sandbox-server). It is the simplest real backend: one process, plain
@@ -146,6 +161,9 @@ type execResponse struct {
 // Exec runs command in the sandbox via POST /v1/exec. A timeoutSec of 0 omits
 // the field so the server default applies.
 func (b *HTTPBackend) Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error) {
+	if !validSandboxID(sandboxID) {
+		return ExecResult{}, fmt.Errorf("exec: invalid sandbox id %q", sandboxID)
+	}
 	reqBody := map[string]any{
 		"sandbox": sandboxID,
 		"command": command,
@@ -166,6 +184,9 @@ type readFileResponse struct {
 
 // ReadFile reads path from the sandbox via POST /v1/files/read.
 func (b *HTTPBackend) ReadFile(ctx context.Context, sandboxID, path string) (string, error) {
+	if !validSandboxID(sandboxID) {
+		return "", fmt.Errorf("read_file: invalid sandbox id %q", sandboxID)
+	}
 	var resp readFileResponse
 	if err := b.do(ctx, http.MethodPost, "/v1/files/read", map[string]any{
 		"sandbox": sandboxID,
@@ -178,6 +199,9 @@ func (b *HTTPBackend) ReadFile(ctx context.Context, sandboxID, path string) (str
 
 // WriteFile writes content to path in the sandbox via POST /v1/files/write.
 func (b *HTTPBackend) WriteFile(ctx context.Context, sandboxID, path, content string) error {
+	if !validSandboxID(sandboxID) {
+		return fmt.Errorf("write_file: invalid sandbox id %q", sandboxID)
+	}
 	return b.do(ctx, http.MethodPost, "/v1/files/write", map[string]any{
 		"sandbox": sandboxID,
 		"path":    path,
@@ -192,7 +216,13 @@ func (b *HTTPBackend) WriteFile(ctx context.Context, sandboxID, path, content st
 // fork-of-a-fork therefore requires that key to resolve to a known template.
 // The richer k8s SandboxFork path (true fork-of-a-running-sandbox) belongs to
 // the future k8s backend. A replicas value below 1 is treated as 1.
+//
+// On a mid-loop failure, the error wraps the already-created ids so callers can
+// terminate them: "fork created [id1 id2] before failing: <cause>".
 func (b *HTTPBackend) Fork(ctx context.Context, sandboxID string, replicas int) ([]string, error) {
+	if !validSandboxID(sandboxID) {
+		return nil, fmt.Errorf("fork: invalid sandbox id %q", sandboxID)
+	}
 	if replicas < 1 {
 		replicas = 1
 	}
@@ -204,7 +234,7 @@ func (b *HTTPBackend) Fork(ctx context.Context, sandboxID string, replicas int) 
 			"template": sandboxID,
 			"id":       id,
 		}, &resp); err != nil {
-			return ids, err
+			return ids, fmt.Errorf("fork created %v before failing: %w", ids, err)
 		}
 		if resp.ID != "" {
 			ids = append(ids, resp.ID)
@@ -215,7 +245,13 @@ func (b *HTTPBackend) Fork(ctx context.Context, sandboxID string, replicas int) 
 	return ids, nil
 }
 
-// Terminate destroys the sandbox via DELETE /v1/sandboxes/{id}.
+// Terminate destroys the sandbox via DELETE /v1/sandboxes/{id}. The sandbox id
+// is validated against the allowlist and path-escaped before being embedded in
+// the URL so an LLM-controlled id cannot redirect the DELETE to an unintended
+// path.
 func (b *HTTPBackend) Terminate(ctx context.Context, sandboxID string) error {
-	return b.do(ctx, http.MethodDelete, "/v1/sandboxes/"+sandboxID, nil, nil)
+	if !validSandboxID(sandboxID) {
+		return fmt.Errorf("terminate: invalid sandbox id %q", sandboxID)
+	}
+	return b.do(ctx, http.MethodDelete, "/v1/sandboxes/"+url.PathEscape(sandboxID), nil, nil)
 }

--- a/internal/mcp/httpbackend_test.go
+++ b/internal/mcp/httpbackend_test.go
@@ -277,3 +277,81 @@ func TestHTTPBackendNeverLeaksToken(t *testing.T) {
 		t.Fatalf("token leaked into error: %q", err.Error())
 	}
 }
+
+// TestHTTPBackendUnsafeIDRejected asserts that Terminate and Exec with a
+// path-traversal sandbox id return an error without sending any HTTP request.
+func TestHTTPBackendUnsafeIDRejected(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"status": "ok"}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok", srv.Client())
+
+	unsafeIDs := []string{"../../x", "../etc/passwd", "", "sbx/bad", "sbx..bad"}
+	for _, id := range unsafeIDs {
+		err := b.Terminate(context.Background(), id)
+		if err == nil {
+			t.Errorf("Terminate(%q): expected error, got nil", id)
+		}
+		_, err = b.Exec(context.Background(), id, "echo", 0)
+		if err == nil {
+			t.Errorf("Exec(%q): expected error, got nil", id)
+		}
+	}
+	if len(got) != 0 {
+		t.Errorf("backend sent %d requests, want 0", len(got))
+	}
+}
+
+// TestHTTPBackendForkPartialIDsInError asserts that when a mid-loop fork fails,
+// the returned error names the sandbox ids that were already created so the
+// caller can terminate them.
+func TestHTTPBackendForkPartialIDsInError(t *testing.T) {
+	call := 0
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		call++
+		if call == 1 {
+			// First fork succeeds; capture the id it used.
+			return http.StatusOK, map[string]any{"id": cr.Body["id"]}
+		}
+		// Second fork fails.
+		return http.StatusInternalServerError, map[string]any{"error": "quota exceeded"}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok", srv.Client())
+	ids, err := b.Fork(context.Background(), "sbx-src", 2)
+	if err == nil {
+		t.Fatal("expected error on second fork, got nil")
+	}
+	// The error must name the id created in the first (successful) call.
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 partial id returned, got %d: %v", len(ids), ids)
+	}
+	if !strings.Contains(err.Error(), ids[0]) {
+		t.Errorf("error %q does not mention created id %q", err.Error(), ids[0])
+	}
+}
+
+// TestHTTPBackendTerminatePathEscape asserts that a valid sandbox id that
+// contains URL-special chars (none allowed by validSandboxID, but an id whose
+// PathEscape is a no-op for safe chars) is embedded correctly.
+func TestHTTPBackendTerminatePathEscape(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, nil
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok", srv.Client())
+	// sbx-abc is valid and path-safe; confirm the path is built correctly.
+	if err := b.Terminate(context.Background(), "sbx-abc"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if len(got) != 1 || got[0].Path != "/v1/sandboxes/sbx-abc" {
+		t.Fatalf("path = %q, want /v1/sandboxes/sbx-abc", got[0].Path)
+	}
+}

--- a/internal/mcp/httpbackend_test.go
+++ b/internal/mcp/httpbackend_test.go
@@ -1,0 +1,279 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// capturedRequest records what the backend sent so assertions can inspect the
+// method, path, headers, and decoded body of each HTTP call.
+type capturedRequest struct {
+	Method string
+	Path   string
+	Auth   string
+	Body   map[string]any
+}
+
+// recordingServer returns an httptest.Server that records every request into
+// got and replies with the per-path canned response. The handler func decides
+// the response body and status for a given request.
+func recordingServer(t *testing.T, got *[]capturedRequest, handler func(cr capturedRequest) (int, any)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		cr := capturedRequest{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Auth:   r.Header.Get("Authorization"),
+		}
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &cr.Body)
+		}
+		*got = append(*got, cr)
+		status, body := handler(cr)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+}
+
+func TestHTTPBackendCreate(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"id": cr.Body["id"], "template_id": cr.Body["template"]}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	id, err := b.Create(context.Background(), "python")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id == "" {
+		t.Fatal("Create returned empty id")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(got))
+	}
+	req := got[0]
+	if req.Method != http.MethodPost || req.Path != "/v1/fork" {
+		t.Fatalf("Create sent %s %s, want POST /v1/fork", req.Method, req.Path)
+	}
+	if req.Auth != "Bearer tok-123" {
+		t.Fatalf("Create auth = %q, want Bearer tok-123", req.Auth)
+	}
+	if req.Body["template"] != "python" {
+		t.Fatalf("Create body template = %v, want python", req.Body["template"])
+	}
+	if req.Body["id"] != id {
+		t.Fatalf("Create body id %v != returned id %s", req.Body["id"], id)
+	}
+}
+
+func TestHTTPBackendExec(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"exit_code": 7, "stdout": "out", "stderr": "err"}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	res, err := b.Exec(context.Background(), "sbx-1", "echo hi", 12)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 7 || res.Stdout != "out" || res.Stderr != "err" {
+		t.Fatalf("Exec result = %+v", res)
+	}
+	req := got[0]
+	if req.Method != http.MethodPost || req.Path != "/v1/exec" {
+		t.Fatalf("Exec sent %s %s, want POST /v1/exec", req.Method, req.Path)
+	}
+	if req.Auth != "Bearer tok-123" {
+		t.Fatalf("Exec auth = %q", req.Auth)
+	}
+	if req.Body["sandbox"] != "sbx-1" || req.Body["command"] != "echo hi" {
+		t.Fatalf("Exec body = %v", req.Body)
+	}
+	if req.Body["timeout"] != float64(12) {
+		t.Fatalf("Exec timeout = %v, want 12", req.Body["timeout"])
+	}
+}
+
+func TestHTTPBackendReadFile(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"content": "hello", "size": 5}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	content, err := b.ReadFile(context.Background(), "sbx-1", "/etc/hosts")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if content != "hello" {
+		t.Fatalf("ReadFile content = %q", content)
+	}
+	req := got[0]
+	if req.Method != http.MethodPost || req.Path != "/v1/files/read" {
+		t.Fatalf("ReadFile sent %s %s, want POST /v1/files/read", req.Method, req.Path)
+	}
+	if req.Body["sandbox"] != "sbx-1" || req.Body["path"] != "/etc/hosts" {
+		t.Fatalf("ReadFile body = %v", req.Body)
+	}
+}
+
+func TestHTTPBackendWriteFile(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"status": "ok"}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	if err := b.WriteFile(context.Background(), "sbx-1", "/tmp/x", "data"); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	req := got[0]
+	if req.Method != http.MethodPost || req.Path != "/v1/files/write" {
+		t.Fatalf("WriteFile sent %s %s, want POST /v1/files/write", req.Method, req.Path)
+	}
+	if req.Body["sandbox"] != "sbx-1" || req.Body["path"] != "/tmp/x" || req.Body["content"] != "data" {
+		t.Fatalf("WriteFile body = %v", req.Body)
+	}
+}
+
+func TestHTTPBackendFork(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"id": cr.Body["id"], "template_id": cr.Body["template"]}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	ids, err := b.Fork(context.Background(), "sbx-1", 3)
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("Fork returned %d ids, want 3", len(ids))
+	}
+	if len(got) != 3 {
+		t.Fatalf("Fork made %d requests, want 3", len(got))
+	}
+	seen := map[string]bool{}
+	for i, req := range got {
+		if req.Method != http.MethodPost || req.Path != "/v1/fork" {
+			t.Fatalf("Fork req %d = %s %s", i, req.Method, req.Path)
+		}
+		if req.Auth != "Bearer tok-123" {
+			t.Fatalf("Fork req %d auth = %q", i, req.Auth)
+		}
+		id, _ := req.Body["id"].(string)
+		if id == "" || seen[id] {
+			t.Fatalf("Fork req %d had empty or duplicate id %q", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestHTTPBackendForkDefaultsToOne(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"id": cr.Body["id"]}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	ids, err := b.Fork(context.Background(), "sbx-1", 0)
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if len(ids) != 1 || len(got) != 1 {
+		t.Fatalf("Fork with 0 replicas made %d reqs / %d ids, want 1/1", len(got), len(ids))
+	}
+}
+
+func TestHTTPBackendTerminate(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"status": "terminated"}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	if err := b.Terminate(context.Background(), "sbx-1"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	req := got[0]
+	if req.Method != http.MethodDelete || req.Path != "/v1/sandboxes/sbx-1" {
+		t.Fatalf("Terminate sent %s %s, want DELETE /v1/sandboxes/sbx-1", req.Method, req.Path)
+	}
+	if req.Auth != "Bearer tok-123" {
+		t.Fatalf("Terminate auth = %q", req.Auth)
+	}
+}
+
+func TestHTTPBackendNoTokenOmitsHeader(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusOK, map[string]any{"id": cr.Body["id"]}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "", srv.Client())
+	if _, err := b.Create(context.Background(), "python"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got[0].Auth != "" {
+		t.Fatalf("expected no Authorization header without a token, got %q", got[0].Auth)
+	}
+}
+
+func TestHTTPBackendNon2xxIsError(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		return http.StatusNotFound, map[string]any{"error": "template \"nope\" not found"}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	_, err := b.Create(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected an error on non-2xx response")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error should carry response body context, got %q", err.Error())
+	}
+}
+
+// TestHTTPBackendNeverLeaksToken asserts the token never appears in an error
+// returned to the caller, even when the server echoes the Authorization header
+// back in its error body. The backend must not log; this test guards the error
+// path, the only string the backend surfaces.
+func TestHTTPBackendNeverLeaksToken(t *testing.T) {
+	const token = "super-secret-token-value"
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		// Hostile server echoes the presented auth header into its error body.
+		return http.StatusInternalServerError, map[string]any{"error": cr.Auth}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, token, srv.Client())
+	_, err := b.Exec(context.Background(), "sbx-1", "x", 0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("token leaked into error: %q", err.Error())
+	}
+}

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// JSON-RPC 2.0 over the MCP stdio transport. The stdio transport frames
+// messages as newline-delimited JSON: each message is a single JSON object on
+// its own line, with no embedded newlines.
+
+const jsonrpcVersion = "2.0"
+
+// Standard JSON-RPC 2.0 error codes (subset used by this server).
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+// Request is an incoming JSON-RPC request or notification. A notification has a
+// nil ID.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// IsNotification reports whether the request carries no id (and so expects no
+// response).
+func (r *Request) IsNotification() bool {
+	return len(r.ID) == 0
+}
+
+// Response is an outgoing JSON-RPC response. Exactly one of Result or Error is
+// set.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is a JSON-RPC 2.0 error object. This is a transport-level error
+// (malformed request, unknown method); tool-call failures are reported inside a
+// successful result via isError, not here.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("jsonrpc error %d: %s", e.Code, e.Message)
+}
+
+// frameReader reads newline-delimited JSON-RPC messages.
+type frameReader struct {
+	sc *bufio.Scanner
+}
+
+func newFrameReader(r io.Reader) *frameReader {
+	sc := bufio.NewScanner(r)
+	// Allow large messages (file contents may be sizeable).
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	return &frameReader{sc: sc}
+}
+
+// Read returns the next raw message line, or io.EOF when the stream is
+// exhausted. Blank lines are skipped.
+func (fr *frameReader) Read() ([]byte, error) {
+	for fr.sc.Scan() {
+		line := fr.sc.Bytes()
+		if len(trimSpace(line)) == 0 {
+			continue
+		}
+		// Copy: Scanner reuses its buffer on the next Scan.
+		out := make([]byte, len(line))
+		copy(out, line)
+		return out, nil
+	}
+	if err := fr.sc.Err(); err != nil {
+		return nil, err
+	}
+	return nil, io.EOF
+}
+
+func trimSpace(b []byte) []byte {
+	start := 0
+	for start < len(b) && (b[start] == ' ' || b[start] == '\t' || b[start] == '\r' || b[start] == '\n') {
+		start++
+	}
+	end := len(b)
+	for end > start && (b[end-1] == ' ' || b[end-1] == '\t' || b[end-1] == '\r' || b[end-1] == '\n') {
+		end--
+	}
+	return b[start:end]
+}
+
+// frameWriter writes newline-delimited JSON-RPC messages.
+type frameWriter struct {
+	w io.Writer
+}
+
+func newFrameWriter(w io.Writer) *frameWriter {
+	return &frameWriter{w: w}
+}
+
+// Write marshals v and writes it as a single newline-terminated line.
+func (fw *frameWriter) Write(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal jsonrpc message: %w", err)
+	}
+	b = append(b, '\n')
+	if _, err := fw.w.Write(b); err != nil {
+		return fmt.Errorf("write jsonrpc message: %w", err)
+	}
+	return nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,12 @@ import (
 	"io"
 )
 
+// scanResult carries one line from the scan goroutine or the terminal error.
+type scanResult struct {
+	line []byte
+	err  error
+}
+
 // Protocol and server identity constants.
 const (
 	// protocolVersion is the MCP protocol revision this server speaks.
@@ -106,40 +112,65 @@ type llmError struct {
 	Remediation string `json:"remediation"`
 }
 
-// Run drives the stdio JSON-RPC loop, reading newline-delimited requests from in
-// and writing responses to out until in reaches EOF or ctx is cancelled.
+// Run drives the stdio JSON-RPC loop, reading newline-delimited requests from
+// in and writing responses to out until in reaches EOF or ctx is cancelled.
+//
+// The scan loop runs in a separate goroutine so that a cancelled ctx unblocks
+// promptly without waiting for the next line on the reader. When ctx is
+// cancelled, Run returns ctx.Err() (or nil if EOF and ctx are both done). The
+// scan goroutine will remain blocked on its next Read until the caller closes
+// in (the normal behavior for a stdio process receiving SIGTERM), which is
+// acceptable; the goroutine does not leak any other resources.
 func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
 	reader := newFrameReader(in)
 	writer := newFrameWriter(out)
 
+	lines := make(chan scanResult, 1)
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			raw, err := reader.Read()
+			select {
+			case lines <- scanResult{line: raw, err: err}:
+			case <-done:
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
 	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case sr := <-lines:
+			if errors.Is(sr.err, io.EOF) {
+				return nil
+			}
+			if sr.err != nil {
+				return fmt.Errorf("read request: %w", sr.err)
+			}
 
-		raw, err := reader.Read()
-		if errors.Is(err, io.EOF) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("read request: %w", err)
-		}
+			var req Request
+			if uerr := json.Unmarshal(sr.line, &req); uerr != nil {
+				// Cannot recover an id from an unparseable request.
+				if werr := writer.Write(errorResponse(nil, codeParseError, "parse error")); werr != nil {
+					return werr
+				}
+				continue
+			}
 
-		var req Request
-		if uerr := json.Unmarshal(raw, &req); uerr != nil {
-			// Cannot recover an id from an unparseable request.
-			if werr := writer.Write(errorResponse(nil, codeParseError, "parse error")); werr != nil {
+			resp, hasResp := s.handle(ctx, &req)
+			if !hasResp {
+				continue // notification: no response
+			}
+			if werr := writer.Write(resp); werr != nil {
 				return werr
 			}
-			continue
-		}
-
-		resp, hasResp := s.handle(ctx, &req)
-		if !hasResp {
-			continue // notification: no response
-		}
-		if werr := writer.Write(resp); werr != nil {
-			return werr
 		}
 	}
 }
@@ -233,11 +264,11 @@ func parseArgs(tool Tool, raw json.RawMessage) (parsedArgs, *llmError) {
 
 	for _, reqField := range tool.InputSchema.Required {
 		v, present := m[reqField]
-		if !present || v == nil || v == "" {
+		if !present || v == nil {
 			return parsedArgs{}, &llmError{
 				Code:        "missing_required_argument",
-				Cause:       fmt.Sprintf("Tool %q requires the %q argument, which was missing or empty.", tool.Name, reqField),
-				Remediation: fmt.Sprintf("Retry the call including a non-empty %q value; see the tool inputSchema for all required fields.", reqField),
+				Cause:       fmt.Sprintf("Tool %q requires the %q argument, which was missing or null.", tool.Name, reqField),
+				Remediation: fmt.Sprintf("Retry the call including a %q value; see the tool inputSchema for all required fields.", reqField),
 			}
 		}
 	}
@@ -305,7 +336,7 @@ func (s *Server) dispatch(ctx context.Context, name string, a parsedArgs) toolRe
 	case ToolSandboxFork:
 		ids, err := s.backend.Fork(ctx, a.sandbox, a.replicas)
 		if err != nil {
-			return backendErrorResult(name, err)
+			return backendForkErrorResult(err)
 		}
 		payload, _ := json.Marshal(ids)
 		return textResult(string(payload))
@@ -349,6 +380,17 @@ func backendErrorResult(tool string, err error) toolResult {
 		Code:        "backend_error",
 		Cause:       fmt.Sprintf("The %s operation failed: %s", tool, err.Error()),
 		Remediation: "Verify the sandbox id and arguments, check sandbox status, and retry; if it persists the backend may be unavailable.",
+	})
+}
+
+// backendForkErrorResult maps a fork backend error to an LLM-legible tool
+// error. The error string is expected to name any partially-created sandbox ids
+// so the LLM can terminate them.
+func backendForkErrorResult(err error) toolResult {
+	return toolErrorResult(llmError{
+		Code:        "backend_error",
+		Cause:       fmt.Sprintf("The %s operation failed: %s", ToolSandboxFork, err.Error()),
+		Remediation: "The error message names any sandbox ids that were created before the failure; terminate them to avoid resource leaks, then retry.",
 	})
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,369 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Protocol and server identity constants.
+const (
+	// protocolVersion is the MCP protocol revision this server speaks.
+	protocolVersion = "2025-06-18"
+	serverName      = "agentrun-mcp"
+	serverVersion   = "0.1.0"
+)
+
+// Options configures a Server.
+type Options struct {
+	// ServerVersion overrides the advertised server version when set.
+	ServerVersion string
+	// EnableWorkspaceTools advertises the workspace tools in tools/list. Their
+	// dispatch is deferred (#21); enabling only affects discovery.
+	EnableWorkspaceTools bool
+}
+
+// Server is an MCP server that dispatches tool calls to a SandboxBackend.
+type Server struct {
+	backend SandboxBackend
+	opts    Options
+	tools   []Tool
+	byName  map[string]Tool
+}
+
+// New builds a Server over the given backend.
+func New(backend SandboxBackend, opts Options) *Server {
+	tools := coreTools()
+	if opts.EnableWorkspaceTools {
+		tools = append(tools, workspaceTools()...)
+	}
+	byName := make(map[string]Tool, len(tools))
+	for _, t := range tools {
+		byName[t.Name] = t
+	}
+	return &Server{backend: backend, opts: opts, tools: tools, byName: byName}
+}
+
+// version returns the advertised server version.
+func (s *Server) version() string {
+	if s.opts.ServerVersion != "" {
+		return s.opts.ServerVersion
+	}
+	return serverVersion
+}
+
+// ---- wire types ----
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type toolsCapability struct {
+	ListChanged bool `json:"listChanged"`
+}
+
+type capabilities struct {
+	Tools *toolsCapability `json:"tools,omitempty"`
+}
+
+type initializeResult struct {
+	ProtocolVersion string       `json:"protocolVersion"`
+	Capabilities    capabilities `json:"capabilities"`
+	ServerInfo      serverInfo   `json:"serverInfo"`
+}
+
+type toolsListResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+type toolsCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// textContent is a single MCP content block of type text.
+type textContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// toolResult is the result of a tools/call. isError marks an LLM-legible tool
+// failure (as opposed to a transport-level JSON-RPC error).
+type toolResult struct {
+	Content []textContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+// llmError is the LLM-legible error payload carried inside a failed tool
+// result. It is never a bare code: cause is a one-sentence human explanation and
+// remediation is an actionable next step (API v2 rule, issue #28).
+type llmError struct {
+	Code        string `json:"code"`
+	Cause       string `json:"cause"`
+	Remediation string `json:"remediation"`
+}
+
+// Run drives the stdio JSON-RPC loop, reading newline-delimited requests from in
+// and writing responses to out until in reaches EOF or ctx is cancelled.
+func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
+	reader := newFrameReader(in)
+	writer := newFrameWriter(out)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		raw, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read request: %w", err)
+		}
+
+		var req Request
+		if uerr := json.Unmarshal(raw, &req); uerr != nil {
+			// Cannot recover an id from an unparseable request.
+			if werr := writer.Write(errorResponse(nil, codeParseError, "parse error")); werr != nil {
+				return werr
+			}
+			continue
+		}
+
+		resp, hasResp := s.handle(ctx, &req)
+		if !hasResp {
+			continue // notification: no response
+		}
+		if werr := writer.Write(resp); werr != nil {
+			return werr
+		}
+	}
+}
+
+// handle routes a single request. The second return is false for notifications,
+// which must not produce a response.
+func (s *Server) handle(ctx context.Context, req *Request) (Response, bool) {
+	if req.JSONRPC != jsonrpcVersion {
+		if req.IsNotification() {
+			return Response{}, false
+		}
+		return errorResponse(req.ID, codeInvalidRequest, "invalid jsonrpc version"), true
+	}
+
+	switch req.Method {
+	case "initialize":
+		return s.okResponse(req.ID, s.handleInitialize()), true
+	case "notifications/initialized":
+		return Response{}, false
+	case "tools/list":
+		return s.okResponse(req.ID, toolsListResult{Tools: s.tools}), true
+	case "tools/call":
+		return s.handleToolsCall(ctx, req), true
+	default:
+		if req.IsNotification() {
+			return Response{}, false
+		}
+		return errorResponse(req.ID, codeMethodNotFound, fmt.Sprintf("unknown method %q", req.Method)), true
+	}
+}
+
+func (s *Server) handleInitialize() initializeResult {
+	return initializeResult{
+		ProtocolVersion: protocolVersion,
+		Capabilities:    capabilities{Tools: &toolsCapability{ListChanged: false}},
+		ServerInfo:      serverInfo{Name: serverName, Version: s.version()},
+	}
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, req *Request) Response {
+	var params toolsCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, codeInvalidParams, "invalid tools/call params")
+	}
+
+	tool, ok := s.byName[params.Name]
+	if !ok {
+		return s.okResponse(req.ID, toolErrorResult(llmError{
+			Code:        "unknown_tool",
+			Cause:       fmt.Sprintf("No tool named %q is registered on this server.", params.Name),
+			Remediation: "Call tools/list to see the available tool names and retry with one of them.",
+		}))
+	}
+
+	args, verr := parseArgs(tool, params.Arguments)
+	if verr != nil {
+		return s.okResponse(req.ID, toolErrorResult(*verr))
+	}
+
+	result := s.dispatch(ctx, tool.Name, args)
+	return s.okResponse(req.ID, result)
+}
+
+// parsedArgs holds the validated, typed arguments for a tool call.
+type parsedArgs struct {
+	pool       string
+	sandbox    string
+	command    string
+	path       string
+	content    string
+	timeoutSec int
+	replicas   int
+}
+
+// parseArgs validates required fields against the tool schema and extracts typed
+// values. On a validation failure it returns an LLM-legible error.
+func parseArgs(tool Tool, raw json.RawMessage) (parsedArgs, *llmError) {
+	var m map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return parsedArgs{}, &llmError{
+				Code:        "invalid_arguments",
+				Cause:       fmt.Sprintf("The arguments for tool %q were not a JSON object.", tool.Name),
+				Remediation: "Pass arguments as a JSON object matching the tool inputSchema.",
+			}
+		}
+	}
+	if m == nil {
+		m = map[string]any{}
+	}
+
+	for _, reqField := range tool.InputSchema.Required {
+		v, present := m[reqField]
+		if !present || v == nil || v == "" {
+			return parsedArgs{}, &llmError{
+				Code:        "missing_required_argument",
+				Cause:       fmt.Sprintf("Tool %q requires the %q argument, which was missing or empty.", tool.Name, reqField),
+				Remediation: fmt.Sprintf("Retry the call including a non-empty %q value; see the tool inputSchema for all required fields.", reqField),
+			}
+		}
+	}
+
+	var a parsedArgs
+	a.pool = stringArg(m, "pool")
+	a.sandbox = stringArg(m, "sandbox")
+	a.command = stringArg(m, "command")
+	a.path = stringArg(m, "path")
+	a.content = stringArg(m, "content")
+	a.timeoutSec = intArg(m, "timeout_seconds")
+	a.replicas = intArg(m, "replicas")
+	return a, nil
+}
+
+func stringArg(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func intArg(m map[string]any, key string) int {
+	switch v := m[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		return 0
+	}
+}
+
+// dispatch routes a validated tool call to the backend and shapes the result.
+func (s *Server) dispatch(ctx context.Context, name string, a parsedArgs) toolResult {
+	switch name {
+	case ToolSandboxCreate:
+		id, err := s.backend.Create(ctx, a.pool)
+		if err != nil {
+			return backendErrorResult(name, err)
+		}
+		return textResult(fmt.Sprintf("Created sandbox %s", id))
+
+	case ToolSandboxExec:
+		res, err := s.backend.Exec(ctx, a.sandbox, a.command, a.timeoutSec)
+		if err != nil {
+			return backendErrorResult(name, err)
+		}
+		payload, _ := json.Marshal(res)
+		return textResult(string(payload))
+
+	case ToolSandboxReadFile:
+		content, err := s.backend.ReadFile(ctx, a.sandbox, a.path)
+		if err != nil {
+			return backendErrorResult(name, err)
+		}
+		return textResult(content)
+
+	case ToolSandboxWriteFile:
+		if err := s.backend.WriteFile(ctx, a.sandbox, a.path, a.content); err != nil {
+			return backendErrorResult(name, err)
+		}
+		return textResult(fmt.Sprintf("Wrote %d bytes to %s in sandbox %s", len(a.content), a.path, a.sandbox))
+
+	case ToolSandboxFork:
+		ids, err := s.backend.Fork(ctx, a.sandbox, a.replicas)
+		if err != nil {
+			return backendErrorResult(name, err)
+		}
+		payload, _ := json.Marshal(ids)
+		return textResult(string(payload))
+
+	case ToolSandboxTerminate:
+		if err := s.backend.Terminate(ctx, a.sandbox); err != nil {
+			return backendErrorResult(name, err)
+		}
+		return textResult(fmt.Sprintf("Terminated sandbox %s", a.sandbox))
+
+	default:
+		// Reachable only if a tool is advertised but not dispatched (the
+		// workspace stubs); report it LLM-legibly rather than panicking.
+		return toolErrorResult(llmError{
+			Code:        "tool_not_dispatchable",
+			Cause:       fmt.Sprintf("Tool %q is advertised but not yet dispatchable on this server.", name),
+			Remediation: "Use one of the sandbox_* tools; workspace tools are not yet implemented (issue #21).",
+		})
+	}
+}
+
+// ---- result helpers ----
+
+func textResult(text string) toolResult {
+	return toolResult{Content: []textContent{{Type: "text", Text: text}}}
+}
+
+func toolErrorResult(e llmError) toolResult {
+	payload, _ := json.Marshal(e)
+	return toolResult{
+		Content: []textContent{{Type: "text", Text: string(payload)}},
+		IsError: true,
+	}
+}
+
+// backendErrorResult maps a backend error to an LLM-legible tool error. Secret
+// values are never logged or echoed; only the error string the backend chose to
+// surface is included, and backends are responsible for keeping it clean.
+func backendErrorResult(tool string, err error) toolResult {
+	return toolErrorResult(llmError{
+		Code:        "backend_error",
+		Cause:       fmt.Sprintf("The %s operation failed: %s", tool, err.Error()),
+		Remediation: "Verify the sandbox id and arguments, check sandbox status, and retry; if it persists the backend may be unavailable.",
+	})
+}
+
+func (s *Server) okResponse(id json.RawMessage, result any) Response {
+	b, err := json.Marshal(result)
+	if err != nil {
+		return errorResponse(id, codeInternalError, "failed to marshal result")
+	}
+	return Response{JSONRPC: jsonrpcVersion, ID: id, Result: b}
+}
+
+func errorResponse(id json.RawMessage, code int, msg string) Response {
+	return Response{
+		JSONRPC: jsonrpcVersion,
+		ID:      id,
+		Error:   &RPCError{Code: code, Message: msg},
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,247 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// callServer invokes a single request against a Server via handle and returns
+// the decoded response. It is the in-process path used by unit tests; the full
+// stdio loop is exercised by the conformance test.
+func callServer(t *testing.T, s *Server, method string, params any) Response {
+	t.Helper()
+	var rawParams json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		rawParams = b
+	}
+	req := Request{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  rawParams,
+	}
+	resp, ok := s.handle(context.Background(), &req)
+	if !ok {
+		t.Fatalf("method %q produced no response", method)
+	}
+	return resp
+}
+
+func decodeToolResult(t *testing.T, resp Response) toolResult {
+	t.Helper()
+	if resp.Error != nil {
+		t.Fatalf("unexpected jsonrpc error: %+v", resp.Error)
+	}
+	var tr toolResult
+	if err := json.Unmarshal(resp.Result, &tr); err != nil {
+		t.Fatalf("decode tool result: %v", err)
+	}
+	return tr
+}
+
+func decodeLLMError(t *testing.T, tr toolResult) llmError {
+	t.Helper()
+	if !tr.IsError {
+		t.Fatalf("expected isError tool result, got %+v", tr)
+	}
+	if len(tr.Content) == 0 {
+		t.Fatalf("error tool result has no content")
+	}
+	var e llmError
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &e); err != nil {
+		t.Fatalf("decode llmError from %q: %v", tr.Content[0].Text, err)
+	}
+	if e.Code == "" || e.Cause == "" || e.Remediation == "" {
+		t.Fatalf("llmError missing fields: %+v", e)
+	}
+	return e
+}
+
+func TestInitialize(t *testing.T) {
+	s := New(NewFakeBackend(), Options{})
+	resp := callServer(t, s, "initialize", map[string]any{})
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %+v", resp.Error)
+	}
+	var res initializeResult
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatalf("decode initialize: %v", err)
+	}
+	if res.ProtocolVersion == "" {
+		t.Error("protocolVersion empty")
+	}
+	if res.Capabilities.Tools == nil {
+		t.Error("capabilities.tools not advertised")
+	}
+	if res.ServerInfo.Name == "" || res.ServerInfo.Version == "" {
+		t.Errorf("serverInfo incomplete: %+v", res.ServerInfo)
+	}
+}
+
+func TestToolsListCoreOnly(t *testing.T) {
+	s := New(NewFakeBackend(), Options{})
+	resp := callServer(t, s, "tools/list", nil)
+	var res toolsListResult
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	if len(res.Tools) != 6 {
+		t.Fatalf("expected 6 tools, got %d", len(res.Tools))
+	}
+	names := map[string]bool{}
+	for _, tool := range res.Tools {
+		names[tool.Name] = true
+	}
+	for _, want := range []string{
+		ToolSandboxCreate, ToolSandboxExec, ToolSandboxReadFile,
+		ToolSandboxWriteFile, ToolSandboxFork, ToolSandboxTerminate,
+	} {
+		if !names[want] {
+			t.Errorf("tools/list missing %q", want)
+		}
+	}
+	for _, ws := range workspaceToolNames {
+		if names[ws] {
+			t.Errorf("workspace tool %q present when disabled", ws)
+		}
+	}
+}
+
+func TestToolsListWithWorkspaceEnabled(t *testing.T) {
+	s := New(NewFakeBackend(), Options{EnableWorkspaceTools: true})
+	resp := callServer(t, s, "tools/list", nil)
+	var res toolsListResult
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tool := range res.Tools {
+		names[tool.Name] = true
+	}
+	for _, ws := range workspaceToolNames {
+		if !names[ws] {
+			t.Errorf("workspace tool %q missing when enabled", ws)
+		}
+	}
+	if len(res.Tools) != 6+len(workspaceToolNames) {
+		t.Errorf("expected %d tools, got %d", 6+len(workspaceToolNames), len(res.Tools))
+	}
+}
+
+func TestToolsCallDispatchesCreate(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.CreateID = "sbx-77"
+	s := New(fb, Options{})
+
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      ToolSandboxCreate,
+		Arguments: json.RawMessage(`{"pool":"default"}`),
+	})
+	tr := decodeToolResult(t, resp)
+	if tr.IsError {
+		t.Fatalf("unexpected error result: %+v", tr)
+	}
+	if got := tr.Content[0].Text; got != "Created sandbox sbx-77" {
+		t.Errorf("unexpected text %q", got)
+	}
+
+	calls := fb.RecordedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 backend call, got %d", len(calls))
+	}
+	if calls[0].Method != "create" || calls[0].Pool != "default" {
+		t.Errorf("backend recorded %+v", calls[0])
+	}
+}
+
+func TestToolsCallDispatchesExecWithArgs(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ExecResultV = ExecResult{ExitCode: 2, Stdout: "out", Stderr: "err"}
+	s := New(fb, Options{})
+
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      ToolSandboxExec,
+		Arguments: json.RawMessage(`{"sandbox":"sbx-1","command":"ls","timeout_seconds":5}`),
+	})
+	tr := decodeToolResult(t, resp)
+	if tr.IsError {
+		t.Fatalf("unexpected error result: %+v", tr)
+	}
+	var res ExecResult
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &res); err != nil {
+		t.Fatalf("decode exec result: %v", err)
+	}
+	if res != fb.ExecResultV {
+		t.Errorf("exec result %+v != canned %+v", res, fb.ExecResultV)
+	}
+
+	calls := fb.RecordedCalls()
+	if calls[0].SandboxID != "sbx-1" || calls[0].Command != "ls" || calls[0].TimeoutSec != 5 {
+		t.Errorf("backend recorded %+v", calls[0])
+	}
+}
+
+func TestToolsCallUnknownTool(t *testing.T) {
+	s := New(NewFakeBackend(), Options{})
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      "no_such_tool",
+		Arguments: json.RawMessage(`{}`),
+	})
+	tr := decodeToolResult(t, resp)
+	e := decodeLLMError(t, tr)
+	if e.Code != "unknown_tool" {
+		t.Errorf("code = %q, want unknown_tool", e.Code)
+	}
+}
+
+func TestToolsCallMissingRequiredArg(t *testing.T) {
+	fb := NewFakeBackend()
+	s := New(fb, Options{})
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      ToolSandboxExec,
+		Arguments: json.RawMessage(`{"sandbox":"sbx-1"}`), // missing command
+	})
+	tr := decodeToolResult(t, resp)
+	e := decodeLLMError(t, tr)
+	if e.Code != "missing_required_argument" {
+		t.Errorf("code = %q, want missing_required_argument", e.Code)
+	}
+	if len(fb.RecordedCalls()) != 0 {
+		t.Errorf("backend should not be called on validation failure")
+	}
+}
+
+func TestToolsCallBackendErrorInjection(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.Errors["create"] = errors.New("pool exhausted")
+	s := New(fb, Options{})
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      ToolSandboxCreate,
+		Arguments: json.RawMessage(`{"pool":"default"}`),
+	})
+	tr := decodeToolResult(t, resp)
+	e := decodeLLMError(t, tr)
+	if e.Code != "backend_error" {
+		t.Errorf("code = %q, want backend_error", e.Code)
+	}
+	if e.Remediation == "" {
+		t.Error("backend error must carry remediation")
+	}
+}
+
+func TestUnknownMethodReturnsJSONRPCError(t *testing.T) {
+	s := New(NewFakeBackend(), Options{})
+	resp := callServer(t, s, "does/not/exist", nil)
+	if resp.Error == nil {
+		t.Fatal("expected jsonrpc error for unknown method")
+	}
+	if resp.Error.Code != codeMethodNotFound {
+		t.Errorf("code = %d, want %d", resp.Error.Code, codeMethodNotFound)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"testing"
+	"time"
 )
 
 // callServer invokes a single request against a Server via handle and returns
@@ -243,5 +245,85 @@ func TestUnknownMethodReturnsJSONRPCError(t *testing.T) {
 	}
 	if resp.Error.Code != codeMethodNotFound {
 		t.Errorf("code = %d, want %d", resp.Error.Code, codeMethodNotFound)
+	}
+}
+
+// TestRunReturnsOnCtxCancel verifies that Server.Run returns promptly when the
+// context is cancelled while the reader is blocked waiting for input. The write
+// end of the pipe stays open so the scan goroutine remains blocked on Read; the
+// ctx cancel must unblock Run independently.
+func TestRunReturnsOnCtxCancel(t *testing.T) {
+	s := New(NewFakeBackend(), Options{})
+
+	// Pipe whose write end we never close during the test body.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run(ctx, pr, io.Discard)
+	}()
+
+	// Give Run a moment to reach the blocking select, then cancel.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s after ctx cancel")
+	}
+}
+
+// TestWriteFileEmptyContent asserts that sandbox_write_file with content=""
+// dispatches to the backend and does not return missing_required_argument.
+func TestWriteFileEmptyContent(t *testing.T) {
+	fb := NewFakeBackend()
+	s := New(fb, Options{})
+
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      ToolSandboxWriteFile,
+		Arguments: json.RawMessage(`{"sandbox":"sbx-1","path":"/tmp/empty","content":""}`),
+	})
+	tr := decodeToolResult(t, resp)
+	if tr.IsError {
+		t.Fatalf("expected success for empty content, got error: %+v", tr)
+	}
+
+	calls := fb.RecordedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 backend call, got %d", len(calls))
+	}
+	c := calls[0]
+	if c.Method != "write_file" {
+		t.Errorf("method = %q, want write_file", c.Method)
+	}
+	if c.Content != "" {
+		t.Errorf("content = %q, want empty string", c.Content)
+	}
+}
+
+// TestWriteFileMissingContentStillFails asserts that a genuinely absent content
+// field (not present in JSON at all) still fails validation.
+func TestWriteFileMissingContentStillFails(t *testing.T) {
+	fb := NewFakeBackend()
+	s := New(fb, Options{})
+
+	resp := callServer(t, s, "tools/call", toolsCallParams{
+		Name:      ToolSandboxWriteFile,
+		Arguments: json.RawMessage(`{"sandbox":"sbx-1","path":"/tmp/x"}`),
+	})
+	tr := decodeToolResult(t, resp)
+	e := decodeLLMError(t, tr)
+	if e.Code != "missing_required_argument" {
+		t.Errorf("code = %q, want missing_required_argument", e.Code)
+	}
+	if len(fb.RecordedCalls()) != 0 {
+		t.Errorf("backend should not be called on validation failure")
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,176 @@
+package mcp
+
+// ToolSchemaVersion identifies the version of the tool input-schema contract
+// this server advertises. Bump it whenever a tool's name, required fields, or
+// property semantics change in a way clients must observe.
+const ToolSchemaVersion = "1.0.0"
+
+// JSONSchema is the subset of JSON Schema used for tool input schemas: an
+// object with named properties and a required list.
+type JSONSchema struct {
+	Type       string                    `json:"type"`
+	Properties map[string]SchemaProperty `json:"properties"`
+	Required   []string                  `json:"required,omitempty"`
+}
+
+// SchemaProperty describes a single property in a tool input schema.
+type SchemaProperty struct {
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+}
+
+// Tool is an MCP tool advertised over tools/list and dispatched via tools/call.
+type Tool struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	InputSchema JSONSchema `json:"inputSchema"`
+}
+
+// Tool names. Centralized so the server dispatch and tests share one source of
+// truth.
+const (
+	ToolSandboxCreate    = "sandbox_create"
+	ToolSandboxExec      = "sandbox_exec"
+	ToolSandboxReadFile  = "sandbox_read_file"
+	ToolSandboxWriteFile = "sandbox_write_file"
+	ToolSandboxFork      = "sandbox_fork"
+	ToolSandboxTerminate = "sandbox_terminate"
+)
+
+func str(desc string) SchemaProperty { return SchemaProperty{Type: "string", Description: desc} }
+func num(desc string) SchemaProperty { return SchemaProperty{Type: "integer", Description: desc} }
+
+// coreTools returns the six always-on sandbox lifecycle tools.
+func coreTools() []Tool {
+	return []Tool{
+		{
+			Name:        ToolSandboxCreate,
+			Description: "Create a new sandbox from a sandbox pool and return its id.",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"pool": str("Name of the SandboxPool to create the sandbox from."),
+				},
+				Required: []string{"pool"},
+			},
+		},
+		{
+			Name:        ToolSandboxExec,
+			Description: "Run a shell command inside a sandbox and return its exit code, stdout, and stderr.",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"sandbox":         str("Id of the sandbox to run the command in."),
+					"command":         str("Shell command to execute."),
+					"timeout_seconds": num("Optional timeout in seconds; 0 or omitted uses the backend default."),
+				},
+				Required: []string{"sandbox", "command"},
+			},
+		},
+		{
+			Name:        ToolSandboxReadFile,
+			Description: "Read the contents of a file inside a sandbox.",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"sandbox": str("Id of the sandbox to read from."),
+					"path":    str("Absolute path of the file to read inside the sandbox."),
+				},
+				Required: []string{"sandbox", "path"},
+			},
+		},
+		{
+			Name:        ToolSandboxWriteFile,
+			Description: "Write contents to a file inside a sandbox, creating or overwriting it.",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"sandbox": str("Id of the sandbox to write to."),
+					"path":    str("Absolute path of the file to write inside the sandbox."),
+					"content": str("Contents to write to the file."),
+				},
+				Required: []string{"sandbox", "path", "content"},
+			},
+		},
+		{
+			Name:        ToolSandboxFork,
+			Description: "Fork a sandbox into one or more copies and return the new sandbox ids.",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"sandbox":  str("Id of the sandbox to fork."),
+					"replicas": num("Optional number of forks to create; omitted means one."),
+				},
+				Required: []string{"sandbox"},
+			},
+		},
+		{
+			Name:        ToolSandboxTerminate,
+			Description: "Terminate a sandbox and release its resources.",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"sandbox": str("Id of the sandbox to terminate."),
+				},
+				Required: []string{"sandbox"},
+			},
+		},
+	}
+}
+
+// workspaceToolNames lists the workspace tools that will be registered once
+// workspace support (#21) lands. They are advertised only when
+// Options.EnableWorkspaceTools is set; dispatch is deferred and intentionally
+// not yet wired to the backend.
+var workspaceToolNames = []string{
+	"workspace_create",
+	"workspace_list",
+	"workspace_attach",
+	"workspace_delete",
+}
+
+// workspaceTools returns stub Tool definitions for the workspace tools. These
+// carry valid schemas so clients can introspect them, but the server does not
+// dispatch them yet.
+func workspaceTools() []Tool {
+	return []Tool{
+		{
+			Name:        "workspace_create",
+			Description: "Create a persistent workspace volume. Deferred: not yet dispatched (issue #21).",
+			InputSchema: JSONSchema{
+				Type:       "object",
+				Properties: map[string]SchemaProperty{"name": str("Name of the workspace to create.")},
+				Required:   []string{"name"},
+			},
+		},
+		{
+			Name:        "workspace_list",
+			Description: "List persistent workspaces. Deferred: not yet dispatched (issue #21).",
+			InputSchema: JSONSchema{
+				Type:       "object",
+				Properties: map[string]SchemaProperty{},
+			},
+		},
+		{
+			Name:        "workspace_attach",
+			Description: "Attach a workspace to a sandbox. Deferred: not yet dispatched (issue #21).",
+			InputSchema: JSONSchema{
+				Type: "object",
+				Properties: map[string]SchemaProperty{
+					"sandbox":   str("Id of the sandbox to attach to."),
+					"workspace": str("Name of the workspace to attach."),
+				},
+				Required: []string{"sandbox", "workspace"},
+			},
+		},
+		{
+			Name:        "workspace_delete",
+			Description: "Delete a persistent workspace. Deferred: not yet dispatched (issue #21).",
+			InputSchema: JSONSchema{
+				Type:       "object",
+				Properties: map[string]SchemaProperty{"name": str("Name of the workspace to delete.")},
+				Required:   []string{"name"},
+			},
+		},
+	}
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+import "testing"
+
+// TestCoreToolsSchemaValidity asserts every core tool has a non-empty name and
+// description and a structurally valid object schema whose required fields all
+// exist in properties.
+func TestCoreToolsSchemaValidity(t *testing.T) {
+	tools := coreTools()
+	if len(tools) != 6 {
+		t.Fatalf("expected 6 core tools, got %d", len(tools))
+	}
+
+	seen := map[string]bool{}
+	for _, tool := range tools {
+		if tool.Name == "" {
+			t.Errorf("tool has empty name")
+		}
+		if seen[tool.Name] {
+			t.Errorf("duplicate tool name %q", tool.Name)
+		}
+		seen[tool.Name] = true
+
+		if tool.Description == "" {
+			t.Errorf("tool %q has empty description", tool.Name)
+		}
+		if tool.InputSchema.Type != "object" {
+			t.Errorf("tool %q schema type = %q, want object", tool.Name, tool.InputSchema.Type)
+		}
+		if tool.InputSchema.Properties == nil {
+			t.Errorf("tool %q has nil properties", tool.Name)
+		}
+		for _, req := range tool.InputSchema.Required {
+			if _, ok := tool.InputSchema.Properties[req]; !ok {
+				t.Errorf("tool %q requires %q which is not in properties", tool.Name, req)
+			}
+		}
+	}
+
+	for _, want := range []string{
+		ToolSandboxCreate, ToolSandboxExec, ToolSandboxReadFile,
+		ToolSandboxWriteFile, ToolSandboxFork, ToolSandboxTerminate,
+	} {
+		if !seen[want] {
+			t.Errorf("core tools missing %q", want)
+		}
+	}
+}
+
+// TestWorkspaceToolsSchemaValidity asserts the deferred workspace stubs are also
+// structurally valid and match the declared name list.
+func TestWorkspaceToolsSchemaValidity(t *testing.T) {
+	tools := workspaceTools()
+	if len(tools) != len(workspaceToolNames) {
+		t.Fatalf("workspaceTools count %d != names count %d", len(tools), len(workspaceToolNames))
+	}
+	names := map[string]bool{}
+	for _, n := range workspaceToolNames {
+		names[n] = true
+	}
+	for _, tool := range tools {
+		if !names[tool.Name] {
+			t.Errorf("workspace tool %q not in workspaceToolNames", tool.Name)
+		}
+		if tool.Description == "" {
+			t.Errorf("workspace tool %q has empty description", tool.Name)
+		}
+		if tool.InputSchema.Type != "object" {
+			t.Errorf("workspace tool %q schema type = %q, want object", tool.Name, tool.InputSchema.Type)
+		}
+		for _, req := range tool.InputSchema.Required {
+			if _, ok := tool.InputSchema.Properties[req]; !ok {
+				t.Errorf("workspace tool %q requires %q not in properties", tool.Name, req)
+			}
+		}
+	}
+}
+
+// TestToolSchemaVersion guards that the version constant is set.
+func TestToolSchemaVersion(t *testing.T) {
+	if ToolSchemaVersion == "" {
+		t.Fatal("ToolSchemaVersion must not be empty")
+	}
+}


### PR DESCRIPTION
## Summary

- Dependency-free MCP server over a stdio JSON-RPC 2.0 transport (the `initialize`/`tools/list`/`tools/call` subset implemented directly, keeping the binary on go 1.24).
- Six always-on tools: `sandbox_create`, `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_fork`, `sandbox_terminate`, each with a versioned JSON input schema (`ToolSchemaVersion`).
- LLM-legible tool errors carrying a code, a one-sentence cause, and an actionable remediation (issue #28), with `isError` set so clients distinguish tool failures from transport errors.
- Token-scoped HTTP backend over the sandbox-server REST API: every request carries the launch-time bearer token, so the server can do exactly what that token authorizes. The token is never logged and is redacted from any error context.
- `cmd/agentrun-mcp` wires the backend to the server over stdio, logs only to stderr (stdout is the MCP channel), and cancels on SIGINT/SIGTERM.
- A conformance test drives the server as a real MCP client over the same wire framing in the standard `go-test` CI job (no KVM); the underlying exec/fork path is exercised by the existing KVM CI.
- Docs in `docs/mcp.md`; README and ROADMAP updated.
- Workspace tools (#21) and capability budgets (#24) remain open.

`Closes #27`

## Test plan

- [x] `go build ./...` and `GOOS=linux go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` darwin and `GOOS=linux`
- [x] `go test ./internal/... -count=1 -race` (envtest) including `internal/mcp`
- [x] Python SDK suite (`pytest`)
- [x] `go build ./cmd/agentrun-mcp/`
- [x] go 1.24.0 directive unchanged
- [x] gofmt clean; no em/en dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)