### PR TITLE
fix: conflict-tolerant facade test spec updates

### DIFF
--- a/internal/facade/extension_reconciler_test.go
+++ b/internal/facade/extension_reconciler_test.go
@@ -171,13 +171,9 @@ func TestFacadeWarmPoolReplicasFollowUpstream(t *testing.T) {
 
 	// Simulate an HPA scaling their warm pool to 5.
 	var cur extv1alpha1.SandboxWarmPool
-	if err := k8sClient.Get(testCtx, types.NamespacedName{Name: "ext-warmpool-hpa", Namespace: "default"}, &cur); err != nil {
-		t.Fatalf("get ext warm pool: %v", err)
-	}
-	cur.Spec.Replicas = 5
-	if err := k8sClient.Update(testCtx, &cur); err != nil {
-		t.Fatalf("scale ext warm pool to 5: %v", err)
-	}
+	updateWithRetry(t, types.NamespacedName{Name: "ext-warmpool-hpa", Namespace: "default"}, &cur, func() {
+		cur.Spec.Replicas = 5
+	})
 
 	eventually(t, "our pool follows the upstream replica change to 5", func() bool {
 		p, ok := getOurPool(t, "ext-warmpool-hpa")
@@ -314,11 +310,10 @@ func TestFacadeClaimMirrorsStatusAndGCs(t *testing.T) {
 	})
 
 	// Drive our claim Ready (the test seam the real husk activation path sets).
-	claim.Status.Phase = runv1alpha1.SandboxReady
-	claim.Status.Endpoint = "10.0.0.9:9091"
-	if err := k8sClient.Status().Update(testCtx, claim); err != nil {
-		t.Fatalf("drive our claim ready: %v", err)
-	}
+	statusUpdateWithRetry(t, types.NamespacedName{Name: "ext-claim-status", Namespace: "default"}, claim, func() {
+		claim.Status.Phase = runv1alpha1.SandboxReady
+		claim.Status.Endpoint = "10.0.0.9:9091"
+	})
 
 	eventually(t, "upstream claim status mirrors Bound/Ready + sandbox name", func() bool {
 		var got extv1alpha1.SandboxClaim

--- a/internal/facade/reconciler_test.go
+++ b/internal/facade/reconciler_test.go
@@ -137,11 +137,10 @@ func TestFacadeMirrorsReadyIntoSandboxStatus(t *testing.T) {
 
 	// Drive our claim Ready via the status subresource (the test seam: the real
 	// husk activation path sets this phase).
-	claim.Status.Phase = runv1alpha1.SandboxReady
-	claim.Status.Endpoint = "10.0.0.5:9091"
-	if err := k8sClient.Status().Update(testCtx, claim); err != nil {
-		t.Fatalf("drive claim ready: %v", err)
-	}
+	statusUpdateWithRetry(t, types.NamespacedName{Name: "facade-ready", Namespace: "default"}, claim, func() {
+		claim.Status.Phase = runv1alpha1.SandboxReady
+		claim.Status.Endpoint = "10.0.0.5:9091"
+	})
 
 	eventually(t, "sandbox status mirrors Ready=True", func() bool {
 		got := getSandbox(t, "facade-ready")
@@ -170,12 +169,11 @@ func TestFacadeReplicasZeroTerminatesClaim(t *testing.T) {
 	})
 
 	// Scale to zero.
-	cur := getSandbox(t, "facade-scale")
+	var cur agentsv1alpha1.Sandbox
 	zero := int32(0)
-	cur.Spec.Replicas = &zero
-	if err := k8sClient.Update(testCtx, cur); err != nil {
-		t.Fatalf("scale to zero: %v", err)
-	}
+	updateWithRetry(t, types.NamespacedName{Name: "facade-scale", Namespace: "default"}, &cur, func() {
+		cur.Spec.Replicas = &zero
+	})
 
 	eventually(t, "claim terminated on replicas 0", func() bool {
 		_, ok := getClaim(t, "facade-scale")
@@ -195,15 +193,11 @@ func TestFacadeReplicasZeroTerminatesClaim(t *testing.T) {
 // Sandbox status.
 func driveClaimReady(t *testing.T, name string) {
 	t.Helper()
-	claim, ok := getClaim(t, name)
-	if !ok {
-		t.Fatalf("claim %s not found to drive ready", name)
-	}
-	claim.Status.Phase = runv1alpha1.SandboxReady
-	claim.Status.Endpoint = "10.0.0.5:9091"
-	if err := k8sClient.Status().Update(testCtx, claim); err != nil {
-		t.Fatalf("drive claim %s ready: %v", name, err)
-	}
+	var claim runv1alpha1.SandboxClaim
+	statusUpdateWithRetry(t, types.NamespacedName{Name: name, Namespace: "default"}, &claim, func() {
+		claim.Status.Phase = runv1alpha1.SandboxReady
+		claim.Status.Endpoint = "10.0.0.5:9091"
+	})
 	eventually(t, "facade mirrors Ready + endpoint for "+name, func() bool {
 		got := getSandbox(t, name)
 		cond := apimeta.FindStatusCondition(got.Status.Conditions, string(agentsv1alpha1.SandboxConditionReady))
@@ -232,12 +226,11 @@ func TestFacadePauseReleasesEndpointObservables(t *testing.T) {
 	driveClaimReady(t, "facade-pause")
 
 	// Pause: replicas 0.
-	cur := getSandbox(t, "facade-pause")
+	var cur agentsv1alpha1.Sandbox
 	zero := int32(0)
-	cur.Spec.Replicas = &zero
-	if err := k8sClient.Update(testCtx, cur); err != nil {
-		t.Fatalf("pause to zero: %v", err)
-	}
+	updateWithRetry(t, types.NamespacedName{Name: "facade-pause", Namespace: "default"}, &cur, func() {
+		cur.Spec.Replicas = &zero
+	})
 
 	eventually(t, "claim released to the warm pool on pause", func() bool {
 		_, ok := getClaim(t, "facade-pause")
@@ -269,24 +262,21 @@ func TestFacadeResumeReactivates(t *testing.T) {
 	driveClaimReady(t, "facade-resume")
 
 	// Pause.
-	cur := getSandbox(t, "facade-resume")
+	var cur agentsv1alpha1.Sandbox
 	zero := int32(0)
-	cur.Spec.Replicas = &zero
-	if err := k8sClient.Update(testCtx, cur); err != nil {
-		t.Fatalf("pause to zero: %v", err)
-	}
+	updateWithRetry(t, types.NamespacedName{Name: "facade-resume", Namespace: "default"}, &cur, func() {
+		cur.Spec.Replicas = &zero
+	})
 	eventually(t, "claim released on pause", func() bool {
 		_, ok := getClaim(t, "facade-resume")
 		return !ok
 	})
 
 	// Resume: replicas 1.
-	cur = getSandbox(t, "facade-resume")
 	one := int32(1)
-	cur.Spec.Replicas = &one
-	if err := k8sClient.Update(testCtx, cur); err != nil {
-		t.Fatalf("resume to one: %v", err)
-	}
+	updateWithRetry(t, types.NamespacedName{Name: "facade-resume", Namespace: "default"}, &cur, func() {
+		cur.Spec.Replicas = &one
+	})
 	eventually(t, "claim re-activated on resume", func() bool {
 		_, ok := getClaim(t, "facade-resume")
 		return ok
@@ -306,11 +296,10 @@ func TestFacadePauseResumeToggleStable(t *testing.T) {
 	t.Cleanup(func() { _ = k8sClient.Delete(testCtx, sb) })
 
 	setReplicas := func(n int32) {
-		cur := getSandbox(t, "facade-toggle")
-		cur.Spec.Replicas = &n
-		if err := k8sClient.Update(testCtx, cur); err != nil {
-			t.Fatalf("set replicas %d: %v", n, err)
-		}
+		var cur agentsv1alpha1.Sandbox
+		updateWithRetry(t, types.NamespacedName{Name: "facade-toggle", Namespace: "default"}, &cur, func() {
+			cur.Spec.Replicas = &n
+		})
 	}
 	claimPresent := func() bool {
 		_, ok := getClaim(t, "facade-toggle")
@@ -348,14 +337,13 @@ func TestFacadePauseResumeToggleStable(t *testing.T) {
 
 	// Idempotent: re-applying replicas 0 (no spec change but a forced reconcile
 	// via an annotation bump) keeps the released state; the claim stays absent.
-	cur := getSandbox(t, "facade-toggle")
-	if cur.Annotations == nil {
-		cur.Annotations = map[string]string{}
-	}
-	cur.Annotations["test.agentrun.dev/nudge"] = "1"
-	if err := k8sClient.Update(testCtx, cur); err != nil {
-		t.Fatalf("nudge a reconcile: %v", err)
-	}
+	var nudge agentsv1alpha1.Sandbox
+	updateWithRetry(t, types.NamespacedName{Name: "facade-toggle", Namespace: "default"}, &nudge, func() {
+		if nudge.Annotations == nil {
+			nudge.Annotations = map[string]string{}
+		}
+		nudge.Annotations["test.agentrun.dev/nudge"] = "1"
+	})
 	// Give the reconcile a moment, then assert the claim is still absent.
 	eventually(t, "idempotent re-reconcile keeps the claim released", claimAbsent)
 	got := getSandbox(t, "facade-toggle")

--- a/internal/facade/suite_test.go
+++ b/internal/facade/suite_test.go
@@ -11,8 +11,10 @@ import (
 	extv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -136,4 +138,36 @@ func eventually(t *testing.T, msg string, cond func() bool) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+// updateWithRetry re-Gets obj and re-applies mutate before each Update attempt,
+// so a test spec change does not flake on an optimistic-lock conflict with the
+// reconciler's concurrent status writes.
+func updateWithRetry(t *testing.T, key types.NamespacedName, obj client.Object, mutate func()) {
+	t.Helper()
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := k8sClient.Get(testCtx, key, obj); err != nil {
+			return err
+		}
+		mutate()
+		return k8sClient.Update(testCtx, obj)
+	}); err != nil {
+		t.Fatalf("update %s: %v", key.Name, err)
+	}
+}
+
+// statusUpdateWithRetry re-Gets obj and re-applies mutate before each
+// Status().Update attempt, so a test status write does not flake on an
+// optimistic-lock conflict with the reconciler's concurrent writes.
+func statusUpdateWithRetry(t *testing.T, key types.NamespacedName, obj client.Object, mutate func()) {
+	t.Helper()
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := k8sClient.Get(testCtx, key, obj); err != nil {
+			return err
+		}
+		mutate()
+		return k8sClient.Status().Update(testCtx, obj)
+	}); err != nil {
+		t.Fatalf("status update %s: %v", key.Name, err)
+	}
 }


### PR DESCRIPTION
## Summary

- Several facade tests mutated a spec or status via Get+Update that raced the reconciler's concurrent writes, intermittently failing go-test with an optimistic-lock conflict (e.g. TestFacadeWarmPoolReplicasFollowUpstream).
- Added shared `updateWithRetry` and `statusUpdateWithRetry` helpers in `suite_test.go` that re-Get and re-apply the mutation on each retry attempt using `retry.RetryOnConflict`.
- Converted every racy spec-Update site (6 in `reconciler_test.go`, 1 in `extension_reconciler_test.go`) and every racy Status().Update site (`driveClaimReady`, `TestFacadeMirrorsReadyIntoSandboxStatus`, `TestFacadeClaimMirrorsStatusAndGCs`) to use the helpers.
- The flaky test passes `-count=10` and the full facade suite passes `-count=3` with no failures.

## Test plan

- [ ] `go test ./internal/facade/ -run TestFacadeWarmPoolReplicasFollowUpstream -count=10` passes every run.
- [ ] `go test ./internal/facade/ -count=3` passes every run.
- [ ] `golangci-lint run --timeout=5m ./internal/facade/` passes (darwin).
- [ ] `GOOS=linux golangci-lint run --timeout=5m ./internal/facade/` passes.
- [ ] `gofmt -l ./internal/facade/` prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)