### PR TITLE
agentrun CLI: run, sandbox, and one-command local dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,10 +70,39 @@ jobs:
           docker build -f Dockerfile.forkd -t agent-run-forkd:ci .
           kind load docker-image agent-run-controller:ci --name agent-run-ci
           kind load docker-image agent-run-forkd:ci --name agent-run-ci
-      - name: Install CRDs
+      - name: Build agentrun CLI
+        run: go build -o /usr/local/bin/agentrun ./cmd/agentrun/
+      - name: agentrun dev up (mock control plane on the existing kind cluster)
+        # The dev overlay (deploy/dev/) runs a MOCK control plane: forkd --mock
+        # (no KVM, no /dev/kvm, no kvm nodeSelector) and the controller with
+        # --mock --disable-pki-bootstrap so it dials forkd over insecure gRPC.
+        # --skip-cluster-create targets the kind cluster this job already stood
+        # up. The dev manifests reference the agent-run-controller:ci /
+        # agent-run-forkd:ci images loaded above with imagePullPolicy:
+        # IfNotPresent.
+        run: agentrun dev up --skip-cluster-create
+      - name: Wait for the mock control plane to be Ready
         run: |
-          make manifests 2>/dev/null || true
-          kubectl apply -f deploy/crds/ 2>/dev/null || echo "CRDs not generated yet"
-      - name: Apply examples
+          kubectl -n agent-run rollout status deployment/agent-run-controller --timeout=180s
+          kubectl -n agent-run rollout status daemonset/agent-run-forkd --timeout=180s
+      - name: agentrun sandbox ls (control-plane dispatch lists claims)
+        run: agentrun sandbox ls
+      - name: agentrun sandbox create reaches Ready on the mock engine
+        # The controller discovers the mock forkd, builds the dev-default pool
+        # snapshot over insecure gRPC, and the claim forks via the mock engine
+        # and reaches Ready. The mock engine has NO guest VM, so this asserts the
+        # claim/fork path (claim -> Ready) and control-plane dispatch only; real
+        # in-VM exec is NOT exercised here (proven by the KVM CI of the API).
         run: |
-          kubectl apply -f examples/python-pool.yaml 2>/dev/null || echo "Skipped (CRDs needed)"
+          set -euo pipefail
+          # Give the pool reconciler time to build the snapshot on the discovered
+          # mock forkd before claiming.
+          kubectl -n default wait --for=jsonpath='{.status.readySnapshots}'=1 \
+            sandboxpool/dev-default --timeout=120s
+          ID=$(agentrun sandbox create --pool dev-default)
+          echo "created sandbox: $ID"
+          agentrun sandbox ls | grep -q "$ID"
+          agentrun sandbox terminate "$ID"
+      - name: agentrun dev down (cleanup)
+        if: always()
+        run: kubectl delete -k deploy/dev/ --ignore-not-found=true || true

--- a/README.md
+++ b/README.md
@@ -104,18 +104,32 @@ Sandboxes are not pods. Pod-scoped Kubernetes mechanisms do not govern sandbox V
 
 ### Local development (no KVM required)
 
-```bash
-go run ./cmd/sandbox-server --mock --addr :8080
+One command brings up a local kind cluster running a mock control plane, then the
+`agentrun` CLI drives the full claim path:
 
-cd sdk/python && pip install -e .
-python -c "
-from agent_run.direct import SandboxServer
-s = SandboxServer('http://localhost:8080')
-s.create_template('python')
-sb = s.fork('python')
-print(sb.exec('echo hello').stdout)
-"
+```bash
+go build -o agentrun ./cmd/agentrun/
+
+# build + load the dev images the overlay references, then bring up the cluster
+docker build -f Dockerfile.controller -t agent-run-controller:ci .
+docker build -f Dockerfile.forkd -t agent-run-forkd:ci .
+kind create cluster --name agentrun-dev --config hack/kind-config.yaml
+kind load docker-image agent-run-controller:ci --name agentrun-dev
+kind load docker-image agent-run-forkd:ci --name agentrun-dev
+
+./agentrun dev up --skip-cluster-create
+./agentrun sandbox create --pool dev-default   # reaches Ready on the mock engine
+./agentrun sandbox ls
+./agentrun run echo hello --pool dev-default
+./agentrun dev down
 ```
+
+The local dev cluster uses the mock fork engine (no KVM): claims reconcile to
+`Ready` and control-plane dispatch works, but a real in-VM `exec` needs a node
+with `/dev/kvm`. See [docs/cli.md](docs/cli.md) for the full command reference,
+the backends, and what is proven. For the no-cluster REST loop, run
+`go run ./cmd/sandbox-server --mock --addr :8080` and use the Python SDK
+(`sdk/python`).
 
 ### On a cluster
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -276,6 +276,15 @@ verified. In rough order of leverage:
   zero SDK integration. A conformance test drives the server as a real MCP
   client in standard CI; see docs/mcp.md. Open: workspace tools (#21) and
   capability-budget advertisement (#24).
+- ✅ **agentrun CLI + one-command local dev**: `agentrun run` and `agentrun
+  sandbox create|ls|exec|fork|terminate` drive the `SandboxClaim` path over
+  kubeconfig with token-scoped exec; `agentrun dev up|down` brings up a kind
+  cluster running a mock control plane (controller `--mock
+  --disable-pki-bootstrap`, forkd `--mock`, no KVM) from `deploy/dev/`. PROVEN in
+  the kind CI smoke: `dev up` + `sandbox create` reaches Ready + `ls` + `terminate`
+  on the mock engine; real in-VM exec is proven by the KVM CI of the API. See
+  docs/cli.md. OPEN: workspace verbs (`agentrun ws ...`) deferred to Workspace
+  (#21).
 - ⬜ Streaming exec (stdout/stderr), stdin, **PTY mode**, file transfer,
   port forwarding, the daily-driver agent-harness needs
 - ⬜ Code-interpreter-compatible API shim (drop-in for LangChain/LlamaIndex
@@ -286,8 +295,9 @@ verified. In rough order of leverage:
 - ⬜ TypeScript SDK (currently does not exist; README labels it planned)
   + shared Python/TS conformance suite; README samples executed in CI
 - ⬜ Agent Sandbox (k8s-sigs) CRD adapter: assess, decide, document either way
-- ⬜ `make dev` one-command local story (kind + mock engine today; document
-  KVM-passthrough path)
+- ✅ One-command local story: `agentrun dev up` (kind + mock control plane from
+  deploy/dev/), proven in the kind CI smoke. OPEN: document the KVM-passthrough
+  path for real local exec.
 - ⬜ Helm chart (README previously implied one exists; it does not yet)
 
 ## 8. Observability

--- a/cmd/agentrun/main.go
+++ b/cmd/agentrun/main.go
@@ -1,0 +1,169 @@
+// Command agentrun is the command-line interface for snapshot-fork sandboxes.
+// It drives the sandbox lifecycle (create, exec, file IO, fork, terminate, list)
+// against a Kubernetes cluster, and brings a local kind dev cluster up or down.
+//
+// Usage:
+//
+//	agentrun run <command> [--pool P] [--timeout N]
+//	agentrun sandbox create|ls|exec|fork|terminate ...
+//	agentrun dev up|down
+//
+// The cluster connection is resolved from the standard kubeconfig (KUBECONFIG,
+// --kubeconfig, or in-cluster). The sandbox API bearer token is read from the
+// per-sandbox Secret at request time and is never logged.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/paperclipinc/sandbox/internal/agentcli"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+// run parses the global flags, splits the dev path (which needs no cluster
+// backend) from the sandbox path, and dispatches into agentcli.Run.
+func run(args []string) int {
+	ctx := context.Background()
+
+	// Global flags may precede the subcommand: --namespace and --pool. Parse
+	// them out manually so they can appear before the subcommand without the
+	// stdlib flag parser swallowing the subcommand's own flags.
+	namespace, pool, rest := parseGlobalFlags(args)
+
+	if len(rest) == 0 {
+		return agentcli.Run(ctx, rest, nil, os.Stdout, os.Stderr)
+	}
+
+	// The dev subcommand orchestrates kind/kubectl and needs no cluster backend.
+	if rest[0] == "dev" {
+		return runDev(ctx, rest[1:])
+	}
+
+	backend, err := buildBackend(namespace)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+
+	// When a global --pool is set and the subcommand is one that creates a
+	// sandbox without its own --pool, default it in by appending the flag. The
+	// CLI's own --pool on the subcommand still wins because flag parsing takes
+	// the last value.
+	rest = applyDefaultPool(rest, pool)
+
+	return agentcli.Run(ctx, rest, backend, os.Stdout, os.Stderr)
+}
+
+// parseGlobalFlags extracts a leading --namespace/-n and --pool from args,
+// returning them plus the remaining args (the subcommand and its arguments).
+// Only flags that appear before the first non-flag token are consumed.
+func parseGlobalFlags(args []string) (namespace, pool string, rest []string) {
+	i := 0
+	for i < len(args) {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 < len(args) {
+				namespace = args[i+1]
+				i += 2
+				continue
+			}
+			i++
+		case "--pool":
+			if i+1 < len(args) {
+				pool = args[i+1]
+				i += 2
+				continue
+			}
+			i++
+		default:
+			return namespace, pool, args[i:]
+		}
+	}
+	return namespace, pool, args[i:]
+}
+
+// applyDefaultPool injects a --pool flag for the create-style subcommands when a
+// global pool was given and the subcommand did not specify its own. It is a
+// best-effort convenience; the subcommand's explicit --pool always wins.
+func applyDefaultPool(rest []string, pool string) []string {
+	if pool == "" {
+		return rest
+	}
+	hasPool := false
+	for _, a := range rest {
+		if a == "--pool" {
+			hasPool = true
+			break
+		}
+	}
+	if hasPool {
+		return rest
+	}
+	switch {
+	case len(rest) >= 1 && rest[0] == "run":
+		out := append([]string{rest[0], "--pool", pool}, rest[1:]...)
+		return out
+	case len(rest) >= 2 && rest[0] == "sandbox" && rest[1] == "create":
+		out := append([]string{rest[0], rest[1], "--pool", pool}, rest[2:]...)
+		return out
+	default:
+		return rest
+	}
+}
+
+// buildBackend resolves the kubeconfig and builds a cluster backend scoped to
+// namespace (empty means the backend default).
+func buildBackend(namespace string) (*agentcli.ClusterBackend, error) {
+	cfg, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load kubeconfig: %w", err)
+	}
+	c, err := client.New(cfg, client.Options{Scheme: agentcli.Scheme()})
+	if err != nil {
+		return nil, fmt.Errorf("build kubernetes client: %w", err)
+	}
+	return agentcli.NewClusterBackend(c, namespace, nil), nil
+}
+
+// runDev dispatches the dev subcommand (up|down) using a runner that shells out
+// to kind and kubectl. Output goes to stdout; errors to stderr.
+func runDev(ctx context.Context, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "dev: 'up' or 'down' is required")
+		return 2
+	}
+	runner := func(ctx context.Context, argv []string) error {
+		if len(argv) == 0 {
+			return fmt.Errorf("empty command")
+		}
+		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+	switch args[0] {
+	case "up":
+		if err := agentcli.DevUp(ctx, agentcli.DevOptions{}, runner, os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, "dev up:", err)
+			return 1
+		}
+		return 0
+	case "down":
+		if err := agentcli.DevDown(ctx, agentcli.DevOptions{}, runner, os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, "dev down:", err)
+			return 1
+		}
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "unknown dev subcommand %q\n", args[0])
+		return 2
+	}
+}

--- a/cmd/agentrun/main.go
+++ b/cmd/agentrun/main.go
@@ -47,6 +47,12 @@ func run(args []string) int {
 		return runDev(ctx, rest[1:])
 	}
 
+	// Usage is printable without a cluster, so a developer with no kubeconfig
+	// can still discover the commands.
+	if rest[0] == "-h" || rest[0] == "--help" || rest[0] == "help" {
+		return agentcli.Run(ctx, rest, nil, os.Stdout, os.Stderr)
+	}
+
 	backend, err := buildBackend(namespace)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/cmd/agentrun/main.go
+++ b/cmd/agentrun/main.go
@@ -151,7 +151,16 @@ func runDev(ctx context.Context, args []string) int {
 	}
 	switch args[0] {
 	case "up":
-		if err := agentcli.DevUp(ctx, agentcli.DevOptions{}, runner, os.Stdout); err != nil {
+		// --skip-cluster-create targets an already-running cluster (the current
+		// kubectl context) instead of running `kind create`; CI uses it to apply
+		// the dev control plane onto a cluster it stood up itself.
+		opts := agentcli.DevOptions{}
+		for _, a := range args[1:] {
+			if a == "--skip-cluster-create" {
+				opts.SkipClusterCreate = true
+			}
+		}
+		if err := agentcli.DevUp(ctx, opts, runner, os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, "dev up:", err)
 			return 1
 		}

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -1,0 +1,55 @@
+# Dev overlay: mock control plane for `agentrun dev up`
+
+This directory is the local-dev control plane that `agentrun dev up` applies to a
+kind cluster. It runs a MOCK-mode control plane so the full claim path completes
+without KVM:
+
+- **controller** Deployment with `--mock --disable-pki-bootstrap`. `--mock` is a
+  no-op on the controller today (mock mode lives in forkd), but it documents the
+  intent; `--disable-pki-bootstrap` skips the control plane CA and TLS Secrets so
+  the controller dials forkd over insecure gRPC.
+- **forkd** DaemonSet with `--mock` and no TLS flags. It uses the no-KVM mock fork
+  engine (`internal/fork/mock.go`), mounts no `/dev/kvm`, and carries no
+  `agentrun.dev/kvm` nodeSelector so it schedules on the plain kind node. The
+  controller discovers it by the `app.kubernetes.io/component: forkd` pod label,
+  builds the pool snapshot over insecure gRPC, and claims fork via the mock engine
+  and reach Ready.
+- a default `SandboxTemplate` + `SandboxPool` (`dev-default`) in the `default`
+  namespace so `agentrun sandbox create --pool dev-default` has a pool to claim
+  from. Pools, templates, and claims are namespaced and looked up in the claim's
+  namespace; the CLI creates claims in `default`, so the dev pool lives there too.
+  The control plane itself runs in the `agent-run` namespace (the forkd discovery
+  default).
+
+## Mock-engine limitation
+
+The mock engine has no guest VM, so a real in-VM `exec` is NOT exercised here.
+The dev cluster proves the control-plane dispatch and the claim/fork path
+(claim -> Ready) only. Real exec is proven by the KVM CI of the API. To run real
+sandboxes locally you need a node with `/dev/kvm` and the production manifests
+(`deploy/controller/`, `deploy/daemon/`) plus a KVM nodeSelector label.
+
+## Images
+
+The controller and forkd Deployments reference `agent-run-controller:ci` and
+`agent-run-forkd:ci` with `imagePullPolicy: IfNotPresent`. These are the tags the
+kind CI builds and `kind load docker-image`s into the cluster. For local use,
+build and load the same tags before `agentrun dev up`:
+
+```bash
+docker build -f Dockerfile.controller -t agent-run-controller:ci .
+docker build -f Dockerfile.forkd -t agent-run-forkd:ci .
+kind load docker-image agent-run-controller:ci --name agentrun-dev
+kind load docker-image agent-run-forkd:ci --name agentrun-dev
+```
+
+## Apply
+
+```bash
+kubectl apply -f deploy/crds/
+kubectl apply -k deploy/dev/
+```
+
+The CRDs are applied separately because kustomize refuses to reference files
+outside `deploy/dev/` under its default load restrictor. `agentrun dev up` runs
+both steps for you.

--- a/deploy/dev/controller.yaml
+++ b/deploy/dev/controller.yaml
@@ -1,0 +1,111 @@
+# Dev controller: mock control plane on kind, no KVM, no PKI.
+# --disable-pki-bootstrap makes the controller dial forkd over insecure gRPC,
+# matching the no-TLS dev forkd. --mock is a documented no-op (mock mode lives in
+# forkd). A single replica is enough for local dev.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-run-controller
+  namespace: agent-run
+  labels:
+    app.kubernetes.io/name: agent-run
+    app.kubernetes.io/component: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent-run
+      app.kubernetes.io/component: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-run
+        app.kubernetes.io/component: controller
+    spec:
+      serviceAccountName: agent-run-controller
+      containers:
+        - name: controller
+          image: agent-run-controller:ci
+          imagePullPolicy: IfNotPresent
+          args:
+            - --metrics-bind-address=:8080
+            - --health-probe-bind-address=:8081
+            - --mock
+            - --disable-pki-bootstrap
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: health
+              containerPort: 8081
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-run-controller
+  namespace: agent-run
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-run-controller
+rules:
+  - apiGroups: ["agentrun.dev"]
+    resources: ["sandboxtemplates", "sandboxpools", "sandboxclaims", "sandboxforks"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["agentrun.dev"]
+    resources: ["sandboxpools/status", "sandboxclaims/status", "sandboxforks/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["agentrun.dev"]
+    resources: ["sandboxclaims/finalizers", "sandboxforks/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["agentrun.dev"]
+    resources: ["sandboxpools/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-run-controller
+subjects:
+  - kind: ServiceAccount
+    name: agent-run-controller
+    namespace: agent-run
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-run-controller

--- a/deploy/dev/forkd.yaml
+++ b/deploy/dev/forkd.yaml
@@ -1,0 +1,72 @@
+# Dev forkd: mock fork engine on kind, no KVM, no jailer, no TLS.
+# --mock selects internal/fork/mock.go (KVMAvailable=false). No /dev/kvm mount
+# and no agentrun.dev/kvm nodeSelector, so it schedules on the plain kind node.
+# No --tls-* flags, so the gRPC listener is insecure; the controller dials it
+# insecure because PKI bootstrap is disabled. The controller discovers this pod
+# by the app.kubernetes.io/component: forkd label.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-run-forkd
+  namespace: agent-run
+  labels:
+    app.kubernetes.io/name: agent-run
+    app.kubernetes.io/component: forkd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent-run
+      app.kubernetes.io/component: forkd
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-run
+        app.kubernetes.io/component: forkd
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9091"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: forkd
+          image: agent-run-forkd:ci
+          imagePullPolicy: IfNotPresent
+          args:
+            - --listen=:9090
+            - --http=:9091
+            - --data-dir=/var/lib/agent-run
+            - --mock
+          ports:
+            - name: grpc
+              containerPort: 9090
+            - name: metrics
+              containerPort: 9091
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/agent-run
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9091
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9091
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/deploy/dev/kustomization.yaml
+++ b/deploy/dev/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Dev overlay: a MOCK control plane for `agentrun dev up` on kind (no KVM).
+# The controller and forkd run in mock mode and the default pool gives
+# `agentrun sandbox create` something to claim. The CRDs are applied separately
+# (`kubectl apply -f deploy/crds/`) because kustomize refuses to reference files
+# outside this directory under its default load restrictor; `agentrun dev up`
+# applies the CRDs before this overlay.
+resources:
+  - namespace.yaml
+  - controller.yaml
+  - forkd.yaml
+  - pool.yaml

--- a/deploy/dev/namespace.yaml
+++ b/deploy/dev/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-run
+  labels:
+    app.kubernetes.io/name: agent-run

--- a/deploy/dev/pool.yaml
+++ b/deploy/dev/pool.yaml
@@ -1,0 +1,26 @@
+# Default dev pool in the `default` namespace: `agentrun sandbox create` creates
+# claims there and the claim reconciler looks up the pool in the claim's
+# namespace. The controller (in agent-run) discovers the mock forkd, builds this
+# template's snapshot over insecure gRPC, and claims fork via the mock engine and
+# reach Ready. No CSI/snapshot volumes, so it reconciles on the no-KVM node.
+apiVersion: agentrun.dev/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: dev-default
+  namespace: default
+spec:
+  image: python:3.12-slim
+  resources:
+    cpu: "1"
+    memory: "512Mi"
+---
+apiVersion: agentrun.dev/v1alpha1
+kind: SandboxPool
+metadata:
+  name: dev-default
+  namespace: default
+spec:
+  templateRef:
+    name: dev-default
+  replicas: 1
+  snapshotAfter: Ready

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,129 @@
+# agentrun CLI
+
+`agentrun` is the command-line interface for snapshot-fork sandboxes. It drives
+the sandbox lifecycle (create, exec, file IO, fork, terminate, list) against a
+Kubernetes cluster, and brings a local kind dev cluster up or down for a
+one-command local-dev loop.
+
+```bash
+go build -o agentrun ./cmd/agentrun/
+```
+
+## Command reference
+
+```
+agentrun run <command> [--pool P] [--timeout N]   create a sandbox, run the
+                                                  command, terminate, exit with
+                                                  the command's exit code
+agentrun sandbox create [--pool P]                create a sandbox, print its id
+agentrun sandbox ls [-n namespace] [-A]           list sandboxes
+agentrun sandbox exec <id> <command...>           run a command in a sandbox
+agentrun sandbox fork <id> [--replicas N]         fork a sandbox, print new ids
+agentrun sandbox terminate <id>                   destroy a sandbox
+agentrun dev up [--skip-cluster-create]           bring a local kind dev cluster
+                                                  up with a mock control plane
+agentrun dev down                                 delete the local kind dev cluster
+```
+
+Global flags `--namespace`/`-n` and `--pool` may appear before the subcommand.
+`agentrun run` exits with the executed command's exit code so it chains in shell
+pipelines.
+
+## Backends
+
+### Cluster backend (kubeconfig)
+
+For every `run` and `sandbox` verb, `agentrun` resolves a Kubernetes connection
+from the standard kubeconfig (`KUBECONFIG`, `--kubeconfig`, or in-cluster). It
+then:
+
+- `sandbox create` creates a `SandboxClaim` referencing the pool and waits for it
+  to reach the `Ready` phase, then prints the claim name as the sandbox id.
+- `sandbox exec` / file IO reads the per-sandbox bearer token from the claim's
+  Secret at request time and calls the claim's HTTP sandbox API. The token value
+  is held in memory only for the request and is never logged; it is redacted from
+  any error string.
+- `sandbox fork` creates a `SandboxFork` and waits for the requested number of
+  forks to be `Ready`.
+- `sandbox ls` lists `SandboxClaim`s (a namespace with `-n`, all namespaces with
+  `-A`, or the backend default otherwise).
+- `sandbox terminate` deletes the `SandboxClaim`, which the controller reaps.
+
+This is the same `SandboxClaim` path the controller and forkd implement; the CLI
+is a thin client over the CRDs plus the token-scoped HTTP exec.
+
+### Dev mock-mode local cluster
+
+`agentrun dev up` brings up a local kind cluster running a MOCK control plane so
+the full claim path completes without KVM:
+
+1. `kind create cluster` (tolerating an already-existing cluster; skipped with
+   `--skip-cluster-create` to target a cluster you already stood up).
+2. `kubectl apply -f deploy/crds/` (the CRDs).
+3. `kubectl apply -k deploy/dev/` (the dev overlay).
+
+The dev overlay (`deploy/dev/`) runs:
+
+- the **controller** with `--mock --disable-pki-bootstrap`, so it dials forkd over
+  insecure gRPC (no control plane CA or TLS Secrets).
+- a **forkd** DaemonSet with `--mock` and no TLS flags, using the no-KVM mock fork
+  engine. It mounts no `/dev/kvm` and carries no `agentrun.dev/kvm` nodeSelector,
+  so it schedules on the plain kind node.
+- a default `SandboxTemplate` + `SandboxPool` named `dev-default` in the `default`
+  namespace.
+
+The controller discovers the mock forkd by its `app.kubernetes.io/component:
+forkd` pod label, builds the `dev-default` pool snapshot over insecure gRPC, and a
+claim forks via the mock engine and reaches `Ready`:
+
+```bash
+agentrun dev up
+agentrun sandbox create --pool dev-default   # prints the sandbox id, Ready
+agentrun sandbox ls
+agentrun sandbox terminate <id>
+agentrun dev down
+```
+
+The dev manifests reference the `agent-run-controller:ci` and `agent-run-forkd:ci`
+image tags with `imagePullPolicy: IfNotPresent`. Build and load them before
+`agentrun dev up` (CI does this automatically):
+
+```bash
+docker build -f Dockerfile.controller -t agent-run-controller:ci .
+docker build -f Dockerfile.forkd -t agent-run-forkd:ci .
+kind load docker-image agent-run-controller:ci --name agentrun-dev
+kind load docker-image agent-run-forkd:ci --name agentrun-dev
+```
+
+## Mock-engine limitation
+
+The dev cluster uses the mock fork engine, which has NO guest VM. A claim
+reconciles to `Ready` and the control-plane dispatch works, but a real in-VM
+`exec` is not exercised on the dev cluster. To run real sandboxes locally you need
+a node with `/dev/kvm` and the production manifests (`deploy/controller/` +
+`deploy/daemon/`) with the `agentrun.dev/kvm=true` node label.
+
+## What is proven
+
+PROVEN in CI:
+
+- command dispatch for `run` and every `sandbox` verb;
+- the cluster `SandboxClaim` claim path with token-scoped exec;
+- `agentrun dev up` orchestration (CRDs + mock controller + mock forkd + pool);
+- `sandbox ls` over the control plane;
+- on the dev mock cluster on kind: `sandbox create` reaches `Ready`, `sandbox ls`
+  shows it, and `sandbox terminate` removes it.
+
+The mock-engine exec limitation above is the one gap: real in-VM `exec` is proven
+by the KVM CI of the API, not by the kind dev smoke.
+
+## Follow-ups
+
+- workspace verbs (`agentrun ws log|diff|revert|branch`) pending Workspace
+  ([#21](https://github.com/paperclipinc/sandbox/issues/21));
+- `agentrun pool create|refresh` beyond what `dev up` needs;
+- streaming exec / PTY (`exec_stream`) pending the Connect protocol
+  ([#23](https://github.com/paperclipinc/sandbox/issues/23));
+- a `curl | sh` installer and `get.agentrun.dev` distribution
+  ([#37](https://github.com/paperclipinc/sandbox/issues/37));
+- shell completions and a code-interpreter-compatible API shim.

--- a/docs/superpowers/plans/2026-06-11-agentrun-cli.md
+++ b/docs/superpowers/plans/2026-06-11-agentrun-cli.md
@@ -1,0 +1,51 @@
+# agentrun CLI Implementation Plan (issue #26)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issue #26. Ship the `agentrun` CLI: `agentrun run <cmd>` (one-shot create-exec-terminate), `agentrun sandbox create|ls|exec|fork|terminate`, and `agentrun dev up|down` (one-command local cluster: kind plus the controller plus a default pool). The CLI is the developer-facing capstone of the adoption surface (SDK, MCP, CLI all over the same operations), and `dev up` delivers the time-to-first-exec promise: a contributor with no cluster gets a working control plane in one command. Verified in CI: the command tree and dispatch are unit-tested against a fake backend, and `dev up` is exercised on kind (cluster plus controller plus pool come up, `agentrun sandbox ls` talks to the control plane, `dev down` tears it down).
+
+**Honesty constraint:** on kind there is no KVM, so the engine is the mock (claims reach Ready but exec does not run a real VM). The CLI's exec/fork against a real VM is proven by the existing KVM CI of the underlying API; the CLI layer (parsing, dispatch, the cluster claim path, dev orchestration) is what this PR proves. `agentrun dev up` prints a clear note that local dev uses the mock engine and real exec needs a KVM node. No command claims a latency or capability the harness did not exercise.
+
+**Architecture:** A new `internal/agentcli` package defines the command tree (using the stdlib flag package with subcommand dispatch, or cobra only if it is already an indirect dependency and go-1.24-clean) dispatching to a `Backend` interface (Create, Exec, ReadFile, WriteFile, Fork, Terminate, ListSandboxes) reused/aligned with the MCP `SandboxBackend`. A cluster backend creates a `SandboxClaim`, waits for Ready, reads the claim-owned bearer-token Secret, and execs via the forkd HTTP sandbox API (mirroring the Python SDK). `agentrun dev up` orchestrates kind plus `kubectl apply` of CRDs/controller plus a default pool, in mock mode. `cmd/agentrun` wires the real backend and the kubeconfig.
+
+**Context for the implementer:**
+- The operations the CLI wraps exist: the Python SDK `sdk/python/agent_run/sandbox.py` shows the cluster claim path (create SandboxClaim, poll status to Ready, read `<claim>-sandbox-token` Secret, exec via `http://<endpoint>/v1/exec` with the bearer token). The MCP `internal/mcp/backend.go` SandboxBackend + `httpbackend.go` show the HTTP shapes against sandbox-server; reuse/align the interface.
+- `kubectl sandbox ls` exists (`cmd/kubectl-sandbox`, `internal/cli/sandboxtable`); reuse the sandboxtable formatters for `agentrun sandbox ls`.
+- Local dev assets: `hack/kind-setup.sh`, `hack/e2e-test.sh`, `deploy/crds/`, `deploy/controller/`, `examples/python-pool.yaml`. `cmd/controller --mock` runs without KVM. The kind CI job in `.github/workflows/ci.yaml` shows the kind setup pattern.
+- k8s client: mirror `cmd/controller`/`cmd/kubectl-sandbox` (runtime scheme + v1alpha1.AddToScheme + controller-runtime client from kubeconfig).
+- Conventions: CLAUDE.md authoritative. No em/en dashes. TDD. Explicit-path git add. Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Lint darwin + GOOS=linux. Do not regress go 1.24. Never log tokens.
+
+---
+
+### Task 1: `internal/agentcli` command tree + Backend, unit-tested with a fake
+
+**Files:** Create `internal/agentcli/cli.go`, `internal/agentcli/backend.go`, `internal/agentcli/commands.go`, and `_test.go`.
+
+- [ ] CLI framework decision: prefer the stdlib `flag` package with a subcommand dispatcher (dependency-free), UNLESS `github.com/spf13/cobra` is already an indirect dependency (check `go list -m github.com/spf13/cobra` and `github.com/spf13/pflag`) and using it adds no new direct-dep risk on go 1.24. State the decision. The stdlib approach is the safe default.
+- [ ] `backend.go`: `type Backend interface { Create(ctx, pool string) (sandboxID string, err error); Exec(ctx, sandboxID, command string, timeoutSec int) (ExecResult, error); ReadFile/WriteFile; Fork(ctx, sandboxID string, n int) ([]string, error); Terminate(ctx, sandboxID string) error; List(ctx, namespace string) ([]SandboxInfo, error) }` (align with mcp.SandboxBackend where possible; SandboxInfo = name/pool/phase/node/endpoint/age fields for ls). A `FakeBackend` recording calls and returning canned results.
+- [ ] `commands.go` / `cli.go`: the command tree. `agentrun run <cmd> [--pool P] [--timeout N]` = Create(pool) then Exec then Terminate, printing stdout/stderr/exit code. `agentrun sandbox create [--pool P]` prints the id; `sandbox ls [-n ns] [-A]` prints a table (reuse internal/cli/sandboxtable if it lists claims, or format SandboxInfo); `sandbox exec <id> <cmd>`; `sandbox fork <id> [--replicas N]`; `sandbox terminate <id>`. `agentrun dev up|down` dispatched to Task 2. A top-level `Run(ctx, args []string, backend Backend, out, errw io.Writer) int` returning an exit code so it is fully testable. Errors are clear and actionable (the LLM-legible spirit, but human-facing here).
+- [ ] Tests: `Run` with a FakeBackend and captured output: `run` creates+execs+terminates (assert the backend recorded all three and the output contains stdout); `sandbox create` prints the id; `sandbox ls` formats the fake list; `sandbox exec/fork/terminate` dispatch; unknown subcommand and missing args print usage and return a nonzero exit. No cluster.
+- [ ] Commit `feat: agentrun CLI command tree and Backend interface`.
+
+### Task 2: `agentrun dev up|down` + cluster Backend
+
+**Files:** `internal/agentcli/dev.go` + test, `internal/agentcli/clusterbackend.go` + test, `cmd/agentrun/main.go`.
+
+- [ ] `dev.go`: `DevUp(ctx, opts)` orchestrates (shell out to `kind`/`kubectl`, which CI and devs have): create a kind cluster (a fixed name, reuse hack/kind-config.yaml shape), `kubectl apply -f deploy/crds/ -f deploy/controller/`, run the controller in `--mock` mode (or apply a mock-mode controller manifest), and apply a default pool (a minimal SandboxPool/Template). `DevDown` deletes the kind cluster. Inject the command runner (a `runner func(ctx, argv []string) error`) so the orchestration sequence is unit-testable without a real kind. Print a clear note: local dev uses the mock engine; real exec needs a KVM node. Idempotent where reasonable (dev up twice does not fail hard).
+- [ ] `clusterbackend.go`: a `Backend` over the k8s cluster: Create = create a SandboxClaim from the pool, poll to Ready (bounded), return the claim name as the sandbox id; Exec/ReadFile/WriteFile = read the `<claim>-sandbox-token` Secret and POST to the claim endpoint with the bearer token (mirror the Python SDK and mcp.HTTPBackend shapes); Fork = create a SandboxFork; Terminate = delete the claim; List = list SandboxClaims (reuse the sandboxtable mapping). Never log the token. Unit-test the HTTP exec part against an httptest server (bearer header sent, body shape) and the claim translation with a fake k8s client (controller-runtime fake client) for Create/List/Terminate.
+- [ ] `cmd/agentrun/main.go`: wire kubeconfig + the cluster backend; flags (`--namespace`, `--pool`); `agentrun dev` uses the dev orchestration (no backend needed). Log to stderr; never the token.
+- [ ] TDD: DevUp with a recording runner asserts the kind-create / kubectl-apply / pool-apply sequence and DevDown the delete; the cluster backend Create/List/Terminate against a fake k8s client; the exec HTTP against httptest.
+- [ ] Commit `feat: agentrun dev up/down and cluster backend`.
+
+### Task 3: kind CI smoke + docs + PR
+
+**Files:** `.github/workflows/ci.yaml` (extend the kind-e2e job), `docs/cli.md` (new), `README.md` (quick-start uses agentrun), `ROADMAP.md`, full verification.
+
+- [ ] kind CI: in the existing kind-e2e job (which already stands up a kind cluster), build `cmd/agentrun`, run `agentrun dev up` against the kind cluster (or assert the orchestration applies the CRDs/controller/pool if the job already has a cluster, adapt so dev up uses the existing cluster or creates its own), then `agentrun sandbox ls` (asserts the CLI talks to the control plane and lists, even if empty -> "No sandboxes found"), create a claim via `agentrun sandbox create` and assert it reaches Ready (mock engine), then `agentrun dev down` (or cleanup). Gate on the CLI commands succeeding. Keep it honest: do NOT assert a real exec on kind (mock engine); assert claim Ready + ls + control-plane dispatch. Document the mock limitation in the step.
+- [ ] `docs/cli.md` (new): the command reference (run, sandbox *, dev up/down), the two backends (cluster via kubeconfig; the dev mock-mode local cluster), how `agentrun dev up` works and the mock-engine note, examples. What is PROVEN (command dispatch, cluster claim path, dev orchestration, ls, in CI) vs the mock-engine exec limitation on kind (real exec proven by the KVM CI of the API).
+- [ ] README: update the Quick start so the local-dev path uses `agentrun dev up` + `agentrun run` (with the mock-engine note), pointing at docs/cli.md. Keep scoped; no unverified claims.
+- [ ] ROADMAP section 7 (ergonomics): flip the agentrun CLI + one-command local dev line to done (run/sandbox/dev verbs, kind smoke), noting workspace verbs (ws) deferred to Workspace #21.
+- [ ] Full verification (build darwin + GOOS=linux, vet, lint both, all Go suites with envtest, Python suite, gofmt zero, dash grep zero, go 1.24 preserved, YAML parse, `go build ./cmd/agentrun`).
+- [ ] Push `feat/agentrun-cli`, PR `agentrun CLI: run, sandbox, and one-command local dev` body Closes #26 (run/sandbox/dev proven; ws verbs deferred to #21), watch CI, dismiss guarded CodeQL alerts with justification if any, merge when green.
+
+**Out of scope (follow-ups):** `agentrun ws log|diff|revert|branch` (workspace verbs pending Workspace #21); `agentrun pool create|refresh` beyond what dev up needs; streaming exec / PTY (`exec_stream`) pending the Connect protocol #23; the `curl | sh` installer and a `get.agentrun.dev` (release/distribution, ties into release machinery #37); shell completions; the code-interpreter-compatible API shim.

--- a/internal/agentcli/backend.go
+++ b/internal/agentcli/backend.go
@@ -1,0 +1,189 @@
+// Package agentcli implements the agentrun command-line interface: a thin,
+// dependency-free command tree over a Backend that drives the sandbox lifecycle
+// (create, exec, file IO, fork, terminate, list).
+//
+// The CLI is built on the standard library flag package with a hand-written
+// subcommand dispatcher rather than a third-party framework. spf13/cobra is only
+// an indirect dependency in this repo; promoting it to a direct dependency would
+// add maintenance surface and dependency risk on go 1.24 for no real gain, since
+// the command surface here is small and fully covered by stdlib flag. This
+// mirrors how internal/mcp implements its protocol surface directly to stay
+// dependency free.
+//
+// Run is the testable entry point: it takes the Backend, output writers, and the
+// raw argument slice, and returns a process exit code. cmd/agentrun is a thin
+// wrapper that builds a real cluster Backend and calls Run.
+package agentcli
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ExecResult is the outcome of running a command inside a sandbox. It mirrors
+// mcp.ExecResult so the HTTP exec shapes can be reused.
+type ExecResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+// SandboxInfo is one row of the sandbox listing. Age is derived from the
+// object's creation timestamp at list time.
+type SandboxInfo struct {
+	Name     string
+	Pool     string
+	Phase    string
+	Node     string
+	Endpoint string
+	Age      time.Duration
+}
+
+// Backend is the sandbox lifecycle surface the CLI dispatches to. It is narrow
+// on purpose so tests can supply a FakeBackend and the real implementation (the
+// cluster backend) can wrap the controller-runtime client plus the sandbox HTTP
+// API.
+type Backend interface {
+	// Create provisions a new sandbox from the named pool and returns its id.
+	Create(ctx context.Context, pool string) (sandboxID string, err error)
+	// Exec runs command inside the sandbox. A timeoutSec of 0 means the backend
+	// default applies.
+	Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error)
+	// ReadFile returns the contents of path inside the sandbox.
+	ReadFile(ctx context.Context, sandboxID, path string) (string, error)
+	// WriteFile writes content to path inside the sandbox.
+	WriteFile(ctx context.Context, sandboxID, path, content string) error
+	// Fork forks the sandbox into n copies and returns their ids.
+	Fork(ctx context.Context, sandboxID string, n int) (forkIDs []string, err error)
+	// Terminate destroys the sandbox.
+	Terminate(ctx context.Context, sandboxID string) error
+	// List returns the sandboxes in namespace. An empty namespace means the
+	// backend default (all namespaces, or its configured default).
+	List(ctx context.Context, namespace string) ([]SandboxInfo, error)
+}
+
+// FakeCall records a single backend invocation for assertions in tests.
+type FakeCall struct {
+	Method     string
+	Pool       string
+	SandboxID  string
+	Command    string
+	TimeoutSec int
+	Path       string
+	Content    string
+	Replicas   int
+	Namespace  string
+}
+
+// FakeBackend is a test double that records every call and returns canned
+// responses. An error can be injected per method via Errors to exercise the
+// error path.
+type FakeBackend struct {
+	mu    sync.Mutex
+	Calls []FakeCall
+
+	// Canned responses.
+	CreateID    string
+	ExecResultV ExecResult
+	ReadContent string
+	ForkIDs     []string
+	ListInfos   []SandboxInfo
+
+	// Errors injects an error for the named method ("create", "exec",
+	// "read_file", "write_file", "fork", "terminate", "list"). When set for a
+	// method, that method returns the error instead of its canned response.
+	Errors map[string]error
+}
+
+// NewFakeBackend returns a FakeBackend with sensible default canned responses.
+func NewFakeBackend() *FakeBackend {
+	return &FakeBackend{
+		CreateID:    "sbx-fake-1",
+		ExecResultV: ExecResult{ExitCode: 0, Stdout: "ok", Stderr: ""},
+		ReadContent: "file-contents",
+		ForkIDs:     []string{"sbx-fork-1", "sbx-fork-2"},
+		Errors:      map[string]error{},
+	}
+}
+
+func (f *FakeBackend) record(c FakeCall) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, c)
+}
+
+func (f *FakeBackend) err(method string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.Errors == nil {
+		return nil
+	}
+	return f.Errors[method]
+}
+
+// RecordedCalls returns a copy of the recorded calls.
+func (f *FakeBackend) RecordedCalls() []FakeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]FakeCall, len(f.Calls))
+	copy(out, f.Calls)
+	return out
+}
+
+// Create implements Backend.
+func (f *FakeBackend) Create(_ context.Context, pool string) (string, error) {
+	f.record(FakeCall{Method: "create", Pool: pool})
+	if e := f.err("create"); e != nil {
+		return "", e
+	}
+	return f.CreateID, nil
+}
+
+// Exec implements Backend.
+func (f *FakeBackend) Exec(_ context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error) {
+	f.record(FakeCall{Method: "exec", SandboxID: sandboxID, Command: command, TimeoutSec: timeoutSec})
+	if e := f.err("exec"); e != nil {
+		return ExecResult{}, e
+	}
+	return f.ExecResultV, nil
+}
+
+// ReadFile implements Backend.
+func (f *FakeBackend) ReadFile(_ context.Context, sandboxID, path string) (string, error) {
+	f.record(FakeCall{Method: "read_file", SandboxID: sandboxID, Path: path})
+	if e := f.err("read_file"); e != nil {
+		return "", e
+	}
+	return f.ReadContent, nil
+}
+
+// WriteFile implements Backend.
+func (f *FakeBackend) WriteFile(_ context.Context, sandboxID, path, content string) error {
+	f.record(FakeCall{Method: "write_file", SandboxID: sandboxID, Path: path, Content: content})
+	return f.err("write_file")
+}
+
+// Fork implements Backend.
+func (f *FakeBackend) Fork(_ context.Context, sandboxID string, n int) ([]string, error) {
+	f.record(FakeCall{Method: "fork", SandboxID: sandboxID, Replicas: n})
+	if e := f.err("fork"); e != nil {
+		return nil, e
+	}
+	return f.ForkIDs, nil
+}
+
+// Terminate implements Backend.
+func (f *FakeBackend) Terminate(_ context.Context, sandboxID string) error {
+	f.record(FakeCall{Method: "terminate", SandboxID: sandboxID})
+	return f.err("terminate")
+}
+
+// List implements Backend.
+func (f *FakeBackend) List(_ context.Context, namespace string) ([]SandboxInfo, error) {
+	f.record(FakeCall{Method: "list", Namespace: namespace})
+	if e := f.err("list"); e != nil {
+		return nil, e
+	}
+	return f.ListInfos, nil
+}

--- a/internal/agentcli/cli.go
+++ b/internal/agentcli/cli.go
@@ -29,21 +29,6 @@ Flags:
   -h, --help         print this help
 `
 
-// DevRunner runs an external command (kind, kubectl) for the dev subcommand.
-// Task 2 wires a real exec runner via SetDevRunner; in Task 1 it is nil and the
-// dev subcommand reports that it is not wired.
-type DevRunner func(ctx context.Context, argv []string) error
-
-// devUpFn and devDownFn are the dev orchestration entry points. They are package
-// variables so cmd/agentrun (Task 2) can wire the real DevUp/DevDown without the
-// CLI dispatcher importing the k8s machinery directly. When nil (Task 1), dev
-// reports that it is not wired.
-var (
-	devUpFn   func(ctx context.Context, runner DevRunner, out io.Writer) int
-	devDownFn func(ctx context.Context, runner DevRunner, out io.Writer) int
-	devRunner DevRunner
-)
-
 // Run is the testable CLI entry point. It dispatches args (without the program
 // name) against backend, writing normal output to out and diagnostics to errw,
 // and returns a process exit code:

--- a/internal/agentcli/cli.go
+++ b/internal/agentcli/cli.go
@@ -1,0 +1,77 @@
+package agentcli
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+const usage = `agentrun: snapshot-fork sandboxes for AI agents
+
+Usage:
+  agentrun run <command> [--pool P] [--timeout N]   create a sandbox, run the
+                                                    command, terminate, and exit
+                                                    with the command's exit code
+  agentrun sandbox create [--pool P]                create a sandbox, print its id
+  agentrun sandbox ls [-n namespace] [-A]           list sandboxes
+  agentrun sandbox exec <id> <command...>           run a command in a sandbox
+  agentrun sandbox fork <id> [--replicas N]         fork a sandbox, print new ids
+  agentrun sandbox terminate <id>                   destroy a sandbox
+  agentrun dev up | down                            bring a local kind dev
+                                                    cluster up or down
+
+Flags:
+  --pool string      pool to create sandboxes from
+  --timeout int      exec timeout in seconds (0 = backend default)
+  -n string          namespace (ls)
+  -A                 all namespaces (ls)
+  --replicas int     number of forks (fork)
+  -h, --help         print this help
+`
+
+// DevRunner runs an external command (kind, kubectl) for the dev subcommand.
+// Task 2 wires a real exec runner via SetDevRunner; in Task 1 it is nil and the
+// dev subcommand reports that it is not wired.
+type DevRunner func(ctx context.Context, argv []string) error
+
+// devUpFn and devDownFn are the dev orchestration entry points. They are package
+// variables so cmd/agentrun (Task 2) can wire the real DevUp/DevDown without the
+// CLI dispatcher importing the k8s machinery directly. When nil (Task 1), dev
+// reports that it is not wired.
+var (
+	devUpFn   func(ctx context.Context, runner DevRunner, out io.Writer) int
+	devDownFn func(ctx context.Context, runner DevRunner, out io.Writer) int
+	devRunner DevRunner
+)
+
+// Run is the testable CLI entry point. It dispatches args (without the program
+// name) against backend, writing normal output to out and diagnostics to errw,
+// and returns a process exit code:
+//
+//	0  success (for run: the command's exit code)
+//	2  usage error (unknown subcommand, missing argument, bad flag)
+//	1  a backend or runtime error
+//
+// For run, the exit code is the executed command's exit code so callers can
+// chain agentrun in shell pipelines.
+func Run(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprint(errw, usage)
+		return 2
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		fmt.Fprint(out, usage)
+		return 0
+	case "run":
+		return cmdRun(ctx, args[1:], backend, out, errw)
+	case "sandbox":
+		return cmdSandbox(ctx, args[1:], backend, out, errw)
+	case "dev":
+		return cmdDev(ctx, args[1:], out, errw)
+	default:
+		fmt.Fprintf(errw, "unknown subcommand %q\n\n%s", args[0], usage)
+		return 2
+	}
+}

--- a/internal/agentcli/cli_test.go
+++ b/internal/agentcli/cli_test.go
@@ -1,0 +1,268 @@
+package agentcli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runCLI is a test helper that runs the CLI with a fresh FakeBackend and
+// captured output, returning the exit code and the two buffers.
+func runCLI(t *testing.T, backend Backend, args ...string) (int, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var out, errw bytes.Buffer
+	code := Run(context.Background(), args, backend, &out, &errw)
+	return code, &out, &errw
+}
+
+func methods(calls []FakeCall) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = c.Method
+	}
+	return out
+}
+
+func TestRunCommandCreatesExecsTerminates(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ExecResultV = ExecResult{ExitCode: 0, Stdout: "hi\n", Stderr: ""}
+
+	code, out, _ := runCLI(t, fb, "run", "echo hi")
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	got := methods(fb.RecordedCalls())
+	want := []string{"create", "exec", "terminate"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("recorded calls = %v, want %v", got, want)
+	}
+	if !strings.Contains(out.String(), "hi") {
+		t.Fatalf("stdout = %q, want it to contain stdout 'hi'", out.String())
+	}
+}
+
+func TestRunCommandPassesPoolAndTimeout(t *testing.T) {
+	fb := NewFakeBackend()
+	code, _, _ := runCLI(t, fb, "run", "--pool", "mypool", "--timeout", "45", "ls")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	calls := fb.RecordedCalls()
+	if calls[0].Pool != "mypool" {
+		t.Fatalf("create pool = %q, want mypool", calls[0].Pool)
+	}
+	if calls[1].TimeoutSec != 45 {
+		t.Fatalf("exec timeout = %d, want 45", calls[1].TimeoutSec)
+	}
+	if calls[1].Command != "ls" {
+		t.Fatalf("exec command = %q, want ls", calls[1].Command)
+	}
+}
+
+func TestRunCommandReturnsExecExitCode(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ExecResultV = ExecResult{ExitCode: 7, Stdout: "", Stderr: "boom\n"}
+
+	code, _, errw := runCLI(t, fb, "run", "false")
+
+	if code != 7 {
+		t.Fatalf("exit code = %d, want 7 (exec exit code)", code)
+	}
+	if !strings.Contains(errw.String(), "boom") {
+		t.Fatalf("stderr = %q, want it to contain 'boom'", errw.String())
+	}
+	// Terminate must still run even when exec is nonzero.
+	if got := methods(fb.RecordedCalls()); got[len(got)-1] != "terminate" {
+		t.Fatalf("last call = %v, want terminate", got)
+	}
+}
+
+func TestRunCommandTerminatesEvenOnExecError(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.Errors["exec"] = errors.New("exec failed")
+
+	code, _, errw := runCLI(t, fb, "run", "echo hi")
+
+	if code == 0 {
+		t.Fatalf("exit code = %d, want nonzero on exec error", code)
+	}
+	got := methods(fb.RecordedCalls())
+	if got[len(got)-1] != "terminate" {
+		t.Fatalf("calls = %v, want terminate last even on exec error", got)
+	}
+	if !strings.Contains(errw.String(), "exec failed") {
+		t.Fatalf("stderr = %q, want exec error reported", errw.String())
+	}
+}
+
+func TestSandboxCreatePrintsID(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.CreateID = "sbx-abc"
+	code, out, _ := runCLI(t, fb, "sandbox", "create", "--pool", "p")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "sbx-abc") {
+		t.Fatalf("stdout = %q, want it to contain the id", out.String())
+	}
+	if fb.RecordedCalls()[0].Pool != "p" {
+		t.Fatalf("create pool = %q, want p", fb.RecordedCalls()[0].Pool)
+	}
+}
+
+func TestSandboxLsFormatsList(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ListInfos = []SandboxInfo{
+		{Name: "sbx-1", Pool: "python", Phase: "Ready", Node: "node-a", Endpoint: "10.0.0.1:9091", Age: 90 * time.Second},
+	}
+	code, out, _ := runCLI(t, fb, "sandbox", "ls", "-n", "team")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	s := out.String()
+	for _, want := range []string{"NAME", "POOL", "PHASE", "NODE", "ENDPOINT", "AGE", "sbx-1", "python", "Ready", "node-a", "10.0.0.1:9091", "1m"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("ls output = %q, want it to contain %q", s, want)
+		}
+	}
+	if fb.RecordedCalls()[0].Namespace != "team" {
+		t.Fatalf("list namespace = %q, want team", fb.RecordedCalls()[0].Namespace)
+	}
+}
+
+func TestSandboxLsEmpty(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ListInfos = nil
+	code, out, _ := runCLI(t, fb, "sandbox", "ls")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "No sandboxes found") {
+		t.Fatalf("ls output = %q, want the empty message", out.String())
+	}
+}
+
+func TestSandboxExecDispatch(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ExecResultV = ExecResult{ExitCode: 3, Stdout: "o", Stderr: "e"}
+	code, out, errw := runCLI(t, fb, "sandbox", "exec", "sbx-1", "echo", "hi")
+	if code != 3 {
+		t.Fatalf("exit code = %d, want 3", code)
+	}
+	calls := fb.RecordedCalls()
+	if calls[0].Method != "exec" || calls[0].SandboxID != "sbx-1" {
+		t.Fatalf("calls = %v, want exec on sbx-1", calls)
+	}
+	if calls[0].Command != "echo hi" {
+		t.Fatalf("exec command = %q, want 'echo hi'", calls[0].Command)
+	}
+	if !strings.Contains(out.String(), "o") || !strings.Contains(errw.String(), "e") {
+		t.Fatalf("out=%q err=%q, want stdout and stderr printed", out.String(), errw.String())
+	}
+}
+
+func TestSandboxForkDispatch(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.ForkIDs = []string{"f1", "f2", "f3"}
+	code, out, _ := runCLI(t, fb, "sandbox", "fork", "sbx-1", "--replicas", "3")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	calls := fb.RecordedCalls()
+	if calls[0].Method != "fork" || calls[0].SandboxID != "sbx-1" || calls[0].Replicas != 3 {
+		t.Fatalf("calls = %v, want fork sbx-1 x3", calls)
+	}
+	for _, id := range []string{"f1", "f2", "f3"} {
+		if !strings.Contains(out.String(), id) {
+			t.Fatalf("fork output = %q, want it to contain %q", out.String(), id)
+		}
+	}
+}
+
+func TestSandboxTerminateDispatch(t *testing.T) {
+	fb := NewFakeBackend()
+	code, _, _ := runCLI(t, fb, "sandbox", "terminate", "sbx-1")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	calls := fb.RecordedCalls()
+	if calls[0].Method != "terminate" || calls[0].SandboxID != "sbx-1" {
+		t.Fatalf("calls = %v, want terminate sbx-1", calls)
+	}
+}
+
+func TestUnknownSubcommandReturnsTwo(t *testing.T) {
+	fb := NewFakeBackend()
+	code, _, errw := runCLI(t, fb, "frobnicate")
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(errw.String(), "Usage") && !strings.Contains(errw.String(), "usage") {
+		t.Fatalf("stderr = %q, want usage printed", errw.String())
+	}
+}
+
+func TestMissingArgsReturnsTwo(t *testing.T) {
+	cases := [][]string{
+		{},
+		{"run"},
+		{"sandbox"},
+		{"sandbox", "exec"},
+		{"sandbox", "exec", "sbx-1"},
+		{"sandbox", "fork"},
+		{"sandbox", "terminate"},
+	}
+	for _, args := range cases {
+		fb := NewFakeBackend()
+		code, _, errw := runCLI(t, fb, args...)
+		if code != 2 {
+			t.Fatalf("args %v: exit code = %d, want 2", args, code)
+		}
+		if errw.Len() == 0 {
+			t.Fatalf("args %v: want usage on stderr", args)
+		}
+	}
+}
+
+func TestHelpReturnsZero(t *testing.T) {
+	fb := NewFakeBackend()
+	for _, h := range []string{"--help", "-h"} {
+		code, out, _ := runCLI(t, fb, h)
+		if code != 0 {
+			t.Fatalf("%s: exit code = %d, want 0", h, code)
+		}
+		if !strings.Contains(out.String(), "Usage") && !strings.Contains(out.String(), "usage") {
+			t.Fatalf("%s: out = %q, want usage", h, out.String())
+		}
+	}
+}
+
+func TestBackendErrorReportedNonzero(t *testing.T) {
+	fb := NewFakeBackend()
+	fb.Errors["create"] = errors.New("cluster unreachable")
+	code, _, errw := runCLI(t, fb, "sandbox", "create")
+	if code == 0 {
+		t.Fatalf("exit code = %d, want nonzero on backend error", code)
+	}
+	if !strings.Contains(errw.String(), "cluster unreachable") {
+		t.Fatalf("stderr = %q, want the backend error", errw.String())
+	}
+}
+
+func TestDevStubReturnsNotWired(t *testing.T) {
+	// In Task 1 dev is a stub; Task 2 wires it. Either way an unwired backend
+	// path must not panic and must report something to stderr with a nonzero
+	// code when no runner is configured.
+	fb := NewFakeBackend()
+	code, _, errw := runCLI(t, fb, "dev", "up")
+	if code == 0 {
+		t.Fatalf("exit code = %d, want nonzero for unwired dev", code)
+	}
+	if errw.Len() == 0 {
+		t.Fatalf("want a message on stderr for unwired dev")
+	}
+}

--- a/internal/agentcli/clusterbackend.go
+++ b/internal/agentcli/clusterbackend.go
@@ -1,0 +1,287 @@
+package agentcli
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"time"
+
+	v1alpha1 "github.com/paperclipinc/sandbox/api/v1alpha1"
+	"github.com/paperclipinc/sandbox/internal/mcp"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// tokenSecretSuffix is appended to a claim or fork name to form the name of the
+// Secret holding its sandbox API bearer token. It mirrors the controller's
+// constant (internal/controller/token_secret.go).
+const tokenSecretSuffix = "-sandbox-token"
+
+// Scheme is the runtime scheme with the agentrun v1alpha1 and core types
+// registered, for building a controller-runtime client against a real cluster.
+func Scheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(v1alpha1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	return s
+}
+
+// ClusterBackend implements Backend over a Kubernetes cluster: it creates
+// SandboxClaims and SandboxForks, reads the per-sandbox token Secret, and drives
+// exec and file IO over the claim's HTTP endpoint with the bearer token. The
+// token value is read into memory only for the duration of a request and is
+// never logged; the underlying mcp.HTTPBackend redacts any echo of it from error
+// strings.
+type ClusterBackend struct {
+	client     client.Client
+	namespace  string
+	httpClient *http.Client
+	now        func() time.Time
+
+	pollInterval time.Duration
+	pollTimeout  time.Duration
+
+	// readyHook / forkReadyHook are test seams: when set, they are invoked once
+	// right after the claim or fork is created, simulating the controller
+	// reconciling it to Ready. In production they are nil and the poll observes
+	// the real controller.
+	readyHook     func(ctx context.Context, name string)
+	forkReadyHook func(ctx context.Context, name string, n int)
+}
+
+// NewClusterBackend builds a ClusterBackend against the cluster reachable by c,
+// scoped to namespace. A nil httpClient uses http.DefaultClient.
+func NewClusterBackend(c client.Client, namespace string, httpClient *http.Client) *ClusterBackend {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	return &ClusterBackend{
+		client:       c,
+		namespace:    namespace,
+		httpClient:   httpClient,
+		now:          time.Now,
+		pollInterval: 500 * time.Millisecond,
+		pollTimeout:  60 * time.Second,
+	}
+}
+
+// randName returns a short random suffix so generated claim and fork names do
+// not collide across concurrent callers.
+func randName(prefix string) string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return prefix + "-fallback"
+	}
+	return prefix + "-" + hex.EncodeToString(b[:])
+}
+
+// Create creates a SandboxClaim referencing pool, waits for it to reach the
+// Ready phase (bounded by pollTimeout), and returns the claim name as the
+// sandbox id.
+func (b *ClusterBackend) Create(ctx context.Context, pool string) (string, error) {
+	if pool == "" {
+		return "", fmt.Errorf("create: a pool is required")
+	}
+	name := randName("sbx")
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: b.namespace},
+		Spec:       v1alpha1.SandboxClaimSpec{PoolRef: v1alpha1.LocalObjectReference{Name: pool}},
+	}
+	if err := b.client.Create(ctx, claim); err != nil {
+		return "", fmt.Errorf("create claim: %w", err)
+	}
+	if b.readyHook != nil {
+		b.readyHook(ctx, name)
+	}
+	if err := b.waitClaimReady(ctx, name); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+// waitClaimReady polls the claim until its phase is Ready (success), Failed
+// (error), or the timeout elapses.
+func (b *ClusterBackend) waitClaimReady(ctx context.Context, name string) error {
+	deadline := b.now().Add(b.pollTimeout)
+	for {
+		var claim v1alpha1.SandboxClaim
+		if err := b.client.Get(ctx, client.ObjectKey{Namespace: b.namespace, Name: name}, &claim); err != nil {
+			return fmt.Errorf("get claim %s: %w", name, err)
+		}
+		switch claim.Status.Phase {
+		case v1alpha1.SandboxReady:
+			if claim.Status.Endpoint != "" {
+				return nil
+			}
+		case v1alpha1.SandboxFailed:
+			return fmt.Errorf("sandbox %s failed", name)
+		}
+		if b.now().After(deadline) {
+			return fmt.Errorf("sandbox %s not ready after %s", name, b.pollTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(b.pollInterval):
+		}
+	}
+}
+
+// sandboxHTTP builds an mcp.HTTPBackend for the named claim by reading its
+// endpoint and token Secret. The token is held only for the lifetime of the
+// returned backend's request; the redaction in mcp.HTTPBackend keeps it out of
+// any error string.
+func (b *ClusterBackend) sandboxHTTP(ctx context.Context, name string) (*mcp.HTTPBackend, error) {
+	var claim v1alpha1.SandboxClaim
+	if err := b.client.Get(ctx, client.ObjectKey{Namespace: b.namespace, Name: name}, &claim); err != nil {
+		return nil, fmt.Errorf("get claim %s: %w", name, err)
+	}
+	endpoint := claim.Status.Endpoint
+
+	var secret corev1.Secret
+	token := ""
+	if err := b.client.Get(ctx, client.ObjectKey{Namespace: b.namespace, Name: name + tokenSecretSuffix}, &secret); err == nil {
+		token = string(secret.Data["token"])
+		if endpoint == "" {
+			endpoint = string(secret.Data["endpoint"])
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("read token secret for %s: %w", name, err)
+	}
+
+	if endpoint == "" {
+		return nil, fmt.Errorf("sandbox %s has no endpoint yet", name)
+	}
+	return mcp.NewHTTPBackend("http://"+endpoint, token, b.httpClient), nil
+}
+
+// Exec runs command in the sandbox over its HTTP endpoint with the bearer token.
+func (b *ClusterBackend) Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error) {
+	hb, err := b.sandboxHTTP(ctx, sandboxID)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	res, err := hb.Exec(ctx, sandboxID, command, timeoutSec)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return ExecResult{ExitCode: res.ExitCode, Stdout: res.Stdout, Stderr: res.Stderr}, nil
+}
+
+// ReadFile reads path from the sandbox over its HTTP endpoint.
+func (b *ClusterBackend) ReadFile(ctx context.Context, sandboxID, path string) (string, error) {
+	hb, err := b.sandboxHTTP(ctx, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	return hb.ReadFile(ctx, sandboxID, path)
+}
+
+// WriteFile writes content to path in the sandbox over its HTTP endpoint.
+func (b *ClusterBackend) WriteFile(ctx context.Context, sandboxID, path, content string) error {
+	hb, err := b.sandboxHTTP(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	return hb.WriteFile(ctx, sandboxID, path, content)
+}
+
+// Fork creates a SandboxFork sourced at sandboxID with n replicas, waits for the
+// forks to be Ready (bounded), and returns the fork sandbox names.
+func (b *ClusterBackend) Fork(ctx context.Context, sandboxID string, n int) ([]string, error) {
+	if n < 1 {
+		n = 1
+	}
+	name := randName(sandboxID + "-fork")
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: b.namespace},
+		Spec: v1alpha1.SandboxForkSpec{
+			SourceRef: v1alpha1.LocalObjectReference{Name: sandboxID},
+			Replicas:  int32(n),
+		},
+	}
+	if err := b.client.Create(ctx, fork); err != nil {
+		return nil, fmt.Errorf("create fork: %w", err)
+	}
+	if b.forkReadyHook != nil {
+		b.forkReadyHook(ctx, name, n)
+	}
+	return b.waitForksReady(ctx, name, n)
+}
+
+// waitForksReady polls the SandboxFork until at least n forks are Ready, then
+// returns their names.
+func (b *ClusterBackend) waitForksReady(ctx context.Context, name string, n int) ([]string, error) {
+	deadline := b.now().Add(b.pollTimeout)
+	for {
+		var fork v1alpha1.SandboxFork
+		if err := b.client.Get(ctx, client.ObjectKey{Namespace: b.namespace, Name: name}, &fork); err != nil {
+			return nil, fmt.Errorf("get fork %s: %w", name, err)
+		}
+		ready := make([]string, 0, n)
+		for i := range fork.Status.Forks {
+			fi := &fork.Status.Forks[i]
+			if fi.Phase == v1alpha1.SandboxReady {
+				ready = append(ready, fi.Name)
+			}
+		}
+		if len(ready) >= n {
+			return ready[:n], nil
+		}
+		if b.now().After(deadline) {
+			return nil, fmt.Errorf("fork %s not ready after %s", name, b.pollTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(b.pollInterval):
+		}
+	}
+}
+
+// Terminate deletes the SandboxClaim, which the controller reaps.
+func (b *ClusterBackend) Terminate(ctx context.Context, sandboxID string) error {
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxID, Namespace: b.namespace},
+	}
+	if err := b.client.Delete(ctx, claim); err != nil {
+		return fmt.Errorf("delete claim %s: %w", sandboxID, err)
+	}
+	return nil
+}
+
+// List returns the SandboxClaims in namespace mapped to SandboxInfo. An empty
+// namespace lists across all namespaces.
+func (b *ClusterBackend) List(ctx context.Context, namespace string) ([]SandboxInfo, error) {
+	var opts []client.ListOption
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	var claims v1alpha1.SandboxClaimList
+	if err := b.client.List(ctx, &claims, opts...); err != nil {
+		return nil, fmt.Errorf("list claims: %w", err)
+	}
+	now := b.now()
+	infos := make([]SandboxInfo, 0, len(claims.Items))
+	for i := range claims.Items {
+		c := &claims.Items[i]
+		infos = append(infos, SandboxInfo{
+			Name:     c.Name,
+			Pool:     c.Spec.PoolRef.Name,
+			Phase:    string(c.Status.Phase),
+			Node:     c.Status.Node,
+			Endpoint: c.Status.Endpoint,
+			Age:      now.Sub(c.CreationTimestamp.Time),
+		})
+	}
+	return infos, nil
+}

--- a/internal/agentcli/clusterbackend_test.go
+++ b/internal/agentcli/clusterbackend_test.go
@@ -1,0 +1,250 @@
+package agentcli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	v1alpha1 "github.com/paperclipinc/sandbox/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(v1alpha1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	return s
+}
+
+func TestClusterBackendCreatePollsReady(t *testing.T) {
+	// Pre-seed a Ready claim so the poll returns immediately. The backend names
+	// the claim deterministically only for new objects; here we drive Create and
+	// then assert it created a claim and returned its name. To exercise the
+	// Ready poll we use a fake client whose Create stores the object and a status
+	// that the backend can read back as Ready.
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.SandboxClaim{}).
+		Build()
+
+	be := &ClusterBackend{
+		client:    c,
+		namespace: "default",
+		now:       time.Now,
+		// A short poll so the test stays fast; the backend flips the claim to
+		// Ready via the readyHook injected for the test.
+		pollInterval: time.Millisecond,
+		pollTimeout:  2 * time.Second,
+	}
+	// readyHook simulates the controller reconciling the claim to Ready: as soon
+	// as the backend created the claim, mark it Ready with an endpoint.
+	be.readyHook = func(ctx context.Context, name string) {
+		var claim v1alpha1.SandboxClaim
+		if err := c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &claim); err != nil {
+			return
+		}
+		claim.Status.Phase = v1alpha1.SandboxReady
+		claim.Status.Endpoint = "10.0.0.5:9091"
+		_ = c.Status().Update(ctx, &claim)
+	}
+
+	id, err := be.Create(context.Background(), "python-pool")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id == "" {
+		t.Fatalf("Create returned an empty id")
+	}
+
+	var claim v1alpha1.SandboxClaim
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: id}, &claim); err != nil {
+		t.Fatalf("created claim not found: %v", err)
+	}
+	if claim.Spec.PoolRef.Name != "python-pool" {
+		t.Fatalf("claim poolRef = %q, want python-pool", claim.Spec.PoolRef.Name)
+	}
+}
+
+func TestClusterBackendList(t *testing.T) {
+	scheme := testScheme(t)
+	created := metav1.NewTime(time.Now().Add(-90 * time.Second))
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default", CreationTimestamp: created},
+		Spec:       v1alpha1.SandboxClaimSpec{PoolRef: v1alpha1.LocalObjectReference{Name: "python"}},
+		Status: v1alpha1.SandboxClaimStatus{
+			Phase: v1alpha1.SandboxReady, Node: "node-a", Endpoint: "10.0.0.1:9091",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claim).Build()
+
+	be := &ClusterBackend{client: c, namespace: "default", now: time.Now}
+	infos, err := be.List(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("List len = %d, want 1", len(infos))
+	}
+	got := infos[0]
+	if got.Name != "sbx-1" || got.Pool != "python" || got.Phase != "Ready" || got.Node != "node-a" || got.Endpoint != "10.0.0.1:9091" {
+		t.Fatalf("List info = %+v, want mapped fields", got)
+	}
+	if got.Age < 80*time.Second || got.Age > 200*time.Second {
+		t.Fatalf("List age = %v, want ~90s", got.Age)
+	}
+}
+
+func TestClusterBackendTerminate(t *testing.T) {
+	scheme := testScheme(t)
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
+		Spec:       v1alpha1.SandboxClaimSpec{PoolRef: v1alpha1.LocalObjectReference{Name: "p"}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claim).Build()
+	be := &ClusterBackend{client: c, namespace: "default", now: time.Now}
+
+	if err := be.Terminate(context.Background(), "sbx-1"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	var got v1alpha1.SandboxClaim
+	err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "sbx-1"}, &got)
+	if err == nil {
+		t.Fatalf("claim still exists after Terminate")
+	}
+}
+
+func TestClusterBackendForkCreatesFork(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.SandboxFork{}).
+		Build()
+	be := &ClusterBackend{
+		client: c, namespace: "default", now: time.Now,
+		pollInterval: time.Millisecond, pollTimeout: 2 * time.Second,
+	}
+	be.forkReadyHook = func(ctx context.Context, name string, n int) {
+		var fk v1alpha1.SandboxFork
+		if err := c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &fk); err != nil {
+			return
+		}
+		forks := make([]v1alpha1.ForkInfo, 0, n)
+		for i := 0; i < n; i++ {
+			forks = append(forks, v1alpha1.ForkInfo{Name: name + "-" + string(rune('a'+i)), Phase: v1alpha1.SandboxReady})
+		}
+		fk.Status.ReadyForks = int32(n)
+		fk.Status.TotalForks = int32(n)
+		fk.Status.Forks = forks
+		_ = c.Status().Update(ctx, &fk)
+	}
+
+	ids, err := be.Fork(context.Background(), "sbx-1", 2)
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("Fork ids = %v, want 2", ids)
+	}
+	var forkList v1alpha1.SandboxForkList
+	if err := c.List(context.Background(), &forkList); err != nil {
+		t.Fatalf("list forks: %v", err)
+	}
+	if len(forkList.Items) != 1 {
+		t.Fatalf("want 1 SandboxFork created, got %d", len(forkList.Items))
+	}
+	if forkList.Items[0].Spec.SourceRef.Name != "sbx-1" {
+		t.Fatalf("fork sourceRef = %q, want sbx-1", forkList.Items[0].Spec.SourceRef.Name)
+	}
+}
+
+func TestClusterBackendExecSendsBearerAndRedactsToken(t *testing.T) {
+	const token = "super-secret-token-value"
+	var gotAuth string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		if r.URL.Path == "/v1/exec" {
+			// Echo the token back in the error to prove redaction protects it.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom token=` + token + `"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+	scheme := testScheme(t)
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
+		Status:     v1alpha1.SandboxClaimStatus{Phase: v1alpha1.SandboxReady, Endpoint: endpoint},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1-sandbox-token", Namespace: "default"},
+		Data:       map[string][]byte{"token": []byte(token), "endpoint": []byte(endpoint)},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claim, secret).Build()
+	be := &ClusterBackend{client: c, namespace: "default", now: time.Now, httpClient: srv.Client()}
+
+	_, err := be.Exec(context.Background(), "sbx-1", "echo hi", 10)
+	if err == nil {
+		t.Fatalf("Exec: want an error from the 500 response")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaked the token: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "REDACTED") {
+		t.Fatalf("error should show the token redacted, got: %q", err.Error())
+	}
+	if gotAuth != "Bearer "+token {
+		t.Fatalf("Authorization header = %q, want bearer token", gotAuth)
+	}
+	if gotBody["command"] != "echo hi" || gotBody["sandbox"] != "sbx-1" {
+		t.Fatalf("exec body = %v, want sandbox/command set", gotBody)
+	}
+}
+
+func TestClusterBackendExecSuccess(t *testing.T) {
+	const token = "tkn"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"exit_code":5,"stdout":"out","stderr":"err"}`))
+	}))
+	defer srv.Close()
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+	scheme := testScheme(t)
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
+		Status:     v1alpha1.SandboxClaimStatus{Phase: v1alpha1.SandboxReady, Endpoint: endpoint},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1-sandbox-token", Namespace: "default"},
+		Data:       map[string][]byte{"token": []byte(token)},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claim, secret).Build()
+	be := &ClusterBackend{client: c, namespace: "default", now: time.Now, httpClient: srv.Client()}
+
+	res, err := be.Exec(context.Background(), "sbx-1", "ls", 0)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 5 || res.Stdout != "out" || res.Stderr != "err" {
+		t.Fatalf("Exec result = %+v, want {5 out err}", res)
+	}
+}

--- a/internal/agentcli/commands.go
+++ b/internal/agentcli/commands.go
@@ -187,28 +187,20 @@ func cmdSandboxTerminate(ctx context.Context, args []string, backend Backend, ou
 	return 0
 }
 
-// cmdDev dispatches `dev up|down`. The orchestration lives behind devUpFn /
-// devDownFn package variables so the CLI dispatcher does not depend on the k8s
-// machinery. When those are nil (Task 1, or a binary built without dev wiring),
-// dev reports that it is not wired.
-func cmdDev(ctx context.Context, args []string, out, errw io.Writer) int {
+// cmdDev validates the `dev up|down` arguments. The dev orchestration shells out
+// to kind and kubectl, which the pure CLI dispatcher does not do; cmd/agentrun
+// intercepts the dev subcommand before agentcli.Run and runs DevUp/DevDown with
+// a real exec runner. Reaching cmdDev means dev was invoked through a path that
+// did not wire the runner, so it reports that and returns nonzero.
+func cmdDev(_ context.Context, args []string, _, errw io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintf(errw, "dev: 'up' or 'down' is required\n\n%s", usage)
 		return 2
 	}
 	switch args[0] {
-	case "up":
-		if devUpFn == nil {
-			fmt.Fprintln(errw, "dev up: not wired in this build")
-			return 1
-		}
-		return devUpFn(ctx, devRunner, out)
-	case "down":
-		if devDownFn == nil {
-			fmt.Fprintln(errw, "dev down: not wired in this build")
-			return 1
-		}
-		return devDownFn(ctx, devRunner, out)
+	case "up", "down":
+		fmt.Fprintf(errw, "dev %s: run via the agentrun binary, which wires the kind/kubectl runner\n", args[0])
+		return 1
 	default:
 		fmt.Fprintf(errw, "unknown dev subcommand %q\n\n%s", args[0], usage)
 		return 2

--- a/internal/agentcli/commands.go
+++ b/internal/agentcli/commands.go
@@ -1,0 +1,316 @@
+package agentcli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// newFlagSet builds a flag set that writes its own errors to errw (so a bad flag
+// surfaces on the CLI's error stream) and never calls os.Exit.
+func newFlagSet(name string, errw io.Writer) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(errw)
+	fs.Usage = func() {}
+	return fs
+}
+
+// cmdRun implements `agentrun run <command> [--pool P] [--timeout N]`: create a
+// sandbox, run the command, terminate the sandbox, and return the command's exit
+// code. Terminate runs even when exec fails.
+func cmdRun(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	fs := newFlagSet("run", errw)
+	pool := fs.String("pool", "", "pool to create the sandbox from")
+	timeout := fs.Int("timeout", 0, "exec timeout in seconds (0 = backend default)")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprint(errw, usage)
+		return 2
+	}
+	command := strings.Join(fs.Args(), " ")
+	if command == "" {
+		fmt.Fprintf(errw, "run: a command is required\n\n%s", usage)
+		return 2
+	}
+
+	id, err := backend.Create(ctx, *pool)
+	if err != nil {
+		fmt.Fprintf(errw, "create sandbox: %v\n", err)
+		return 1
+	}
+
+	result, execErr := backend.Exec(ctx, id, command, *timeout)
+
+	// Always attempt termination, even on exec error, so a sandbox is not
+	// leaked. A terminate failure is reported but does not mask the exec
+	// outcome.
+	if termErr := backend.Terminate(ctx, id); termErr != nil {
+		fmt.Fprintf(errw, "terminate sandbox %s: %v\n", id, termErr)
+	}
+
+	if execErr != nil {
+		fmt.Fprintf(errw, "exec: %v\n", execErr)
+		return 1
+	}
+	if result.Stdout != "" {
+		fmt.Fprint(out, result.Stdout)
+	}
+	if result.Stderr != "" {
+		fmt.Fprint(errw, result.Stderr)
+	}
+	return result.ExitCode
+}
+
+// cmdSandbox dispatches the `sandbox` subcommands.
+func cmdSandbox(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintf(errw, "sandbox: a subcommand is required\n\n%s", usage)
+		return 2
+	}
+	switch args[0] {
+	case "create":
+		return cmdSandboxCreate(ctx, args[1:], backend, out, errw)
+	case "ls":
+		return cmdSandboxLs(ctx, args[1:], backend, out, errw)
+	case "exec":
+		return cmdSandboxExec(ctx, args[1:], backend, out, errw)
+	case "fork":
+		return cmdSandboxFork(ctx, args[1:], backend, out, errw)
+	case "terminate":
+		return cmdSandboxTerminate(ctx, args[1:], backend, out, errw)
+	default:
+		fmt.Fprintf(errw, "unknown sandbox subcommand %q\n\n%s", args[0], usage)
+		return 2
+	}
+}
+
+func cmdSandboxCreate(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	fs := newFlagSet("sandbox create", errw)
+	pool := fs.String("pool", "", "pool to create the sandbox from")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprint(errw, usage)
+		return 2
+	}
+	id, err := backend.Create(ctx, *pool)
+	if err != nil {
+		fmt.Fprintf(errw, "create sandbox: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(out, id)
+	return 0
+}
+
+func cmdSandboxLs(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	fs := newFlagSet("sandbox ls", errw)
+	namespace := fs.String("n", "", "namespace")
+	allNamespaces := fs.Bool("A", false, "all namespaces")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprint(errw, usage)
+		return 2
+	}
+	ns := *namespace
+	if *allNamespaces {
+		ns = ""
+	}
+	infos, err := backend.List(ctx, ns)
+	if err != nil {
+		fmt.Fprintf(errw, "list sandboxes: %v\n", err)
+		return 1
+	}
+	fmt.Fprint(out, formatSandboxInfos(infos))
+	return 0
+}
+
+func cmdSandboxExec(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	if len(args) < 2 {
+		fmt.Fprintf(errw, "sandbox exec: <id> and a command are required\n\n%s", usage)
+		return 2
+	}
+	id := args[0]
+	command := strings.Join(args[1:], " ")
+	result, err := backend.Exec(ctx, id, command, 0)
+	if err != nil {
+		fmt.Fprintf(errw, "exec: %v\n", err)
+		return 1
+	}
+	if result.Stdout != "" {
+		fmt.Fprint(out, result.Stdout)
+	}
+	if result.Stderr != "" {
+		fmt.Fprint(errw, result.Stderr)
+	}
+	return result.ExitCode
+}
+
+func cmdSandboxFork(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	// Accept the sandbox id either before or after the flags, so both
+	// `fork sbx-1 --replicas 3` and `fork --replicas 3 sbx-1` work. The stdlib
+	// flag parser stops at the first non-flag token, so split the id out first.
+	id, rest := splitFirstPositional(args)
+	fs := newFlagSet("sandbox fork", errw)
+	replicas := fs.Int("replicas", 1, "number of forks")
+	if err := fs.Parse(rest); err != nil {
+		fmt.Fprint(errw, usage)
+		return 2
+	}
+	if id == "" && fs.NArg() > 0 {
+		id = fs.Arg(0)
+	}
+	if id == "" {
+		fmt.Fprintf(errw, "sandbox fork: a sandbox id is required\n\n%s", usage)
+		return 2
+	}
+	ids, err := backend.Fork(ctx, id, *replicas)
+	if err != nil {
+		fmt.Fprintf(errw, "fork: %v\n", err)
+		return 1
+	}
+	for _, fid := range ids {
+		fmt.Fprintln(out, fid)
+	}
+	return 0
+}
+
+func cmdSandboxTerminate(ctx context.Context, args []string, backend Backend, out, errw io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintf(errw, "sandbox terminate: a sandbox id is required\n\n%s", usage)
+		return 2
+	}
+	id := args[0]
+	if err := backend.Terminate(ctx, id); err != nil {
+		fmt.Fprintf(errw, "terminate: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(out, "terminated %s\n", id)
+	return 0
+}
+
+// cmdDev dispatches `dev up|down`. The orchestration lives behind devUpFn /
+// devDownFn package variables so the CLI dispatcher does not depend on the k8s
+// machinery. When those are nil (Task 1, or a binary built without dev wiring),
+// dev reports that it is not wired.
+func cmdDev(ctx context.Context, args []string, out, errw io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintf(errw, "dev: 'up' or 'down' is required\n\n%s", usage)
+		return 2
+	}
+	switch args[0] {
+	case "up":
+		if devUpFn == nil {
+			fmt.Fprintln(errw, "dev up: not wired in this build")
+			return 1
+		}
+		return devUpFn(ctx, devRunner, out)
+	case "down":
+		if devDownFn == nil {
+			fmt.Fprintln(errw, "dev down: not wired in this build")
+			return 1
+		}
+		return devDownFn(ctx, devRunner, out)
+	default:
+		fmt.Fprintf(errw, "unknown dev subcommand %q\n\n%s", args[0], usage)
+		return 2
+	}
+}
+
+// splitFirstPositional returns the first argument that is not a flag (does not
+// start with "-") and the remaining args with that token removed, so a leading
+// positional id can appear before flags that the stdlib flag parser would
+// otherwise stop at. If there is no positional token, id is empty and rest is
+// args unchanged.
+func splitFirstPositional(args []string) (id string, rest []string) {
+	for i, a := range args {
+		if !strings.HasPrefix(a, "-") {
+			rest = make([]string, 0, len(args)-1)
+			rest = append(rest, args[:i]...)
+			rest = append(rest, args[i+1:]...)
+			return a, rest
+		}
+	}
+	return "", args
+}
+
+// formatSandboxInfos renders SandboxInfo rows as an aligned table with columns
+// NAME POOL PHASE NODE ENDPOINT AGE. An empty list returns a friendly message.
+// The age formatting matches the kubectl-style rendering used by the
+// kubectl-sandbox plugin (single largest unit).
+func formatSandboxInfos(infos []SandboxInfo) string {
+	if len(infos) == 0 {
+		return "No sandboxes found.\n"
+	}
+	header := []string{"NAME", "POOL", "PHASE", "NODE", "ENDPOINT", "AGE"}
+	rows := make([][]string, 0, len(infos))
+	for i := range infos {
+		in := &infos[i]
+		rows = append(rows, []string{
+			in.Name,
+			orDash(in.Pool),
+			orDash(in.Phase),
+			orDash(in.Node),
+			orDash(in.Endpoint),
+			formatAge(in.Age),
+		})
+	}
+	return renderTable(header, rows)
+}
+
+const dash = "-"
+
+func orDash(s string) string {
+	if s == "" {
+		return dash
+	}
+	return s
+}
+
+// formatAge renders a duration as kubectl does: the single largest unit.
+func formatAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours())/24)
+	}
+}
+
+// renderTable lays out header + rows as a left-aligned, space-padded table with
+// a trailing newline. Each column is widened to its longest cell.
+func renderTable(header []string, rows [][]string) string {
+	widths := make([]int, len(header))
+	for i, h := range header {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+	var b strings.Builder
+	writeRow := func(cells []string) {
+		for i, cell := range cells {
+			if i == len(cells)-1 {
+				b.WriteString(cell)
+			} else {
+				b.WriteString(cell)
+				b.WriteString(strings.Repeat(" ", widths[i]-len(cell)+2))
+			}
+		}
+		b.WriteByte('\n')
+	}
+	writeRow(header)
+	for _, row := range rows {
+		writeRow(row)
+	}
+	return b.String()
+}

--- a/internal/agentcli/dev.go
+++ b/internal/agentcli/dev.go
@@ -1,0 +1,159 @@
+package agentcli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// defaultClusterName is the kind cluster name DevUp/DevDown manage when
+// DevOptions.ClusterName is empty.
+const defaultClusterName = "agentrun-dev"
+
+// kindConfigPath is the kind cluster config DevUp passes to `kind create
+// cluster`. It is repo-relative, matching how CI references it; run agentrun dev
+// from the repo root.
+const kindConfigPath = "hack/kind-config.yaml"
+
+// devPoolYAML is the minimal SandboxTemplate + SandboxPool DevUp applies so a
+// fresh dev cluster has a pool to claim from. It uses the mock-friendly defaults
+// (no snapshot/CSI volumes) so it reconciles without a KVM node.
+const devPoolYAML = `apiVersion: agentrun.dev/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: dev-default
+spec:
+  image: python:3.12-slim
+  resources:
+    cpu: "1"
+    memory: "512Mi"
+---
+apiVersion: agentrun.dev/v1alpha1
+kind: SandboxPool
+metadata:
+  name: dev-default
+spec:
+  templateRef:
+    name: dev-default
+  replicas: 1
+  snapshotAfter: Ready
+`
+
+// DevOptions configures the local dev cluster orchestration.
+type DevOptions struct {
+	// ClusterName overrides the kind cluster name. Empty uses defaultClusterName.
+	ClusterName string
+}
+
+// CommandRunner runs an external command argv. DevUp/DevDown take a runner so
+// the orchestration sequence is unit-testable without a real kind or kubectl;
+// cmd/agentrun injects a runner that shells out.
+type CommandRunner func(ctx context.Context, argv []string) error
+
+func (o DevOptions) clusterName() string {
+	if o.ClusterName != "" {
+		return o.ClusterName
+	}
+	return defaultClusterName
+}
+
+// DevUp brings a local kind dev cluster up and installs the control plane:
+//
+//  1. kind create cluster (tolerating an already-existing cluster of the same name)
+//  2. kubectl apply -f deploy/crds/
+//  3. kubectl apply -f deploy/controller/
+//  4. kubectl apply -f - with a minimal default pool
+//
+// Each external command runs through runner so the sequence is testable. DevUp
+// prints progress and a clear note to out that local dev uses the mock engine
+// and that real exec needs a KVM node. The control plane brought up here is the
+// stock controller manifest; for a fully local mock-mode controller (no KVM,
+// the --mock flag on cmd/controller) the controller deployment args need that
+// flag added, which is a manifest tweak left to the operator. DevUp applies what
+// brings the CRDs and controller up honestly and notes the mock requirement.
+func DevUp(ctx context.Context, opts DevOptions, runner CommandRunner, out io.Writer) error {
+	name := opts.clusterName()
+
+	fmt.Fprintf(out, "Creating kind cluster %q...\n", name)
+	if err := runner(ctx, []string{"kind", "create", "cluster", "--name", name, "--config", kindConfigPath}); err != nil {
+		// A cluster that already exists is not a failure: dev up is meant to be
+		// re-runnable. kind reports this on stderr; the message contains
+		// "already exist".
+		if !isAlreadyExists(err) {
+			return fmt.Errorf("create kind cluster %q: %w", name, err)
+		}
+		fmt.Fprintf(out, "kind cluster %q already exists, continuing.\n", name)
+	}
+
+	fmt.Fprintln(out, "Applying CRDs...")
+	if err := runner(ctx, []string{"kubectl", "apply", "-f", "deploy/crds/"}); err != nil {
+		return fmt.Errorf("apply CRDs: %w", err)
+	}
+
+	fmt.Fprintln(out, "Applying controller...")
+	if err := runner(ctx, []string{"kubectl", "apply", "-f", "deploy/controller/"}); err != nil {
+		return fmt.Errorf("apply controller: %w", err)
+	}
+
+	fmt.Fprintln(out, "Applying default pool...")
+	// The runner takes argv only (no stdin), so write the inline pool YAML to a
+	// temp file and apply that, then clean up. This keeps the orchestration
+	// fully testable while still applying a minimal mock-friendly pool rather
+	// than the CSI-backed examples/python-pool.yaml that a no-KVM cluster would
+	// not reconcile.
+	poolFile, cleanup, err := writeTempYAML(devPoolYAML)
+	if err != nil {
+		return fmt.Errorf("write default pool manifest: %w", err)
+	}
+	defer cleanup()
+	if err := runner(ctx, []string{"kubectl", "apply", "-f", poolFile}); err != nil {
+		return fmt.Errorf("apply default pool: %w", err)
+	}
+
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Local dev cluster is up.")
+	fmt.Fprintln(out, "Note: local dev uses the mock fork engine (no KVM). Sandboxes")
+	fmt.Fprintln(out, "reconcile to Ready, but real in-VM exec needs a KVM node and the")
+	fmt.Fprintln(out, "controller running in --mock mode is the no-KVM path.")
+	return nil
+}
+
+// DevDown deletes the local kind dev cluster. Deleting a non-existent cluster is
+// reported by kind but is not treated as fatal here.
+func DevDown(ctx context.Context, opts DevOptions, runner CommandRunner, out io.Writer) error {
+	name := opts.clusterName()
+	fmt.Fprintf(out, "Deleting kind cluster %q...\n", name)
+	if err := runner(ctx, []string{"kind", "delete", "cluster", "--name", name}); err != nil {
+		return fmt.Errorf("delete kind cluster %q: %w", name, err)
+	}
+	return nil
+}
+
+// writeTempYAML writes content to a temp file with a recognizable name and
+// returns its path plus a cleanup function that removes it.
+func writeTempYAML(content string) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "agentrun-dev-pool-*.yaml")
+	if err != nil {
+		return "", func() {}, err
+	}
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", func() {}, err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", func() {}, err
+	}
+	return f.Name(), func() { _ = os.Remove(f.Name()) }, nil
+}
+
+// isAlreadyExists reports whether err is kind's "cluster already exists" signal.
+func isAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already exist")
+}

--- a/internal/agentcli/dev.go
+++ b/internal/agentcli/dev.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 )
 
@@ -17,34 +16,30 @@ const defaultClusterName = "agentrun-dev"
 // from the repo root.
 const kindConfigPath = "hack/kind-config.yaml"
 
-// devPoolYAML is the minimal SandboxTemplate + SandboxPool DevUp applies so a
-// fresh dev cluster has a pool to claim from. It uses the mock-friendly defaults
-// (no snapshot/CSI volumes) so it reconciles without a KVM node.
-const devPoolYAML = `apiVersion: agentrun.dev/v1alpha1
-kind: SandboxTemplate
-metadata:
-  name: dev-default
-spec:
-  image: python:3.12-slim
-  resources:
-    cpu: "1"
-    memory: "512Mi"
----
-apiVersion: agentrun.dev/v1alpha1
-kind: SandboxPool
-metadata:
-  name: dev-default
-spec:
-  templateRef:
-    name: dev-default
-  replicas: 1
-  snapshotAfter: Ready
-`
+// crdsPath is the directory of CRD manifests DevUp applies before the dev
+// overlay. The overlay cannot reference these out-of-tree files under the
+// kustomize load restrictor, so they are applied separately. Repo-relative.
+const crdsPath = "deploy/crds/"
+
+// devOverlayPath is the kustomize overlay DevUp applies after the CRDs. It runs a
+// mock-mode controller (--mock --disable-pki-bootstrap), a mock-mode forkd
+// DaemonSet (--mock, no KVM device, no kvm nodeSelector, no TLS), and a default
+// pool, so a kind cluster forks via the mock engine and claims reach Ready
+// without KVM. Repo-relative; run agentrun dev from the repo root.
+const devOverlayPath = "deploy/dev/"
+
+// devPoolName is the SandboxPool the dev overlay creates; agentrun sandbox
+// create --pool dev-default claims from it. Exported so docs and CI agree.
+const devPoolName = "dev-default"
 
 // DevOptions configures the local dev cluster orchestration.
 type DevOptions struct {
 	// ClusterName overrides the kind cluster name. Empty uses defaultClusterName.
 	ClusterName string
+	// SkipClusterCreate makes DevUp target an already-running cluster (the
+	// current kubectl context) instead of running `kind create cluster`. CI uses
+	// this to apply the dev control plane onto a cluster it stood up itself.
+	SkipClusterCreate bool
 }
 
 // CommandRunner runs an external command argv. DevUp/DevDown take a runner so
@@ -59,64 +54,54 @@ func (o DevOptions) clusterName() string {
 	return defaultClusterName
 }
 
-// DevUp brings a local kind dev cluster up and installs the control plane:
+// DevUp brings a local kind dev cluster up and installs a MOCK control plane:
 //
-//  1. kind create cluster (tolerating an already-existing cluster of the same name)
-//  2. kubectl apply -f deploy/crds/
-//  3. kubectl apply -f deploy/controller/
-//  4. kubectl apply -f - with a minimal default pool
+//  1. kind create cluster (tolerating an already-existing cluster; skipped when
+//     opts.SkipClusterCreate targets an existing cluster, e.g. in CI)
+//  2. kubectl apply -f deploy/crds/ (the CRDs)
+//  3. kubectl apply -k deploy/dev/ (mock controller + mock forkd + default pool)
 //
-// Each external command runs through runner so the sequence is testable. DevUp
-// prints progress and a clear note to out that local dev uses the mock engine
-// and that real exec needs a KVM node. The control plane brought up here is the
-// stock controller manifest; for a fully local mock-mode controller (no KVM,
-// the --mock flag on cmd/controller) the controller deployment args need that
-// flag added, which is a manifest tweak left to the operator. DevUp applies what
-// brings the CRDs and controller up honestly and notes the mock requirement.
+// Each external command runs through runner so the sequence is testable. The dev
+// overlay runs the controller with --mock --disable-pki-bootstrap and forkd with
+// --mock and no TLS, on the plain kind node (no KVM device, no kvm nodeSelector).
+// The controller discovers the mock forkd, builds the pool snapshot over insecure
+// gRPC, and claims fork via the mock engine and reach Ready without KVM. DevUp
+// prints progress and a clear note that local dev uses the mock engine, so real
+// in-VM exec needs a KVM node and the production manifests.
 func DevUp(ctx context.Context, opts DevOptions, runner CommandRunner, out io.Writer) error {
 	name := opts.clusterName()
 
-	fmt.Fprintf(out, "Creating kind cluster %q...\n", name)
-	if err := runner(ctx, []string{"kind", "create", "cluster", "--name", name, "--config", kindConfigPath}); err != nil {
-		// A cluster that already exists is not a failure: dev up is meant to be
-		// re-runnable. kind reports this on stderr; the message contains
-		// "already exist".
-		if !isAlreadyExists(err) {
-			return fmt.Errorf("create kind cluster %q: %w", name, err)
+	if opts.SkipClusterCreate {
+		fmt.Fprintf(out, "Targeting the existing cluster (kind cluster %q assumed up); skipping kind create.\n", name)
+	} else {
+		fmt.Fprintf(out, "Creating kind cluster %q...\n", name)
+		if err := runner(ctx, []string{"kind", "create", "cluster", "--name", name, "--config", kindConfigPath}); err != nil {
+			// A cluster that already exists is not a failure: dev up is meant to be
+			// re-runnable. kind reports this on stderr; the message contains
+			// "already exist".
+			if !isAlreadyExists(err) {
+				return fmt.Errorf("create kind cluster %q: %w", name, err)
+			}
+			fmt.Fprintf(out, "kind cluster %q already exists, continuing.\n", name)
 		}
-		fmt.Fprintf(out, "kind cluster %q already exists, continuing.\n", name)
 	}
 
 	fmt.Fprintln(out, "Applying CRDs...")
-	if err := runner(ctx, []string{"kubectl", "apply", "-f", "deploy/crds/"}); err != nil {
-		return fmt.Errorf("apply CRDs: %w", err)
+	if err := runner(ctx, []string{"kubectl", "apply", "-f", crdsPath}); err != nil {
+		return fmt.Errorf("apply CRDs %s: %w", crdsPath, err)
 	}
 
-	fmt.Fprintln(out, "Applying controller...")
-	if err := runner(ctx, []string{"kubectl", "apply", "-f", "deploy/controller/"}); err != nil {
-		return fmt.Errorf("apply controller: %w", err)
-	}
-
-	fmt.Fprintln(out, "Applying default pool...")
-	// The runner takes argv only (no stdin), so write the inline pool YAML to a
-	// temp file and apply that, then clean up. This keeps the orchestration
-	// fully testable while still applying a minimal mock-friendly pool rather
-	// than the CSI-backed examples/python-pool.yaml that a no-KVM cluster would
-	// not reconcile.
-	poolFile, cleanup, err := writeTempYAML(devPoolYAML)
-	if err != nil {
-		return fmt.Errorf("write default pool manifest: %w", err)
-	}
-	defer cleanup()
-	if err := runner(ctx, []string{"kubectl", "apply", "-f", poolFile}); err != nil {
-		return fmt.Errorf("apply default pool: %w", err)
+	fmt.Fprintln(out, "Applying the dev mock control plane (mock controller, mock forkd, default pool)...")
+	if err := runner(ctx, []string{"kubectl", "apply", "-k", devOverlayPath}); err != nil {
+		return fmt.Errorf("apply dev overlay %s: %w", devOverlayPath, err)
 	}
 
 	fmt.Fprintln(out, "")
-	fmt.Fprintln(out, "Local dev cluster is up.")
-	fmt.Fprintln(out, "Note: local dev uses the mock fork engine (no KVM). Sandboxes")
-	fmt.Fprintln(out, "reconcile to Ready, but real in-VM exec needs a KVM node and the")
-	fmt.Fprintln(out, "controller running in --mock mode is the no-KVM path.")
+	fmt.Fprintln(out, "Local dev cluster is up with a mock control plane.")
+	fmt.Fprintf(out, "Create a sandbox: agentrun sandbox create --pool %s\n", devPoolName)
+	fmt.Fprintln(out, "Note: local dev uses the mock fork engine (no KVM). Claims reconcile")
+	fmt.Fprintln(out, "to Ready, but real in-VM exec needs a KVM node and the production")
+	fmt.Fprintln(out, "manifests (deploy/controller/ + deploy/daemon/). See docs/cli.md.")
 	return nil
 }
 
@@ -129,25 +114,6 @@ func DevDown(ctx context.Context, opts DevOptions, runner CommandRunner, out io.
 		return fmt.Errorf("delete kind cluster %q: %w", name, err)
 	}
 	return nil
-}
-
-// writeTempYAML writes content to a temp file with a recognizable name and
-// returns its path plus a cleanup function that removes it.
-func writeTempYAML(content string) (path string, cleanup func(), err error) {
-	f, err := os.CreateTemp("", "agentrun-dev-pool-*.yaml")
-	if err != nil {
-		return "", func() {}, err
-	}
-	if _, err := f.WriteString(content); err != nil {
-		_ = f.Close()
-		_ = os.Remove(f.Name())
-		return "", func() {}, err
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(f.Name())
-		return "", func() {}, err
-	}
-	return f.Name(), func() { _ = os.Remove(f.Name()) }, nil
 }
 
 // isAlreadyExists reports whether err is kind's "cluster already exists" signal.

--- a/internal/agentcli/dev_test.go
+++ b/internal/agentcli/dev_test.go
@@ -1,0 +1,124 @@
+package agentcli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// recordingRunner records every argv it is asked to run and optionally returns a
+// canned error for the call whose argv contains a given substring.
+type recordingRunner struct {
+	calls   [][]string
+	failOn  string
+	failErr error
+}
+
+func (r *recordingRunner) run(_ context.Context, argv []string) error {
+	r.calls = append(r.calls, argv)
+	if r.failOn != "" && strings.Contains(strings.Join(argv, " "), r.failOn) {
+		return r.failErr
+	}
+	return nil
+}
+
+func joinedCalls(calls [][]string) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = strings.Join(c, " ")
+	}
+	return out
+}
+
+func TestDevUpSequence(t *testing.T) {
+	rr := &recordingRunner{}
+	var out strings.Builder
+	err := DevUp(context.Background(), DevOptions{}, rr.run, &out)
+	if err != nil {
+		t.Fatalf("DevUp: %v", err)
+	}
+	got := joinedCalls(rr.calls)
+	if len(got) < 4 {
+		t.Fatalf("want at least 4 commands, got %d: %v", len(got), got)
+	}
+	// First command must create the kind cluster with the configured name and
+	// the kind config file.
+	if !strings.HasPrefix(got[0], "kind create cluster") {
+		t.Fatalf("first command = %q, want 'kind create cluster ...'", got[0])
+	}
+	if !strings.Contains(got[0], "--name "+defaultClusterName) {
+		t.Fatalf("kind create missing cluster name: %q", got[0])
+	}
+	if !strings.Contains(got[0], "hack/kind-config.yaml") {
+		t.Fatalf("kind create missing config: %q", got[0])
+	}
+	// CRDs and controller are applied.
+	all := strings.Join(got, "\n")
+	if !strings.Contains(all, "kubectl apply -f deploy/crds/") {
+		t.Fatalf("want CRDs applied, got:\n%s", all)
+	}
+	if !strings.Contains(all, "deploy/controller/") {
+		t.Fatalf("want controller applied, got:\n%s", all)
+	}
+	// A pool is applied (the inline mock-friendly pool written to a temp file).
+	poolApplied := strings.Contains(all, "agentrun-dev-pool") ||
+		strings.Contains(all, "python-pool.yaml") ||
+		(strings.Contains(all, "kubectl apply") && strings.Contains(all, "SandboxPool"))
+	if !poolApplied {
+		t.Fatalf("want a default pool applied, got:\n%s", all)
+	}
+	// A clear mock-engine note is printed.
+	if !strings.Contains(strings.ToLower(out.String()), "mock") {
+		t.Fatalf("DevUp output = %q, want a mock-engine note", out.String())
+	}
+}
+
+func TestDevUpToleratesExistingCluster(t *testing.T) {
+	rr := &recordingRunner{failOn: "kind create cluster", failErr: errors.New("node(s) already exist for a cluster with the name")}
+	var out strings.Builder
+	err := DevUp(context.Background(), DevOptions{}, rr.run, &out)
+	if err != nil {
+		t.Fatalf("DevUp should tolerate an existing cluster, got: %v", err)
+	}
+	// It must continue past the create to apply the CRDs.
+	all := strings.Join(joinedCalls(rr.calls), "\n")
+	if !strings.Contains(all, "kubectl apply -f deploy/crds/") {
+		t.Fatalf("want it to continue to apply CRDs after existing cluster, got:\n%s", all)
+	}
+}
+
+func TestDevUpFailsOnApplyError(t *testing.T) {
+	rr := &recordingRunner{failOn: "deploy/crds/", failErr: errors.New("apply boom")}
+	var out strings.Builder
+	err := DevUp(context.Background(), DevOptions{}, rr.run, &out)
+	if err == nil {
+		t.Fatalf("DevUp should fail when applying CRDs fails")
+	}
+}
+
+func TestDevUpCustomClusterName(t *testing.T) {
+	rr := &recordingRunner{}
+	var out strings.Builder
+	if err := DevUp(context.Background(), DevOptions{ClusterName: "mycluster"}, rr.run, &out); err != nil {
+		t.Fatalf("DevUp: %v", err)
+	}
+	if !strings.Contains(joinedCalls(rr.calls)[0], "--name mycluster") {
+		t.Fatalf("want custom cluster name, got: %q", joinedCalls(rr.calls)[0])
+	}
+}
+
+func TestDevDownDeletesCluster(t *testing.T) {
+	rr := &recordingRunner{}
+	var out strings.Builder
+	if err := DevDown(context.Background(), DevOptions{}, rr.run, &out); err != nil {
+		t.Fatalf("DevDown: %v", err)
+	}
+	got := joinedCalls(rr.calls)
+	if len(got) != 1 {
+		t.Fatalf("DevDown should run exactly one command, got %d: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], "kind delete cluster") || !strings.Contains(got[0], "--name "+defaultClusterName) {
+		t.Fatalf("DevDown command = %q, want 'kind delete cluster --name %s'", got[0], defaultClusterName)
+	}
+}

--- a/internal/agentcli/dev_test.go
+++ b/internal/agentcli/dev_test.go
@@ -39,8 +39,8 @@ func TestDevUpSequence(t *testing.T) {
 		t.Fatalf("DevUp: %v", err)
 	}
 	got := joinedCalls(rr.calls)
-	if len(got) < 4 {
-		t.Fatalf("want at least 4 commands, got %d: %v", len(got), got)
+	if len(got) < 2 {
+		t.Fatalf("want at least 2 commands, got %d: %v", len(got), got)
 	}
 	// First command must create the kind cluster with the configured name and
 	// the kind config file.
@@ -53,24 +53,38 @@ func TestDevUpSequence(t *testing.T) {
 	if !strings.Contains(got[0], "hack/kind-config.yaml") {
 		t.Fatalf("kind create missing config: %q", got[0])
 	}
-	// CRDs and controller are applied.
+	// CRDs are applied, then the dev mock control plane as a kustomize overlay
+	// (mock controller, mock forkd, default pool all live under deploy/dev/).
 	all := strings.Join(got, "\n")
-	if !strings.Contains(all, "kubectl apply -f deploy/crds/") {
-		t.Fatalf("want CRDs applied, got:\n%s", all)
+	if !strings.Contains(all, "kubectl apply -f "+crdsPath) {
+		t.Fatalf("want CRDs applied via kubectl apply -f %s, got:\n%s", crdsPath, all)
 	}
-	if !strings.Contains(all, "deploy/controller/") {
-		t.Fatalf("want controller applied, got:\n%s", all)
-	}
-	// A pool is applied (the inline mock-friendly pool written to a temp file).
-	poolApplied := strings.Contains(all, "agentrun-dev-pool") ||
-		strings.Contains(all, "python-pool.yaml") ||
-		(strings.Contains(all, "kubectl apply") && strings.Contains(all, "SandboxPool"))
-	if !poolApplied {
-		t.Fatalf("want a default pool applied, got:\n%s", all)
+	if !strings.Contains(all, "kubectl apply -k "+devOverlayPath) {
+		t.Fatalf("want the dev overlay applied via kubectl apply -k %s, got:\n%s", devOverlayPath, all)
 	}
 	// A clear mock-engine note is printed.
 	if !strings.Contains(strings.ToLower(out.String()), "mock") {
 		t.Fatalf("DevUp output = %q, want a mock-engine note", out.String())
+	}
+}
+
+func TestDevUpSkipClusterCreate(t *testing.T) {
+	rr := &recordingRunner{}
+	var out strings.Builder
+	err := DevUp(context.Background(), DevOptions{SkipClusterCreate: true}, rr.run, &out)
+	if err != nil {
+		t.Fatalf("DevUp: %v", err)
+	}
+	got := joinedCalls(rr.calls)
+	// With SkipClusterCreate, no kind create runs; only the overlay is applied.
+	for _, c := range got {
+		if strings.HasPrefix(c, "kind create cluster") {
+			t.Fatalf("SkipClusterCreate should not run kind create, got: %q", c)
+		}
+	}
+	all := strings.Join(got, "\n")
+	if !strings.Contains(all, "kubectl apply -k "+devOverlayPath) {
+		t.Fatalf("want the dev overlay applied even when skipping cluster create, got:\n%s", all)
 	}
 }
 
@@ -81,19 +95,19 @@ func TestDevUpToleratesExistingCluster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DevUp should tolerate an existing cluster, got: %v", err)
 	}
-	// It must continue past the create to apply the CRDs.
+	// It must continue past the create to apply the dev overlay.
 	all := strings.Join(joinedCalls(rr.calls), "\n")
-	if !strings.Contains(all, "kubectl apply -f deploy/crds/") {
-		t.Fatalf("want it to continue to apply CRDs after existing cluster, got:\n%s", all)
+	if !strings.Contains(all, "kubectl apply -k "+devOverlayPath) {
+		t.Fatalf("want it to continue to apply the dev overlay after existing cluster, got:\n%s", all)
 	}
 }
 
 func TestDevUpFailsOnApplyError(t *testing.T) {
-	rr := &recordingRunner{failOn: "deploy/crds/", failErr: errors.New("apply boom")}
+	rr := &recordingRunner{failOn: "apply -k " + devOverlayPath, failErr: errors.New("apply boom")}
 	var out strings.Builder
 	err := DevUp(context.Background(), DevOptions{}, rr.run, &out)
 	if err == nil {
-		t.Fatalf("DevUp should fail when applying CRDs fails")
+		t.Fatalf("DevUp should fail when applying the dev overlay fails")
 	}
 }
 


### PR DESCRIPTION
## Summary

- stdlib-based agentrun CLI: `agentrun run` and `agentrun sandbox create|ls|exec|fork|terminate`.
- cluster backend over the `SandboxClaim` path with token-scoped exec (the per-sandbox bearer token is read at request time and never logged).
- `agentrun dev up|down` brings up a mock control plane on kind from `deploy/dev/`: controller `--mock --disable-pki-bootstrap`, forkd `--mock` (no KVM device, no `agentrun.dev/kvm` nodeSelector, no TLS), plus a default `dev-default` pool.
- kind CI proves `dev up` + `sandbox create` reaches Ready + `ls` + `terminate` on the mock engine; real in-VM exec is proven by the KVM CI of the API.
- `Closes #26`; ws verbs deferred to #21.

## Test plan

- [ ] `go build ./...` and `GOOS=linux go build ./...`
- [ ] `go vet ./...`
- [ ] `golangci-lint run` (darwin) and `GOOS=linux golangci-lint run`
- [ ] `go test ./internal/... -race` (controller via envtest)
- [ ] Python SDK suite (`pytest sdk/python/tests`)
- [ ] `kustomize build deploy/dev/` resolves
- [ ] kind CI: `agentrun dev up --skip-cluster-create`, controller + mock forkd Ready, `sandbox create --pool dev-default` reaches Ready, `sandbox ls` shows it, `sandbox terminate`
- [ ] gofmt clean, no em/en dashes, YAML parses, go 1.24 preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)