### PR TITLE
fix: validateVMID barrier at TemplateManager entry points

### DIFF
--- a/internal/firecracker/template.go
+++ b/internal/firecracker/template.go
@@ -182,6 +182,13 @@ type TemplateResult struct {
 // `pip install`) is never served. With no init commands the VM is snapshotted
 // as soon as it has booted. The VM is killed after snapshot.
 func (tm *TemplateManager) CreateTemplate(id string, cfg VMConfig, initCommands []string) (*TemplateResult, error) {
+	// Re-assert the allowlist barrier locally: the id is validated at the forkd
+	// gRPC boundary (validateSandboxID), but a defense-in-depth check here keeps
+	// every path that joins the id provably free of separators and traversal,
+	// and is the CodeQL-recognized barrier for the go/path-injection flows below.
+	if err := validateVMID(id); err != nil {
+		return nil, err
+	}
 	start := time.Now()
 
 	snapshotDir := filepath.Join(tm.dataDir, "templates", id, "snapshot")
@@ -333,6 +340,11 @@ func (tm *TemplateManager) CreateTemplate(id string, cfg VMConfig, initCommands 
 
 // DeleteTemplate removes a template and its snapshot files.
 func (tm *TemplateManager) DeleteTemplate(id string) error {
+	// Defense-in-depth allowlist barrier before joining the id into a path that
+	// is then recursively removed (see CreateTemplate).
+	if err := validateVMID(id); err != nil {
+		return err
+	}
 	dir := filepath.Join(tm.dataDir, "templates", id)
 	return os.RemoveAll(dir)
 }
@@ -362,6 +374,11 @@ func (tm *TemplateManager) ListTemplates() ([]string, error) {
 
 // HasTemplate checks if a template snapshot exists.
 func (tm *TemplateManager) HasTemplate(id string) bool {
+	// An id that fails the allowlist names no valid template; refuse before
+	// joining it into a path (defense-in-depth, see CreateTemplate).
+	if err := validateVMID(id); err != nil {
+		return false
+	}
 	memFile := filepath.Join(tm.dataDir, "templates", id, "snapshot", "mem")
 	_, err := os.Stat(memFile)
 	return err == nil

--- a/internal/firecracker/template_validate_test.go
+++ b/internal/firecracker/template_validate_test.go
@@ -1,0 +1,50 @@
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTemplateManagerRejectsTraversalIDs asserts the defense-in-depth
+// validateVMID barrier at the TemplateManager entry points: an id that could
+// introduce a path separator or a traversal segment is refused before it is
+// joined into a filesystem path, so a path-injection cannot escape the data
+// dir even if the gRPC-boundary guard is ever bypassed.
+func TestTemplateManagerRejectsTraversalIDs(t *testing.T) {
+	dataDir := t.TempDir()
+	tm := &TemplateManager{dataDir: dataDir}
+
+	bad := []string{"../escape", "a/b", "..", "../../etc", "with space", "", "/abs"}
+
+	for _, id := range bad {
+		if _, err := tm.CreateTemplate(id, VMConfig{}, nil); err == nil {
+			t.Errorf("CreateTemplate(%q) returned nil error; expected validation rejection", id)
+		}
+		if err := tm.DeleteTemplate(id); err == nil {
+			t.Errorf("DeleteTemplate(%q) returned nil error; expected validation rejection", id)
+		}
+		if tm.HasTemplate(id) {
+			t.Errorf("HasTemplate(%q) returned true for an invalid id", id)
+		}
+	}
+
+	// A delete of an invalid id must not have removed anything from the data dir
+	// (the barrier returns before os.RemoveAll runs).
+	sentinel := filepath.Join(dataDir, "templates", "keep")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := tm.DeleteTemplate("../templates"); err == nil {
+		t.Error("DeleteTemplate(../templates) should be rejected")
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("a rejected DeleteTemplate must not remove anything: %v", err)
+	}
+
+	// A valid id passes the barrier (HasTemplate returns false only because no
+	// such template exists, not because the id was rejected).
+	if tm.HasTemplate("valid-id_1") {
+		t.Error("HasTemplate(valid-id_1) should be false (no such template), not error out")
+	}
+}


### PR DESCRIPTION
## Summary
- `TemplateManager.CreateTemplate`, `DeleteTemplate`, and `HasTemplate` join a caller-supplied id into a filesystem path. The id is validated at the forkd gRPC boundary (`validateSandboxID`), but the local path builders had no barrier, so CodeQL flagged the joins as `go/path-injection` and the alerts re-opened on every CodeQL re-extraction (the go 1.26 bump re-surfaced them).
- Add the `validateVMID` allowlist barrier at each entry: defense-in-depth that keeps the joined path provably free of separators and traversal even if the boundary guard is ever bypassed, and the barrier CodeQL recognizes, so the findings close permanently instead of being re-dismissed.
- A rejected `DeleteTemplate` provably removes nothing (the barrier returns before `os.RemoveAll`).

## Test plan
- `TestTemplateManagerRejectsTraversalIDs`: CreateTemplate/DeleteTemplate/HasTemplate reject traversal/separator/empty/absolute ids; a rejected DeleteTemplate leaves a sentinel dir intact; a valid id passes the barrier.
- Build (darwin + linux), `go vet`, and golangci-lint (darwin + GOOS=linux) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)