### PR TITLE
fix: reliable phase.changed emit (uncached read) and conflict-tolerant test setup

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -146,6 +146,7 @@ func main() {
 	// bootstrap, exactly like nodeRegistry.TLS.
 	claimReconciler := &controller.SandboxClaimReconciler{
 		Client:             mgr.GetClient(),
+		APIReader:          mgr.GetAPIReader(),
 		NodeRegistry:       nodeRegistry,
 		MaxPendingDuration: maxPendingDuration,
 		EnableHuskPods:     enableHuskPods,

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -57,6 +57,15 @@ type SandboxClaimReconciler struct {
 	client.Client
 	NodeRegistry *NodeRegistry
 
+	// APIReader is an uncached reader straight to the apiserver
+	// (mgr.GetAPIReader()). The deferred phase.changed emit reads the
+	// post-reconcile phase through it so it always observes the status this
+	// reconcile just persisted: the controller-runtime cache lags the apiserver
+	// write, so a cached re-Get can read the stale phase, see no change, and drop
+	// the event. A nil APIReader (a bare unit-test struct with no manager) falls
+	// back to the cached client so those tests do not nil-panic.
+	APIReader client.Reader
+
 	// Feed is the workspace/sandbox change feed: the always-on Kubernetes Event
 	// channel plus the opt-in CloudEvents sink. The claim reconciler emits a
 	// sandbox.phase.changed event on every persisted phase transition. A zero Feed
@@ -209,8 +218,19 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// nothing. The time is stamped from the feed clock at the emit site.
 	entryPhase := claim.Status.Phase
 	defer func() {
+		// Read the post-reconcile phase through the uncached APIReader: the
+		// controller-runtime cache lags the apiserver write this reconcile just
+		// made, so a cached re-Get can observe the OLD phase, see no change, and
+		// drop the event (the next reconcile then reads the new phase at entry and
+		// never emits either). The uncached reader always sees the just-persisted
+		// phase. A nil APIReader (a bare unit-test struct) falls back to the cached
+		// client so those tests do not nil-panic.
+		reader := r.APIReader
+		if reader == nil {
+			reader = r.Client
+		}
 		var fresh v1alpha1.SandboxClaim
-		if err := r.Get(ctx, req.NamespacedName, &fresh); err != nil {
+		if err := reader.Get(ctx, req.NamespacedName, &fresh); err != nil {
 			return
 		}
 		if fresh.Status.Phase != "" && fresh.Status.Phase != entryPhase {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -363,6 +363,7 @@ func TestMain(m *testing.M) {
 
 	rawClaim := &controller.SandboxClaimReconciler{
 		Client:       mgr.GetClient(),
+		APIReader:    mgr.GetAPIReader(),
 		NodeRegistry: nodeRegistry,
 	}
 	// The raw (forkd) claim reconciler ignores husk-test claims so it does not
@@ -438,6 +439,7 @@ func TestMain(m *testing.M) {
 	// activator is swappable per test via setHuskTestActivator.
 	huskClaim := &controller.SandboxClaimReconciler{
 		Client:         mgr.GetClient(),
+		APIReader:      mgr.GetAPIReader(),
 		NodeRegistry:   nodeRegistry,
 		EnableHuskPods: true,
 		HuskTLS:        &tls.Config{}, //nolint:gosec // test stub; the fake activator ignores it

--- a/internal/controller/workspace_binding_test.go
+++ b/internal/controller/workspace_binding_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/paperclipinc/sandbox/internal/workspace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -408,8 +409,17 @@ func TestClaimWorkspaceGitOutputPushes(t *testing.T) {
 	defer stop()
 
 	ws := makeWorkspace(t, "ws-git", v1alpha1.WorkspaceRetention{})
-	ws.Spec.Git = v1alpha1.WorkspaceGit{Paths: []string{"/workspace/repo"}}
-	if err := k8sClient.Update(ctx, ws); err != nil {
+	// Re-Get inside RetryOnConflict so each attempt carries a fresh
+	// resourceVersion: the WorkspaceReconciler updates the workspace status
+	// concurrently, so a plain Update here loses an optimistic-lock race
+	// intermittently.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws); err != nil {
+			return err
+		}
+		ws.Spec.Git = v1alpha1.WorkspaceGit{Paths: []string{"/workspace/repo"}}
+		return k8sClient.Update(ctx, ws)
+	}); err != nil {
 		t.Fatalf("set workspace git paths: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

The sandbox.phase.changed feed event was emitted from a deferred CACHED re-Get that lags the just-persisted status, so the Ready event could be dropped: a lost feed event for indexers and the TestFeedEmitsPhaseChanged flake. The deferred now reads via the uncached APIReader so it always sees the post-reconcile phase. TestClaimWorkspaceGitOutputPushes setup raced the WorkspaceReconciler on an optimistic lock; the setup Update is now retry-on-conflict. Both previously-flaky tests pass -count=5.

## Test plan

- `go build ./...` and `GOOS=linux go build ./...` and `go vet ./...`: clean.
- `golangci-lint run --timeout=5m` darwin and `GOOS=linux`: clean.
- `go test ./internal/controller/ -run "TestFeedEmitsPhaseChanged|TestClaimWorkspaceGitOutputPushes" -count=5`: all 5 pass.
- `go test ./internal/controller/ -count=1`: full suite green.
- `gofmt -l ./internal ./cmd`: 0.
- No em/en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)