### PR TITLE
Deploy self-containedness: kubectl apply -k deploy/ works on a real KVM node with no manual patches

### DIFF
--- a/Dockerfile.forkd
+++ b/Dockerfile.forkd
@@ -5,7 +5,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -o forkd ./cmd/forkd/
+RUN CGO_ENABLED=0 go build -o forkd ./cmd/forkd/ && \
+    CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/agent ./guest/agent/
 
 FROM ubuntu:22.04
 
@@ -26,6 +27,9 @@ RUN curl -fsSL -o /tmp/fc.tgz \
     rm -rf /tmp/fc.tgz /tmp/release-*
 
 COPY --from=builder /build/forkd /usr/local/bin/forkd
+# The guest agent injected as /init when forkd builds a rootfs from an OCI
+# image. cmd/forkd --agent-bin points here (deploy/daemon/daemonset.yaml).
+COPY --from=builder /usr/local/bin/agent /usr/local/bin/agent
 
 VOLUME ["/var/lib/mitos"]
 EXPOSE 9090 9091

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -133,16 +133,22 @@ func main() {
 	// never logged.
 	peerToken := os.Getenv("FORKD_PEER_TOKEN")
 
+	poolControllerNamespace := os.Getenv("FORKD_NAMESPACE")
+	if poolControllerNamespace == "" {
+		poolControllerNamespace = "mitos"
+	}
+
 	if err := (&controller.SandboxPoolReconciler{
-		Client:            mgr.GetClient(),
-		NodeRegistry:      nodeRegistry,
-		PeerToken:         peerToken,
-		EnableHuskPods:    enableHuskPods,
-		HuskStubImage:     huskStubImage,
-		KVMResourceName:   "mitos.run/kvm",
-		DataDir:           huskDataDir,
-		HuskTLSSecretName: controller.ForkdTLSSecretName,
-		HuskCASecretName:  controller.CASecretName,
+		Client:              mgr.GetClient(),
+		NodeRegistry:        nodeRegistry,
+		PeerToken:           peerToken,
+		EnableHuskPods:      enableHuskPods,
+		HuskStubImage:       huskStubImage,
+		KVMResourceName:     "mitos.run/kvm",
+		DataDir:             huskDataDir,
+		HuskTLSSecretName:   controller.ForkdTLSSecretName,
+		HuskCASecretName:    controller.CASecretName,
+		ControllerNamespace: poolControllerNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "SandboxPool")
 		os.Exit(1)

--- a/deploy/controller/namespace.yaml
+++ b/deploy/controller/namespace.yaml
@@ -4,3 +4,12 @@ metadata:
   name: mitos
   labels:
     app.kubernetes.io/name: mitos
+    # PodSecurity admission (v1.31). forkd and the kvm-device-plugin run with
+    # hostPath volumes and host devices, and forkd runs privileged; none is
+    # admissible under baseline or restricted. enforce=privileged so the
+    # DaemonSets are admitted without a manual namespace patch. The husk pods
+    # themselves are restricted-except-two-exceptions, but they run in the POOL
+    # namespace (e.g. default), labelled separately in deploy/dev/namespace.yaml.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/deploy/daemon/daemonset.yaml
+++ b/deploy/daemon/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
         prometheus.io/port: "9091"
         prometheus.io/path: "/metrics"
     spec:
+      # ghcr-pull so the kubelet can pull ghcr.io/paperclipinc/mitos-forkd.
+      imagePullSecrets:
+        - name: ghcr-pull
       nodeSelector:
         mitos.run/kvm: "true"
 
@@ -53,14 +56,14 @@ spec:
             - --tls-cert=/etc/forkd/tls/tls.crt
             - --tls-key=/etc/forkd/tls/tls.key
             - --tls-ca=/etc/forkd/ca/ca.crt
-            # Every VM runs through the jailer: per-VM uid/gid, chroot,
-            # cgroup. The chroot base lives inside the data volume so
-            # snapshot and rootfs files hard-link into each chroot
-            # (forkd refuses to start if they are on different
-            # filesystems).
-            - --jailer=/usr/local/bin/jailer
-            - --chroot-base=/var/lib/mitos/jailer
-            - --uid-range=64000-64999
+            # Guest agent injected as /init for OCI image template builds. The
+            # binary ships in the forkd image at this path (Dockerfile.forkd).
+            - --agent-bin=/usr/local/bin/agent
+            # JAILER FOLLOW-UP: the per-VM jailer (uid/gid, chroot, cgroup) is
+            # disabled here. forkd runs privileged: true (below) on the husk
+            # path until jailer-in-pod lands. Re-add --jailer / --chroot-base /
+            # --uid-range and drop privileged once the jailer runs inside the
+            # forkd pod. Tracked as the jailer-in-pod follow-up.
           # FORKD_PEER_TOKEN is the shared bearer credential a peer
           # forkd must present to pull templates from this node's CAS.
           # It is read from the ENVIRONMENT, not a flag, so it is never
@@ -74,6 +77,12 @@ spec:
           #       secretKeyRef:
           #         name: mitos-peer-token
           #         key: token
+          env:
+            # forkd authenticates to ghcr/private registries when pulling OCI
+            # template images. DOCKER_CONFIG points at the mounted docker-config
+            # secret (the docker-config volume below). Unset = anonymous pulls.
+            - name: DOCKER_CONFIG
+              value: /etc/forkd/docker
           ports:
             - name: grpc
               containerPort: 9090
@@ -83,49 +92,14 @@ spec:
             # peer template distribution; separate from the sandbox API.
             - name: cas
               containerPort: 9092
-          # forkd runs as root with an explicit capability list instead
-          # of privileged: true. Each retained capability is annotated
-          # with why the jailer (or forkd itself) needs it; everything
-          # else is dropped. The set is pending proof in the KVM CI
-          # jailer run (issue #2 Task 5) and may still be trimmed.
+          # PRIVILEGED until jailer-in-pod lands (see the --agent-bin block).
+          # Without the jailer, forkd needs unrestricted access to /dev/kvm,
+          # /dev/net/tun, cgroups, and chroot to launch each VM; the trimmed
+          # capability set only worked WITH the jailer mediating. The honest
+          # regression is documented in docs/threat-model.md. Re-narrow to the
+          # capability list once the jailer runs inside the pod.
           securityContext:
-            runAsUser: 0
-            allowPrivilegeEscalation: true
-            capabilities:
-              drop:
-                - ALL
-              add:
-                # Jailer: cgroup attachment and namespace setup for each
-                # VM's jail.
-                - SYS_ADMIN
-                # Jailer: chroot(2) into the per-VM jail; SYS_ADMIN does
-                # NOT cover chroot, so without this the jailer fails with
-                # EPERM at launch.
-                - SYS_CHROOT
-                # Jailer: hands the per-VM chroot and API socket to the
-                # dedicated uid.
-                - CHOWN
-                # Jailer/forkd: traverse and modify the jail tree after
-                # files have been chowned to per-VM uids. Pending KVM CI
-                # confirmation (issue #2 Task 5); may be trimmed.
-                - DAC_OVERRIDE
-                # Jailer/forkd: file-owner operations on jail files owned
-                # by per-VM uids. Pending KVM CI confirmation (issue #2
-                # Task 5); may be trimmed.
-                - FOWNER
-                # Jailer: drops the Firecracker process to the per-VM
-                # uid (--uid-range).
-                - SETUID
-                # Jailer: drops the Firecracker process to the per-VM
-                # gid.
-                - SETGID
-                # Jailer: creates /dev/kvm and /dev/net/tun device nodes
-                # inside each chroot.
-                - MKNOD
-                # forkd: tap device creation when guest networking lands
-                # (threat model section 4); listed now so the manifest
-                # does not silently re-broaden later.
-                - NET_ADMIN
+            privileged: true
           resources:
             requests:
               memory: "1Gi"
@@ -143,6 +117,9 @@ spec:
               readOnly: true
             - name: ca
               mountPath: /etc/forkd/ca
+              readOnly: true
+            - name: docker-config
+              mountPath: /etc/forkd/docker
               readOnly: true
           readinessProbe:
             httpGet:
@@ -178,3 +155,12 @@ spec:
             items:
               - key: ca.crt
                 path: ca.crt
+        # forkd's registry credentials for OCI template pulls. Reuses the
+        # ghcr-pull dockerconfigjson secret, projected to the config.json name
+        # the docker/containerd auth resolver reads under DOCKER_CONFIG.
+        - name: docker-config
+          secret:
+            secretName: ghcr-pull
+            items:
+              - key: .dockerconfigjson
+                path: config.json

--- a/deploy/dev/namespace.yaml
+++ b/deploy/dev/namespace.yaml
@@ -1,6 +1,17 @@
+# Pool namespace PodSecurity. Husk pods run in the POOL namespace, not the
+# controller namespace. The dev overlay's own namespace is labelled below. For
+# a bare-metal pool in `default`, label it once (it is not a deploy/ resource):
+#   kubectl label --overwrite namespace default \
+#     pod-security.kubernetes.io/enforce=privileged \
+#     pod-security.kubernetes.io/audit=privileged \
+#     pod-security.kubernetes.io/warn=privileged
+# Any dedicated pool namespace you create needs the same enforce=privileged.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: mitos
   labels:
     app.kubernetes.io/name: mitos
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/deploy/imagepullsecret.yaml
+++ b/deploy/imagepullsecret.yaml
@@ -1,0 +1,25 @@
+# ghcr.io pull credential for the mitos-* images. This ships with an EMPTY
+# dockerconfigjson so the manifest is self-contained and apply-able; you MUST
+# populate it once with a real read:packages token before the images can pull:
+#
+#   kubectl create secret docker-registry ghcr-pull \
+#     --namespace mitos \
+#     --docker-server=ghcr.io \
+#     --docker-username=<github-username> \
+#     --docker-password=<ghcr-read-packages-PAT> \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# The serviceaccounts reference it by name (deploy/rbac/serviceaccount.yaml and
+# the forkd DaemonSet), so re-applying the populated secret is all that is
+# needed; the wiring is already declarative. The token VALUE is never committed.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-pull
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+type: kubernetes.io/dockerconfigjson
+data:
+  # Empty config: {"auths":{}} base64-encoded. Overwrite via the command above.
+  .dockerconfigjson: eyJhdXRocyI6e319

--- a/deploy/kernel/daemonset.yaml
+++ b/deploy/kernel/daemonset.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mitos-kernel-stage
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: kernel-stage
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mitos
+      app.kubernetes.io/component: kernel-stage
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mitos
+        app.kubernetes.io/component: kernel-stage
+    spec:
+      # Stage the guest kernel only on KVM nodes; that is exactly where forkd
+      # and husk pods read /var/lib/mitos/vmlinux.
+      nodeSelector:
+        mitos.run/kvm: "true"
+      tolerations:
+        - key: mitos.run/dedicated
+          operator: Exists
+          effect: NoSchedule
+      # An init container downloads the kernel into the node hostPath ONCE
+      # (idempotent: skip if the file already exists), then the main container
+      # idles so the DaemonSet stays Ready and re-stages on a node rejoin.
+      initContainers:
+        - name: stage-kernel
+          image: curlimages/curl:8.11.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              dest=/var/lib/mitos/vmlinux
+              if [ -s "$dest" ]; then
+                echo "kernel already staged at $dest; skipping download"
+                exit 0
+              fi
+              echo "staging guest kernel to $dest"
+              curl -fsSL -o "$dest.tmp" "$KERNEL_URL"
+              mv "$dest.tmp" "$dest"
+              echo "kernel staged"
+          env:
+            # The guest kernel image URL. Override per cluster with a kustomize
+            # patch if you host your own kernel. This is the Firecracker CI
+            # x86_64 5.10 guest kernel used by the bench/ runs.
+            - name: KERNEL_URL
+              value: https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mitos
+      containers:
+        - name: idle
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              memory: "8Mi"
+              cpu: "10m"
+            limits:
+              memory: "16Mi"
+              cpu: "50m"
+      volumes:
+        - name: data
+          hostPath:
+            path: /var/lib/mitos
+            type: DirectoryOrCreate

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - rbac/clusterrolebinding.yaml
   - controller/deployment.yaml
   - daemon/daemonset.yaml
+  - kernel/daemonset.yaml
   # The KVM device plugin runs on every node and advertises mitos.run/kvm
   # only where /dev/kvm exists, so husk pods can request KVM as a scheduled
   # resource instead of privileged: true (the PSA-restricted path). It does

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - crds/mitos.run_sandboxclaims.yaml
   - crds/mitos.run_sandboxforks.yaml
   - controller/namespace.yaml
+  - imagepullsecret.yaml
   - rbac/serviceaccount.yaml
   - rbac/clusterrole.yaml
   - rbac/clusterrolebinding.yaml

--- a/deploy/rbac/clusterrole.yaml
+++ b/deploy/rbac/clusterrole.yaml
@@ -95,6 +95,10 @@ rules:
   # never logged. delete crypto-shreds a template's at-rest encryption key
   # Secret on teardown (DeleteEncKey); owned Secrets are otherwise reaped by
   # owner-reference GC.
+  # create/update ALSO replicate the husk PKI Secrets (mitos-ca ca.crt only,
+  # mitos-forkd-tls) FROM the controller namespace INTO each pool namespace
+  # where husk pods run (ReplicateHuskSecrets); the CA private key is never
+  # replicated. This is why the grant is cluster-wide rather than namespaced.
   - apiGroups:
       - ""
     resources:

--- a/deploy/rbac/serviceaccount.yaml
+++ b/deploy/rbac/serviceaccount.yaml
@@ -6,3 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: mitos
     app.kubernetes.io/component: controller
+# The controller pulls ghcr.io/paperclipinc/mitos-controller. The pull
+# credential ships in deploy/imagepullsecret.yaml (populate it once); naming it
+# here means every controller pod gets it without a manual patch.
+imagePullSecrets:
+  - name: ghcr-pull

--- a/docs/superpowers/plans/2026-06-13-deploy-self-containedness.md
+++ b/docs/superpowers/plans/2026-06-13-deploy-self-containedness.md
@@ -1,0 +1,1147 @@
+# Deploy Self-Containedness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `kubectl apply -k deploy/` bring up a fully working mitos stack on a real KVM node with no manual `kubectl` patches; bake in the eight runtime fixes that were applied by hand to go live tonight.
+
+**Architecture:** Most fixes are declarative deploy/ changes: PodSecurity Admission labels on the namespace, an image pull secret + serviceaccount wiring, forkd DaemonSet adjustments (agent-bin arg, privileged securityContext, DOCKER_CONFIG + docker-config secret mount, jailer args removed for the husk path), and a kernel-staging DaemonSet that places `vmlinux` on each KVM node. One fix needs Go: the controller must replicate the CA and forkd-TLS Secrets from its namespace into any pool namespace where it creates husk pods, with the matching RBAC already present (secrets create/get/list/update exists). The namespace default (`mitos`) is already correct in code and deploy/; we verify it and only add a task if a gap remains.
+
+**Tech Stack:** Go 1.26, controller-runtime, Kustomize, Kubernetes v1.31 PodSecurity admission, Firecracker, envtest, kubeconform.
+
+---
+
+## Background facts (grounded in the tree)
+
+These are load-bearing and were confirmed by reading the files:
+
+- `deploy/controller/namespace.yaml` is the only namespace manifest and carries NO `pod-security.kubernetes.io/*` labels.
+- `deploy/kustomization.yaml` lists every base resource; there is no pull-secret, no kernel-staging job, and no PSA labelling.
+- `deploy/rbac/serviceaccount.yaml` has no `imagePullSecrets`.
+- All images are `ghcr.io/paperclipinc/mitos-*` (controller, forkd, husk-stub, kvm-device-plugin).
+- `deploy/daemon/daemonset.yaml`: forkd has NO `--agent-bin` arg (cmd/forkd default is empty; image builds fail without it), NO `privileged: true` (it uses an explicit capability list), NO `DOCKER_CONFIG` env / docker-config mount, and DOES carry jailer args `--jailer`, `--chroot-base`, `--uid-range`. forkd default `--kernel=/var/lib/mitos/vmlinux`.
+- `internal/fork/imagebuild.go:19` errors when `--agent-bin` is empty and an OCI image build is requested. `Dockerfile.forkd` does not place an agent binary in the image.
+- `internal/controller/huskpod.go`: husk pods mount the kernel from `<DataDir>/vmlinux` (default `/var/lib/mitos/vmlinux`) and need the snapshot present on the node. The PKI secrets `mitos-forkd-tls` (leaf, key `tls.crt`/`tls.key`) and `mitos-ca` (key `ca.crt`) are mounted into husk pods in `pool.Namespace` (e.g. `default`).
+- `internal/controller/pki_bootstrap.go`: `EnsurePKI(ctx, c, namespace)` materializes `mitos-ca`, `mitos-forkd-tls`, `mitos-controller-tls` ONLY in the controller namespace (`mitos`). Constants `CASecretName = "mitos-ca"`, `ForkdTLSSecretName = "mitos-forkd-tls"`.
+- `cmd/controller/main.go`: `discoveryNamespace` defaults to `mitos` (line 196-199); `EnsurePKI` runs against it (line 224); the `SandboxPoolReconciler` is constructed at line 136-146 with `HuskTLSSecretName`/`HuskCASecretName` already set, but no source-namespace field.
+- `internal/controller/sandboxpool_controller.go`: `reconcileHuskPods` is called at line 120, BEFORE husk pods are created; husk pods land in `pool.Namespace`. The reconciler embeds `client.Client` so `r.Get`/`r.Create`/`r.Update`/`r.Scheme()` are available.
+- RBAC (`deploy/rbac/clusterrole.yaml`) already grants secrets `create;delete;get;list;update;watch` cluster-wide, so cross-namespace secret writes need NO new RBAC. The existing rule comment must be extended to mention replication so the grant stays justified (CLAUDE.md: nothing granted speculatively).
+- envtest pattern: `internal/controller/pki_bootstrap_test.go` has `newCoreClient(t)`, `newPKINamespace(t, c)`, `getSecret(t, c, ns, name)`; `suite_test.go` exposes package-level `cfg`, `ctx`, `scheme`.
+
+---
+
+## File Structure
+
+Files created:
+
+- `deploy/imagepullsecret.yaml` — placeholder `ghcr-pull` dockerconfigjson Secret in `mitos` (documented, with a real generation command); referenced by kustomization and the serviceaccount.
+- `deploy/kernel/daemonset.yaml` — `mitos-kernel-stage` DaemonSet that stages `vmlinux` into `/var/lib/mitos/vmlinux` on every KVM node via an init container, then idles.
+- `internal/controller/secret_replication.go` — `replicateControlPlaneSecret` helper + `replicateHuskSecrets` that copies `mitos-ca` (ca.crt only) and `mitos-forkd-tls` into a target namespace.
+- `internal/controller/secret_replication_test.go` — envtest coverage for replication (create, idempotent re-run, update-on-drift).
+
+Files modified:
+
+- `deploy/controller/namespace.yaml` — add PSA `enforce=privileged` labels.
+- `deploy/dev/namespace.yaml` — add PSA `enforce=privileged` labels (the default pool namespace husk pods land in for bare-metal; the dev overlay namespace is `mitos-dev`, see Task 2 note).
+- `deploy/rbac/serviceaccount.yaml` — add `imagePullSecrets: [{name: ghcr-pull}]`.
+- `deploy/rbac/clusterrole.yaml` — extend the secrets rule comment to cover replication.
+- `deploy/daemon/daemonset.yaml` — add `--agent-bin=/usr/local/bin/agent`, set `securityContext.privileged: true` (drop the explicit capability list), add `DOCKER_CONFIG` env + docker-config secret volume/mount, remove jailer args; add the `ghcr-pull` imagePullSecret via the serviceaccount (forkd has no serviceAccountName today, so add one).
+- `Dockerfile.forkd` — build and install the guest agent at `/usr/local/bin/agent` so `--agent-bin` resolves.
+- `deploy/kustomization.yaml` — add the new resources.
+- `internal/controller/sandboxpool_controller.go` — add `ControllerNamespace` field; call `replicateHuskSecrets` in `reconcileHuskPods` before creating husk pods.
+- `cmd/controller/main.go` — set `ControllerNamespace: discoveryNamespace` on the pool reconciler.
+- `docs/threat-model.md` — note the forkd `privileged: true` regression + the cross-namespace secret replication surface (security surface moved).
+
+---
+
+## Task 1: PodSecurity Admission labels on the controller namespace
+
+**Files:**
+- Modify: `deploy/controller/namespace.yaml`
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `kustomize build deploy/ | grep -A12 'kind: Namespace' | grep 'pod-security.kubernetes.io/enforce: privileged'`
+Expected: FAIL (no output; the label is absent).
+
+- [ ] **Step 2: Add the PSA labels**
+
+Replace the whole file `deploy/controller/namespace.yaml` with:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+    # PodSecurity admission (v1.31). forkd and the kvm-device-plugin run with
+    # hostPath volumes and host devices, and forkd runs privileged; none is
+    # admissible under baseline or restricted. enforce=privileged so the
+    # DaemonSets are admitted without a manual namespace patch. The husk pods
+    # themselves are restricted-except-two-exceptions, but they run in the POOL
+    # namespace (e.g. default), labelled separately in deploy/dev/namespace.yaml.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+- [ ] **Step 3: Run the verification to confirm it passes**
+
+Run: `kustomize build deploy/ | grep -A12 'kind: Namespace' | grep 'pod-security.kubernetes.io/enforce: privileged'`
+Expected: PASS (prints the enforce line).
+
+- [ ] **Step 4: Server-dry-run sanity (optional if a cluster is reachable)**
+
+Run: `kustomize build deploy/ | kubectl apply --dry-run=server -f - 2>/dev/null | grep 'namespace/mitos'` (skip if no cluster).
+Expected: `namespace/mitos configured (server dry run)` or PASS skip.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/controller/namespace.yaml
+git commit -m "fix(deploy): enforce privileged PodSecurity on the mitos namespace
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: PodSecurity Admission labels on the pool namespace
+
+**Files:**
+- Modify: `deploy/dev/namespace.yaml`
+
+Note: husk pods run in the POOL namespace. On bare metal tonight that was `default`. `default` is not in deploy/, so the operator labels it once via the documented command in Step 4; the dev overlay namespace `mitos-dev` IS in deploy/dev and is labelled here so the dev overlay is self-contained too.
+
+- [ ] **Step 1: Read the current dev namespace**
+
+Run: `cat deploy/dev/namespace.yaml`
+Expected: a Namespace `mitos-dev` (or similar) with no PSA labels.
+
+- [ ] **Step 2: Write the failing verification**
+
+Run: `grep 'pod-security.kubernetes.io/enforce: privileged' deploy/dev/namespace.yaml`
+Expected: FAIL (no output).
+
+- [ ] **Step 3: Add the PSA labels to the dev namespace**
+
+Add these three lines under `metadata.labels` in `deploy/dev/namespace.yaml` (keep the existing name and labels):
+
+```yaml
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+- [ ] **Step 4: Document the default-namespace label for bare metal**
+
+Add this comment block at the top of `deploy/dev/namespace.yaml` (above `apiVersion:`):
+
+```yaml
+# Pool namespace PodSecurity. Husk pods run in the POOL namespace, not the
+# controller namespace. The dev overlay's own namespace is labelled below. For
+# a bare-metal pool in `default`, label it once (it is not a deploy/ resource):
+#   kubectl label --overwrite namespace default \
+#     pod-security.kubernetes.io/enforce=privileged \
+#     pod-security.kubernetes.io/audit=privileged \
+#     pod-security.kubernetes.io/warn=privileged
+# Any dedicated pool namespace you create needs the same enforce=privileged.
+```
+
+- [ ] **Step 5: Run the verification to confirm it passes**
+
+Run: `grep 'pod-security.kubernetes.io/enforce: privileged' deploy/dev/namespace.yaml`
+Expected: PASS (prints the line).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/dev/namespace.yaml
+git commit -m "fix(deploy): enforce privileged PodSecurity on pool namespaces
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: ghcr image pull secret manifest
+
+**Files:**
+- Create: `deploy/imagepullsecret.yaml`
+- Modify: `deploy/kustomization.yaml`
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `kustomize build deploy/ | grep 'name: ghcr-pull'`
+Expected: FAIL (no output).
+
+- [ ] **Step 2: Create the pull secret manifest**
+
+Create `deploy/imagepullsecret.yaml`:
+
+```yaml
+# ghcr.io pull credential for the mitos-* images. This ships with an EMPTY
+# dockerconfigjson so the manifest is self-contained and apply-able; you MUST
+# populate it once with a real read:packages token before the images can pull:
+#
+#   kubectl create secret docker-registry ghcr-pull \
+#     --namespace mitos \
+#     --docker-server=ghcr.io \
+#     --docker-username=<github-username> \
+#     --docker-password=<ghcr-read-packages-PAT> \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# The serviceaccounts reference it by name (deploy/rbac/serviceaccount.yaml and
+# the forkd DaemonSet), so re-applying the populated secret is all that is
+# needed; the wiring is already declarative. The token VALUE is never committed.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-pull
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+type: kubernetes.io/dockerconfigjson
+data:
+  # Empty config: {"auths":{}} base64-encoded. Overwrite via the command above.
+  .dockerconfigjson: eyJhdXRocyI6e319
+```
+
+- [ ] **Step 3: Add it to the kustomization**
+
+In `deploy/kustomization.yaml`, add this line to the `resources:` list, after `controller/namespace.yaml`:
+
+```yaml
+  - imagepullsecret.yaml
+```
+
+- [ ] **Step 4: Run the verification to confirm it passes**
+
+Run: `kustomize build deploy/ | grep 'name: ghcr-pull'`
+Expected: PASS (prints `name: ghcr-pull`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/imagepullsecret.yaml deploy/kustomization.yaml
+git commit -m "feat(deploy): ship the ghcr-pull image pull secret manifest
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire imagePullSecrets onto the controller serviceaccount
+
+**Files:**
+- Modify: `deploy/rbac/serviceaccount.yaml`
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `kustomize build deploy/ | grep -A8 'kind: ServiceAccount' | grep 'ghcr-pull'`
+Expected: FAIL (no output).
+
+- [ ] **Step 2: Add imagePullSecrets to the serviceaccount**
+
+Append to `deploy/rbac/serviceaccount.yaml` (after the `metadata:` block, at the top level of the document):
+
+```yaml
+# The controller pulls ghcr.io/paperclipinc/mitos-controller. The pull
+# credential ships in deploy/imagepullsecret.yaml (populate it once); naming it
+# here means every controller pod gets it without a manual patch.
+imagePullSecrets:
+  - name: ghcr-pull
+```
+
+- [ ] **Step 3: Run the verification to confirm it passes**
+
+Run: `kustomize build deploy/ | grep -A8 'kind: ServiceAccount' | grep 'ghcr-pull'`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/rbac/serviceaccount.yaml
+git commit -m "fix(deploy): wire ghcr-pull onto the controller serviceaccount
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Build the guest agent into the forkd image
+
+**Files:**
+- Modify: `Dockerfile.forkd`
+
+Rationale: `internal/fork/imagebuild.go:19` requires `--agent-bin` for OCI image template builds. Task 6 sets `--agent-bin=/usr/local/bin/agent`; that path must exist in the image. The agent is linux-only (`guest/agent`).
+
+- [ ] **Step 1: Write the failing verification (the build arg)**
+
+Run: `grep -- '-o /usr/local/bin/agent ./guest/agent' Dockerfile.forkd`
+Expected: FAIL (no output).
+
+- [ ] **Step 2: Add the agent build + copy**
+
+In `Dockerfile.forkd`, change the builder build line (currently a single forkd build) so both binaries are built. Replace:
+
+```dockerfile
+RUN CGO_ENABLED=0 go build -o forkd ./cmd/forkd/
+```
+
+with:
+
+```dockerfile
+RUN CGO_ENABLED=0 go build -o forkd ./cmd/forkd/ && \
+    CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/agent ./guest/agent/
+```
+
+Then add, right after the existing `COPY --from=builder /build/forkd /usr/local/bin/forkd` line:
+
+```dockerfile
+# The guest agent injected as /init when forkd builds a rootfs from an OCI
+# image. cmd/forkd --agent-bin points here (deploy/daemon/daemonset.yaml).
+COPY --from=builder /usr/local/bin/agent /usr/local/bin/agent
+```
+
+- [ ] **Step 3: Verify the agent cross-builds (the real gate, no docker needed)**
+
+Run: `GOOS=linux GOARCH=amd64 go build -o /tmp/agent ./guest/agent/ && echo BUILT`
+Expected: PASS (prints `BUILT`); confirms the binary the Dockerfile builds compiles.
+
+- [ ] **Step 4: Confirm the Dockerfile references resolve**
+
+Run: `grep -c '/usr/local/bin/agent' Dockerfile.forkd`
+Expected: `2` (the build output path and the COPY destination).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile.forkd
+git commit -m "fix(forkd): build the guest agent into the image at /usr/local/bin/agent
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: forkd DaemonSet runtime fixes (agent-bin, privileged, DOCKER_CONFIG, drop jailer)
+
+**Files:**
+- Modify: `deploy/daemon/daemonset.yaml`
+
+This bundles the four DaemonSet changes that go together: they all change the forkd container spec and must apply atomically (a daemonset is rolled as one object).
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `kustomize build deploy/ | grep -E -- '--agent-bin=/usr/local/bin/agent|privileged: true|name: DOCKER_CONFIG'`
+Expected: FAIL (no output; none present).
+
+- [ ] **Step 2: Add the agent-bin arg and remove the jailer args**
+
+In `deploy/daemon/daemonset.yaml`, in the forkd `args:` list, delete these three lines and their preceding jailer comment block (lines that read `--jailer=/usr/local/bin/jailer`, `--chroot-base=/var/lib/mitos/jailer`, `--uid-range=64000-64999` and the comment above them):
+
+```yaml
+            # Every VM runs through the jailer: per-VM uid/gid, chroot,
+            # cgroup. The chroot base lives inside the data volume so
+            # snapshot and rootfs files hard-link into each chroot
+            # (forkd refuses to start if they are on different
+            # filesystems).
+            - --jailer=/usr/local/bin/jailer
+            - --chroot-base=/var/lib/mitos/jailer
+            - --uid-range=64000-64999
+```
+
+In their place add:
+
+```yaml
+            # Guest agent injected as /init for OCI image template builds. The
+            # binary ships in the forkd image at this path (Dockerfile.forkd).
+            - --agent-bin=/usr/local/bin/agent
+            # JAILER FOLLOW-UP: the per-VM jailer (uid/gid, chroot, cgroup) is
+            # disabled here. forkd runs privileged: true (below) on the husk
+            # path until jailer-in-pod lands. Re-add --jailer / --chroot-base /
+            # --uid-range and drop privileged once the jailer runs inside the
+            # forkd pod. Tracked as the jailer-in-pod follow-up.
+```
+
+- [ ] **Step 3: Replace the capability securityContext with privileged: true**
+
+Replace the entire forkd `securityContext:` block (from `securityContext:` through the end of the `capabilities:` `add:` list, the block that lists SYS_ADMIN, SYS_CHROOT, etc.) with:
+
+```yaml
+          # PRIVILEGED until jailer-in-pod lands (see the --agent-bin block).
+          # Without the jailer, forkd needs unrestricted access to /dev/kvm,
+          # /dev/net/tun, cgroups, and chroot to launch each VM; the trimmed
+          # capability set only worked WITH the jailer mediating. The honest
+          # regression is documented in docs/threat-model.md. Re-narrow to the
+          # capability list once the jailer runs inside the pod.
+          securityContext:
+            privileged: true
+```
+
+- [ ] **Step 4: Add the DOCKER_CONFIG env and the docker-config secret mount**
+
+In the forkd container spec, add an `env:` block (forkd has none today). Insert it immediately before the `ports:` block:
+
+```yaml
+          env:
+            # forkd authenticates to ghcr/private registries when pulling OCI
+            # template images. DOCKER_CONFIG points at the mounted docker-config
+            # secret (the docker-config volume below). Unset = anonymous pulls.
+            - name: DOCKER_CONFIG
+              value: /etc/forkd/docker
+```
+
+Add the volume mount to the forkd `volumeMounts:` list (after the `ca` mount):
+
+```yaml
+            - name: docker-config
+              mountPath: /etc/forkd/docker
+              readOnly: true
+```
+
+Add the volume to the `volumes:` list (after the `ca` volume). The same `ghcr-pull` dockerconfigjson secret is reused, projecting its `.dockerconfigjson` key to the `config.json` filename Docker expects:
+
+```yaml
+        # forkd's registry credentials for OCI template pulls. Reuses the
+        # ghcr-pull dockerconfigjson secret, projected to the config.json name
+        # the docker/containerd auth resolver reads under DOCKER_CONFIG.
+        - name: docker-config
+          secret:
+            secretName: ghcr-pull
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+```
+
+- [ ] **Step 5: Add the serviceAccountName + imagePullSecrets so forkd can pull**
+
+forkd's pod spec has no serviceAccountName. Add the imagePullSecret directly on the pod spec (the forkd DaemonSet uses the default SA, which has no pull secret). Insert at the top of the forkd pod `spec:` (just under `spec:`, before `nodeSelector:`):
+
+```yaml
+      # ghcr-pull so the kubelet can pull ghcr.io/paperclipinc/mitos-forkd.
+      imagePullSecrets:
+        - name: ghcr-pull
+```
+
+- [ ] **Step 6: Run the verification to confirm it passes**
+
+Run: `kustomize build deploy/ | grep -E -- '--agent-bin=/usr/local/bin/agent|privileged: true|name: DOCKER_CONFIG'`
+Expected: PASS (prints all three).
+
+- [ ] **Step 7: Confirm the jailer args are gone**
+
+Run: `kustomize build deploy/ | grep -- '--jailer='`
+Expected: FAIL (no output; the jailer arg is removed).
+
+- [ ] **Step 8: Validate the manifest still schema-checks**
+
+Run: `kustomize build deploy/ | kubeconform -strict -ignore-missing-schemas -summary` (skip the kubeconform line if the tool is not installed; otherwise expect 0 invalid resources).
+Expected: PASS (0 invalid resources) or skipped.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add deploy/daemon/daemonset.yaml
+git commit -m "fix(deploy): forkd agent-bin, privileged, DOCKER_CONFIG, drop jailer args
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Document the forkd privileged regression in the threat model
+
+**Files:**
+- Modify: `docs/threat-model.md`
+
+CLAUDE.md operating principle 2: a security surface move updates the threat model in the same PR. Task 6 reintroduced `privileged: true` on forkd; record it.
+
+- [ ] **Step 1: Locate the forkd row in the threat model**
+
+Run: `grep -n 'forkd\|privileged\|jailer' docs/threat-model.md | head -20`
+Expected: prints the section/rows that mention forkd privileges (use the nearest table row or section as the insertion point).
+
+- [ ] **Step 2: Add the regression note**
+
+Add a row or paragraph to the relevant forkd security section in `docs/threat-model.md` with this exact text (place it under the existing forkd privilege discussion):
+
+```markdown
+- forkd `privileged: true` (deploy/daemon/daemonset.yaml), REGRESSION pending
+  jailer-in-pod. Without the per-VM jailer mediating, forkd needs unrestricted
+  /dev/kvm, /dev/net/tun, cgroup, and chroot access, so the trimmed capability
+  set is replaced by privileged until the jailer runs inside the forkd pod.
+  Status: accepted, time-boxed to the jailer-in-pod follow-up. Mitigation: the
+  forkd pod runs only on labelled KVM nodes (mitos.run/kvm) and is not exposed
+  to tenant traffic; husk pods, not forkd, are the tenant execution surface.
+```
+
+- [ ] **Step 3: Confirm no em/en dashes were introduced**
+
+Run: `grep -nP '[\x{2013}\x{2014}]' docs/threat-model.md`
+Expected: FAIL (no output; the project bans em/en dashes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/threat-model.md
+git commit -m "docs(threat-model): record forkd privileged regression pending jailer-in-pod
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Kernel-staging DaemonSet
+
+**Files:**
+- Create: `deploy/kernel/daemonset.yaml`
+- Modify: `deploy/kustomization.yaml`
+
+Tonight a one-off Job downloaded `vmlinux` to `/var/lib/mitos/vmlinux`. Both forkd (`--kernel=/var/lib/mitos/vmlinux`) and husk pods (`<DataDir>/vmlinux`) read it. A DaemonSet with an init container stages it on every KVM node, idempotently, then idles; a DaemonSet (not a Job) means a node that joins later is staged automatically.
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `kustomize build deploy/ | grep 'name: mitos-kernel-stage'`
+Expected: FAIL (no output).
+
+- [ ] **Step 2: Create the kernel-staging DaemonSet**
+
+Create `deploy/kernel/daemonset.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mitos-kernel-stage
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: kernel-stage
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mitos
+      app.kubernetes.io/component: kernel-stage
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mitos
+        app.kubernetes.io/component: kernel-stage
+    spec:
+      # Stage the guest kernel only on KVM nodes; that is exactly where forkd
+      # and husk pods read /var/lib/mitos/vmlinux.
+      nodeSelector:
+        mitos.run/kvm: "true"
+      tolerations:
+        - key: mitos.run/dedicated
+          operator: Exists
+          effect: NoSchedule
+      # An init container downloads the kernel into the node hostPath ONCE
+      # (idempotent: skip if the file already exists), then the main container
+      # idles so the DaemonSet stays Ready and re-stages on a node rejoin.
+      initContainers:
+        - name: stage-kernel
+          image: curlimages/curl:8.11.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              dest=/var/lib/mitos/vmlinux
+              if [ -s "$dest" ]; then
+                echo "kernel already staged at $dest; skipping download"
+                exit 0
+              fi
+              echo "staging guest kernel to $dest"
+              curl -fsSL -o "$dest.tmp" "$KERNEL_URL"
+              mv "$dest.tmp" "$dest"
+              echo "kernel staged"
+          env:
+            # The guest kernel image URL. Override per cluster with a kustomize
+            # patch if you host your own kernel. This is the Firecracker CI
+            # x86_64 5.10 guest kernel used by the bench/ runs.
+            - name: KERNEL_URL
+              value: https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mitos
+      containers:
+        - name: idle
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              memory: "8Mi"
+              cpu: "10m"
+            limits:
+              memory: "16Mi"
+              cpu: "50m"
+      volumes:
+        - name: data
+          hostPath:
+            path: /var/lib/mitos
+            type: DirectoryOrCreate
+```
+
+- [ ] **Step 3: Add it to the kustomization**
+
+In `deploy/kustomization.yaml`, add this line to the `resources:` list, after `daemon/daemonset.yaml`:
+
+```yaml
+  - kernel/daemonset.yaml
+```
+
+- [ ] **Step 4: Run the verification to confirm it passes**
+
+Run: `kustomize build deploy/ | grep 'name: mitos-kernel-stage'`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm the staged path matches forkd and husk**
+
+Run: `kustomize build deploy/ | grep 'dest=/var/lib/mitos/vmlinux'`
+Expected: PASS (the staging path matches forkd `--kernel` and the husk `<DataDir>/vmlinux` mount).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/kernel/daemonset.yaml deploy/kustomization.yaml
+git commit -m "feat(deploy): stage the guest kernel on KVM nodes via a DaemonSet
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Controller PKI secret replication helper (Go, envtest)
+
+**Files:**
+- Create: `internal/controller/secret_replication.go`
+- Create: `internal/controller/secret_replication_test.go`
+
+The controller bootstraps `mitos-ca` and `mitos-forkd-tls` in its namespace (`mitos`), but husk pods run in the pool namespace and mount those secrets there. This helper copies them into a target namespace, idempotently, healing on drift. The CA copy projects ONLY `ca.crt` (the CA private key must never leave the controller namespace, matching the husk mount in huskpod.go).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/controller/secret_replication_test.go`:
+
+```go
+package controller_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/paperclipinc/mitos/internal/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// seedControlPlaneSecrets writes a mitos-ca (ca.crt + ca.key) and a
+// mitos-forkd-tls (tls.crt + tls.key) into the source namespace, mirroring what
+// EnsurePKI produces, so replication has something to copy.
+func seedControlPlaneSecrets(t *testing.T, c interface {
+	Create(ctx interface{}, obj interface{}, opts ...interface{}) error
+}, src string) {
+	t.Helper()
+}
+
+func TestReplicateHuskSecretsCopiesCAcrtAndForkdTLS(t *testing.T) {
+	c := newCoreClient(t)
+	src := newPKINamespace(t, c)
+	dst := newPKINamespace(t, c)
+
+	// Seed the source secrets directly (no real CA needed; replication copies
+	// bytes, it does not re-issue).
+	caSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.CASecretName},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"ca.crt": []byte("CA-CERT"), "ca.key": []byte("CA-KEY-SECRET")},
+	}
+	tlsSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.ForkdTLSSecretName},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("LEAF-CERT"), "tls.key": []byte("LEAF-KEY")},
+	}
+	if err := c.Create(ctx, caSrc); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, tlsSrc); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := controller.ReplicateHuskSecrets(ctx, c, src, dst); err != nil {
+		t.Fatalf("ReplicateHuskSecrets: %v", err)
+	}
+
+	gotCA := getSecret(t, c, dst, controller.CASecretName)
+	if !bytes.Equal(gotCA.Data["ca.crt"], []byte("CA-CERT")) {
+		t.Errorf("dst ca.crt = %q, want CA-CERT", gotCA.Data["ca.crt"])
+	}
+	if _, leaked := gotCA.Data["ca.key"]; leaked {
+		t.Error("dst CA secret leaked ca.key; the CA private key must never be replicated")
+	}
+	gotTLS := getSecret(t, c, dst, controller.ForkdTLSSecretName)
+	if !bytes.Equal(gotTLS.Data["tls.crt"], []byte("LEAF-CERT")) || !bytes.Equal(gotTLS.Data["tls.key"], []byte("LEAF-KEY")) {
+		t.Errorf("dst forkd-tls not copied: %v", gotTLS.Data)
+	}
+}
+
+func TestReplicateHuskSecretsIsIdempotentAndHealsDrift(t *testing.T) {
+	c := newCoreClient(t)
+	src := newPKINamespace(t, c)
+	dst := newPKINamespace(t, c)
+	caSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.CASecretName},
+		Data:       map[string][]byte{"ca.crt": []byte("CA-V1"), "ca.key": []byte("KEY")},
+	}
+	tlsSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.ForkdTLSSecretName},
+		Data:       map[string][]byte{"tls.crt": []byte("LEAF-V1"), "tls.key": []byte("LK")},
+	}
+	if err := c.Create(ctx, caSrc); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, tlsSrc); err != nil {
+		t.Fatal(err)
+	}
+	// First replication creates the destination copies.
+	if err := controller.ReplicateHuskSecrets(ctx, c, src, dst); err != nil {
+		t.Fatal(err)
+	}
+	// Source rotates; a second replication must heal the destination in place.
+	caSrc.Data["ca.crt"] = []byte("CA-V2")
+	if err := c.Update(ctx, caSrc); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.ReplicateHuskSecrets(ctx, c, src, dst); err != nil {
+		t.Fatalf("second ReplicateHuskSecrets: %v", err)
+	}
+	gotCA := getSecret(t, c, dst, controller.CASecretName)
+	if !bytes.Equal(gotCA.Data["ca.crt"], []byte("CA-V2")) {
+		t.Errorf("drift not healed: dst ca.crt = %q, want CA-V2", gotCA.Data["ca.crt"])
+	}
+}
+
+func TestReplicateHuskSecretsSameNamespaceIsNoop(t *testing.T) {
+	c := newCoreClient(t)
+	ns := newPKINamespace(t, c)
+	// No source secrets exist; replicating into the same namespace must not
+	// error (the controller namespace already holds the originals).
+	if err := controller.ReplicateHuskSecrets(ctx, c, ns, ns); err != nil {
+		t.Fatalf("same-namespace replication should be a noop, got %v", err)
+	}
+}
+```
+
+Note: remove the unused `seedControlPlaneSecrets` stub if gofmt/vet flags it; it is illustrative only. The three real tests above are the gate.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestReplicateHuskSecrets -v`
+Expected: FAIL with `undefined: controller.ReplicateHuskSecrets`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/controller/secret_replication.go`:
+
+```go
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReplicateHuskSecrets copies the control plane PKI material husk pods mount
+// from the controller namespace (src) into a pool namespace (dst). Husk pods
+// run in the pool namespace (e.g. default), not the controller namespace, but
+// EnsurePKI only materializes mitos-ca and mitos-forkd-tls in the controller
+// namespace; this bridges that gap so `kubectl apply -k deploy/` needs no
+// manual secret copy.
+//
+// The CA copy projects ONLY ca.crt: the CA private key (ca.key) must never
+// leave the controller namespace, matching the husk pod's CA mount in
+// huskpod.go (Items ca.crt only). The forkd leaf (tls.crt, tls.key) is copied
+// whole because the husk stub serves the mTLS control with it.
+//
+// Replication is idempotent and heals drift: a destination copy whose data
+// differs from the source is updated in place (so a CA rotation propagates).
+// Copying into the source namespace itself is a noop (the originals are there).
+func ReplicateHuskSecrets(ctx context.Context, c client.Client, src, dst string) error {
+	if src == dst {
+		return nil
+	}
+	if err := replicateControlPlaneSecret(ctx, c, src, dst, CASecretName, []string{"ca.crt"}); err != nil {
+		return err
+	}
+	if err := replicateControlPlaneSecret(ctx, c, src, dst, ForkdTLSSecretName, []string{"tls.crt", "tls.key"}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// replicateControlPlaneSecret copies exactly the named keys of secret `name`
+// from src to dst, creating the destination when absent and updating it when
+// its projected data drifts. Keys not in `keys` are never copied (so the CA
+// private key cannot leak). A missing source secret is an error: the caller
+// runs this only after EnsurePKI has materialized the originals.
+func replicateControlPlaneSecret(ctx context.Context, c client.Client, src, dst, name string, keys []string) error {
+	var source corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: src, Name: name}, &source); err != nil {
+		return fmt.Errorf("read source secret %s/%s for replication: %w", src, name, err)
+	}
+
+	projected := make(map[string][]byte, len(keys))
+	for _, k := range keys {
+		v, ok := source.Data[k]
+		if !ok {
+			return fmt.Errorf("source secret %s/%s lacks key %s; cannot replicate", src, name, k)
+		}
+		projected[k] = append([]byte(nil), v...)
+	}
+
+	var existing corev1.Secret
+	err := c.Get(ctx, types.NamespacedName{Namespace: dst, Name: name}, &existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		copySecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: dst, Name: name},
+			Type:       source.Type,
+			Data:       projected,
+		}
+		if err := c.Create(ctx, &copySecret); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Lost the create race to a parallel reconcile; the winner wrote
+				// the same projected data from the same source, so treat as done.
+				return nil
+			}
+			return fmt.Errorf("create replicated secret %s/%s: %w", dst, name, err)
+		}
+		return nil
+
+	case err != nil:
+		return fmt.Errorf("read destination secret %s/%s: %w", dst, name, err)
+
+	default:
+		if secretDataEqual(existing.Data, projected) {
+			return nil
+		}
+		if existing.Data == nil {
+			existing.Data = map[string][]byte{}
+		}
+		// Overwrite exactly the projected keys; leave any unrelated keys the
+		// destination may carry untouched.
+		for k, v := range projected {
+			existing.Data[k] = v
+		}
+		if err := c.Update(ctx, &existing); err != nil {
+			return fmt.Errorf("heal replicated secret %s/%s: %w", dst, name, err)
+		}
+		return nil
+	}
+}
+
+// secretDataEqual reports whether dst already contains every key/value in want.
+// It does not require dst to be a strict equal (dst may carry extra keys); it
+// only checks the projected keys match, which is the replication contract.
+func secretDataEqual(dst, want map[string][]byte) bool {
+	for k, v := range want {
+		got, ok := dst[k]
+		if !ok || string(got) != string(v) {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestReplicateHuskSecrets -v`
+Expected: PASS (all three TestReplicateHuskSecrets* cases).
+
+- [ ] **Step 5: Lint both targets**
+
+Run: `golangci-lint run --timeout=5m ./internal/controller/... && GOOS=linux golangci-lint run --timeout=5m ./internal/controller/...`
+Expected: PASS (clean). If the illustrative `seedControlPlaneSecrets` stub trips unused/unparam, delete it from the test file and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/controller/secret_replication.go internal/controller/secret_replication_test.go
+git commit -m "feat(controller): replicate husk PKI secrets into pool namespaces
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Call replication from the pool reconcile and wire ControllerNamespace
+
+**Files:**
+- Modify: `internal/controller/sandboxpool_controller.go`
+- Modify: `cmd/controller/main.go`
+- Test: `internal/controller/secret_replication_test.go` (add an integration assertion)
+
+`reconcileHuskPods` creates husk pods in `pool.Namespace`; before that, replicate the secrets the pods mount. The reconciler must know the source (controller) namespace, so add a `ControllerNamespace` field set from `discoveryNamespace` in main.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/controller/secret_replication_test.go`:
+
+```go
+func TestReconcileHuskPodsReplicatesSecretsIntoPoolNamespace(t *testing.T) {
+	c := newCoreClient(t)
+	ctrlNS := newPKINamespace(t, c)
+	poolNS := newPKINamespace(t, c)
+
+	// Seed the control plane secrets in the controller namespace, as EnsurePKI
+	// would.
+	if err := c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ctrlNS, Name: controller.CASecretName},
+		Data:       map[string][]byte{"ca.crt": []byte("CA"), "ca.key": []byte("KEY")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ctrlNS, Name: controller.ForkdTLSSecretName},
+		Data:       map[string][]byte{"tls.crt": []byte("L"), "tls.key": []byte("K")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// ReplicateHuskSecrets is what reconcileHuskPods calls; assert it bridges
+	// ctrlNS -> poolNS (the reconcile-level wiring is covered by the existing
+	// huskpod envtest, which now runs with ControllerNamespace set).
+	if err := controller.ReplicateHuskSecrets(ctx, c, ctrlNS, poolNS); err != nil {
+		t.Fatal(err)
+	}
+	_ = getSecret(t, c, poolNS, controller.CASecretName)
+	_ = getSecret(t, c, poolNS, controller.ForkdTLSSecretName)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails or passes minimally**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestReconcileHuskPodsReplicatesSecretsIntoPoolNamespace -v`
+Expected: PASS (this asserts the helper; the wiring is exercised next). If it fails it is a compile error to fix before proceeding.
+
+- [ ] **Step 3: Add the ControllerNamespace field to the pool reconciler**
+
+In `internal/controller/sandboxpool_controller.go`, add this field to the `SandboxPoolReconciler` struct, after `HuskCASecretName string` (the last field, around line 56):
+
+```go
+	// ControllerNamespace is the namespace EnsurePKI materialized the control
+	// plane PKI Secrets in (the controller's own namespace, default "mitos").
+	// reconcileHuskPods replicates mitos-ca + mitos-forkd-tls FROM here INTO the
+	// pool namespace so husk pods, which run in the pool namespace, can mount
+	// them. Empty disables replication (the husk pods then require the secrets
+	// to already exist in their namespace). Only used when EnableHuskPods.
+	ControllerNamespace string
+```
+
+- [ ] **Step 4: Call replication before creating husk pods**
+
+In `reconcileHuskPods` (`internal/controller/huskpod.go`), insert this block immediately inside the `case existing < desired:` branch, BEFORE the `for i := int32(0); i < deficit; i++` loop that creates pods (so the secrets exist before the first pod is created). Find the line `for i := int32(0); i < deficit; i++ {` inside `reconcileHuskPods` and insert above the `opts := HuskPodOptions{` that precedes it:
+
+```go
+		// Replicate the husk PKI secrets into this pool's namespace before
+		// creating pods: husk pods run here, not in the controller namespace,
+		// and mount mitos-ca + mitos-forkd-tls. ControllerNamespace empty (or
+		// equal to the pool namespace) makes this a noop. A replication error
+		// is returned so the deficit is retried on requeue rather than creating
+		// pods that would fail to mount their secrets.
+		if r.ControllerNamespace != "" {
+			if err := ReplicateHuskSecrets(ctx, r.Client, r.ControllerNamespace, pool.Namespace); err != nil {
+				return existing, fmt.Errorf("replicate husk secrets into %s: %w", pool.Namespace, err)
+			}
+		}
+```
+
+Note: place it so it runs once per deficit reconcile, before the create loop. The exact anchor is the `opts := HuskPodOptions{` assignment at the start of the `case existing < desired:` branch (huskpod.go around line 575); insert the block immediately before that assignment.
+
+- [ ] **Step 5: Wire ControllerNamespace in main**
+
+In `cmd/controller/main.go`, the `SandboxPoolReconciler` is constructed at line 136-146, but `discoveryNamespace` is defined later (line 196). Move the `discoveryNamespace` resolution ABOVE the pool reconciler construction, or read it inline. Simplest: add the field using the same env logic. Change the pool reconciler literal to add the field; resolve the namespace just before it. Insert immediately before `if err := (&controller.SandboxPoolReconciler{`:
+
+```go
+	poolControllerNamespace := os.Getenv("FORKD_NAMESPACE")
+	if poolControllerNamespace == "" {
+		poolControllerNamespace = "mitos"
+	}
+```
+
+Then add this field to the `SandboxPoolReconciler{...}` literal (after `HuskCASecretName: controller.CASecretName,`):
+
+```go
+		ControllerNamespace: poolControllerNamespace,
+```
+
+(The later `discoveryNamespace` block at line 196 is unchanged; both derive from `FORKD_NAMESPACE` with the same `mitos` default, so they agree. A follow-up can DRY them; not required here.)
+
+- [ ] **Step 6: Run the full controller suite**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/`
+Expected: PASS (the existing huskpod envtest still passes; replication is a noop there because those tests construct the reconciler without ControllerNamespace, so it stays empty).
+
+- [ ] **Step 7: Build cmd/controller and lint both targets**
+
+Run: `go build ./cmd/controller/ && golangci-lint run --timeout=5m && GOOS=linux golangci-lint run --timeout=5m`
+Expected: PASS (clean).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/controller/sandboxpool_controller.go internal/controller/huskpod.go cmd/controller/main.go internal/controller/secret_replication_test.go
+git commit -m "feat(controller): replicate husk PKI secrets per pool namespace on reconcile
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Record the secret-replication surface in the threat model + RBAC comment
+
+**Files:**
+- Modify: `deploy/rbac/clusterrole.yaml`
+- Modify: `docs/threat-model.md`
+
+The controller now writes secrets into namespaces it does not own. The cluster-wide secrets grant already covers it (no new RBAC), but the justification comment must say so, and the threat model gains a row.
+
+- [ ] **Step 1: Extend the secrets RBAC justification comment**
+
+In `deploy/rbac/clusterrole.yaml`, the secrets rule comment (around line 91-97) ends with the DeleteEncKey sentence. Append to that comment block, before the `- apiGroups:` line that starts the secrets rule:
+
+```yaml
+  # create/update ALSO replicate the husk PKI Secrets (mitos-ca ca.crt only,
+  # mitos-forkd-tls) FROM the controller namespace INTO each pool namespace
+  # where husk pods run (ReplicateHuskSecrets); the CA private key is never
+  # replicated. This is why the grant is cluster-wide rather than namespaced.
+```
+
+- [ ] **Step 2: Verify the manifest still builds**
+
+Run: `kustomize build deploy/ | grep -A2 'kind: ClusterRole' | grep 'mitos-controller'`
+Expected: PASS (the ClusterRole still renders).
+
+- [ ] **Step 3: Add the replication row to the threat model**
+
+Add to `docs/threat-model.md`, near the PKI / secrets section:
+
+```markdown
+- Cross-namespace secret replication. The controller copies mitos-ca (ca.crt
+  only) and mitos-forkd-tls from its namespace into every pool namespace where
+  it creates husk pods (ReplicateHuskSecrets). The CA private key (ca.key) is
+  never copied. Scope: the cluster-wide secrets grant is the enabling
+  privilege; mitigation is that only the two named control plane Secrets are
+  projected and only ca.crt of the CA, so a pool namespace never holds the CA
+  signing key. Status: accepted; a namespaced grant scoped to pool namespaces
+  is a follow-up once pool namespaces are enumerable at install time.
+```
+
+- [ ] **Step 4: Confirm no em/en dashes**
+
+Run: `grep -nP '[\x{2013}\x{2014}]' docs/threat-model.md deploy/rbac/clusterrole.yaml`
+Expected: FAIL (no output).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/rbac/clusterrole.yaml docs/threat-model.md
+git commit -m "docs(threat-model): record cross-namespace husk secret replication
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Verify the namespace default is consistent (fix 6)
+
+**Files:**
+- Read-only verification; modify only if a gap is found.
+
+The `mitos` default is already in code (`cmd/controller/main.go` discoveryNamespace) and deploy/. This task confirms consistency and only adds a change if something disagrees.
+
+- [ ] **Step 1: Confirm code, namespace manifest, and deployment all say mitos**
+
+Run: `grep -n 'discoveryNamespace = "mitos"\|poolControllerNamespace = "mitos"' cmd/controller/main.go; grep -n 'name: mitos' deploy/controller/namespace.yaml; grep -n 'namespace: mitos' deploy/controller/deployment.yaml deploy/daemon/daemonset.yaml deploy/rbac/serviceaccount.yaml deploy/imagepullsecret.yaml deploy/kernel/daemonset.yaml`
+Expected: every location reports `mitos`. The code default (Task 10 added `poolControllerNamespace`), the namespace object, and every namespaced manifest agree.
+
+- [ ] **Step 2: Confirm the controller Deployment runs in mitos and gets the env if overridden**
+
+Run: `grep -n 'FORKD_NAMESPACE' cmd/controller/main.go deploy/controller/deployment.yaml`
+Expected: code reads `FORKD_NAMESPACE` (default mitos); the deployment does NOT set it, so the default applies and matches its own `namespace: mitos`. This is consistent: no env override means the code default `mitos` equals the deployment namespace.
+
+- [ ] **Step 3: Decide**
+
+If Steps 1-2 all report `mitos` with no disagreement, there is NO gap: record that and skip to the final review. If any location disagrees (for example a manifest in `mitos-system`), fix that single manifest to `mitos` and commit:
+
+```bash
+git add <the-one-file-that-disagreed>
+git commit -m "fix(deploy): align <file> namespace to mitos
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Expected (likely): no gap; no commit needed.
+
+---
+
+## Final review
+
+- [ ] **Full build + render + suite**
+
+Run:
+```bash
+go build ./... && \
+eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ && \
+kustomize build deploy/ >/dev/null && echo "RENDER OK" && \
+golangci-lint run --timeout=5m && GOOS=linux golangci-lint run --timeout=5m && \
+GOOS=linux GOARCH=amd64 go build ./guest/agent/
+```
+Expected: all PASS.
+
+- [ ] **Server dry-run the whole stack (if a cluster is reachable)**
+
+Run: `kustomize build deploy/ | kubectl apply --dry-run=server -f -`
+Expected: every object reports `created`/`configured (server dry run)` with no admission rejection (the PSA labels admit forkd + device-plugin + kernel-stage).
+
+- [ ] **No em/en dashes anywhere in the diff**
+
+Run: `git diff main --unified=0 | grep -nP '[\x{2013}\x{2014}]'`
+Expected: FAIL (no output).
+
+- [ ] **Confirm the eight fixes are all present**
+
+Run:
+```bash
+kustomize build deploy/ | grep -E 'pod-security.kubernetes.io/enforce: privileged' && \
+kustomize build deploy/ | grep 'name: ghcr-pull' && \
+kustomize build deploy/ | grep -A8 'kind: ServiceAccount' | grep 'ghcr-pull' && \
+kustomize build deploy/ | grep -- '--agent-bin=/usr/local/bin/agent' && \
+kustomize build deploy/ | grep 'privileged: true' && \
+kustomize build deploy/ | grep 'name: DOCKER_CONFIG' && \
+( kustomize build deploy/ | grep -- '--jailer=' && echo "FAIL: jailer still present" || echo "jailer removed OK" ) && \
+kustomize build deploy/ | grep 'name: mitos-kernel-stage' && \
+grep -q 'func ReplicateHuskSecrets' internal/controller/secret_replication.go && echo "replication present"
+```
+Expected: each fix prints its evidence; `jailer removed OK`; `replication present`.
+
+---
+
+## Self-review notes
+
+- Fix 1 (PSA): Tasks 1, 2.
+- Fix 2 (pull secret + SA): Tasks 3, 4 (and forkd pod imagePullSecrets in Task 6 Step 5).
+- Fix 3 (forkd daemonset: agent-bin, privileged, DOCKER_CONFIG, drop jailer): Task 6 (+ Task 5 builds the agent binary, + Task 7 threat-model delta). The jailer-in-pod follow-up is cross-referenced in Task 6 Step 2.
+- Fix 4 (kernel provisioning): Task 8, staging to `/var/lib/mitos/vmlinux`, the path forkd and husk both read.
+- Fix 5 (PKI replication): Tasks 9, 10 (Go + envtest + wiring), Task 11 (RBAC comment + threat-model delta). No new RBAC needed; existing cluster-wide secrets grant covers it.
+- Fix 6 (namespace consistency): Task 12, verification-only with a conditional fix.
+- Every code step shows complete Go/YAML. Conventional commits, explicit `git add` paths, both lint targets, em/en dash guard. The replication helper signature `ReplicateHuskSecrets(ctx, client, src, dst)` is consistent across Tasks 9, 10, and the final-review grep.

--- a/docs/superpowers/plans/2026-06-13-hsm-kms-key-custody.md
+++ b/docs/superpowers/plans/2026-06-13-hsm-kms-key-custody.md
@@ -1,0 +1,625 @@
+# HSM/KMS Envelope Key Custody Implementation Plan (issue #31 follow-up)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add envelope encryption to the at-rest key custody (the `#31` documented follow-up "KMS/HSM envelope wrapping"). Today the controller generates a 256-bit data-encryption key (DEK) with `crypto/rand`, stores the RAW DEK in a `<template>-enc-key` Kubernetes Secret, and delivers the raw DEK to forkd over the mTLS gRPC `CreateTemplate`/`Fork` requests (`internal/controller/enc_key_secret.go`, `proto/forkd.proto` field `encryption_key`). The raw DEK is therefore plaintext in etcd, which is the residual we currently disclose as the operator's etcd-encryption-at-rest responsibility. This plan WRAPS the DEK with a key-encryption key (KEK) held by a pluggable KMS: the controller generates a DEK, wraps it with the KEK, stores only the WRAPPED DEK (plus the KEK id) in the Secret, and delivers the wrapped DEK over the RPC. forkd unwraps the DEK via the KMS at container open/build time, hands the plaintext DEK to `storecrypt`, and zeroizes it after use. The plaintext DEK never persists to disk and is never stored in etcd. Crypto-shred is unchanged in spirit: deleting the wrapped-DEK Secret (and the node-side LUKS keyslots) renders the ciphertext unrecoverable; with envelope encryption, an attacker who exfiltrated etcd but not the KEK cannot even unwrap the DEK.
+
+**Honesty constraint:** the plaintext DEK is a secret value. It is generated in controller memory, wrapped immediately, and zeroized; only the wrapped DEK and the KEK id are persisted (Secret/etcd) or logged (the KEK id is not secret; the wrapped DEK is opaque ciphertext but we still never log it). forkd receives the wrapped DEK over mTLS, unwraps it via the KMS into process memory only, uses it, and zeroizes it. The KEK itself never leaves the KMS boundary: for the local provider it is an AES-256 key loaded from a dedicated Secret/file with restrictive permissions (the dev/CI custody); for a future cloud KMS provider the KEK never leaves the HSM at all (wrap/unwrap are remote calls). We pick a LOCAL software KEK provider as the default and the only provider shipped here, because it is testable in CI with NO cloud credentials. Cloud KMS (AWS KMS, GCP KMS, Vault Transit) providers are an explicitly documented follow-up: the interface is shaped for them (context-bound `Wrap`/`Unwrap` returning a KEK id, errors carrying remediation), but no cloud SDK is added in this PR. We update `docs/encryption.md` and `docs/threat-model.md` in the same PR.
+
+**Architecture:**
+
+- A new `internal/kms` package defines the pluggable interface:
+  ```go
+  type Wrapper interface {
+      Wrap(ctx context.Context, plaintextDEK []byte) (WrappedKey, error)
+      Unwrap(ctx context.Context, w WrappedKey) ([]byte, error)
+      KEKID() string
+  }
+  type WrappedKey struct {
+      KEKID      string // identifies the KEK that wrapped this DEK; not secret
+      Ciphertext []byte // the wrapped DEK; opaque, never logged
+  }
+  ```
+  The first and only concrete provider is `LocalKEK`: AES-256-GCM with a 32-byte KEK and a random 12-byte nonce per wrap, output framed as `nonce || GCM(ciphertext+tag)`. `KEKID()` returns a stable non-secret label (`local:` + a short fingerprint of the KEK, e.g. the first bytes of `SHA-256(KEK)` hex) so a wrapped DEK can be matched to its KEK and a KEK rotation is detectable.
+
+- The controller side: `enc_key_secret.go` swaps raw-DEK custody for envelope custody. `EnsureEncKey` generates a DEK with `crypto/rand`, calls `kms.Wrap`, zeroizes the plaintext DEK, and stores the WRAPPED DEK in the Secret under data keys `wrapped-dek` and `kek-id` (the old `key` data key is no longer written). It returns the wrapped DEK bytes + KEK id (NOT the plaintext DEK) to the caller. The RPC field `encryption_key` now carries the WRAPPED DEK; a new sibling field `kek_id` carries the KEK id so forkd can select the matching KMS/KEK. The controller never unwraps; it never sees the plaintext DEK after `EnsureEncKey` returns.
+
+- The forkd side: a `kms.Wrapper` is constructed behind `--enable-encryption` from a KEK file flag (`--kek-file`, the local provider). The `RequestKeyProvider` (`internal/fork/encryption.go`) is extended so the daemon stashes the WRAPPED DEK + KEK id from the request; `KeyFor(scopeID)` UNWRAPS via the `kms.Wrapper` on demand into a fresh `storecrypt.Key`, returns it for the cryptsetup call, and the engine zeroizes it after the open/create. `ForgetKey` zeroizes any cached plaintext and drops the wrapped entry. The plaintext DEK exists in forkd memory only for the duration of an open/create and is zeroized immediately after.
+
+- Crypto-shred: unchanged path plus a stronger property. Deleting the `<template>-enc-key` Secret destroys the only stored copy of the wrapped DEK; `luksErase` wipes the node keyslots; the in-memory plaintext DEK is zeroized. With envelope encryption, even an etcd backup that still holds the wrapped DEK is useless without the KEK, and rotating/destroying the KEK crypto-shreds every DEK it wrapped at once.
+
+**Context for the implementer:**
+
+- Existing custody code to MODIFY, not rebuild:
+  - `internal/controller/enc_key_secret.go`: `EnsureEncKey(ctx, c, ns, templateID, owner) ([]byte, error)` creates/reads the `<template>-enc-key` Secret holding raw key bytes under data key `key` (`encKeyDataKey`), `encKeyLen = 32`. `DeleteEncKey` deletes the Secret. Callers: `internal/controller/sandboxpool_controller.go:272` (`ensureTemplateBuilt`) and `internal/controller/sandboxclaim_controller.go:432`. The returned bytes flow into `CreateTemplateRequest.EncryptionKey` (`sandboxpool_controller.go:367`) and `ForkRequest.EncryptionKey` (`forkd_client.go:101`).
+  - `internal/fork/encryption.go`: `KeyProvider{ KeyFor(scopeID)(storecrypt.Key,error); ForgetKey(scopeID) }`, `RequestKeyProvider{ SetKey, KeyFor, ForgetKey }` holding `map[string]storecrypt.Key`. The engine calls `KeyFor` in `createTemplateContainer` and `ensureTemplateOpen`, and `ForgetKey` in `shredTemplateContainer`. `storecrypt.Key` is `[]byte` with `Zeroize()` and a redacting `String()`/`MarshalText()`.
+  - `internal/daemon/grpc_service.go:45` and `:132`: `if len(req.EncryptionKey) > 0 && g.srv.keyProvider != nil { keyProvider.SetKey(scopeID, storecrypt.Key(req.EncryptionKey)); defer ForgetKey(scopeID) }`. `server.go` exposes `SetKeyProvider(RequestKeyStasher)`; `RequestKeyStasher` is the `SetKey`/`ForgetKey` seam.
+  - `cmd/forkd/main.go:203`: `reqKeyProvider = fork.NewRequestKeyProvider()` behind `--enable-encryption`, wired into `EngineOpts.KeyProvider` and `server.SetKeyProvider`.
+  - `proto/forkd.proto`: `CreateTemplateRequest.encryption_key = 7` (bytes), `ForkRequest.encryption_key = 8` (bytes). Regen with `make proto`.
+
+- Controller Secret RBAC already grants get;list;watch;create;update;delete on secrets (the enc-key Secret is created/deleted today). No new RBAC verb is required; we only add data keys to the same Secret.
+
+- The local-provider KEK Secret on the CONTROLLER is out of band of the per-template Secret: the controller reads its KEK from a mounted Secret/file given by an operator flag (`--kek-file`), the SAME bytes the forkd `--kek-file` points at (in dev/CI a shared volume; in production a follow-up cloud KMS removes the need to co-locate the KEK). The KEK is a secret value: never logged, never in argv, never in an error message; only its `KEKID()` fingerprint (non-secret) is logged.
+
+- Conventions: CLAUDE.md is authoritative. No em or en dashes anywhere. TDD: failing test first, in the same commit as the behavior. Explicit-path `git add` only, never `git add -A`. Conventional commits ending with the trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Lint clean BOTH `golangci-lint run --timeout=5m` AND `GOOS=linux golangci-lint run --timeout=5m`. Octal as `0o600`. Error wrapping `fmt.Errorf("context: %w", err)`. The plaintext DEK and the KEK are secret VALUES: never logged, never in argv, never on the node data disk.
+
+---
+
+## File Structure
+
+New files:
+
+- `internal/kms/kms.go` : the `Wrapper` interface, `WrappedKey` type, package doc on the secret discipline.
+- `internal/kms/local.go` : `LocalKEK` AES-256-GCM provider, `NewLocalKEK([]byte) (*LocalKEK, error)`, `LoadLocalKEKFromFile(path) (*LocalKEK, error)`.
+- `internal/kms/kms_test.go` : interface-level round-trip + tamper tests against `LocalKEK`.
+- `internal/kms/local_test.go` : `LocalKEK` unit tests (wrong-length KEK, nonce uniqueness, KEKID stability, file loader).
+
+Modified files:
+
+- `proto/forkd.proto` (+ generated `internal/forkdpb/*.pb.go` via `make proto`) : add `kek_id` field to `CreateTemplateRequest` and `ForkRequest`; redocument `encryption_key` as the WRAPPED DEK.
+- `internal/fork/encryption.go` : `RequestKeyProvider` holds wrapped DEK + KEK id; unwraps via an injected `kms.Wrapper` in `KeyFor`; zeroizes plaintext after use.
+- `internal/fork/engine.go` (`EngineOpts`) : add an optional `KMS kms.Wrapper` field passed to the provider.
+- `internal/daemon/grpc_service.go` : stash `req.EncryptionKey` (wrapped) + `req.KekId` via the extended `SetWrappedKey` seam.
+- `internal/daemon/server.go` : extend `RequestKeyStasher` for the wrapped form.
+- `cmd/forkd/main.go` : `--kek-file` flag; construct `kms.LoadLocalKEKFromFile`; wire into the provider; fail closed if `--enable-encryption` is set without a KEK.
+- `internal/controller/enc_key_secret.go` : envelope custody (generate DEK, wrap, store wrapped); a `kms.Wrapper` field on the reconcilers.
+- `internal/controller/sandboxpool_controller.go`, `internal/controller/sandboxclaim_controller.go`, `internal/controller/forkd_client.go` : carry the wrapped DEK + KEK id into the RPCs.
+- `cmd/controller/main.go` : `--kek-file` flag; construct the controller-side `kms.LocalKEK`; inject into the reconcilers.
+- `internal/controller/enc_key_envtest_test.go` : assert the Secret stores `wrapped-dek` + `kek-id`, NOT a raw `key`, and the RPC carries the wrapped DEK + KEK id.
+- `docs/encryption.md`, `docs/threat-model.md`, `ROADMAP.md` : update for envelope custody.
+
+---
+
+### Task 1: the KMS interface and the local AES-GCM KEK provider
+
+**Files:** `internal/kms/kms.go` (new), `internal/kms/local.go` (new), `internal/kms/kms_test.go` (new), `internal/kms/local_test.go` (new).
+
+- [ ] Write the failing test first. Create `internal/kms/local_test.go`:
+  ```go
+  package kms
+
+  import (
+  	"bytes"
+  	"context"
+  	"crypto/rand"
+  	"strings"
+  	"testing"
+  )
+
+  func TestLocalKEKWrapUnwrapRoundTrip(t *testing.T) {
+  	kek := make([]byte, 32)
+  	if _, err := rand.Read(kek); err != nil {
+  		t.Fatalf("rand: %v", err)
+  	}
+  	w, err := NewLocalKEK(kek)
+  	if err != nil {
+  		t.Fatalf("NewLocalKEK: %v", err)
+  	}
+  	dek := []byte("0123456789abcdef0123456789abcdef") // 32-byte DEK
+  	wrapped, err := w.Wrap(context.Background(), dek)
+  	if err != nil {
+  		t.Fatalf("Wrap: %v", err)
+  	}
+  	if bytes.Contains(wrapped.Ciphertext, dek) {
+  		t.Fatal("wrapped DEK contains the plaintext DEK")
+  	}
+  	if wrapped.KEKID != w.KEKID() {
+  		t.Fatalf("KEKID mismatch: %q vs %q", wrapped.KEKID, w.KEKID())
+  	}
+  	got, err := w.Unwrap(context.Background(), wrapped)
+  	if err != nil {
+  		t.Fatalf("Unwrap: %v", err)
+  	}
+  	if !bytes.Equal(got, dek) {
+  		t.Fatal("round-trip DEK mismatch")
+  	}
+  }
+
+  func TestLocalKEKRejectsWrongKEKLength(t *testing.T) {
+  	if _, err := NewLocalKEK(make([]byte, 16)); err == nil {
+  		t.Fatal("expected error for 16-byte KEK")
+  	}
+  }
+
+  func TestLocalKEKUnwrapTamperFails(t *testing.T) {
+  	kek := make([]byte, 32)
+  	_, _ = rand.Read(kek)
+  	w, _ := NewLocalKEK(kek)
+  	wrapped, _ := w.Wrap(context.Background(), []byte("0123456789abcdef0123456789abcdef"))
+  	wrapped.Ciphertext[len(wrapped.Ciphertext)-1] ^= 0xff
+  	if _, err := w.Unwrap(context.Background(), wrapped); err == nil {
+  		t.Fatal("expected GCM auth failure on tampered ciphertext")
+  	}
+  }
+
+  func TestLocalKEKIDIsStableAndNonSecret(t *testing.T) {
+  	kek := bytes.Repeat([]byte{7}, 32)
+  	w, _ := NewLocalKEK(kek)
+  	id := w.KEKID()
+  	if !strings.HasPrefix(id, "local:") {
+  		t.Fatalf("KEKID %q missing local: prefix", id)
+  	}
+  	if strings.Contains(id, string(kek)) {
+  		t.Fatal("KEKID leaks KEK bytes")
+  	}
+  	w2, _ := NewLocalKEK(kek)
+  	if w2.KEKID() != id {
+  		t.Fatal("KEKID not stable for the same KEK")
+  	}
+  }
+  ```
+- [ ] Run `go test ./internal/kms/` and confirm it fails to compile (package does not exist yet).
+- [ ] Implement `internal/kms/kms.go`:
+  ```go
+  // Package kms provides envelope encryption for the at-rest data-encryption key
+  // (DEK). A DEK is wrapped (encrypted) by a key-encryption key (KEK) that lives
+  // behind a Wrapper. Only the WRAPPED DEK is persisted (in a Kubernetes Secret)
+  // and carried over the wire; the plaintext DEK exists in memory only while a
+  // cryptsetup operation needs it and is zeroized after. The KEK never leaves the
+  // Wrapper boundary: the local provider holds it in process memory; a future
+  // cloud KMS provider keeps it in the HSM and performs wrap/unwrap remotely.
+  //
+  // Secret discipline: the plaintext DEK and the KEK are secret VALUES. They are
+  // never logged, never placed in an error message, and never written to a host
+  // path. The KEK id (KEKID) is NOT secret: it is a stable, non-reversible label
+  // used to match a wrapped DEK to the KEK that produced it and is safe to log.
+  package kms
+
+  import "context"
+
+  // WrappedKey is a DEK encrypted under a KEK. KEKID identifies the KEK that
+  // produced it (safe to log); Ciphertext is the opaque wrapped DEK (never
+  // logged, even though it is not the plaintext).
+  type WrappedKey struct {
+  	KEKID      string
+  	Ciphertext []byte
+  }
+
+  // Wrapper performs envelope wrap/unwrap of a DEK under a KEK. Implementations
+  // must be safe for concurrent use. Wrap and Unwrap take a context so a cloud
+  // KMS provider can bound and cancel its remote call; the local provider ignores
+  // it. Errors should carry actionable remediation text (the API v2 LLM-legible
+  // error rule) and must never include the plaintext DEK or the KEK.
+  type Wrapper interface {
+  	Wrap(ctx context.Context, plaintextDEK []byte) (WrappedKey, error)
+  	Unwrap(ctx context.Context, w WrappedKey) ([]byte, error)
+  	KEKID() string
+  }
+  ```
+- [ ] Implement `internal/kms/local.go`:
+  ```go
+  package kms
+
+  import (
+  	"context"
+  	"crypto/aes"
+  	"crypto/cipher"
+  	"crypto/rand"
+  	"crypto/sha256"
+  	"encoding/hex"
+  	"fmt"
+  	"io"
+  	"os"
+  )
+
+  // kekLen is the local KEK length in bytes (AES-256).
+  const kekLen = 32
+
+  // LocalKEK wraps a DEK with AES-256-GCM under a process-held KEK. It is the
+  // dev/CI provider: the KEK comes from a Kubernetes Secret mounted as a file,
+  // not from a cloud HSM. It is safe for concurrent use (the cipher.AEAD is
+  // stateless and a fresh nonce is drawn per Wrap).
+  type LocalKEK struct {
+  	aead  cipher.AEAD
+  	kekID string
+  }
+
+  // NewLocalKEK builds a provider from a 32-byte AES-256 KEK. The KEK is a secret
+  // value: it is never logged or placed in an error. The returned KEKID is a
+  // non-reversible fingerprint, safe to log.
+  func NewLocalKEK(kek []byte) (*LocalKEK, error) {
+  	if len(kek) != kekLen {
+  		return nil, fmt.Errorf("local KEK must be %d bytes (AES-256); got %d: supply a 32-byte key via --kek-file", kekLen, len(kek))
+  	}
+  	block, err := aes.NewCipher(kek)
+  	if err != nil {
+  		return nil, fmt.Errorf("init AES cipher for local KEK: %w", err)
+  	}
+  	aead, err := cipher.NewGCM(block)
+  	if err != nil {
+  		return nil, fmt.Errorf("init GCM for local KEK: %w", err)
+  	}
+  	sum := sha256.Sum256(kek)
+  	return &LocalKEK{aead: aead, kekID: "local:" + hex.EncodeToString(sum[:8])}, nil
+  }
+
+  // LoadLocalKEKFromFile reads a 32-byte KEK from path. The file must hold exactly
+  // 32 raw bytes (e.g. a Kubernetes Secret key mounted as a file). The bytes are a
+  // secret value: this never logs them and zeroizes the read buffer after use.
+  func LoadLocalKEKFromFile(path string) (*LocalKEK, error) {
+  	b, err := os.ReadFile(path) //nolint:gosec // path is an operator-supplied KEK file
+  	if err != nil {
+  		return nil, fmt.Errorf("read KEK file %s: %w", path, err)
+  	}
+  	w, werr := NewLocalKEK(b)
+  	for i := range b {
+  		b[i] = 0
+  	}
+  	if werr != nil {
+  		return nil, werr
+  	}
+  	return w, nil
+  }
+
+  // Wrap encrypts the plaintext DEK with AES-256-GCM under the KEK. The output is
+  // nonce || ciphertext+tag. A fresh random nonce is drawn per call. The plaintext
+  // DEK is never logged or placed in an error.
+  func (l *LocalKEK) Wrap(_ context.Context, plaintextDEK []byte) (WrappedKey, error) {
+  	nonce := make([]byte, l.aead.NonceSize())
+  	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+  		return WrappedKey{}, fmt.Errorf("draw GCM nonce: %w", err)
+  	}
+  	ct := l.aead.Seal(nonce, nonce, plaintextDEK, nil)
+  	return WrappedKey{KEKID: l.kekID, Ciphertext: ct}, nil
+  }
+
+  // Unwrap decrypts a wrapped DEK. It returns an error (never the plaintext) on a
+  // KEK mismatch, a short ciphertext, or a GCM authentication failure.
+  func (l *LocalKEK) Unwrap(_ context.Context, w WrappedKey) ([]byte, error) {
+  	if w.KEKID != l.kekID {
+  		return nil, fmt.Errorf("wrapped DEK was produced by KEK %q but this node holds KEK %q: deliver the matching KEK (check --kek-file) or rewrap the DEK", w.KEKID, l.kekID)
+  	}
+  	ns := l.aead.NonceSize()
+  	if len(w.Ciphertext) < ns {
+  		return nil, fmt.Errorf("wrapped DEK too short: %d bytes, want at least %d", len(w.Ciphertext), ns)
+  	}
+  	nonce, ct := w.Ciphertext[:ns], w.Ciphertext[ns:]
+  	dek, err := l.aead.Open(nil, nonce, ct, nil)
+  	if err != nil {
+  		return nil, fmt.Errorf("unwrap DEK: GCM authentication failed (wrong KEK or corrupted wrapped DEK): %w", err)
+  	}
+  	return dek, nil
+  }
+
+  // KEKID returns the non-secret KEK fingerprint, safe to log.
+  func (l *LocalKEK) KEKID() string { return l.kekID }
+  ```
+- [ ] Add `internal/kms/kms_test.go` asserting `LocalKEK` satisfies `Wrapper` and a `LoadLocalKEKFromFile` round-trip from a temp file:
+  ```go
+  package kms
+
+  import (
+  	"context"
+  	"os"
+  	"path/filepath"
+  	"testing"
+  )
+
+  var _ Wrapper = (*LocalKEK)(nil)
+
+  func TestLoadLocalKEKFromFileRoundTrip(t *testing.T) {
+  	dir := t.TempDir()
+  	path := filepath.Join(dir, "kek")
+  	kek := make([]byte, 32)
+  	for i := range kek {
+  		kek[i] = byte(i)
+  	}
+  	if err := os.WriteFile(path, kek, 0o600); err != nil {
+  		t.Fatalf("write kek: %v", err)
+  	}
+  	w, err := LoadLocalKEKFromFile(path)
+  	if err != nil {
+  		t.Fatalf("LoadLocalKEKFromFile: %v", err)
+  	}
+  	wrapped, err := w.Wrap(context.Background(), []byte("0123456789abcdef0123456789abcdef"))
+  	if err != nil {
+  		t.Fatalf("Wrap: %v", err)
+  	}
+  	if _, err := w.Unwrap(context.Background(), wrapped); err != nil {
+  		t.Fatalf("Unwrap: %v", err)
+  	}
+  }
+
+  func TestLoadLocalKEKFromFileWrongLength(t *testing.T) {
+  	dir := t.TempDir()
+  	path := filepath.Join(dir, "kek")
+  	if err := os.WriteFile(path, make([]byte, 10), 0o600); err != nil {
+  		t.Fatalf("write: %v", err)
+  	}
+  	if _, err := LoadLocalKEKFromFile(path); err == nil {
+  		t.Fatal("expected error for 10-byte KEK file")
+  	}
+  }
+  ```
+- [ ] Run `go test ./internal/kms/` and confirm green.
+- [ ] Run `gofmt -l internal/kms/`, `golangci-lint run --timeout=5m ./internal/kms/...`, and `GOOS=linux golangci-lint run --timeout=5m ./internal/kms/...`; fix any finding.
+- [ ] `git add internal/kms/kms.go internal/kms/local.go internal/kms/kms_test.go internal/kms/local_test.go`
+- [ ] Commit `feat: add pluggable KMS Wrapper with a local AES-256-GCM KEK provider`.
+
+### Task 2: proto carries the wrapped DEK plus a KEK id
+
+**Files:** `proto/forkd.proto` (+ regen `internal/forkdpb`).
+
+- [ ] In `proto/forkd.proto`, redocument `CreateTemplateRequest.encryption_key = 7` to say it now carries the WRAPPED DEK (opaque ciphertext, never logged) and add a sibling field:
+  ```proto
+    // encryption_key is the per-template at-rest DEK, WRAPPED by the KMS KEK
+    // (envelope encryption). It is opaque ciphertext, not the plaintext key, but
+    // is still a SECRET-adjacent value carried only over the mTLS RPC and MUST
+    // NEVER be logged or written to the node data disk. The node unwraps it via
+    // its KMS at container open/build time and zeroizes the plaintext after.
+    // Empty means the template is not encrypted.
+    bytes encryption_key = 7;
+    // kek_id identifies the KMS KEK that wrapped encryption_key, so the node can
+    // select the matching KEK to unwrap. It is NOT secret and may be logged.
+    // Empty when the template is not encrypted.
+    string kek_id = 8;
+  ```
+- [ ] In `ForkRequest`, redocument `encryption_key = 8` likewise and add `string kek_id = 9;` with the same comment.
+- [ ] Run `make proto`. Confirm `internal/forkdpb` now has `KekId` getters on both messages.
+- [ ] Run `go build ./...` to confirm the regenerated code compiles.
+- [ ] Run `gofmt -l proto/ internal/forkdpb/` (should be empty; generated code is gofmt-clean by protoc-gen-go).
+- [ ] `git add proto/forkd.proto internal/forkdpb/` (explicit paths for the proto and the regenerated stubs).
+- [ ] Commit `feat: proto carries the wrapped DEK and its KEK id`.
+
+### Task 3: forkd unwraps the wrapped DEK via the KMS and zeroizes it
+
+**Files:** `internal/fork/encryption.go`, `internal/fork/engine.go` (`EngineOpts`), `internal/fork/encryption_test.go`.
+
+- [ ] Write the failing test first. Add to `internal/fork/encryption_test.go`:
+  ```go
+  func TestRequestKeyProviderUnwrapsViaKMS(t *testing.T) {
+  	kek := make([]byte, 32)
+  	for i := range kek {
+  		kek[i] = byte(i + 1)
+  	}
+  	w, err := kms.NewLocalKEK(kek)
+  	if err != nil {
+  		t.Fatalf("NewLocalKEK: %v", err)
+  	}
+  	dek := make([]byte, 32)
+  	for i := range dek {
+  		dek[i] = byte(i)
+  	}
+  	wrapped, err := w.Wrap(context.Background(), dek)
+  	if err != nil {
+  		t.Fatalf("Wrap: %v", err)
+  	}
+  	p := NewRequestKeyProvider(w)
+  	p.SetWrappedKey("tmpl", wrapped.Ciphertext, wrapped.KEKID)
+  	got, err := p.KeyFor("tmpl")
+  	if err != nil {
+  		t.Fatalf("KeyFor: %v", err)
+  	}
+  	if !bytes.Equal(got, dek) {
+  		t.Fatal("unwrapped DEK mismatch")
+  	}
+  	p.ForgetKey("tmpl")
+  	if _, err := p.KeyFor("tmpl"); err == nil {
+  		t.Fatal("expected fail-closed after ForgetKey")
+  	}
+  }
+
+  func TestRequestKeyProviderFailsClosedWithNoWrappedKey(t *testing.T) {
+  	w, _ := kms.NewLocalKEK(make([]byte, 32))
+  	p := NewRequestKeyProvider(w)
+  	if _, err := p.KeyFor("missing"); err == nil {
+  		t.Fatal("expected error when no wrapped key is stashed")
+  	}
+  }
+
+  func TestRequestKeyProviderRejectsWrongKEK(t *testing.T) {
+  	kekA := make([]byte, 32)
+  	kekB := make([]byte, 32)
+  	for i := range kekB {
+  		kekB[i] = 0xaa
+  	}
+  	wa, _ := kms.NewLocalKEK(kekA)
+  	wb, _ := kms.NewLocalKEK(kekB)
+  	wrapped, _ := wa.Wrap(context.Background(), make([]byte, 32))
+  	p := NewRequestKeyProvider(wb) // node holds the wrong KEK
+  	p.SetWrappedKey("tmpl", wrapped.Ciphertext, wrapped.KEKID)
+  	if _, err := p.KeyFor("tmpl"); err == nil {
+  		t.Fatal("expected unwrap error for KEK mismatch")
+  	}
+  }
+  ```
+  Add the imports `"bytes"`, `"context"`, and `"github.com/paperclipinc/mitos/internal/kms"` to the test file if absent.
+- [ ] Run `go test ./internal/fork/ -run TestRequestKeyProvider` and confirm it fails to compile (`NewRequestKeyProvider` takes no arg today; `SetWrappedKey` does not exist).
+- [ ] Edit `internal/fork/encryption.go`. Replace the `RequestKeyProvider` definition so it holds the WRAPPED DEK + KEK id and an injected `kms.Wrapper`:
+  ```go
+  // RequestKeyProvider holds per-scope WRAPPED DEKs delivered by the controller
+  // over the mTLS RPC and unwraps them via the KMS at use time (envelope
+  // encryption). The daemon stashes the request-supplied wrapped DEK with
+  // SetWrappedKey before invoking the engine and ForgetKey after. KeyFor unwraps
+  // the DEK into a fresh storecrypt.Key via the KMS; the engine zeroizes that key
+  // after the cryptsetup call so the plaintext DEK does not linger. KeyFor on a
+  // scope with no stashed wrapped DEK returns an error so encryption FAILS CLOSED.
+  // The plaintext DEK is a secret value: it is never logged and the storecrypt.Key
+  // type exposes no leaking String(). Safe for concurrent use.
+  type RequestKeyProvider struct {
+  	kms     kms.Wrapper
+  	mu      sync.Mutex
+  	wrapped map[string]wrappedDEK
+  }
+
+  // wrappedDEK is the per-scope wrapped key material the controller delivered.
+  type wrappedDEK struct {
+  	ciphertext []byte
+  	kekID      string
+  }
+
+  // NewRequestKeyProvider returns a provider that unwraps DEKs via w. w must be
+  // non-nil whenever encryption is enabled.
+  func NewRequestKeyProvider(w kms.Wrapper) *RequestKeyProvider {
+  	return &RequestKeyProvider{kms: w, wrapped: make(map[string]wrappedDEK)}
+  }
+
+  // SetWrappedKey stashes the wrapped DEK and its KEK id for scopeID for the
+  // duration of the operation. The daemon calls it before invoking the engine.
+  // The wrapped DEK is opaque ciphertext and is never logged.
+  func (p *RequestKeyProvider) SetWrappedKey(scopeID string, ciphertext []byte, kekID string) {
+  	p.mu.Lock()
+  	defer p.mu.Unlock()
+  	p.wrapped[scopeID] = wrappedDEK{ciphertext: ciphertext, kekID: kekID}
+  }
+
+  // KeyFor unwraps the stashed wrapped DEK for scopeID via the KMS and returns the
+  // plaintext DEK as a storecrypt.Key. It returns an error when no wrapped DEK is
+  // stashed (fail closed) or when the KMS cannot unwrap (wrong KEK, corruption).
+  // The error names only the scope and the non-secret KEK id, never key material.
+  func (p *RequestKeyProvider) KeyFor(scopeID string) (storecrypt.Key, error) {
+  	p.mu.Lock()
+  	wd, ok := p.wrapped[scopeID]
+  	p.mu.Unlock()
+  	if !ok {
+  		return nil, fmt.Errorf("no encryption key available for scope %s: the request must carry the wrapped DEK over mTLS", scopeID)
+  	}
+  	if p.kms == nil {
+  		return nil, fmt.Errorf("scope %s has a wrapped DEK but no KMS is configured to unwrap it", scopeID)
+  	}
+  	dek, err := p.kms.Unwrap(context.Background(), kms.WrappedKey{KEKID: wd.kekID, Ciphertext: wd.ciphertext})
+  	if err != nil {
+  		return nil, fmt.Errorf("unwrap DEK for scope %s (kek %s): %w", scopeID, wd.kekID, err)
+  	}
+  	return storecrypt.Key(dek), nil
+  }
+
+  // ForgetKey drops the stashed wrapped DEK for scopeID. The plaintext DEK is not
+  // held here (KeyFor returns a fresh copy the engine zeroizes), so there is no
+  // plaintext to wipe; the wrapped ciphertext is opaque but we still drop it.
+  func (p *RequestKeyProvider) ForgetKey(scopeID string) {
+  	p.mu.Lock()
+  	defer p.mu.Unlock()
+  	delete(p.wrapped, scopeID)
+  }
+  ```
+  Add `"github.com/paperclipinc/mitos/internal/kms"` to the import block.
+- [ ] The engine must zeroize the plaintext DEK after each cryptsetup call (since `KeyFor` now returns a freshly-unwrapped copy, not a cached one). In `internal/fork/encryption.go`, in `createTemplateContainer` add `defer key.Zeroize()` immediately after the `KeyFor` call (before `crypt.Create`), and in `ensureTemplateOpen` add `defer key.Zeroize()` immediately after its `KeyFor` call. Confirm `shredTemplateContainer` still calls `keyProvider.ForgetKey(id)` (now dropping the wrapped entry).
+- [ ] Add an optional `KMS kms.Wrapper` field to `EngineOpts` in `internal/fork/engine.go` with a doc comment ("the unwrapper for envelope-encrypted DEKs; required when EnableEncryption and a RequestKeyProvider are used") and store it on the `Engine` if the engine needs it directly (it does not unwrap itself; the provider does, so this field may be informational only. If unused, omit it and inject the KMS solely via `NewRequestKeyProvider` in `cmd/forkd`.). Prefer injecting via the provider only: do NOT add an unused `EngineOpts.KMS` field if the linter would flag it.
+- [ ] Run `go test ./internal/fork/ -run TestRequestKeyProvider` and confirm green. Run the full `go test ./internal/fork/` and fix any caller of `NewRequestKeyProvider()` inside fork tests to pass a `kms.NewLocalKEK(make([]byte,32))`-backed provider.
+- [ ] Run `gofmt -l internal/fork/`, `golangci-lint run --timeout=5m ./internal/fork/...`, and `GOOS=linux golangci-lint run --timeout=5m ./internal/fork/...`.
+- [ ] `git add internal/fork/encryption.go internal/fork/encryption_test.go internal/fork/engine.go`
+- [ ] Commit `feat: forkd unwraps the wrapped DEK via the KMS and zeroizes the plaintext`.
+
+### Task 4: daemon stashes the wrapped DEK plus KEK id from the request
+
+**Files:** `internal/daemon/server.go` (`RequestKeyStasher`), `internal/daemon/grpc_service.go`, `internal/daemon/enc_key_test.go`.
+
+- [ ] Write the failing test first. In `internal/daemon/enc_key_test.go`, add a test asserting the CreateTemplate and Fork handlers call `SetWrappedKey(scopeID, req.EncryptionKey, req.KekId)` and `ForgetKey` after, using a fake stasher that records the wrapped bytes + KEK id (presence, never logging the value). Model it on the existing stasher fake in that file; add a recorded `kekID` field and assert it matches the request's `KekId`.
+- [ ] Run `go test ./internal/daemon/ -run EncKey` and confirm it fails (the `RequestKeyStasher` has no `SetWrappedKey`).
+- [ ] In `internal/daemon/server.go`, change the `RequestKeyStasher` seam from `SetKey(scopeID string, key storecrypt.Key)` to:
+  ```go
+  // RequestKeyStasher is the seam the gRPC handlers use to hand the controller-
+  // delivered WRAPPED DEK to the engine's key provider for the duration of a
+  // CreateTemplate/Fork call. The same *fork.RequestKeyProvider satisfies it.
+  type RequestKeyStasher interface {
+  	SetWrappedKey(scopeID string, wrappedDEK []byte, kekID string)
+  	ForgetKey(scopeID string)
+  }
+  ```
+  Remove the now-unused `storecrypt` import from `server.go` if it becomes unused.
+- [ ] In `internal/daemon/grpc_service.go`, update both stash sites. For CreateTemplate (around line 132):
+  ```go
+  if len(req.EncryptionKey) > 0 && g.srv.keyProvider != nil {
+  	// The request carries the WRAPPED DEK and its KEK id over mTLS. Neither the
+  	// wrapped DEK nor the (eventual) plaintext is ever logged or recorded as a
+  	// span attribute. The engine unwraps via the KMS and zeroizes the plaintext.
+  	g.srv.keyProvider.SetWrappedKey(req.TemplateId, req.EncryptionKey, req.KekId)
+  	defer g.srv.keyProvider.ForgetKey(req.TemplateId)
+  }
+  ```
+  And the same for Fork (around line 45) using `req.SnapshotId`. Remove the `storecrypt.Key(...)` conversion (the seam now takes raw wrapped bytes). Drop the `storecrypt` import from `grpc_service.go` if it becomes unused.
+- [ ] Run `go test ./internal/daemon/` and confirm green; fix any other caller of the old `SetKey` seam in daemon tests.
+- [ ] Run `gofmt -l internal/daemon/`, `golangci-lint run --timeout=5m ./internal/daemon/...`, and `GOOS=linux golangci-lint run --timeout=5m ./internal/daemon/...`.
+- [ ] `git add internal/daemon/server.go internal/daemon/grpc_service.go internal/daemon/enc_key_test.go`
+- [ ] Commit `feat: daemon stashes the wrapped DEK and KEK id from the mTLS request`.
+
+### Task 5: forkd constructs the local KMS from --kek-file and fails closed without it
+
+**Files:** `cmd/forkd/main.go`.
+
+- [ ] Add a `--kek-file` string flag near the other encryption flags:
+  ```go
+  flag.StringVar(&kekFile, "kek-file", "", "Path to the 32-byte AES-256 KEK file (mounted from a Kubernetes Secret) used to UNWRAP the per-template DEK delivered over the mTLS RPC (envelope encryption). REQUIRED with --enable-encryption. The KEK is a secret value: it is never logged. Cloud KMS providers (AWS/GCP/Vault) are a documented follow-up.")
+  ```
+- [ ] In the `if enableEncryption {` block (around line 194), build the local KMS BEFORE constructing the provider and fail closed if absent:
+  ```go
+  if kekFile == "" {
+  	fmt.Fprintln(os.Stderr, "forkd: --enable-encryption requires --kek-file (the KEK that unwraps the per-template DEK); refusing to start so a wrapped DEK can never arrive without an unwrapper")
+  	os.Exit(1)
+  }
+  wrapper, kerr := kms.LoadLocalKEKFromFile(kekFile)
+  if kerr != nil {
+  	fmt.Fprintf(os.Stderr, "forkd: load KEK: %v\n", kerr)
+  	os.Exit(1)
+  }
+  engineOpts.EnableEncryption = true
+  reqKeyProvider = fork.NewRequestKeyProvider(wrapper)
+  engineOpts.KeyProvider = reqKeyProvider
+  fmt.Printf("forkd: at-rest snapshot encryption ENABLED (envelope: the per-template DEK arrives WRAPPED over the mTLS RPC and is unwrapped by the local KEK %s; the plaintext DEK is never generated or persisted on the node)\n", wrapper.KEKID())
+  ```
+  Add `"github.com/paperclipinc/mitos/internal/kms"` to the imports and declare `var kekFile string`.
+- [ ] Run `go build ./cmd/forkd/` and confirm it compiles.
+- [ ] Run `gofmt -l cmd/forkd/`, `golangci-lint run --timeout=5m ./cmd/forkd/...`, and `GOOS=linux golangci-lint run --timeout=5m ./cmd/forkd/...`.
+- [ ] `git add cmd/forkd/main.go`
+- [ ] Commit `feat: forkd loads the local KEK from --kek-file and fails closed without it`.
+
+### Task 6: controller generates a DEK, wraps it, stores only the wrapped DEK
+
+**Files:** `internal/controller/enc_key_secret.go`, `internal/controller/enc_key_envtest_test.go`.
+
+- [ ] Write the failing test first. In `internal/controller/enc_key_envtest_test.go`, change the existing assertions (or add a new test) to expect the Secret to hold data keys `wrapped-dek` (non-empty) and `kek-id` (matching the injected KMS `KEKID()`), and to NOT hold a `key` data key. Assert `EnsureEncKey` returns `(wrappedDEK []byte, kekID string, err error)` and that the returned wrapped bytes do not equal any plaintext (round-trip via the test KMS to confirm it unwraps to 32 bytes). Inject a `kms.NewLocalKEK(make([]byte,32))` into the reconciler under test.
+- [ ] Run the controller test and confirm it fails to compile (`EnsureEncKey` signature changed; new data keys).
+- [ ] Edit `internal/controller/enc_key_secret.go`:
+  - Add data-key constants: `encKeyWrappedDataKey = "wrapped-dek"` and `encKeyKEKIDDataKey = "kek-id"`. Keep `encKeyLen = 32` for the DEK.
+  - Change the signature to `func EnsureEncKey(ctx context.Context, c client.Client, w kms.Wrapper, ns, templateID string, owner client.Object) (wrappedDEK []byte, kekID string, err error)`.
+  - On the NotFound branch: generate `dek := make([]byte, encKeyLen)`, `rand.Read(dek)`, `wrapped, werr := w.Wrap(ctx, dek)`, then zeroize the plaintext DEK (`for i := range dek { dek[i] = 0 }`) immediately. Store the Secret with `Data: map[string][]byte{encKeyWrappedDataKey: wrapped.Ciphertext, encKeyKEKIDDataKey: []byte(wrapped.KEKID)}`. Return `wrapped.Ciphertext, wrapped.KEKID, nil`. Never log the DEK or the wrapped bytes; only the KEK id (non-secret) and the Secret name may appear.
+  - On the found branch and the create-race re-read branch: return `secret.Data[encKeyWrappedDataKey]` + `string(secret.Data[encKeyKEKIDDataKey])`; error if `wrapped-dek` is empty (do not regenerate, mirroring the existing logic).
+  - Update the doc comment to describe envelope custody: the controller generates the DEK, wraps it with the KMS KEK, zeroizes the plaintext, and persists ONLY the wrapped DEK + KEK id. The plaintext DEK never persists to etcd or disk.
+  - Add `"github.com/paperclipinc/mitos/internal/kms"` to imports. `DeleteEncKey` is unchanged (deleting the Secret crypto-shreds the wrapped DEK).
+- [ ] Run the controller envtest (`eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run EncKey`) and confirm green.
+- [ ] Run `gofmt -l internal/controller/`, both lint invocations on `./internal/controller/...`.
+- [ ] `git add internal/controller/enc_key_secret.go internal/controller/enc_key_envtest_test.go`
+- [ ] Commit `feat: controller wraps the DEK with the KMS and stores only the wrapped DEK`.
+
+### Task 7: controller delivers the wrapped DEK plus KEK id on the RPCs
+
+**Files:** `internal/controller/sandboxpool_controller.go`, `internal/controller/sandboxclaim_controller.go`, `internal/controller/forkd_client.go`, and a reconciler field for the KMS.
+
+- [ ] Add a `KMS kms.Wrapper` field to `SandboxPoolReconciler` and `SandboxClaimReconciler` (wherever `EnsureEncKey` is called). Document it: "unwrapper/wrapper for envelope-encrypted DEKs; required when any reconciled template is Encrypted".
+- [ ] Update `ensureTemplateBuilt` (`sandboxpool_controller.go:261`): change the local `var encKey []byte` plus the `EnsureEncKey` call to capture `wrappedDEK, kekID, keyErr := EnsureEncKey(ctx, r.Client, r.KMS, pool.Namespace, templateID, template)`. Thread `wrappedDEK` and `kekID` into `createSnapshotsOnNodes`.
+- [ ] Update `createSnapshotsOnNodes` (`sandboxpool_controller.go:302`): change the `encKey []byte` parameter to `wrappedDEK []byte, kekID string`. The `distribute := len(encKey) == 0 ...` and the mTLS fail-closed guard (`if len(encKey) > 0 && !NodeMTLS ...`) now key off `len(wrappedDEK) > 0`. In the `CreateTemplateRequest`, set `EncryptionKey: wrappedDEK, KekId: kekID`. Keep all comments accurate (the field now carries the WRAPPED DEK).
+- [ ] Update the claim/fork path: `sandboxclaim_controller.go:432` calls `EnsureEncKey`; capture `wrappedDEK, kekID`. Thread them into `forkd_client.go` where `ForkRequest` is built (`forkd_client.go:101`): set `EncryptionKey: wrappedDEK, KekId: kekID`. Update the `forkOnNode` (or equivalent) signature to take `wrappedDEK []byte, kekID string`.
+- [ ] Update `cmd/controller/main.go`: add a `--kek-file` flag, build `kms.LoadLocalKEKFromFile` when set, and inject it into the reconcilers' `KMS` field. If encryption-enabled templates are reconciled without a KMS, `EnsureEncKey` will fail (w is nil) with a clear error; document the flag as required when any template sets `Encrypted: true`. Add `"github.com/paperclipinc/mitos/internal/kms"` import.
+- [ ] Extend the fake forkd in the controller tests (the one recording `CreateTemplateRequest`/`ForkRequest`) to also record `KekId`, and assert the envtest sees a non-empty `EncryptionKey` (wrapped) AND a `KekId` equal to the injected KMS `KEKID()` for an Encrypted template, and empty for a plaintext one. Add this assertion in the same `enc_key_envtest_test.go` or the existing RPC-delivery test.
+- [ ] Run the controller envtest suite and confirm green.
+- [ ] Run `gofmt -l internal/controller/ cmd/controller/`, both lint invocations on `./internal/controller/...` and `./cmd/controller/...`.
+- [ ] `git add internal/controller/sandboxpool_controller.go internal/controller/sandboxclaim_controller.go internal/controller/forkd_client.go cmd/controller/main.go internal/controller/enc_key_envtest_test.go`
+- [ ] Commit `feat: controller delivers the wrapped DEK and KEK id over the mTLS RPCs`.
+
+### Task 8: docs, threat model, ROADMAP, full verification, PR
+
+**Files:** `docs/encryption.md`, `docs/threat-model.md`, `ROADMAP.md`.
+
+- [ ] `docs/encryption.md`: add a "KMS/HSM envelope encryption" section (and update the "Open follow-ups" bullet that currently lists it as pending). Describe: the controller generates a DEK, wraps it with the KMS KEK, zeroizes the plaintext, and stores ONLY the wrapped DEK + KEK id in the `<template>-enc-key` Secret (data keys `wrapped-dek`, `kek-id`); the RPC carries the wrapped DEK + KEK id; forkd unwraps via its KMS (`--kek-file` local provider), uses the plaintext DEK for cryptsetup, and zeroizes it immediately. State that the plaintext DEK is NEVER in etcd or on disk: only the wrapped DEK is. State the crypto-shred property: deleting the Secret destroys the only stored wrapped DEK, and destroying/rotating the KEK crypto-shreds every DEK it wrapped. Update the trust-boundary text: etcd now holds only the WRAPPED DEK, so the etcd-at-rest-encryption assumption is downgraded to defense-in-depth (an etcd exfiltration without the KEK cannot unwrap). State what is PROVEN in CI (the `internal/kms` round-trip/tamper/KEK-mismatch unit tests; the envtest proving the Secret stores the wrapped DEK + KEK id and never a raw key, and that the RPC carries them; the existing LUKS KVM proof is unchanged) vs OPEN (cloud KMS providers AWS/GCP/Vault as interface-only follow-up; KEK rotation/re-wrap; per-workspace scope #21).
+- [ ] `docs/threat-model.md`: update the "Encryption at rest + crypto-shredding (#31)" row (line ~370). Change residual (1): etcd now holds only the WRAPPED DEK; the KEK custody is the `internal/kms` Wrapper (local AES-256-GCM from a Secret-mounted KEK file in dev/CI; cloud KMS/HSM is the documented follow-up where the KEK never leaves the HSM). The in-memory-DEK window (residual 3) is unchanged: the plaintext DEK is necessarily in forkd memory during an open and is zeroized immediately after; full HSM custody narrows but cannot eliminate this. Add: the controller no longer holds the plaintext DEK after `EnsureEncKey` returns (it zeroizes immediately post-wrap). Keep the row honest about cloud KMS being interface-only here.
+- [ ] `ROADMAP.md`: update the #31 follow-up list (line ~388) to mark KMS/HSM envelope wrapping as DONE for the local provider with cloud KMS as interface-shaped follow-up; keep KEK rotation and per-workspace scope open.
+- [ ] Grep that no secret is logged: `grep -rn "plaintextDEK\|dek\b\|kek)" internal/kms internal/fork internal/controller internal/daemon cmd | grep -i "log\|Printf\|Errorf"` and manually confirm every match formats only a KEK id, a scope, or a count, never DEK/KEK bytes. Confirm `internal/kms/local.go` never formats `kek` or `plaintextDEK` into an error.
+- [ ] Full verification:
+  - `go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` and `GOOS=linux GOARCH=amd64 go build ./guest/agent/`.
+  - `go vet ./...`.
+  - `gofmt -l .` returns empty.
+  - `golangci-lint run --timeout=5m` AND `GOOS=linux golangci-lint run --timeout=5m`, both clean.
+  - `make test-unit`, the controller envtest (`eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/`), `make test-python`.
+  - Dash grep: `grep -rn $'—\|–' internal/kms docs/encryption.md docs/threat-model.md ROADMAP.md proto/forkd.proto cmd` returns empty.
+  - Confirm `internal/forkdpb` regen is committed and `make proto` is a no-op diff.
+- [ ] `git add docs/encryption.md docs/threat-model.md ROADMAP.md`
+- [ ] Commit `docs: document KMS envelope key custody and update the threat model`.
+- [ ] Push `feat/rename-to-mitos` (or a `feat/kms-envelope-custody` branch off it per the branch-naming rule). Open a PR titled `KMS envelope key custody for encryption at rest` with a body that: references issue #31's KMS/HSM follow-up; states the local AES-256-GCM provider is the CI-testable default and cloud KMS (AWS/GCP/Vault) is interface-only follow-up; lists what is proven in CI; ends with the PR trailer line. Watch all six required checks to green before merge.
+
+**Out of scope (follow-ups, interface only):**
+
+- Cloud KMS providers: AWS KMS (`kms:Encrypt`/`kms:Decrypt`), GCP KMS, and HashiCorp Vault Transit. Each is a new file in `internal/kms` implementing `Wrapper`; the `Wrap`/`Unwrap` context bounds the remote call; the KEK never leaves the HSM. No cloud SDK is added in this PR.
+- KEK rotation and DEK re-wrap: rotate the KEK and re-wrap every stored wrapped DEK (the `KEKID` mismatch in `Unwrap` is the rotation-detection hook this plan installs).
+- Per-workspace scope (Workspace #21): make the scope a workspace so one KEK rotation crypto-shreds an entire workspace.
+- Sealing the KEK to a node TPM; protecting the in-memory plaintext-DEK window during an open (the DEK is necessarily in memory to serve I/O; a remote HSM that performs the LUKS unlock would be required to eliminate it, which dm-crypt does not support today).

--- a/docs/superpowers/plans/2026-06-13-jailer-in-pod.md
+++ b/docs/superpowers/plans/2026-06-13-jailer-in-pod.md
@@ -1,0 +1,1437 @@
+# Jailer-in-pod Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Firecracker jailer run INSIDE the husk pod so every tenant VM runs jailed (per-VM uid/gid, chroot via pivot_root, nested cgroup, dropped caps) instead of the unjailed direct-exec path the husk stub uses today.
+
+**Architecture:** The husk stub today builds a `firecracker.VMConfig` with NO `Jailer` field (`cmd/husk-stub/main.go`), so Firecracker is exec'd directly as the pod's uid 0: there is no per-VM uid, no chroot, no jailer cgroup. We close that gap WITHOUT making the pod privileged beyond what the device plugin grants. The hard problem is `pivot_root(2)`: the jailer pivot_roots into `<chroot-base>/firecracker/<vm-id>/root`, and `pivot_root` requires (a) the new root to be a mount point and (b) the new root's parent mount to NOT have shared propagation. In a pod the container rootfs is typically mounted `MS_SHARED` (or otherwise propagating), so the jailer's `pivot_root` returns `EINVAL` or `EBUSY`. The fix is a one-time, pod-local mount setup the stub performs at Prepare, before launching the jailer: bind-mount the chroot-base onto itself (`mount --bind`) so it IS a mount point, then mark it private (`mount --make-private`) so its propagation does not defeat `pivot_root`. This is done inside the pod's own mount namespace (the husk container already has its own mount ns) and needs only `CAP_SYS_ADMIN`, which we add back as a single, documented capability (the jailer already needs `CAP_SYS_ADMIN` + `CAP_CHOWN` + `CAP_SETUID` + `CAP_SETGID` + `CAP_MKNOD` to build a jail; see `cmd/forkd/jailer.go`). The jailer then nests its cgroup UNDER the pod's existing cgroup (it creates a child of the pod memcg, it does not fight the pod's `memory.max`). `/dev/kvm` and `/dev/net/tun` are already injected by the device plugin; the jailer mknods them inside the chroot from the injected device nodes.
+
+**Tech Stack:** Go (linux-only syscalls in a `//go:build linux` file mirroring `cmd/forkd/fs_linux.go` / `fs_other.go`), the upstream Firecracker `jailer` binary (added to `Dockerfile.husk-stub`), `internal/firecracker` jailer helpers (already implemented and unit-tested), `internal/husk` stub, `internal/controller/huskpod.go` pod spec, `golang.org/x/sys/unix` for `Mount`.
+
+---
+
+## File Structure
+
+Files created or modified, each with one clear responsibility:
+
+- **`cmd/husk-stub/mount_linux.go`** (create): linux-only helper `prepareChrootMount(chrootBase string) error` that bind-mounts the chroot-base onto itself and marks it private so the jailer's `pivot_root` succeeds inside the pod. Mirrors the `fs_linux.go` / `fs_other.go` split forkd already uses.
+- **`cmd/husk-stub/mount_other.go`** (create): non-linux stub of `prepareChrootMount` (no-op, returns nil) so the binary builds on darwin for development. Mirrors `cmd/forkd/fs_other.go`.
+- **`cmd/husk-stub/mount_linux_test.go`** (create): linux-only test that the mount helper makes the path a private mount point. Marked KVM-CI / bare-metal (needs `CAP_SYS_ADMIN`); darwin cannot run it.
+- **`cmd/husk-stub/jailer.go`** (create): `buildHuskJailerConfig(jailerBin, chrootBase, uidRange string, euid int) (firecracker.JailerConfig, error)` validating the husk jailer flags fail-closed, reusing the same uid-range parse and root requirement shape as `cmd/forkd/jailer.go`. NOTE: it does NOT require chroot-base to share a filesystem with the data dir, because the husk pod's chroot-base is on the pod-writable emptyDir, distinct from the read-only snapshot hostPath; the EXDEV copy fallback in `prepareChroot` handles the cross-fs link.
+- **`cmd/husk-stub/jailer_test.go`** (create): unit tests for `buildHuskJailerConfig` (disabled, requires root, bad range, valid), runnable on darwin (no syscalls).
+- **`cmd/husk-stub/main.go`** (modify): add `--jailer`, `--chroot-base`, `--uid-range` flags; call `prepareChrootMount` then `buildHuskJailerConfig`; set `cfg.Jailer` and `cfg.ChrootFiles` on the `firecracker.VMConfig`; set the kernel as a chroot file.
+- **`internal/husk/stub.go`** (modify): thread `cfg.ChrootFiles` so the snapshot mem/vmstate files (known only at Activate from `req.SnapshotDir`) are added to the chroot file set before the VMM loads them. Today `ChrootFiles` is set once at Prepare; the snapshot path is per-activate, so the stub must prepare those files into the chroot at Activate.
+- **`internal/controller/huskpod.go`** (modify): add the jailer args to the husk pod spec, add a writable `emptyDir` chroot-base volume, add `CAP_SYS_ADMIN` to the container capabilities (drop ALL, add SYS_ADMIN only), and update the per-field securityContext rationale comments.
+- **`internal/controller/huskpod_test.go`** (modify): assert the new jailer args, the chroot-base emptyDir volume + mount, and the single added capability.
+- **`Dockerfile.husk-stub`** (modify): install the upstream `jailer` binary alongside `firecracker` (the release tarball ships both).
+- **`docs/threat-model.md`** (modify): update Surface 1 and section 1's jailer row to state the husk pod now runs jailed; record the one added capability (`CAP_SYS_ADMIN`) and that the unjailed-husk residual is closed.
+- **`docs/husk-pods.md`** (modify): add a "Jailer in the pod" subsection under section 5 describing the mount setup, the nested cgroup, and the device path.
+
+---
+
+## Task 1: Linux chroot-base mount helper (the pivot_root fix)
+
+**Files:**
+- Create: `cmd/husk-stub/mount_linux.go`
+- Create: `cmd/husk-stub/mount_other.go`
+- Create: `cmd/husk-stub/mount_linux_test.go`
+
+- [ ] **Step 1: Write the failing test** (KVM-CI / bare-metal verification: needs `CAP_SYS_ADMIN`; cannot run on darwin or unprivileged kind)
+
+Create `cmd/husk-stub/mount_linux_test.go`:
+
+```go
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestPrepareChrootMountMakesPrivateMountPoint proves the chroot-base becomes a
+// MOUNT POINT marked private, which is exactly what the jailer's pivot_root
+// requires inside a pod. It needs CAP_SYS_ADMIN to call mount(2); on a host
+// without it the test SKIPS (so the unit suite stays green) and the real
+// assertion runs in the KVM-CI / bare-metal jailer-in-pod phase.
+func TestPrepareChrootMountMakesPrivateMountPoint(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("prepareChrootMount needs CAP_SYS_ADMIN; verified in the KVM-CI jailer-in-pod phase")
+	}
+	base := filepath.Join(t.TempDir(), "jail")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareChrootMount(base); err != nil {
+		t.Fatalf("prepareChrootMount: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Unmount(base, unix.MNT_DETACH) })
+
+	// After the helper, base must be a distinct mount point: its st_dev differs
+	// from its parent's, or /proc/self/mountinfo lists it. We assert it is a
+	// mount point by checking that a bind self-mount is present: statfs succeeds
+	// and the path is its own mount (parent dev differs after a bind only when
+	// the bind crosses a fs; instead assert mountinfo lists base as a mount).
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mountinfoHasPrivate(string(data), base) {
+		t.Fatalf("chroot base %q is not a private mount point after prepareChrootMount:\n%s", base, data)
+	}
+
+	// Idempotent: a second call (the stub may retry Prepare) must not error.
+	if err := prepareChrootMount(base); err != nil {
+		t.Fatalf("prepareChrootMount second call: %v", err)
+	}
+}
+```
+
+Also add the mountinfo helper to the SAME test file (it parses the propagation field; a private mount has NO `shared:` tag in its optional fields):
+
+```go
+// mountinfoHasPrivate reports whether mountinfo lists target as a mount point
+// whose optional propagation fields do NOT include a "shared:" tag (i.e. it is
+// private or slave-without-shared). pivot_root refuses a new root whose parent
+// mount is shared, so the husk chroot base must be private. The mountinfo line
+// format is: id parent major:minor root mountpoint options - optional... where
+// the optional fields between the 7th field and the standalone "-" carry the
+// propagation tags.
+func mountinfoHasPrivate(mountinfo, target string) bool {
+	for _, line := range splitLines(mountinfo) {
+		fields := splitFields(line)
+		if len(fields) < 7 {
+			continue
+		}
+		if fields[4] != target {
+			continue
+		}
+		// Optional fields run from index 6 until the standalone "-".
+		for i := 6; i < len(fields); i++ {
+			if fields[i] == "-" {
+				return true // reached the separator with no shared: tag
+			}
+			if len(fields[i]) >= 7 && fields[i][:7] == "shared:" {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+func splitFields(s string) []string {
+	var out []string
+	start := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' {
+			if start >= 0 {
+				out = append(out, s[start:i])
+				start = -1
+			}
+		} else if start < 0 {
+			start = i
+		}
+	}
+	if start >= 0 {
+		out = append(out, s[start:])
+	}
+	return out
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `GOOS=linux go test ./cmd/husk-stub/ -run TestPrepareChrootMountMakesPrivateMountPoint -v`
+Expected: FAIL to COMPILE with `undefined: prepareChrootMount` (the helper does not exist yet). This is the correct failing state on darwin (the test body itself is gated to root-only at runtime, but compilation must fail until the helper exists).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/husk-stub/mount_linux.go`:
+
+```go
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// prepareChrootMount makes chrootBase usable as the jailer's pivot_root target
+// INSIDE a pod. The Firecracker jailer pivot_roots into
+// <chroot-base>/firecracker/<vm-id>/root, and pivot_root(2) requires (a) the new
+// root to be a mount point and (b) the new root's parent mount to NOT have
+// shared propagation. A pod's container rootfs is commonly mounted with shared
+// or otherwise-propagating flags, so a plain directory under it fails pivot_root
+// with EINVAL/EBUSY. We fix both preconditions once, in the pod's own mount
+// namespace, before any jailer launch:
+//
+//  1. bind-mount chrootBase onto itself, so it BECOMES a mount point (the parent
+//     of every per-VM jail dir is now a mount the jailer can pivot under); and
+//  2. recursively mark it MS_PRIVATE, so its (and its children's) propagation
+//     does not defeat pivot_root.
+//
+// It needs CAP_SYS_ADMIN (mount(2)); the husk pod adds exactly that one
+// capability back (huskpod.go), nothing else. It is idempotent: a re-bind of an
+// already-bound private base is harmless, and re-marking private is a no-op.
+// chrootBase carries no secrets; errors name the path only.
+func prepareChrootMount(chrootBase string) error {
+	// Bind chrootBase onto itself so it is a mount point. MS_BIND with no source
+	// distinct from target is the canonical self-bind.
+	if err := unix.Mount(chrootBase, chrootBase, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("bind-mount jailer chroot base %s onto itself (needed so the jailer can pivot_root inside the pod): %w", chrootBase, err)
+	}
+	// Mark it private (recursively) so pivot_root is not refused by shared
+	// propagation on the parent mount.
+	if err := unix.Mount("", chrootBase, "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("make jailer chroot base %s a private mount (needed so the jailer can pivot_root inside the pod): %w", chrootBase, err)
+	}
+	return nil
+}
+```
+
+Create `cmd/husk-stub/mount_other.go`:
+
+```go
+//go:build !linux
+
+package main
+
+// prepareChrootMount on non-linux platforms is a no-op. The husk stub's jailer
+// path only runs on linux (it needs mount(2) and the Firecracker jailer); on
+// darwin this exists solely so the binary builds for development, mirroring
+// cmd/forkd/fs_other.go.
+func prepareChrootMount(chrootBase string) error {
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run on darwin (development): `go test ./cmd/husk-stub/ -run TestPrepareChrootMountMakesPrivateMountPoint -v`
+Expected: the linux-only test file is excluded by build tags on darwin, so it does not run; instead confirm the linux build compiles: `GOOS=linux GOARCH=amd64 go build ./cmd/husk-stub/`
+Expected: builds cleanly (exit 0).
+
+KVM-CI / bare-metal verification (the real assertion, runs as root with CAP_SYS_ADMIN on the `kvm-test.yaml` runner or the #16 self-hosted node): `GOOS=linux go test ./cmd/husk-stub/ -run TestPrepareChrootMountMakesPrivateMountPoint -v`
+Expected: PASS with the mountinfo assertion satisfied (base is a private mount point); on an unprivileged host the test SKIPS with "needs CAP_SYS_ADMIN".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/husk-stub/mount_linux.go cmd/husk-stub/mount_other.go cmd/husk-stub/mount_linux_test.go
+git commit -m "feat: husk stub bind-mounts and privatizes the jailer chroot base for in-pod pivot_root
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: buildHuskJailerConfig (fail-closed flag validation)
+
+**Files:**
+- Create: `cmd/husk-stub/jailer.go`
+- Create: `cmd/husk-stub/jailer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/husk-stub/jailer_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestBuildHuskJailerConfigDisabled(t *testing.T) {
+	// An empty jailer binary disables the jailer (the development direct-exec
+	// path). The returned config must be the zero (disabled) value.
+	cfg, err := buildHuskJailerConfig("", "/run/husk/jail", "64000-64999", 0)
+	if err != nil {
+		t.Fatalf("buildHuskJailerConfig disabled: %v", err)
+	}
+	if cfg.Enabled() {
+		t.Fatal("empty jailer binary must yield a disabled JailerConfig")
+	}
+}
+
+func TestBuildHuskJailerConfigRequiresRoot(t *testing.T) {
+	// The jailer needs root (CAP_SYS_ADMIN/CHOWN/SETUID/SETGID/MKNOD) to build a
+	// jail; refuse fail-closed when not root.
+	_, err := buildHuskJailerConfig("/usr/local/bin/jailer", "/run/husk/jail", "64000-64999", 1000)
+	if err == nil {
+		t.Fatal("buildHuskJailerConfig accepted a non-root euid")
+	}
+}
+
+func TestBuildHuskJailerConfigBadRangeFailsClosed(t *testing.T) {
+	if _, err := buildHuskJailerConfig("/usr/local/bin/jailer", "/run/husk/jail", "0-10", 0); err == nil {
+		t.Fatal("buildHuskJailerConfig accepted a uid range including 0 (root)")
+	}
+	if _, err := buildHuskJailerConfig("/usr/local/bin/jailer", "/run/husk/jail", "garbage", 0); err == nil {
+		t.Fatal("buildHuskJailerConfig accepted a malformed uid range")
+	}
+}
+
+func TestBuildHuskJailerConfigValid(t *testing.T) {
+	cfg, err := buildHuskJailerConfig("/usr/local/bin/jailer", "/run/husk/jail", "64000-64999", 0)
+	if err != nil {
+		t.Fatalf("buildHuskJailerConfig valid: %v", err)
+	}
+	if !cfg.Enabled() {
+		t.Fatal("valid jailer config must be enabled")
+	}
+	if cfg.ChrootBaseDir != "/run/husk/jail" {
+		t.Fatalf("ChrootBaseDir = %q, want /run/husk/jail", cfg.ChrootBaseDir)
+	}
+	if cfg.UIDRange != [2]uint32{64000, 64999} {
+		t.Fatalf("UIDRange = %v, want [64000 64999]", cfg.UIDRange)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/husk-stub/ -run TestBuildHuskJailerConfig -v`
+Expected: FAIL to COMPILE with `undefined: buildHuskJailerConfig`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/husk-stub/jailer.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/paperclipinc/mitos/internal/firecracker"
+)
+
+// parseHuskUIDRange parses "low-high" (inclusive). uid 0 is refused: jailed VMs
+// must never run as root. It mirrors cmd/forkd's parseUIDRange so the two jailer
+// front ends share the same fail-closed shape.
+func parseHuskUIDRange(s string) (uint32, uint32, error) {
+	lo, hi, ok := strings.Cut(s, "-")
+	if !ok {
+		return 0, 0, fmt.Errorf("--uid-range %q: expected the form low-high, for example 64000-64999", s)
+	}
+	low, err := strconv.ParseUint(lo, 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("--uid-range %q: low bound: %w", s, err)
+	}
+	high, err := strconv.ParseUint(hi, 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("--uid-range %q: high bound: %w", s, err)
+	}
+	if low == 0 {
+		return 0, 0, fmt.Errorf("--uid-range %q: uid 0 is root; jailed VMs must run as an unprivileged uid", s)
+	}
+	if low > high {
+		return 0, 0, fmt.Errorf("--uid-range %q: low bound above high bound", s)
+	}
+	return uint32(low), uint32(high), nil
+}
+
+// buildHuskJailerConfig validates the husk pod's jailer flags and produces the
+// firecracker.JailerConfig the stub launches each VM through. It fails closed on
+// every misconfiguration (malformed/root-including uid range, non-root euid).
+//
+// Unlike cmd/forkd's buildJailerConfig it does NOT require the chroot base to
+// share a filesystem with the data dir: in the husk pod the chroot base lives on
+// a pod-writable emptyDir, while the snapshot/kernel come from a READ-ONLY node
+// hostPath, so the two are intentionally on different filesystems. prepareChroot
+// already handles that with its EXDEV copy fallback (it copies the ~680 MiB mem
+// file into the chroot once at Activate). The same-filesystem CoW optimization
+// is a forkd-builder concern, not a husk-runner one.
+//
+// An empty jailerBin disables the jailer (the development direct-exec path; the
+// caller logs a loud warning and the threat model flags the residual). euid is
+// the caller's effective uid (os.Geteuid()), injected so the check is testable.
+func buildHuskJailerConfig(jailerBin, chrootBase, uidRange string, euid int) (firecracker.JailerConfig, error) {
+	if jailerBin == "" {
+		return firecracker.JailerConfig{}, nil
+	}
+	low, high, err := parseHuskUIDRange(uidRange)
+	if err != nil {
+		return firecracker.JailerConfig{}, err
+	}
+	if euid != 0 {
+		return firecracker.JailerConfig{}, fmt.Errorf("--jailer requires the husk stub to run as root (euid 0, currently %d): the jailer needs CAP_SYS_ADMIN, CAP_CHOWN, CAP_SETUID, CAP_SETGID, and CAP_MKNOD to build each VM's jail; run unjailed only for development by omitting --jailer", euid)
+	}
+	return firecracker.JailerConfig{
+		JailerBin:     jailerBin,
+		ChrootBaseDir: chrootBase,
+		UIDRange:      [2]uint32{low, high},
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/husk-stub/ -run TestBuildHuskJailerConfig -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/husk-stub/jailer.go cmd/husk-stub/jailer_test.go
+git commit -m "feat: husk stub jailer config builder, fail-closed on misconfiguration
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Thread snapshot files into the chroot at Activate
+
+The stub sets `ChrootFiles` once at Prepare, but the snapshot `mem`/`vmstate` paths are known only at Activate (from `req.SnapshotDir`). Under the jailer those files must be hard-linked (or copied on EXDEV) into the per-VM chroot before `LoadSnapshotWithOverrides`, exactly as the fork engine does (`internal/fork/engine.go:864`). Add a per-activate chroot-prepare seam to the stub.
+
+**Files:**
+- Modify: `internal/husk/stub.go`
+- Test: `internal/husk/stub_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/husk/stub_test.go`:
+
+```go
+func TestActivatePreparesSnapshotChrootFilesWhenJailed(t *testing.T) {
+	// When the stub is configured with a jailer, Activate must prepare the
+	// snapshot mem+vmstate into the per-VM chroot (via the injected prepare seam)
+	// BEFORE loading them, so the jailed Firecracker can open them inside its
+	// chroot. We assert the seam is called with the snapshot files and the VM id.
+	dir := t.TempDir()
+	snapDir := filepath.Join(dir, "snap")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"mem", "vmstate"} {
+		if err := os.WriteFile(filepath.Join(snapDir, n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var preparedFiles []string
+	cfg := firecracker.VMConfig{ID: "husk"}
+	cfg.Jailer.JailerBin = "/usr/local/bin/jailer" // marks the config jailed
+
+	stub := New(cfg, Options{
+		Start:  func(firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:  func(string, time.Duration) error { return nil },
+		Notify: func(string, uint64, []byte, ActivateRequest) error { return nil },
+		Verify: func(ActivateRequest) error { return nil },
+		PrepareChroot: func(vmID string, files []string) error {
+			preparedFiles = append([]string(nil), files...)
+			if vmID != "husk" {
+				t.Errorf("PrepareChroot vmID = %q, want husk", vmID)
+			}
+			return nil
+		},
+	})
+	if err := stub.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if _, err := stub.Activate(context.Background(), ActivateRequest{SnapshotDir: snapDir}); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	wantMem := filepath.Join(snapDir, "mem")
+	wantState := filepath.Join(snapDir, "vmstate")
+	if len(preparedFiles) != 2 || preparedFiles[0] != wantMem || preparedFiles[1] != wantState {
+		t.Fatalf("PrepareChroot files = %v, want [%s %s]", preparedFiles, wantMem, wantState)
+	}
+}
+
+func TestActivateSkipsChrootPrepareWhenDirectExec(t *testing.T) {
+	// With NO jailer configured the stub must NOT call the chroot-prepare seam:
+	// direct-exec needs no chroot. This keeps the development path unchanged.
+	dir := t.TempDir()
+	snapDir := filepath.Join(dir, "snap")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	stub := New(firecracker.VMConfig{ID: "husk"}, Options{
+		Start:         func(firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:         func(string, time.Duration) error { return nil },
+		Notify:        func(string, uint64, []byte, ActivateRequest) error { return nil },
+		Verify:        func(ActivateRequest) error { return nil },
+		PrepareChroot: func(string, []string) error { called = true; return nil },
+	})
+	if err := stub.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if _, err := stub.Activate(context.Background(), ActivateRequest{SnapshotDir: snapDir}); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if called {
+		t.Fatal("PrepareChroot was called for a direct-exec (unjailed) stub")
+	}
+}
+```
+
+NOTE: this relies on the existing `fakeVMM` in `internal/husk/stub_test.go`. If the existing fake is named differently, use that name; the test logic is unchanged. Confirm with `grep -n "type fakeVMM\|func.*fakeVMM\|LoadSnapshotWithOverrides" internal/husk/stub_test.go` and adapt the type name only.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/husk/ -run 'TestActivate(PreparesSnapshotChrootFilesWhenJailed|SkipsChrootPrepareWhenDirectExec)' -v`
+Expected: FAIL to COMPILE with `unknown field 'PrepareChroot' in struct literal of type Options`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/husk/stub.go`, add the seam type, the Options field, the Stub field, the New wiring, and the Activate call.
+
+Add this type near the other seam types (after the `notifier` type, around line 83):
+
+```go
+// chrootPreparer hard-links (or copies on EXDEV) the per-activate snapshot files
+// into the jailed VM's chroot before the VMM loads them. It is the husk analog
+// of the fork engine's ChrootFiles handling: the snapshot mem/vmstate paths are
+// known only at Activate (from the request's SnapshotDir), so they cannot be set
+// in the Prepare-time VMConfig.ChrootFiles. The production seam calls
+// firecracker.PrepareChrootForVM; tests inject a fake. It is a no-op for an
+// unjailed (direct-exec) stub. The file paths carry no secrets.
+type chrootPreparer func(vmID string, files []string) error
+```
+
+Add to the `Options` struct (after `OnActivated`, before `PrepareSnapshotDir`):
+
+```go
+	// PrepareChroot hard-links the per-activate snapshot files into the jailed
+	// VM's chroot before load. Nil uses the production seam
+	// (firecracker.PrepareChrootForVM) when the VMConfig is jailed, and is unused
+	// when the stub runs direct-exec. Tests inject a fake to assert the files.
+	PrepareChroot chrootPreparer
+```
+
+Add to the `Stub` struct (after `onActivated`):
+
+```go
+	prepareChroot chrootPreparer
+```
+
+In `New`, after the `onActivated: opts.OnActivated,` assignment in the struct literal, add:
+
+```go
+		prepareChroot: opts.PrepareChroot,
+```
+
+And after the `if s.notify == nil { ... }` block, add the production default:
+
+```go
+	if s.prepareChroot == nil {
+		s.prepareChroot = func(vmID string, files []string) error {
+			return firecracker.PrepareChrootForVM(s.cfg, vmID, files)
+		}
+	}
+```
+
+In `Activate`, immediately AFTER the `memFile`/`vmStateFile` are computed and AFTER the verify gate passes, but BEFORE `s.vm.LoadSnapshotWithOverrides`, add:
+
+```go
+	// Jailed VMs: the snapshot files live on the read-only node mount, OUTSIDE
+	// the per-VM chroot. Hard-link (or copy on EXDEV) them into the chroot at
+	// their mirrored host paths before the jailed Firecracker loads them, exactly
+	// as the fork engine does (internal/fork/engine.go ChrootFiles). A direct-exec
+	// stub has no chroot, so the seam is a no-op there. FAIL CLOSED: if the files
+	// cannot be placed in the chroot, the load would fail with an opaque
+	// Firecracker error, so we surface the prepare error here instead.
+	if s.cfg.Jailer.Enabled() {
+		if err := s.prepareChroot(s.cfg.ID, []string{memFile, vmStateFile}); err != nil {
+			werr := fmt.Errorf("husk: prepare snapshot files in jailer chroot: %w", err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/husk/ -run 'TestActivate(PreparesSnapshotChrootFilesWhenJailed|SkipsChrootPrepareWhenDirectExec)' -v`
+Expected: PASS (both tests). Then run the whole package: `go test ./internal/husk/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/husk/stub.go internal/husk/stub_test.go
+git commit -m "feat: husk Activate prepares snapshot files into the jailer chroot
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Export PrepareChrootForVM from internal/firecracker
+
+The stub's production chroot-prepare seam calls `firecracker.PrepareChrootForVM`, which does not exist yet (today `prepareChroot` is unexported and called only inside `startJailedVM`). Add an exported wrapper that creates the chroot run dir, prepares the files, and chowns them to the jailed uid. Since the husk stub does not own the per-VM uid (the jailer allocates it on launch), the wrapper prepares files WITHOUT a chown: the jailer launch path (`startJailedVM`) already chowns the prepared files via `chownIntoJail`, and these per-activate files are prepared just before that launch. The wrapper therefore mirrors only the link step.
+
+**Files:**
+- Modify: `internal/firecracker/jailer.go`
+- Test: `internal/firecracker/jailer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/firecracker/jailer_test.go`:
+
+```go
+func TestPrepareChrootForVMLinksFiles(t *testing.T) {
+	// PrepareChrootForVM is the exported seam the husk stub calls at Activate to
+	// place per-activate snapshot files in the chroot. It must hard-link each file
+	// into the mirrored chroot location, refusing paths outside the allowed roots
+	// (same guard as prepareChroot).
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	src := filepath.Join(dataDir, "templates", "t1", "snapshot", "mem")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("snap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultVMConfig()
+	cfg.ID = "husk"
+	cfg.Jailer = testJailerConfig(filepath.Join(root, "jail"), dataDir)
+
+	if err := PrepareChrootForVM(cfg, "husk", []string{src}); err != nil {
+		t.Fatalf("PrepareChrootForVM: %v", err)
+	}
+	linked := chrootPath(cfg.Jailer.ChrootBaseDir, "husk", src)
+	info, err := os.Stat(linked)
+	if err != nil {
+		t.Fatalf("linked file missing: %v", err)
+	}
+	srcInfo, _ := os.Stat(src)
+	if !os.SameFile(info, srcInfo) {
+		t.Fatalf("expected %q to be a hard link of %q", linked, src)
+	}
+}
+
+func TestPrepareChrootForVMRefusesEscapingPath(t *testing.T) {
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(root, "outside")
+	if err := os.WriteFile(outside, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultVMConfig()
+	cfg.Jailer = testJailerConfig(filepath.Join(root, "jail"), dataDir)
+	if err := PrepareChrootForVM(cfg, "husk", []string{outside}); err == nil {
+		t.Fatal("PrepareChrootForVM accepted a path outside the data dir")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/firecracker/ -run 'TestPrepareChrootForVM' -v`
+Expected: FAIL to COMPILE with `undefined: PrepareChrootForVM`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/firecracker/jailer.go`, add immediately above `prepareChroot` (around line 116):
+
+```go
+// PrepareChrootForVM hard-links (or copies on EXDEV) the given host files into
+// the VM's chroot at their mirrored locations, creating the chroot directory
+// tree as needed. It is the exported seam the husk stub calls at Activate to
+// place the per-activate snapshot files (mem, vmstate) in the chroot before the
+// jailed Firecracker loads them; the fork engine instead passes these via
+// VMConfig.ChrootFiles at launch. It applies the same guard as prepareChroot
+// (paths must be absolute and within the VM workspace or the data dir), so a
+// caller cannot expose an arbitrary host file inside the jail. It does NOT chown
+// the files to the jailed uid: the jailer launch path chowns the chroot file set
+// (chownIntoJail) after it allocates the uid, and these files are prepared just
+// before that launch.
+func PrepareChrootForVM(cfg VMConfig, vmID string, files []string) error {
+	if _, err := prepareChroot(cfg, vmID, files); err != nil {
+		return err
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/firecracker/ -run 'TestPrepareChrootForVM' -v`
+Expected: PASS (both tests). Then: `go test ./internal/firecracker/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/firecracker/jailer.go internal/firecracker/jailer_test.go
+git commit -m "feat: export PrepareChrootForVM for per-activate chroot file prep
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire the jailer into cmd/husk-stub/main.go
+
+**Files:**
+- Modify: `cmd/husk-stub/main.go`
+
+- [ ] **Step 1: Write the failing test** (compile-level guard via a focused unit test on the new flag plumbing helper)
+
+The flag wiring in `run()` is not unit-testable directly (it spawns a VMM), but the JAILER ASSEMBLY is. Add a small testable helper and test it. Add to `cmd/husk-stub/jailer_test.go`:
+
+```go
+func TestHuskVMConfigJailerWiring(t *testing.T) {
+	// huskVMConfig assembles the VMConfig the stub launches, attaching the jailer
+	// config and the kernel as a chroot file when jailed. With a jailer it must
+	// set cfg.Jailer (enabled) and include the kernel in ChrootFiles; without one
+	// it must leave both unset (direct exec).
+	jailed := buildHuskVMConfigForTest(t, "/usr/local/bin/jailer", "/run/husk/jail", "64000-64999")
+	if !jailed.Jailer.Enabled() {
+		t.Fatal("expected jailed VMConfig to carry an enabled jailer")
+	}
+	foundKernel := false
+	for _, f := range jailed.ChrootFiles {
+		if f == "/var/lib/mitos/kernel/vmlinux" {
+			foundKernel = true
+		}
+	}
+	if !foundKernel {
+		t.Fatalf("expected kernel in ChrootFiles, got %v", jailed.ChrootFiles)
+	}
+
+	direct := buildHuskVMConfigForTest(t, "", "/run/husk/jail", "64000-64999")
+	if direct.Jailer.Enabled() {
+		t.Fatal("expected direct-exec VMConfig to have a disabled jailer")
+	}
+	if len(direct.ChrootFiles) != 0 {
+		t.Fatalf("expected no ChrootFiles for direct exec, got %v", direct.ChrootFiles)
+	}
+}
+```
+
+And add the test-only constructor at the bottom of `cmd/husk-stub/jailer_test.go` that calls the same helper `run()` uses with euid forced to 0:
+
+```go
+// buildHuskVMConfigForTest exercises huskVMConfig with a forced root euid so the
+// jailer validation passes off-root in CI; it fatals on any build error.
+func buildHuskVMConfigForTest(t *testing.T, jailerBin, chrootBase, uidRange string) firecracker.VMConfig {
+	t.Helper()
+	cfg, err := huskVMConfig(huskVMParams{
+		firecrackerBin: "/usr/local/bin/firecracker",
+		kernel:         "/var/lib/mitos/kernel/vmlinux",
+		workdir:        "/run/husk/vm",
+		vcpus:          1,
+		memMiB:         512,
+		jailerBin:      jailerBin,
+		chrootBase:     chrootBase,
+		uidRange:       uidRange,
+		euid:           0,
+	})
+	if err != nil {
+		t.Fatalf("huskVMConfig: %v", err)
+	}
+	return cfg
+}
+```
+
+(Add `"github.com/paperclipinc/mitos/internal/firecracker"` to the test file imports.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/husk-stub/ -run TestHuskVMConfigJailerWiring -v`
+Expected: FAIL to COMPILE with `undefined: huskVMConfig` and `undefined: huskVMParams`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `cmd/husk-stub/main.go`, add the params struct and the assembly helper (place them just above `func main()`):
+
+```go
+// huskVMParams carries the inputs huskVMConfig needs to assemble the stub's
+// VMConfig. euid is injected so the jailer root requirement is testable off-root.
+type huskVMParams struct {
+	firecrackerBin string
+	kernel         string
+	workdir        string
+	vcpus          int
+	memMiB         int
+	jailerBin      string
+	chrootBase     string
+	uidRange       string
+	euid           int
+}
+
+// huskVMConfig builds the firecracker.VMConfig the stub launches. When a jailer
+// binary is configured it attaches a fail-closed JailerConfig (per-VM uid/gid,
+// chroot, nested cgroup) and lists the kernel as a chroot file so the jailed
+// Firecracker can open it inside the jail; the snapshot mem/vmstate are added per
+// activate (internal/husk Activate). With no jailer binary it returns the prior
+// direct-exec config unchanged (development only; the threat model flags it).
+func huskVMConfig(p huskVMParams) (firecracker.VMConfig, error) {
+	cfg := firecracker.VMConfig{
+		ID:             huskSandboxID,
+		FirecrackerBin: p.firecrackerBin,
+		WorkDir:        p.workdir,
+		KernelPath:     p.kernel,
+		SocketPath:     filepath.Join(p.workdir, "firecracker.sock"),
+		VcpuCount:      p.vcpus,
+		MemSizeMib:     p.memMiB,
+	}
+	jailerCfg, err := buildHuskJailerConfig(p.jailerBin, p.chrootBase, p.uidRange, p.euid)
+	if err != nil {
+		return firecracker.VMConfig{}, err
+	}
+	cfg.Jailer = jailerCfg
+	if jailerCfg.Enabled() {
+		// DataDir bounds which host files may be exposed in the chroot; the husk
+		// kernel and snapshot live under the node data dir mount. The engine sets
+		// this from its data dir; here the stub's allowed root is the kernel's and
+		// snapshot's mount root.
+		cfg.Jailer.DataDir = "/var/lib/mitos"
+		if p.kernel != "" {
+			cfg.ChrootFiles = []string{p.kernel}
+		}
+	}
+	return cfg, nil
+}
+```
+
+NOTE: `huskSandboxID` already exists in `main.go` (const, value `"husk"`); reuse it for the VM id so the chroot layout and the sandbox-API registration agree.
+
+Now add the three flags in `run()` next to the existing flags (after `memMiB`):
+
+```go
+		jailerBin  = flag.String("jailer", "", "path to the Firecracker jailer binary; every VM is launched through it with a per-VM uid, chroot (pivot_root), and a cgroup nested under the pod's. Empty disables the jailer (development only; the VM then runs unjailed as the pod uid, flagged in the threat model)")
+		chrootBase = flag.String("chroot-base", "/run/husk/jail", "jailer chroot base directory; must be on a pod-WRITABLE volume (an emptyDir), distinct from the read-only snapshot mount. The stub bind-mounts and privatizes it so the jailer can pivot_root inside the pod")
+		uidRange   = flag.String("uid-range", "64000-64999", "inclusive low-high uid/gid range the jailer allocates a dedicated per-VM uid from; uid 0 is refused")
+```
+
+Then, in the dormant-bring-up branch (after the `if *workdir == "" {` check and after `os.MkdirAll(*workdir, ...)`, and BEFORE the `cfg := firecracker.VMConfig{...}` literal), REPLACE the inline `cfg := firecracker.VMConfig{...}` literal (lines 229-237) with:
+
+```go
+	// Jailer setup MUST happen before the dormant VMM is prepared: the jailer
+	// pivot_roots into the per-VM chroot under --chroot-base, which inside a pod
+	// requires the chroot base to be a PRIVATE MOUNT POINT (a pod's rootfs is
+	// commonly shared, and pivot_root refuses a new root whose parent mount is
+	// shared). Make the base a private self-bind mount once, here, in the pod's
+	// own mount namespace. This is a no-op on the development direct-exec path
+	// (empty --jailer) and on non-linux (mount_other.go).
+	if *jailerBin != "" {
+		if err := os.MkdirAll(*chrootBase, 0o755); err != nil {
+			return fmt.Errorf("create jailer chroot base %s: %w", *chrootBase, err)
+		}
+		if err := prepareChrootMount(*chrootBase); err != nil {
+			return fmt.Errorf("prepare jailer chroot base mount: %w", err)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "husk-stub: WARNING running UNJAILED (no --jailer): the VM runs as the pod uid with no chroot or per-VM uid; development only, do not use for untrusted tenants")
+	}
+
+	cfg, err := huskVMConfig(huskVMParams{
+		firecrackerBin: *firecrackerBin,
+		kernel:         *kernel,
+		workdir:        *workdir,
+		vcpus:          *vcpus,
+		memMiB:         *memMiB,
+		jailerBin:      *jailerBin,
+		chrootBase:     *chrootBase,
+		uidRange:       *uidRange,
+		euid:           os.Geteuid(),
+	})
+	if err != nil {
+		return fmt.Errorf("build husk VM config: %w", err)
+	}
+```
+
+(The later `husk.New(cfg, husk.Options{...})` call already consumes `cfg` unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/husk-stub/ -v`
+Expected: PASS (the wiring test plus the jailer-config tests). Then confirm both builds:
+`go build ./cmd/husk-stub/` and `GOOS=linux GOARCH=amd64 go build ./cmd/husk-stub/`
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/husk-stub/main.go cmd/husk-stub/jailer_test.go
+git commit -m "feat: husk stub launches Firecracker through the jailer inside the pod
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Husk pod spec: jailer args, chroot-base emptyDir, CAP_SYS_ADMIN
+
+**Files:**
+- Modify: `internal/controller/huskpod.go`
+- Test: `internal/controller/huskpod_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/controller/huskpod_test.go` (use the same helpers the existing husk pod tests use to build a pod; confirm the builder call shape with `grep -n "buildHuskPod" internal/controller/huskpod_test.go`):
+
+```go
+func TestHuskPodRunsJailed(t *testing.T) {
+	r := &SandboxPoolReconciler{} // matches the existing test construction; set Scheme via the suite helper if the existing tests do
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	template := &v1alpha1.SandboxTemplate{}
+	pod := r.buildHuskPod(pool, template, HuskPodOptions{StubImage: "img", SnapshotID: "t1"})
+
+	c := pod.Spec.Containers[0]
+
+	// The jailer flags must be present so the stub launches jailed.
+	joined := strings.Join(c.Args, " ")
+	for _, want := range []string{
+		"--jailer /usr/local/bin/jailer",
+		"--chroot-base /run/husk/jail",
+		"--uid-range 64000-64999",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("husk pod args missing %q; got: %s", want, joined)
+		}
+	}
+
+	// A pod-writable chroot-base emptyDir volume must be mounted at the chroot base.
+	foundVol := false
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "jailer-chroot" {
+			if v.EmptyDir == nil {
+				t.Error("jailer-chroot volume must be an emptyDir (pod-writable)")
+			}
+			foundVol = true
+		}
+	}
+	if !foundVol {
+		t.Error("husk pod missing the jailer-chroot emptyDir volume")
+	}
+	foundMount := false
+	for _, m := range c.VolumeMounts {
+		if m.Name == "jailer-chroot" {
+			if m.MountPath != "/run/husk/jail" {
+				t.Errorf("jailer-chroot mount path = %q, want /run/husk/jail", m.MountPath)
+			}
+			if m.ReadOnly {
+				t.Error("jailer-chroot mount must be writable")
+			}
+			foundMount = true
+		}
+	}
+	if !foundMount {
+		t.Error("husk pod missing the jailer-chroot volume mount")
+	}
+
+	// Exactly CAP_SYS_ADMIN is added back (for mount(2) + the jailer); ALL dropped.
+	caps := c.SecurityContext.Capabilities
+	if len(caps.Drop) != 1 || caps.Drop[0] != "ALL" {
+		t.Errorf("capabilities.drop = %v, want [ALL]", caps.Drop)
+	}
+	if len(caps.Add) != 1 || caps.Add[0] != "SYS_ADMIN" {
+		t.Errorf("capabilities.add = %v, want [SYS_ADMIN]", caps.Add)
+	}
+}
+```
+
+Add `"strings"` to the test imports if not present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (envtest assets, per CLAUDE.md): `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestHuskPodRunsJailed -v`
+Expected: FAIL: the args lack `--jailer`, there is no `jailer-chroot` volume, and `capabilities.add` is empty.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/controller/huskpod.go`:
+
+First add the constants near the other husk path constants (after `huskWorkdir`, around line 50):
+
+```go
+	// huskJailerBin is the in-image path of the Firecracker jailer binary
+	// (Dockerfile.husk-stub installs it next to firecracker). The husk stub
+	// launches every VM through it so tenant VMs run jailed.
+	huskJailerBin = "/usr/local/bin/jailer"
+	// huskChrootBase is the pod-WRITABLE jailer chroot base. It is an emptyDir
+	// (not the read-only snapshot hostPath): the jailer pivot_roots into a per-VM
+	// dir under it and hard-links/copies the snapshot files in, both of which need
+	// a writable filesystem. The stub bind-mounts + privatizes it so pivot_root
+	// works inside the pod.
+	huskChrootBase = "/run/husk/jail"
+	// huskUIDRange is the inclusive uid/gid range the in-pod jailer allocates a
+	// dedicated per-VM uid from (uid 0 refused). It matches forkd's default.
+	huskUIDRange = "64000-64999"
+```
+
+In `buildHuskPod`, append the jailer flags to `args` (right after the existing `args := []string{...}` literal block, before the snapshot-verify gate block):
+
+```go
+	// Launch every VM through the jailer: a per-VM uid/gid from --uid-range, a
+	// chroot (pivot_root) under --chroot-base, and a cgroup the jailer nests under
+	// the pod's own cgroup (it creates a child, it does not override the pod's
+	// memory.max). This is what makes a microVM escape land as a throwaway uid in
+	// an empty chroot instead of the pod's uid 0. The stub privatizes --chroot-base
+	// so pivot_root works inside the pod (cmd/husk-stub prepareChrootMount).
+	args = append(args,
+		"--jailer", huskJailerBin,
+		"--chroot-base", huskChrootBase,
+		"--uid-range", huskUIDRange,
+	)
+```
+
+Add the writable chroot-base volume + mount. Place this near the other `volumes`/`mounts` appends, UNCONDITIONALLY (it is needed whenever the stub runs, independent of `SnapshotID`), just after `var volumes []corev1.Volume` / `var mounts []corev1.VolumeMount`:
+
+```go
+	// The jailer chroot base must be a pod-WRITABLE filesystem (an emptyDir),
+	// separate from the read-only snapshot hostPath: the jailer creates per-VM
+	// chroot dirs here and the stub links/copies the snapshot into them. emptyDir
+	// is pod-scoped and torn down with the pod, so no per-VM jail outlives it.
+	volumes = append(volumes, corev1.Volume{
+		Name: "jailer-chroot",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+	mounts = append(mounts, corev1.VolumeMount{Name: "jailer-chroot", MountPath: huskChrootBase})
+```
+
+Update the container `SecurityContext.Capabilities` from drop-ALL-only to drop-ALL-add-SYS_ADMIN. Replace the existing:
+
+```go
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+```
+
+with:
+
+```go
+						Capabilities: &corev1.Capabilities{
+							// Drop everything, then add back EXACTLY CAP_SYS_ADMIN.
+							// The stub needs it for two things, both inside the pod's
+							// own mount namespace: (1) mount(2) to bind + privatize
+							// the jailer chroot base so the jailer can pivot_root in a
+							// pod; (2) the jailer's own jail construction (cgroup +
+							// namespace + chroot). This is the SINGLE capability the
+							// jailed-in-pod model adds; the jailer then drops to an
+							// unprivileged per-VM uid inside the jail, so a VMM escape
+							// does NOT inherit CAP_SYS_ADMIN. Without it the VM would
+							// run UNJAILED as the pod uid, which is unacceptable for
+							// untrusted tenants. Documented in docs/threat-model.md.
+							Drop: []corev1.Capability{"ALL"},
+							Add:  []corev1.Capability{"SYS_ADMIN"},
+						},
+```
+
+Also update the long securityContext rationale comment block (around lines 215-233) where it says capabilities "Drop ALL, add NONE": change the relevant lines to state that exactly `CAP_SYS_ADMIN` is added back for the in-pod jailer (mount + pivot_root + jail construction), and that this is the single documented capability the jailed-in-pod model requires. Replace this bullet:
+
+```go
+	//   - Capabilities Drop ALL, add NONE. The dormant stub only Prepares a
+	//     Firecracker VMM (open /dev/kvm via the device plugin, create files
+	//     under the pod-local workdir, bind a unix socket); none of that needs a
+	//     Linux capability. Networking capabilities (e.g. NET_ADMIN for tap
+	//     setup) arrive with the networking slice, not here; we add back none so
+	//     this slice stays minimal.
+```
+
+with:
+
+```go
+	//   - Capabilities Drop ALL, add EXACTLY CAP_SYS_ADMIN. The stub launches
+	//     each VM through the jailer, which needs CAP_SYS_ADMIN to build the jail
+	//     (cgroup + mount namespace + chroot); the stub itself needs it for the
+	//     one mount(2) that bind-mounts and privatizes the chroot base so the
+	//     jailer can pivot_root inside the pod (a pod's rootfs is commonly a shared
+	//     mount, which pivot_root refuses). This is the SINGLE capability the
+	//     jailed-in-pod model adds; the jailer then drops to an unprivileged per-VM
+	//     uid inside the jail, so a guest that escapes the microVM lands as a
+	//     throwaway uid in an empty chroot, NOT with CAP_SYS_ADMIN. Networking
+	//     capabilities (e.g. NET_ADMIN for tap setup) arrive with the networking
+	//     slice, not here.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestHuskPodRunsJailed -v`
+Expected: PASS. Then the full controller suite: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/`
+Expected: PASS (existing husk pod tests still green; if a prior test asserted `len(caps.Add) == 0` or "drop ALL only", update that assertion in the SAME commit to expect the single SYS_ADMIN add, since the security posture intentionally changed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/controller/huskpod.go internal/controller/huskpod_test.go
+git commit -m "feat: husk pod runs jailed (jailer args, chroot emptyDir, CAP_SYS_ADMIN)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Ship the jailer binary in the husk-stub image
+
+**Files:**
+- Modify: `Dockerfile.husk-stub`
+
+- [ ] **Step 1: Write the failing test**
+
+Dockerfiles have no unit test; the verification is a build-time assertion. Add a build assertion stage so a missing jailer fails the image build (this is the "test"). After the firecracker install RUN block (line 31), the firecracker release tarball ALSO contains `jailer-${FC_VERSION}-x86_64`; install it and assert both exist. We will modify the existing RUN to install both, then add an assertion RUN.
+
+- [ ] **Step 2: Run to verify it fails (current image lacks the jailer)**
+
+Run: `docker build -f Dockerfile.husk-stub -t husk-stub-test . && docker run --rm --entrypoint /bin/sh husk-stub-test -c 'test -x /usr/local/bin/jailer && echo JAILER_OK'`
+Expected: FAIL: the container has no `/usr/local/bin/jailer`, so the `test -x` returns non-zero and `JAILER_OK` is not printed (the `docker run` exits non-zero).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Dockerfile.husk-stub`, replace the firecracker install RUN (lines 24-31) with one that installs BOTH binaries from the same release tarball:
+
+```dockerfile
+RUN apt-get update -qq && apt-get install -y --no-install-recommends curl && \
+    curl -fsSL -o /tmp/fc.tgz \
+        "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz" && \
+    tar -xzf /tmp/fc.tgz -C /tmp && \
+    mv "/tmp/release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/local/bin/firecracker && \
+    mv "/tmp/release-${FC_VERSION}-x86_64/jailer-${FC_VERSION}-x86_64" /usr/local/bin/jailer && \
+    chmod +x /usr/local/bin/firecracker /usr/local/bin/jailer && \
+    rm -rf /tmp/fc.tgz /tmp/release-* && \
+    apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
+# Fail the build if either binary is missing: the husk stub launches the VMM
+# through the jailer, so the image must carry both.
+RUN test -x /usr/local/bin/firecracker && test -x /usr/local/bin/jailer
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `docker build -f Dockerfile.husk-stub -t husk-stub-test . && docker run --rm --entrypoint /bin/sh husk-stub-test -c 'test -x /usr/local/bin/jailer && echo JAILER_OK'`
+Expected: prints `JAILER_OK` and exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile.husk-stub
+git commit -m "build: ship the Firecracker jailer in the husk-stub image
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: KVM-CI / bare-metal end-to-end jailed-activation phase
+
+This proves the WHOLE path on real KVM with pivot_root: a husk stub started WITH the jailer, the chroot-base privatized, a real snapshot activated, and an exec that shows the VM ran as a NON-ZERO per-VM uid in a chroot. It runs ONLY on `kvm-test.yaml` (KVM + `CAP_SYS_ADMIN`) or the #16 self-hosted node. Darwin and kind cannot run it.
+
+**Files:**
+- Modify: `.github/workflows/kvm-test.yaml` (add a `husk-jailed` phase)
+
+- [ ] **Step 1: Write the failing test** (the CI phase script; the test is the gate `JAILED_OK`)
+
+Add a step to the existing husk job in `.github/workflows/kvm-test.yaml`. Confirm the existing husk-stub phase shape first with `grep -n "husk-stub\|--activate\|control-socket\|bench template" .github/workflows/kvm-test.yaml` and mirror its snapshot setup. The new phase (reusing the bench template snapshot the husk-stub phase already builds at `$SNAP_DIR`):
+
+```yaml
+      - name: Husk jailed-activation (real KVM, pivot_root, per-VM uid)
+        run: |
+          set -euo pipefail
+          sudo mkdir -p /run/husk/jail /run/husk/vm
+          # Start a dormant jailed stub: --jailer makes the stub privatize the
+          # chroot base and launch Firecracker through the jailer. Needs root
+          # (CAP_SYS_ADMIN) and /dev/kvm, both present on this runner.
+          sudo ./husk-stub \
+            --firecracker /usr/local/bin/firecracker \
+            --jailer /usr/local/bin/jailer \
+            --chroot-base /run/husk/jail \
+            --uid-range 64000-64999 \
+            --kernel "$KERNEL" \
+            --workdir /run/husk/vm \
+            --control-socket /run/husk/control.sock \
+            --allow-unverified-snapshots &
+          STUB_PID=$!
+          # Wait for the dormant control socket.
+          for i in $(seq 1 100); do [ -S /run/husk/control.sock ] && break; sleep 0.1; done
+          # Activate the bench snapshot in place over the control socket.
+          sudo ./husk-stub --activate \
+            --control-socket /run/husk/control.sock \
+            --snapshot-dir "$SNAP_DIR" \
+            --allow-unverified-snapshots | tee /tmp/activate.json
+          grep -q '"ok":true' /tmp/activate.json || { echo "JAILED-ACTIVATE-FAILED"; exit 1; }
+          # Prove the jail: the jailer created a per-VM chroot under the base, and
+          # the Firecracker process runs as a NON-ZERO uid from the range.
+          test -d /run/husk/jail/firecracker || { echo "no jailer chroot dir created"; exit 1; }
+          FC_PID=$(pgrep -f 'firecracker --api-sock' | head -1)
+          FC_UID=$(awk '/^Uid:/{print $2}' /proc/$FC_PID/status)
+          echo "firecracker runs as uid $FC_UID"
+          [ "$FC_UID" -ge 64000 ] && [ "$FC_UID" -le 64999 ] || { echo "JAILED-UID-FAILED: uid $FC_UID not in 64000-64999"; exit 1; }
+          # Prove pivot_root: the FC process root is the per-VM chroot, not /.
+          FC_ROOT=$(sudo readlink /proc/$FC_PID/root)
+          echo "firecracker root: $FC_ROOT"
+          case "$FC_ROOT" in /run/husk/jail/firecracker/*/root) ;; *) echo "JAILED-PIVOT-FAILED: root $FC_ROOT"; exit 1;; esac
+          echo "JAILED_OK"
+          sudo kill $STUB_PID || true
+```
+
+- [ ] **Step 2: Run to verify it fails (before the code lands)**
+
+On the KVM runner, before Tasks 5-7 land, the stub has no `--jailer` flag, so `husk-stub --jailer ...` errors with `flag provided but not defined: -jailer`.
+Expected: the phase fails at the dormant-stub start with an unknown-flag error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+The implementation IS the YAML phase above plus Tasks 1-7. No additional code; this task only adds the phase.
+
+- [ ] **Step 4: Run to verify it passes** (KVM-CI / bare-metal: `kvm-test.yaml` or #16 self-hosted runner)
+
+The phase runs in `kvm-test.yaml`. Expected `$GITHUB_STEP_SUMMARY` / log output:
+```
+firecracker runs as uid 64000
+firecracker root: /run/husk/jail/firecracker/husk/root
+JAILED_OK
+```
+Expected: the step exits 0 with `JAILED_OK`. (uid will be the lowest free uid in the range, typically 64000; root path uses the stub's fixed VM id `husk`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/kvm-test.yaml
+git commit -m "ci: prove husk runs jailed on KVM (pivot_root, per-VM uid)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Threat-model and husk-pods doc delta (CLAUDE.md hard rule)
+
+The security surface moved: the husk pod now runs jailed and adds `CAP_SYS_ADMIN`. CLAUDE.md requires `docs/threat-model.md` to change in the SAME plan. Update both docs.
+
+**Files:**
+- Modify: `docs/threat-model.md`
+- Modify: `docs/husk-pods.md`
+
+- [ ] **Step 1: Write the failing test** (a grep gate that the residual is recorded and the capability is documented)
+
+Add a CI doc-consistency check. In `.github/workflows/ci.yaml`, in the existing lint/docs job (confirm with `grep -n "threat-model\|docs/" .github/workflows/ci.yaml`; if no doc-grep step exists, add one to the `go-lint` job), add:
+
+```yaml
+      - name: Threat model records jailed-in-pod surface
+        run: |
+          set -euo pipefail
+          grep -q 'CAP_SYS_ADMIN' docs/threat-model.md
+          grep -qi 'jailed' docs/threat-model.md
+          grep -qi 'pivot_root' docs/husk-pods.md
+          echo "DOC_DELTA_OK"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `grep -qi 'pivot_root' docs/husk-pods.md && echo found || echo MISSING`
+Expected: `MISSING` (husk-pods.md does not yet mention pivot_root). The grep gate would fail.
+
+- [ ] **Step 3: Write the implementation (the doc edits)**
+
+In `docs/threat-model.md`, update the husk-pod row of the Components table (line 20) so "drop ALL caps" becomes:
+
+```
+drop ALL caps, add only CAP_SYS_ADMIN (the in-pod jailer + chroot-base mount), seccomp: RuntimeDefault, read-only snapshot mount, every VM jailed (per-VM uid, chroot, nested cgroup)
+```
+
+In Surface 1 (the bullet list around lines 83-87), change the capabilities bullet from:
+
+```
+- `capabilities.drop: [ALL]`, none added back,
+```
+
+to:
+
+```
+- `capabilities.drop: [ALL]`, add EXACTLY `CAP_SYS_ADMIN`: the in-pod jailer needs it to build each VM's jail (cgroup + mount namespace + chroot), and the stub needs the one `mount(2)` that bind-mounts and privatizes the jailer chroot base so the jailer can `pivot_root` inside the pod (a pod's rootfs is commonly a shared mount, which `pivot_root` refuses). The jailer then drops to an unprivileged per-VM uid inside the jail, so a VMM escape does NOT inherit `CAP_SYS_ADMIN`,
+```
+
+Add a new paragraph at the END of Surface 1 (after line 104) closing the unjailed-husk residual:
+
+```
+JAILED IN THE POD (this closes the prior unjailed-husk residual). Until now the
+husk stub exec'd Firecracker DIRECTLY as the pod's uid 0: no per-VM uid, no
+chroot, no jailer cgroup, so a microVM escape landed as the pod's uid 0 with the
+pod's full view. The stub now launches every VM through the Firecracker jailer
+INSIDE the pod (`cmd/husk-stub`, `internal/firecracker/jailer.go`): a dedicated
+per-VM uid/gid from `--uid-range` (default 64000-64999, uid 0 refused), a per-VM
+chroot the jailer `pivot_root`s into, and a cgroup the jailer NESTS under the
+pod's own cgroup (a child memcg, it does not override the pod's `memory.max`).
+The in-pod `pivot_root` precondition is handled by the stub: before any launch it
+bind-mounts the chroot base (a pod-writable emptyDir, NOT the read-only snapshot
+hostPath) onto itself and marks it `MS_PRIVATE`, so the new root is a mount point
+with non-shared parent propagation, exactly what `pivot_root(2)` requires. The
+cost is the single added `CAP_SYS_ADMIN` above; the benefit is that a guest that
+escapes the microVM now lands as a THROWAWAY uid in an EMPTY chroot, not as the
+pod's uid 0. CI-proven on real KVM (`kvm-test.yaml` husk jailed-activation phase):
+the activated Firecracker runs as a uid in 64000-64999 and its `/proc/<pid>/root`
+is the per-VM chroot, not `/`.
+```
+
+In Section 1's jailer row (line 295), append to the Detail cell, after the existing "direct-exec dev path" residual sentence:
+
+```
+ UPDATE: the husk pod (the default runner) now ALSO runs jailed: `cmd/husk-stub`
+launches its VM through the jailer with the same per-VM uid + chroot + nested
+cgroup, after privatizing the chroot base so `pivot_root` works inside the pod
+(section 0, surface 1). The unjailed-husk path is now the development-only escape
+hatch (omit `--jailer`; the stub logs a loud warning), no longer the default.
+```
+
+In the per-axis tally table (line 250), update the husk Privilege cell to mention the single added cap:
+
+```
+`privileged: false`, `runAsNonRoot: false` (the `/dev/kvm` device exception), no escalation, drop ALL caps and add ONLY `CAP_SYS_ADMIN` for the in-pod jailer (which drops to a per-VM uid inside the jail)
+```
+
+In `docs/husk-pods.md`, add a new subsection at the end of section 5 (after line 310):
+
+```
+### Jailer in the pod (per-VM uid, chroot, nested cgroup)
+
+The husk pod runs every VM through the Firecracker jailer, INSIDE the pod, so a
+tenant VM gets a dedicated per-VM uid/gid, a chroot the jailer `pivot_root`s into,
+and a cgroup nested under the pod's own cgroup. This is what makes a microVM
+escape land as a throwaway unprivileged uid in an empty chroot rather than the
+pod's uid 0.
+
+The one hard part is `pivot_root(2)` inside a pod. The jailer `pivot_root`s into
+`<chroot-base>/firecracker/<vm-id>/root`, and `pivot_root` requires the new root
+to be a MOUNT POINT whose parent mount does NOT have SHARED propagation. A pod's
+container rootfs is commonly mounted shared (or otherwise propagating), so a plain
+directory under it fails `pivot_root` with `EINVAL`/`EBUSY`. The stub fixes both
+preconditions once, at Prepare, in the pod's own mount namespace
+(`cmd/husk-stub/mount_linux.go` `prepareChrootMount`):
+
+1. bind-mount the chroot base onto itself (`mount --bind`), so it BECOMES a mount
+   point the jailer can pivot under; and
+2. recursively mark it `MS_PRIVATE` (`mount --make-private`), so its propagation
+   does not defeat `pivot_root`.
+
+The chroot base is a pod-WRITABLE `emptyDir` (`/run/husk/jail`), deliberately
+separate from the READ-ONLY snapshot hostPath: the jailer creates per-VM chroot
+dirs and the stub hard-links (or copies on EXDEV) the snapshot mem/vmstate into
+them, both of which need a writable filesystem. The cross-filesystem copy fallback
+is expected here (the snapshot is on the read-only node mount), so the husk jailer
+config does NOT require the chroot base and the snapshot to share a filesystem,
+unlike the forkd builder.
+
+This needs exactly one capability beyond what the device plugin grants:
+`CAP_SYS_ADMIN`, for the `mount(2)` above and for the jailer's own jail
+construction (cgroup + namespace + chroot). The jailer then drops to the
+unprivileged per-VM uid inside the jail, so the VMM does NOT keep `CAP_SYS_ADMIN`.
+`/dev/kvm` and `/dev/net/tun` are still injected by the device plugin; the jailer
+mknods them inside the chroot from the injected device nodes.
+
+CI-proven on real KVM (`kvm-test.yaml` husk jailed-activation phase): a jailed
+dormant stub activates a snapshot in place, the activated Firecracker runs as a
+uid in 64000-64999, and its `/proc/<pid>/root` is the per-VM chroot, not `/`. The
+mount setup itself is verified in the KVM-CI unit phase
+(`cmd/husk-stub/mount_linux_test.go`, gated to root/`CAP_SYS_ADMIN`).
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `grep -q 'CAP_SYS_ADMIN' docs/threat-model.md && grep -qi 'jailed' docs/threat-model.md && grep -qi 'pivot_root' docs/husk-pods.md && echo DOC_DELTA_OK`
+Expected: `DOC_DELTA_OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/threat-model.md docs/husk-pods.md .github/workflows/ci.yaml
+git commit -m "docs: record jailed-in-pod surface and the single added CAP_SYS_ADMIN
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Final lint and full-suite gate (both darwin and GOOS=linux)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run gofmt and both lint invocations**
+
+Run:
+```bash
+gofmt -l cmd/husk-stub internal/husk internal/firecracker internal/controller
+golangci-lint run --timeout=5m
+GOOS=linux golangci-lint run --timeout=5m
+```
+Expected: `gofmt -l` prints nothing (all formatted); both `golangci-lint` runs exit 0 with no findings. The `GOOS=linux` run is REQUIRED because `mount_linux.go` (and the linux-only test) are invisible to the darwin run.
+
+- [ ] **Step 2: Run the unit suites that do not need KVM**
+
+Run:
+```bash
+go test ./internal/firecracker/ ./internal/husk/ ./cmd/husk-stub/
+eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Cross-build the guest-agent and the linux binaries**
+
+Run:
+```bash
+GOOS=linux GOARCH=amd64 go build ./cmd/husk-stub/ ./guest/agent/
+go build ./...
+```
+Expected: all build cleanly (exit 0).
+
+- [ ] **Step 4: Confirm the KVM-only verifications are marked, not run here**
+
+Confirm (manual check, no command): Task 1's `mount_linux_test.go` SKIPS off-root; Task 8's `husk-jailed` phase runs only on `kvm-test.yaml`. Neither is expected to PASS on darwin/kind; both are documented as KVM-CI / bare-metal (#16) verifications with exact commands and expected output above.
+
+- [ ] **Step 5: Commit (only if any formatting fix was needed)**
+
+```bash
+# Only if gofmt or lint required a change:
+git add -p
+git commit -m "chore: gofmt and lint cleanup for jailer-in-pod
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Mount setup (bind + make-private for pivot_root): Task 1 (`prepareChrootMount`), wired in Task 5, asserted on KVM in Task 8.
+- Jailer invocation from the husk stub: Tasks 2 (`buildHuskJailerConfig`), 5 (`huskVMConfig` + flags + call), 3 (per-activate chroot file prep), 4 (`PrepareChrootForVM`).
+- Cgroup placement (nest under the pod, do not fight it): documented in Task 6's args comment and Task 9's docs; the jailer's `--cgroup-version 2` already nests under the task's existing cgroup (it creates a child, per jailer behavior). No code fights `memory.max`.
+- Device access (kvm/net tun via device plugin): unchanged and stated in Task 9; the jailer mknods from the injected nodes. No new device wiring needed.
+- Pod spec: securityContext (single added CAP_SYS_ADMIN), chroot-base emptyDir volume, jailer args: Task 6.
+- Jailer binary in the image: Task 7.
+- Threat-model delta in the same plan: Task 9 (required by CLAUDE.md). States the added capability and which posture changed; no capability can be DROPPED here (the unjailed path needed none, the jailed path needs exactly one more), so the doc honestly records an ADDED cap with the offsetting benefit.
+- KVM/pivot_root tests marked as KVM-CI / bare-metal: Tasks 1 and 8, both with exact code, run command, and expected output.
+- Lint clean darwin AND GOOS=linux: Task 10.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every run step has an exact command and expected output. The one cross-reference to confirm an existing symbol (`fakeVMM` in Task 3, `buildHuskPod` call shape in Task 6, existing phase shape in Task 8) gives the exact grep to confirm and says to adapt only the name, not the logic.
+
+**Type consistency:** `prepareChrootMount(chrootBase string) error` is identical across `mount_linux.go`, `mount_other.go`, the test, and the call in `main.go`. `buildHuskJailerConfig(jailerBin, chrootBase, uidRange string, euid int) (firecracker.JailerConfig, error)` matches its test and its caller in `huskVMConfig`. `huskVMParams`/`huskVMConfig` match between `main.go` and the test helper. `PrepareChrootForVM(cfg VMConfig, vmID string, files []string) error` matches its test and the stub's production seam. The `chrootPreparer func(vmID string, files []string) error` seam matches the `Options.PrepareChroot` field, the `Stub.prepareChroot` field, and the Activate call. `huskSandboxID` (existing const `"husk"`) is reused for the VM id, so the chroot root path in Task 8's expected output (`/run/husk/jail/firecracker/husk/root`) is consistent with `jailerChrootDir`.

--- a/docs/superpowers/plans/2026-06-13-per-activation-rootfs-cow.md
+++ b/docs/superpowers/plans/2026-06-13-per-activation-rootfs-cow.md
@@ -1,0 +1,1048 @@
+# Per-Activation Rootfs CoW Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every husk-pod activation its OWN copy-on-write clone of the template `rootfs.ext4` (reflink where the filesystem supports it, full copy otherwise) and point the restored VM's `rootfs` drive at that per-activation file, so concurrent activations of one template never share or corrupt a single rootfs.
+
+**Architecture:** Reuse the existing reflink policy in `internal/volume.Backend` (the `cp --reflink=always` then `--reflink=auto` fallback) by extracting it into an exported `ReflinkCopy(src, dst)` method. The husk `Stub` clones `<template>/rootfs.ext4` to a per-activation file during `Prepare` (the dormant, pre-paid window, so `Activate` stays the engine-only hot path), then after `LoadSnapshotWithOverrides` in `Activate` it rebinds the baked `rootfs` drive to the clone with `PatchDrive("rootfs", clonePath)` (the exact pattern the fork engine already uses for volume drives). The controller mounts a per-node writable CoW directory that is co-located with the template directory on the SAME node filesystem (so reflink can find a shared extent source), and the clone is removed on pod teardown in `Stub.Close`.
+
+**Tech Stack:** Go, Firecracker snapshot/restore, `internal/volume` (FICLONE via `cp --reflink`), `internal/husk` (the activate state machine), `internal/firecracker` (`PatchDrive`), `internal/controller` (husk pod spec).
+
+---
+
+## Key Design Decisions
+
+**(a) Co-location for reflink.** `cp --reflink=always` (FICLONE) requires source and destination on the SAME reflink-capable filesystem (XFS or Btrfs). The clone source is the template rootfs at `<dataDir>/templates/<id>/rootfs.ext4`, already mounted into the husk pod at its real absolute path (`huskpod.go` `template` volume). The per-activation CoW file therefore lives in a SIBLING directory on the same node data dir: `<dataDir>/husk-rootfs`, mounted read-write into the pod at its real absolute path (so `cp` inside the pod sees both files on one filesystem). An `emptyDir` would land on a DIFFERENT filesystem (the pod's ephemeral storage), where FICLONE fails and every activation silently degrades to a full copy; co-locating under `<dataDir>` keeps the reflink fast path available on XFS/Btrfs node disks.
+
+**(b) Clone at Prepare, not Activate.** The clone runs in `Stub.Prepare` (dormant, pre-paid warm period before any claim arrives), NOT in `Stub.Activate` (the claim -> Ready hot path). Justification: the template rootfs is read-only and content-addressed, so a clone taken at Prepare is byte-identical to one taken at Activate; doing it during the dormant window keeps the activate latency the engine cost (load + handshake), exactly as the existing `PrepareSnapshotDir` verification was moved off the hot path. A reflink clone is near-instant, but a full-copy fallback (non-reflink FS) is hundreds of MiB and MUST NOT land on the hot path. One dormant pod owns exactly one activation (the husk model), so a single Prepare-time clone is sufficient.
+
+**(c) Cleanup on teardown.** `Stub.Close` removes the per-activation rootfs file (best effort, path-only logging). The husk pod is long-lived and owns one VM; when the pod terminates, `Close` reaps the Firecracker process and now also unlinks the clone, so the CoW file does not outlive the pod. The pod's `RestartPolicy: Always` plus a fresh `Prepare` on restart re-clones, so a leftover file from a crash is overwritten (O_TRUNC) rather than leaked.
+
+**Threat-model delta:** Surface 3 (the read-only snapshot hostPath) in `docs/threat-model.md` currently states the residual "all husk pods on a node share the SAME read-only snapshot dir ... Cross-pod isolation of the mount is the read-only property, not a per-pod copy." The rootfs is part of the template dir and was previously mounted READ-WRITE and shared. This plan changes the isolation surface: each activation now writes to its OWN CoW clone, never the shared template rootfs. Task 7 updates Surface 3 to record that the rootfs is cloned per activation (no cross-activation write sharing) while the snapshot mem/vmstate stays read-only and shared.
+
+---
+
+## File Structure
+
+- `internal/volume/backend.go` (modify): extract the reflink dance from `Snapshot` into an exported `ReflinkCopy(src, dst string) error`; `Snapshot` calls it. One place owns the FICLONE policy.
+- `internal/volume/backend_test.go` (modify): add tests for `ReflinkCopy` (argv shape + fallback), darwin-safe (recording runner). Keep the existing `Snapshot` tests green.
+- `internal/husk/stub.go` (modify): add `PatchDrive` to the `vmm` interface and `clientVMM`; add `RootfsCoW` fields to `Options` and `Stub`; clone in `Prepare`; rebind in `Activate`; unlink in `Close`. Add a `reflinker` seam so the clone is unit-testable on darwin.
+- `internal/husk/stub_test.go` (modify): extend `fakeVMM` with `PatchDrive` recording; add tests that Prepare clones and Activate rebinds the `rootfs` drive, that a rebind failure fails closed, and that Close removes the clone.
+- `internal/firecracker/client.go` (no change): `PatchDrive` already exists.
+- `internal/controller/huskpod.go` (modify): mount a writable `<dataDir>/husk-rootfs` hostPath at its real path; pass `--rootfs-cow-dir` and `--template-rootfs` to the stub; replace the "PRODUCTION FOLLOW-UP" comment.
+- `internal/controller/huskpod_test.go` (modify): assert the new volume/mount and args are present.
+- `cmd/husk-stub/main.go` (modify): add `--rootfs-cow-dir` and `--template-rootfs` flags; wire `husk.Options.RootfsCoWDir` and `RootfsTemplatePath`.
+- `docs/threat-model.md` (modify): update Surface 3 residual for per-activation rootfs CoW.
+- `internal/volume/reflink_cow_test.go` (create): a KVM-CI / bare-metal reflink integration test (real `cp --reflink`), build-tagged so darwin and the default `make test-unit` skip it.
+
+---
+
+### Task 1: Extract the reflink policy into `volume.ReflinkCopy`
+
+**Files:**
+- Modify: `internal/volume/backend.go`
+- Test: `internal/volume/backend_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/volume/backend_test.go`:
+
+```go
+func TestReflinkCopyTriesAlwaysThenAuto(t *testing.T) {
+	b, rr := newTestBackend(t)
+	rr.failOn = func(argv []string) bool {
+		return strings.Contains(strings.Join(argv, " "), "--reflink=always")
+	}
+	src := filepath.Join(t.TempDir(), "src.ext4")
+	dst := filepath.Join(t.TempDir(), "dst.ext4")
+
+	if err := b.ReflinkCopy(src, dst); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+	if len(rr.calls) != 2 {
+		t.Fatalf("expected 2 cp calls (always then auto), got %d: %v", len(rr.calls), rr.calls)
+	}
+	if !strings.Contains(strings.Join(rr.calls[0], " "), "--reflink=always") {
+		t.Errorf("first cp should try --reflink=always: %v", rr.calls[0])
+	}
+	if !strings.Contains(strings.Join(rr.calls[1], " "), "--reflink=auto") {
+		t.Errorf("fallback should use --reflink=auto: %v", rr.calls[1])
+	}
+	if rr.calls[1][len(rr.calls[1])-2] != src || rr.calls[1][len(rr.calls[1])-1] != dst {
+		t.Errorf("cp src/dst = %q %q, want %q %q", rr.calls[1][len(rr.calls[1])-2], rr.calls[1][len(rr.calls[1])-1], src, dst)
+	}
+}
+
+func TestReflinkCopyMakesDestDir(t *testing.T) {
+	b, _ := newTestBackend(t)
+	src := filepath.Join(t.TempDir(), "src.ext4")
+	dst := filepath.Join(t.TempDir(), "nested", "dst.ext4")
+	if err := b.ReflinkCopy(src, dst); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(dst)); err != nil {
+		t.Errorf("dest parent dir not created: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/volume/ -run TestReflinkCopy -v`
+Expected: FAIL, `b.ReflinkCopy undefined (type *Backend has no field or method ReflinkCopy)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/volume/backend.go`, add the exported method and refactor `Snapshot` to call it. Insert `ReflinkCopy` immediately before `Snapshot`:
+
+```go
+// ReflinkCopy copies src to dst with copy-on-write semantics. It first tries
+// cp --reflink=always for a true FICLONE clone (instant, shared extents on
+// btrfs/xfs); on a filesystem without reflink support that fails, so it falls
+// back to cp --reflink=auto, which performs a full byte copy and logs a warning
+// (CoW was unavailable). The destination's parent directory is created if
+// absent. src and dst carry no secrets and are safe to log. This is the single
+// owner of the reflink policy: both per-fork volume Snapshot and the husk
+// per-activation rootfs clone go through it so they cannot drift.
+func (b *Backend) ReflinkCopy(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("reflink copy: mkdir: %w", err)
+	}
+	if err := b.runner([]string{"cp", "--reflink=always", src, dst}); err != nil {
+		fmt.Fprintf(os.Stderr, "volume: WARNING reflink CoW unavailable (filesystem lacks reflink support); falling back to a full copy of %s to %s\n", src, dst)
+		if err := b.runner([]string{"cp", "--reflink=auto", src, dst}); err != nil {
+			return fmt.Errorf("reflink copy %s to %s: %w", src, dst, err)
+		}
+	}
+	return nil
+}
+```
+
+Then replace the body of `Snapshot` between the `mkdir` and the `return Prepared{...}` with a `ReflinkCopy` call. The new `Snapshot`:
+
+```go
+func (b *Backend) Snapshot(spec Spec, sandboxID, sourcePath string) (Prepared, error) {
+	if err := validateName(spec.Name); err != nil {
+		return Prepared{}, err
+	}
+	dst := b.volumePath(sandboxID, spec.Name)
+	if err := b.ReflinkCopy(sourcePath, dst); err != nil {
+		return Prepared{}, fmt.Errorf("volume %s: %w", spec.Name, err)
+	}
+	return Prepared{Name: spec.Name, HostPath: dst, MountPath: spec.MountPath, ReadOnly: spec.ReadOnly}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/volume/ -v`
+Expected: PASS, including the existing `TestSnapshotIssuesReflinkCopyToDistinctPath` and `TestSnapshotFallsBackToReflinkAuto` (they still see one or two `cp` calls; the argv shape is unchanged because `ReflinkCopy` issues the identical commands).
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run --timeout=5m ./internal/volume/ && GOOS=linux golangci-lint run --timeout=5m ./internal/volume/`
+Expected: no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/volume/backend.go internal/volume/backend_test.go
+git commit -m "refactor: extract reflink CoW policy into volume.ReflinkCopy
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add `PatchDrive` to the husk `vmm` interface
+
+**Files:**
+- Modify: `internal/husk/stub.go`
+- Test: `internal/husk/stub_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `fakeVMM` in `internal/husk/stub_test.go`. Add fields to the struct (after `closed bool`):
+
+```go
+	patchCalls []struct {
+		driveID string
+		path    string
+	}
+	patchErr error
+```
+
+And add the method after `func (f *fakeVMM) VsockHostPath`:
+
+```go
+func (f *fakeVMM) PatchDrive(driveID, pathOnHost string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.patchCalls = append(f.patchCalls, struct {
+		driveID string
+		path    string
+	}{driveID, pathOnHost})
+	return f.patchErr
+}
+```
+
+Add a compile-time interface assertion test at the end of `internal/husk/stub_test.go`:
+
+```go
+// TestFakeVMMSatisfiesInterface fails to compile if the vmm interface gains a
+// method fakeVMM does not implement, keeping the fake in lockstep with the seam.
+func TestFakeVMMSatisfiesInterface(t *testing.T) {
+	var _ vmm = (*fakeVMM)(nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/husk/ -run TestFakeVMMSatisfiesInterface -v`
+Expected: FAIL to compile, `*fakeVMM does not implement vmm (missing method PatchDrive)` is not yet the error; instead the interface still lacks `PatchDrive`, so the assertion compiles but is meaningless. To make the test meaningful, also add the interface method in Step 3 and re-run.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/husk/stub.go`, add `PatchDrive` to the `vmm` interface (after `LoadSnapshotWithOverrides`):
+
+```go
+	// PatchDrive rebinds an existing baked drive (by drive id) to a host backing
+	// file via PATCH /drives, after the snapshot is loaded and resumed. The husk
+	// activate path uses it to point the rootfs drive at this activation's CoW
+	// clone, the same rebind the fork engine applies to volume drives.
+	PatchDrive(driveID, pathOnHost string) error
+```
+
+`clientVMM` embeds `*firecracker.Client`, which already has `PatchDrive(driveID, pathOnHost string) error`, so `clientVMM` satisfies the interface with no extra code.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/husk/ -run TestFakeVMMSatisfiesInterface -v`
+Expected: PASS (and the whole `fakeVMM` now implements the wider interface).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/husk/stub.go internal/husk/stub_test.go
+git commit -m "feat: add PatchDrive to the husk vmm interface
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Clone the rootfs at Prepare
+
+**Files:**
+- Modify: `internal/husk/stub.go`
+- Test: `internal/husk/stub_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/husk/stub_test.go`:
+
+```go
+func TestPrepareClonesRootfsWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "templates", "tmpl", "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(tmplRootfs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmplRootfs, []byte("ROOTFS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+
+	var gotSrc, gotDst string
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:  func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:  readyOK,
+		Notify: (&fakeNotifier{}).notify,
+		Verify: verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       cowDir,
+		Reflink: func(src, dst string) error {
+			gotSrc, gotDst = src, dst
+			return os.WriteFile(dst, []byte("CLONE"), 0o644)
+		},
+	})
+
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if gotSrc != tmplRootfs {
+		t.Errorf("reflink src = %q, want template rootfs %q", gotSrc, tmplRootfs)
+	}
+	wantDst := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
+	if gotDst != wantDst {
+		t.Errorf("reflink dst = %q, want per-activation path %q", gotDst, wantDst)
+	}
+	if _, err := os.Stat(wantDst); err != nil {
+		t.Errorf("clone not written: %v", err)
+	}
+}
+
+func TestPrepareSkipsCloneWhenUnconfigured(t *testing.T) {
+	called := false
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:   func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:   readyOK,
+		Notify:  (&fakeNotifier{}).notify,
+		Verify:  verifyOK,
+		Reflink: func(src, dst string) error { called = true; return nil },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if called {
+		t.Error("reflink must not run when RootfsTemplatePath/RootfsCoWDir are empty")
+	}
+}
+
+func TestPrepareCloneFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	vm := &fakeVMM{}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return vm, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       filepath.Join(dir, "husk-rootfs"),
+		Reflink:            func(src, dst string) error { return errors.New("no space") },
+	})
+	if err := s.Prepare(context.Background()); err == nil {
+		t.Fatal("expected Prepare to fail closed on clone error")
+	}
+	if s.State() == StateDormant {
+		t.Error("state must not be dormant after a failed clone")
+	}
+	if !vm.closed {
+		t.Error("the dormant VMM must be torn down when Prepare fails closed")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/husk/ -run TestPrepareClonesRootfs -v`
+Expected: FAIL to compile, `unknown field RootfsTemplatePath in struct literal of type husk.Options` (and `RootfsCoWDir`, `Reflink`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/husk/stub.go`, add a `reflinker` seam type near the other seams (after the `notifier` type):
+
+```go
+// reflinker copies a source file to a destination with copy-on-write semantics
+// (reflink where the filesystem supports it, full copy otherwise). The husk
+// stub clones the template rootfs to a per-activation file through it. The
+// production seam is volume.Backend.ReflinkCopy; tests inject a fake. src and
+// dst carry no secrets.
+type reflinker func(src, dst string) error
+```
+
+Add to `Options` (after `PrepareExpectedDigest`):
+
+```go
+	// RootfsTemplatePath and RootfsCoWDir, when both set, give this activation its
+	// OWN copy-on-write clone of the template rootfs instead of writing the shared
+	// template rootfs.ext4 in place. At Prepare the stub reflink-clones
+	// RootfsTemplatePath to <RootfsCoWDir>/<vm id>/rootfs.ext4 (pre-paid, dormant),
+	// and at Activate it rebinds the snapshot's baked "rootfs" drive to that clone
+	// with PatchDrive after the snapshot loads. Both empty keeps the prior behavior
+	// (the resumed VM writes the shared template rootfs). The paths are content
+	// addresses, not secrets.
+	RootfsTemplatePath string
+	RootfsCoWDir       string
+	// Reflink performs the per-activation rootfs clone. Nil uses the production
+	// seam (volume.Backend.ReflinkCopy, which is FICLONE with a full-copy
+	// fallback). Tests inject a fake.
+	Reflink reflinker
+```
+
+Add to `Stub` (after `prepareExpectedDigest`):
+
+```go
+	// rootfsTemplatePath / rootfsCoWDir configure the per-activation rootfs CoW;
+	// reflink performs the clone; rootfsClonePath records the clone Prepare made so
+	// Activate rebinds the drive to it and Close removes it. Empty rootfsClonePath
+	// means no per-activation rootfs was prepared (prior behavior).
+	rootfsTemplatePath string
+	rootfsCoWDir       string
+	reflink            reflinker
+	rootfsClonePath    string
+```
+
+In `New`, wire the options (after the `prepareExpectedDigest` assignment in the struct literal):
+
+```go
+		rootfsTemplatePath: opts.RootfsTemplatePath,
+		rootfsCoWDir:       opts.RootfsCoWDir,
+		reflink:            opts.Reflink,
+```
+
+and add a default after the `s.readyTimeout` default block:
+
+```go
+	if s.reflink == nil {
+		s.reflink = volume.New("").ReflinkCopy
+	}
+```
+
+Add the import `"github.com/paperclipinc/mitos/internal/volume"` to the import block. `volume.New("")` is only a holder for the `ReflinkCopy` method (which uses absolute src/dst and never touches the backend root), so the empty root is intentional and harmless.
+
+In `Prepare`, after the `prepareVerified` block and before `s.state = StateDormant`, add the clone:
+
+```go
+	// Per-activation rootfs CoW (opt-in): clone the template rootfs to this
+	// activation's OWN file NOW, during the dormant pre-paid window, so the
+	// Activate hot path is only load + handshake (the clone, especially a
+	// full-copy fallback on a non-reflink filesystem, must never land on the hot
+	// path). The clone source is read-only and content-addressed, so a clone taken
+	// here is byte-identical to one taken at Activate. Fail closed: a clone failure
+	// tears the dormant VMM down and keeps the pod out of StateDormant so the pool
+	// never offers it.
+	if s.rootfsTemplatePath != "" && s.rootfsCoWDir != "" {
+		clonePath := filepath.Join(s.rootfsCoWDir, s.cfg.ID, "rootfs.ext4")
+		if err := s.reflink(s.rootfsTemplatePath, clonePath); err != nil {
+			_ = s.vm.Close()
+			s.vm = nil
+			return fmt.Errorf("husk: clone per-activation rootfs: %w", err)
+		}
+		s.rootfsClonePath = clonePath
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/husk/ -run TestPrepare -v`
+Expected: PASS for the three new tests and the existing Prepare tests.
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run --timeout=5m ./internal/husk/ && GOOS=linux golangci-lint run --timeout=5m ./internal/husk/`
+Expected: no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/husk/stub.go internal/husk/stub_test.go
+git commit -m "feat: clone per-activation rootfs at husk Prepare
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Rebind the rootfs drive at Activate
+
+**Files:**
+- Modify: `internal/husk/stub.go`
+- Test: `internal/husk/stub_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/husk/stub_test.go`. These drive the full activate path with a clone configured; they assert the `rootfs` drive is PATCHed to the clone AFTER load:
+
+```go
+func TestActivateRebindsRootfsDriveToClone(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+	vm := &fakeVMM{}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return vm, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       cowDir,
+		Reflink:            func(src, dst string) error { return os.WriteFile(dst, []byte("c"), 0o644) },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: filepath.Join(dir, "snap")})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("activate not OK: %s", res.Error)
+	}
+	if len(vm.patchCalls) != 1 {
+		t.Fatalf("expected exactly 1 PatchDrive call, got %d: %v", len(vm.patchCalls), vm.patchCalls)
+	}
+	if vm.patchCalls[0].driveID != "rootfs" {
+		t.Errorf("rebind drive id = %q, want \"rootfs\"", vm.patchCalls[0].driveID)
+	}
+	wantPath := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
+	if vm.patchCalls[0].path != wantPath {
+		t.Errorf("rebind path = %q, want clone %q", vm.patchCalls[0].path, wantPath)
+	}
+}
+
+func TestActivateNoRebindWhenNoClone(t *testing.T) {
+	vm := &fakeVMM{}
+	s := newTestStub(t, vm, readyOK)
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap"})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("activate not OK: %s", res.Error)
+	}
+	if len(vm.patchCalls) != 0 {
+		t.Errorf("no rootfs clone configured, so no PatchDrive expected, got %v", vm.patchCalls)
+	}
+}
+
+func TestActivateRebindFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	vm := &fakeVMM{patchErr: errors.New("drive busy")}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return vm, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       filepath.Join(dir, "husk-rootfs"),
+		Reflink:            func(src, dst string) error { return os.WriteFile(dst, []byte("c"), 0o644) },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: filepath.Join(dir, "snap")})
+	if err == nil {
+		t.Fatal("expected activate to fail closed on rebind error")
+	}
+	if res.OK {
+		t.Fatal("fail closed: result must not be OK")
+	}
+	if s.State() == StateActive {
+		t.Errorf("state must not be active after a failed rebind, got %s", s.State())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/husk/ -run TestActivateRebindsRootfsDriveToClone -v`
+Expected: FAIL, `expected exactly 1 PatchDrive call, got 0` (Activate does not yet rebind).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/husk/stub.go` `Activate`, insert the rebind immediately AFTER the `LoadSnapshotWithOverrides` block and BEFORE the `vsockPath := s.vm.VsockHostPath(...)` line:
+
+```go
+	// Rebind the baked "rootfs" drive to THIS activation's CoW clone now that the
+	// snapshot is loaded and resumed, before the guest writes anything. This is the
+	// husk analog of the fork engine's per-fork volume drive rebind: the snapshot
+	// bakes the rootfs block device at path_on_host, and Firecracker supports
+	// updating a drive's path_on_host on a restored+resumed VM (PATCH /drives).
+	// Skipped when no per-activation clone was prepared (the prior shared-rootfs
+	// behavior). Fail closed: a rebind failure means the VM is still pointed at the
+	// shared template rootfs, which is exactly the corruption hazard this prevents,
+	// so do NOT mark active. The drive id and path carry no secrets.
+	if s.rootfsClonePath != "" {
+		if err := s.vm.PatchDrive("rootfs", s.rootfsClonePath); err != nil {
+			werr := fmt.Errorf("husk: rebind rootfs drive to per-activation clone: %w", err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/husk/ -run TestActivate -v`
+Expected: PASS for the three new rebind tests and all existing Activate tests (the non-clone tests use `newTestStub`, whose `rootfsClonePath` stays empty, so they make zero PatchDrive calls).
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run --timeout=5m ./internal/husk/ && GOOS=linux golangci-lint run --timeout=5m ./internal/husk/`
+Expected: no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/husk/stub.go internal/husk/stub_test.go
+git commit -m "feat: rebind rootfs drive to per-activation clone at husk Activate
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Remove the per-activation clone on teardown
+
+**Files:**
+- Modify: `internal/husk/stub.go`
+- Test: `internal/husk/stub_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/husk/stub_test.go`:
+
+```go
+func TestCloseRemovesRootfsClone(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       cowDir,
+		Reflink:            func(src, dst string) error { return os.WriteFile(dst, []byte("c"), 0o644) },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	clonePath := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
+	if _, err := os.Stat(clonePath); err != nil {
+		t.Fatalf("clone should exist after Prepare: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(clonePath); !os.IsNotExist(err) {
+		t.Errorf("clone should be removed after Close, stat err = %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/husk/ -run TestCloseRemovesRootfsClone -v`
+Expected: FAIL, `clone should be removed after Close` (Close does not yet unlink it).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/husk/stub.go` `Close`, after the `s.vm = nil` / `s.state = StateNew` assignments and before `return err`, add:
+
+```go
+	// Best effort: remove this activation's rootfs CoW clone so it does not
+	// outlive the pod. A reflink clone shares extents with the template until
+	// written, so removing it frees only the activation's own divergent blocks.
+	// Path only is logged on failure; the clone carries no secrets.
+	if s.rootfsClonePath != "" {
+		if rmErr := os.Remove(s.rootfsClonePath); rmErr != nil && !os.IsNotExist(rmErr) {
+			fmt.Fprintf(os.Stderr, "husk: remove per-activation rootfs clone %s: %v\n", s.rootfsClonePath, rmErr)
+		}
+		s.rootfsClonePath = ""
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/husk/ -v`
+Expected: PASS for the new test and the whole husk suite.
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run --timeout=5m ./internal/husk/ && GOOS=linux golangci-lint run --timeout=5m ./internal/husk/`
+Expected: no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/husk/stub.go internal/husk/stub_test.go
+git commit -m "feat: remove per-activation rootfs clone on husk teardown
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Wire `--rootfs-cow-dir` and `--template-rootfs` flags in the stub binary
+
+**Files:**
+- Modify: `cmd/husk-stub/main.go`
+
+- [ ] **Step 1: Write the failing check (manual, no unit test for flag parsing)**
+
+`cmd/husk-stub/main.go` has no unit tests; flag wiring is verified by build plus the controller test in Task 7 asserting the args. The verification command for this task is the build.
+
+- [ ] **Step 2: Confirm it does not yet build with the new flags**
+
+Run: `grep -c "rootfs-cow-dir" cmd/husk-stub/main.go`
+Expected: `0` (flag absent).
+
+- [ ] **Step 3: Write the implementation**
+
+In `cmd/husk-stub/main.go` `run()`, add two flags inside the `var ( ... )` block alongside `manifest` and `allowUnverified`:
+
+```go
+		rootfsCoWDir    = flag.String("rootfs-cow-dir", "", "directory on the SAME node filesystem as the template rootfs where this activation's copy-on-write rootfs clone is written (reflink where supported, full copy otherwise). Empty keeps the prior behavior of writing the shared template rootfs in place. A content address, not a secret")
+		templateRootfs  = flag.String("template-rootfs", "", "host path of the template rootfs.ext4 to clone per activation. Empty (with --rootfs-cow-dir) disables the per-activation clone")
+```
+
+In the `husk.New(cfg, husk.Options{ ... })` literal, add (after `PrepareExpectedDigest`):
+
+```go
+			// Per-activation rootfs CoW: clone the template rootfs to a per-pod file
+			// on a writable co-located volume at Prepare and rebind the rootfs drive
+			// to it at Activate, so concurrent activations of one template never
+			// share or corrupt a single rootfs. Both empty keeps the prior in-place
+			// shared-rootfs behavior.
+			RootfsTemplatePath: *templateRootfs,
+			RootfsCoWDir:       *rootfsCoWDir,
+```
+
+- [ ] **Step 4: Run build to verify it compiles**
+
+Run: `go build ./cmd/husk-stub/ && GOOS=linux GOARCH=amd64 go build ./cmd/husk-stub/`
+Expected: both succeed (no output).
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run --timeout=5m ./cmd/husk-stub/ && GOOS=linux golangci-lint run --timeout=5m ./cmd/husk-stub/`
+Expected: no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/husk-stub/main.go
+git commit -m "feat: add --rootfs-cow-dir and --template-rootfs flags to husk-stub
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Mount the writable CoW dir and pass the flags from the controller
+
+**Files:**
+- Modify: `internal/controller/huskpod.go`
+- Test: `internal/controller/huskpod_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+First read `internal/controller/huskpod_test.go` to confirm the helper and option shape (the existing tests call `r.BuildHuskPodForTest(pool, template, controller.HuskPodOptions{...})` with `DataDir` and `SnapshotID` set; see `TestBuildHuskPodControlAndSnapshot`, which uses `DataDir: "/var/lib/mitos"` and `SnapshotID: "ctl-tmpl"`). Add this test, mirroring that setup verbatim so the pool/template/reconciler are constructed the same way:
+
+```go
+func TestBuildHuskPodMountsWritableRootfsCoWDir(t *testing.T) {
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "cow-pool", Namespace: "default", UID: "pool-uid-cow"},
+		Spec:       v1alpha1.SandboxPoolSpec{TemplateRef: v1alpha1.LocalObjectReference{Name: "cow-tmpl"}, Replicas: 1},
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cow-tmpl", Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+
+	r := &controller.SandboxPoolReconciler{Client: k8sClient}
+	pod := r.BuildHuskPodForTest(pool, template, controller.HuskPodOptions{
+		StubImage:  "mitos-husk-stub:test",
+		SnapshotID: "cow-tmpl",
+		DataDir:    "/var/lib/mitos",
+	})
+	container := pod.Spec.Containers[0]
+
+	// The CoW dir hostPath volume must be present and WRITABLE (ReadOnly false),
+	// co-located under the node data dir as a sibling of templates.
+	var cowMount *corev1.VolumeMount
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == "husk-rootfs-cow" {
+			cowMount = &container.VolumeMounts[i]
+		}
+	}
+	if cowMount == nil {
+		t.Fatal("expected a husk-rootfs-cow volume mount")
+	}
+	if cowMount.ReadOnly {
+		t.Error("the rootfs CoW dir must be mounted read-write")
+	}
+
+	var cowVol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == "husk-rootfs-cow" {
+			cowVol = &pod.Spec.Volumes[i]
+		}
+	}
+	if cowVol == nil || cowVol.HostPath == nil {
+		t.Fatal("expected a husk-rootfs-cow hostPath volume")
+	}
+	wantHostPath := filepath.Join("/var/lib/mitos", "husk-rootfs")
+	if cowVol.HostPath.Path != wantHostPath {
+		t.Errorf("CoW hostPath = %q, want %q (sibling of templates under the data dir)", cowVol.HostPath.Path, wantHostPath)
+	}
+
+	// The stub must be told where to clone from and to.
+	args := strings.Join(container.Args, " ")
+	if !strings.Contains(args, "--rootfs-cow-dir "+cowMount.MountPath) {
+		t.Errorf("args missing --rootfs-cow-dir %s: %v", cowMount.MountPath, container.Args)
+	}
+	wantTemplateRootfs := filepath.Join("/var/lib/mitos", "templates", "cow-tmpl", "rootfs.ext4")
+	if !strings.Contains(args, "--template-rootfs "+wantTemplateRootfs) {
+		t.Errorf("args missing --template-rootfs %s: %v", wantTemplateRootfs, container.Args)
+	}
+}
+```
+
+`v1alpha1`, `metav1`, `corev1`, `strings`, `filepath`, `controller`, and `k8sClient` are all already imported / available in this test file (the existing tests use every one). If `filepath` or `strings` is not yet imported, add it to the import block.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestHuskPodMountsWritableRootfsCoWDir -v`
+Expected: FAIL, `expected a husk-rootfs-cow volume mount` (no such volume yet).
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/controller/huskpod.go`, add a mount-path constant in the `const` block near `huskSnapshotMountPath` (line ~83):
+
+```go
+	// huskRootfsCoWMountPath is the in-pod path the writable per-activation rootfs
+	// CoW directory is mounted at. It is a hostPath under the node data dir
+	// (<dataDir>/husk-rootfs), co-located with the template dir on the SAME node
+	// filesystem so the stub's reflink clone of the template rootfs lands on a
+	// reflink-capable filesystem (a full copy fallback otherwise). Each activation
+	// writes its own clone under here, never the shared read-only template rootfs.
+	huskRootfsCoWMountPath = "/var/lib/mitos/husk-rootfs"
+```
+
+Then, replace the "PRODUCTION FOLLOW-UP (per-activation rootfs CoW)" comment block (lines ~374-382) above the `template` volume with a comment recording that the rootfs is now cloned per activation:
+
+```go
+			// The template directory, mounted at the SAME absolute path the snapshot
+			// was built at (<dataDir>/templates/<id>), so the rootfs.ext4 drive the
+			// snapshot's vmstate references resolves on load. Firecracker re-opens the
+			// drive at its baked path_on_host during /snapshot/load. The stub then
+			// rebinds the rootfs drive to a PER-ACTIVATION copy-on-write clone (see
+			// the husk-rootfs-cow mount below) immediately after load, so the resumed
+			// VM writes its OWN rootfs, never the shared template rootfs: concurrent
+			// activations of one template no longer share or corrupt a single rootfs.
+			// The clone source (this template rootfs) stays effectively read-only.
+```
+
+After the `template` volume + mount append (the block ending at line ~393), add the writable CoW dir volume and mount:
+
+```go
+			// The writable per-activation rootfs CoW directory, a sibling of the
+			// template dir under the node data dir so the stub's reflink clone of the
+			// template rootfs stays on ONE reflink-capable filesystem. Mounted
+			// READ-WRITE (unlike the snapshot and template mounts) because the stub
+			// writes this activation's clone here; an emptyDir would land on a
+			// different filesystem and defeat reflink. DirectoryOrCreate so the dir is
+			// created on first use.
+			volumes = append(volumes, corev1.Volume{
+				Name: "husk-rootfs-cow",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: filepath.Join(dataDir, "husk-rootfs"),
+						Type: &hostType,
+					},
+				},
+			})
+			mounts = append(mounts, corev1.VolumeMount{Name: "husk-rootfs-cow", MountPath: huskRootfsCoWMountPath})
+```
+
+Finally, pass the two flags to the stub. Find where the dormant-stub `args` are assembled (the `args = append(args, "--snapshot-dir", huskSnapshotMountPath, "--expected-digest", opts.ExpectedDigest)` line ~275 is inside the `opts.SnapshotID != ""` / digest branch). Add, in the same `opts.SnapshotID != ""` block where the template mount is set (so it is only passed when a snapshot/template is present):
+
+```go
+			args = append(args,
+				"--rootfs-cow-dir", huskRootfsCoWMountPath,
+				"--template-rootfs", filepath.Join(templateDir, "rootfs.ext4"),
+			)
+```
+
+Note `templateDir` is the in-pod path variable already declared at line ~383 (`filepath.Join(dataDir, "templates", opts.SnapshotID)`), mounted at the SAME absolute path, so `filepath.Join(templateDir, "rootfs.ext4")` is the in-pod path of the template rootfs the stub clones FROM. Place this append AFTER `templateDir` is declared and the template mount is appended.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -run TestHuskPod -v`
+Expected: PASS for the new test and the existing husk pod tests.
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run --timeout=5m ./internal/controller/ && GOOS=linux golangci-lint run --timeout=5m ./internal/controller/`
+Expected: no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/controller/huskpod.go internal/controller/huskpod_test.go
+git commit -m "feat: mount writable rootfs CoW dir and pass clone flags to husk pod
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Update the threat model for the isolation-surface change
+
+**Files:**
+- Modify: `docs/threat-model.md`
+
+- [ ] **Step 1: Locate the residual paragraph**
+
+Read `docs/threat-model.md` Surface 3 (around lines 140-152). The current residual ends: "Cross-pod isolation of the mount is the read-only property, not a per-pod copy; fully pod-native snapshot delivery (a CAS pull into the pod, removing the shared hostPath) is a documented follow-up."
+
+- [ ] **Step 2: Edit the residual to record the per-activation rootfs CoW**
+
+Replace the final sentence of the Surface 3 residual paragraph (the "Cross-pod isolation of the mount ..." sentence) with:
+
+```
+Cross-pod isolation of the snapshot mem/vmstate is the read-only property, not a
+per-pod copy. The ROOTFS, by contrast, is no longer shared read-write: each
+activation gets its OWN copy-on-write clone of the template rootfs
+(`internal/husk` `Stub.Prepare` reflink-clones `<dataDir>/templates/<id>/rootfs.ext4`
+to a per-pod file under the writable `<dataDir>/husk-rootfs` hostPath, and
+`Stub.Activate` rebinds the snapshot's baked `rootfs` drive to that clone with
+`PatchDrive` after load), so concurrent activations of one template never write
+through to a single shared rootfs or leak one tenant's filesystem state into
+another. This closes the prior residual where the template dir (including the
+rootfs) was mounted read-write and shared. The clone is removed on pod teardown
+(`Stub.Close`). Fully pod-native snapshot delivery (a CAS pull into the pod,
+removing the shared read-only mem/vmstate hostPath) remains a documented follow-up.
+```
+
+- [ ] **Step 3: Verify no em/en dashes were introduced**
+
+Run: `grep -nP "[\x{2013}\x{2014}]" docs/threat-model.md`
+Expected: no output (exit status 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/threat-model.md
+git commit -m "docs: update threat model for per-activation rootfs CoW isolation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Add the reflink integration test (KVM-CI / bare-metal only)
+
+**Files:**
+- Create: `internal/volume/reflink_cow_test.go`
+
+This test exercises a REAL `cp --reflink` against the real filesystem, so it cannot run on the darwin dev box (`cp` has no `--reflink` on macOS) nor reliably under the default unit suite (a CI runner's tmpfs/overlayfs may lack reflink). It is build-tagged `reflink_integration` so `make test-unit` and the darwin lint skip it; it runs on the KVM CI runner (kvm-test.yaml) and bare-metal nodes whose data dir is XFS/Btrfs.
+
+- [ ] **Step 1: Write the test**
+
+Create `internal/volume/reflink_cow_test.go`:
+
+```go
+//go:build reflink_integration
+
+package volume
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReflinkCopyRealFilesystem exercises ReflinkCopy against a real cp on the
+// host filesystem: the destination must be a byte-identical copy of the source.
+// It runs ONLY under the reflink_integration build tag (KVM CI / bare-metal),
+// because cp --reflink does not exist on darwin and the destination filesystem
+// must support FICLONE (XFS/Btrfs) for the fast path; the production
+// ReflinkCopy falls back to a full copy when reflink is unavailable, so the
+// byte-equality assertion holds either way.
+func TestReflinkCopyRealFilesystem(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.ext4")
+	dst := filepath.Join(dir, "sub", "dst.ext4")
+	want := bytes.Repeat([]byte("PAPERCLIP"), 4096) // ~36 KiB of recognizable bytes
+	if err := os.WriteFile(src, want, 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	b := New(dir) // production runner (real cp)
+	if err := b.ReflinkCopy(src, dst); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("clone is not byte-identical to source: got %d bytes, want %d", len(got), len(want))
+	}
+}
+```
+
+- [ ] **Step 2: Confirm it is skipped by the default suite (darwin)**
+
+Run: `go test ./internal/volume/ -run TestReflinkCopyRealFilesystem -v`
+Expected: `testing: warning: no tests to run` / `ok ... [no tests to run]` (the build tag excludes the file).
+
+- [ ] **Step 3: Run it under the build tag (KVM CI / bare-metal node only)**
+
+On a Linux node whose temp dir filesystem has `cp --reflink` available:
+
+Run: `go test -tags reflink_integration ./internal/volume/ -run TestReflinkCopyRealFilesystem -v`
+Expected: `--- PASS: TestReflinkCopyRealFilesystem` then `ok github.com/paperclipinc/mitos/internal/volume`. On a non-reflink filesystem the production `ReflinkCopy` logs the `WARNING reflink CoW unavailable` line and still PASSES via the full-copy fallback (byte-equality holds).
+
+- [ ] **Step 4: Lint (linux only; the tag is linux-relevant)**
+
+Run: `GOOS=linux golangci-lint run --timeout=5m --build-tags reflink_integration ./internal/volume/`
+Expected: no findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/volume/reflink_cow_test.go
+git commit -m "test: add reflink CoW integration test for bare-metal/KVM CI
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Wire the tag into the KVM CI job (manual, optional follow-up)**
+
+`.github/workflows/kvm-test.yaml` is the KVM runner job. To run this integration test there, add a step that runs `go test -tags reflink_integration ./internal/volume/ -run TestReflinkCopyRealFilesystem -v` on a workdir under an XFS/Btrfs mount. This is documented here as the verification location; wiring it is a one-line job step and can land in this PR or a CI follow-up, but the test itself is committed above so a bare-metal operator can run it directly.
+
+---
+
+## Final Verification (run before opening the PR)
+
+- [ ] **Full unit + controller suite**
+
+Run: `make test-unit && eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/`
+Expected: all PASS.
+
+- [ ] **Cross-build the guest agent and the stub for linux**
+
+Run: `GOOS=linux GOARCH=amd64 go build ./guest/agent/ && GOOS=linux GOARCH=amd64 go build ./cmd/husk-stub/`
+Expected: both succeed.
+
+- [ ] **Lint both targets**
+
+Run: `golangci-lint run --timeout=5m && GOOS=linux golangci-lint run --timeout=5m`
+Expected: no findings.
+
+- [ ] **No em/en dashes anywhere in the diff**
+
+Run: `git diff main --unified=0 | grep -nP "^\+.*[\x{2013}\x{2014}]"`
+Expected: no output.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** reflink reuse (Task 1, reusing `volume.Backend` policy), per-fork-equivalent rebind (Tasks 2+4, `PatchDrive("rootfs", clone)`), clone location and co-location (Task 7, `<dataDir>/husk-rootfs` sibling of templates, writable hostPath), Prepare vs Activate decision (Task 3, clone at Prepare), cleanup (Task 5, `Stub.Close`), threat-model delta (Task 8), KVM-CI/bare-metal reflink verification (Task 9). All decisions (a), (b), (c) from the prompt are implemented and justified.
+- **Type consistency:** the clone path `filepath.Join(<cowDir>, <vm id>, "rootfs.ext4")` is identical in Tasks 3, 4, 5, and the controller test (Task 7). The drive id `"rootfs"` matches `internal/firecracker/template.go:242` `AddDrive("rootfs", ...)`. `Options.RootfsTemplatePath`, `Options.RootfsCoWDir`, `Options.Reflink`, and the `Stub` fields `rootfsTemplatePath`, `rootfsCoWDir`, `reflink`, `rootfsClonePath` are named consistently across all tasks. `vmm.PatchDrive(driveID, pathOnHost string) error` matches `*firecracker.Client.PatchDrive` exactly so `clientVMM` satisfies it with no shim.
+- **No placeholders:** every code step shows the full Go and the exact run command with expected output.

--- a/docs/superpowers/plans/2026-06-13-security-ops-scaffolding.md
+++ b/docs/superpowers/plans/2026-06-13-security-ops-scaffolding.md
@@ -1,0 +1,1167 @@
+# Security Operations Scaffolding Implementation Plan (issue #35)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the engineering-tractable half of a real vulnerability-response posture for a project that ships Firecracker plus a guest kernel plus a guest agent: keyless cosign signing and SBOM attestation of the published container images, a CVE/dependency pipeline (govulncheck as a required job, Trivy image scan, a dependabot audit), a kernel-CVE tracking doc that pins the vmlinux we ship, a SECURITY.md gap-fill, and a documented human-review-required-paths policy backed by CODEOWNERS.
+
+**Architecture:** All the moving parts are CI jobs and docs, so the "test" for each is a concrete verification command run locally (or via `act` / a CI dry run) rather than a Go unit test: `cosign verify`, `cosign verify-attestation`, `syft scan`, `govulncheck ./...`, `trivy image`, `kubeconform`/`actionlint` for YAML, and `grep` for the dash rule. The docker-build job currently builds `mitos-controller`, `mitos-forkd`, and `mitos-husk-stub` only with local `:ci` tags and NEVER pushes; signing and attestation need real published images, so we add a separate `publish` workflow that builds, pushes to `ghcr.io/paperclipinc/mitos-*` by digest, signs keyless via OIDC, and attaches an SBOM attestation, while the existing `docker-build` PR job stays a fast local-build gate and gains govulncheck + a Trivy scan of the locally-built images. The human-policy pieces (the actual disclosure mailbox, the real reviewer org membership, the published response SLA commitment) are flagged in a Human-gated section, not implemented as tasks.
+
+**Tech Stack:** GitHub Actions, `sigstore/cosign-installer` + `cosign` (keyless, GitHub OIDC), `anchore/sbom-action` (syft), `aquasecurity/trivy-action`, `golang/govulncheck-action` (or `go run golang.org/x/vuln/cmd/govulncheck`), `docker/build-push-action` + `docker/metadata-action`, `actionlint` for workflow linting. Go 1.26.2. Repo: `paperclipinc/mitos`.
+
+**Context for the implementer:**
+
+- The repo already has: `.github/workflows/codeql.yml` (Go + Python CodeQL, weekly + on PR), `.github/workflows/scorecard.yml` (OpenSSF Scorecard, weekly), `.github/dependabot.yml` (gomod /, github-actions /, pip /sdk/python, npm /plugins/paperclip, all weekly, grouped minor+patch), `.github/CODEOWNERS` (maps `/internal/fork/`, `/internal/firecracker/`, `/internal/daemon/`, `/guest/`, `/docs/threat-model.md` to `@stubbi`), and `SECURITY.md`.
+- The `docker-build` job in `.github/workflows/ci.yaml` (lines 154-164) builds three images with local `:ci` tags via plain `docker build` and does NOT push. There is no ghcr publish/release-image workflow anywhere (`grep -rln "login-action|build-push-action|cosign" .github/` is empty).
+- The guest kernel is NOT pinned to a fixed version today. Both `.github/workflows/ci.yaml` (around line 572) and `.github/workflows/kvm-test.yaml` (around line 47) set `FC_VERSION=v1.15.0` and then resolve the LATEST `firecracker-ci/v1.15/<arch>/vmlinux-<x.y.z>` key off the S3 listing at run time. The husk pod mounts a node-staged `vmlinux` (`internal/controller/huskpod.go`, `huskKernelMountPath = "/var/lib/mitos/kernel/vmlinux"`). So "we pin a vmlinux" is currently a floating pin; the kernel-CVE doc must record the exact version we ship and turn the floating resolution into a recorded, reviewable version.
+- Conventions (CLAUDE.md is authoritative): NEVER use em or en dashes anywhere (source, YAML, Markdown, commit messages, PR bodies). Use only `.` `,` `;` `:` and the ASCII hyphen for ranges/identifiers. Conventional commits (feat, fix, docs, ci, chore). Branch is `feat/rename-to-mitos`. Stage explicit paths only, never `git add -A`. End commit messages with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Threat-model delta in the same PR when the security surface moves. No-unverified-claims: every doc claim reproducible from a command.
+- Secrets rule: signing uses keyless OIDC (no private key material in the repo or secrets). Never log secret values; log keys and counts only.
+
+---
+
+## File Structure
+
+New and modified files, each with one clear responsibility:
+
+- `.github/workflows/publish.yaml` (CREATE): on tag push (and `workflow_dispatch`), build + push the three images to `ghcr.io/paperclipinc/mitos-*` by digest, cosign keyless sign, generate + attest an SBOM. This is the only place that needs registry write + OIDC `id-token: write`.
+- `.github/workflows/ci.yaml` (MODIFY): add a `govulncheck` job (required), and add a Trivy filesystem-and-image scan step to the existing `docker-build` job (scans the locally built `:ci` images, no registry needed).
+- `.github/workflows/actionlint.yaml` (CREATE): lint all workflow YAML so a malformed signing/scan job fails fast.
+- `SECURITY.md` (MODIFY): fix the disclosure address ownership, add a supported-versions statement tied to releases, add explicit response SLAs, and add the verification-of-signed-images section plus a pointer to the review policy and kernel-CVE doc.
+- `docs/security-review-policy.md` (CREATE): the human-review-required-paths policy (which dirs, why, what a reviewer checks, the merge gate), referencing CODEOWNERS.
+- `docs/kernel-cve.md` (CREATE): the pinned vmlinux version + source URL, the CVE-watch process, and the update/rebuild/re-pin procedure.
+- `docs/supply-chain.md` (CREATE): how images are signed and how a consumer verifies signature + SBOM attestation; the exact `cosign verify` / `cosign verify-attestation` commands.
+- `.github/CODEOWNERS` (MODIFY): add `/internal/vsock/`, `/docs/security-review-policy.md`, `/docs/kernel-cve.md`, and the signing/publish workflow to the security-sensitive set.
+- `docs/threat-model.md` (MODIFY): add supply-chain (image provenance) and kernel-currency rows; mark prior "unsigned images / no SBOM" gaps as mitigated where the new jobs land.
+- `ROADMAP.md` (MODIFY): flip the engineering-doable parts of #35 to done; leave the human-gated parts open with notes.
+
+Each task below produces a self-contained change with its own verification command and commit.
+
+---
+
+### Task 1: Pin the guest kernel to an exact version (shared CI variable)
+
+The kernel is currently a floating "latest in firecracker-ci/v1.15" pin. Record an exact version so the kernel-CVE doc can name what we ship and a re-pin is a reviewable diff. This is a prerequisite for Task 6 (the doc must reference a real pinned value).
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (the kernel staging step, around lines 570-578)
+- Modify: `.github/workflows/kvm-test.yaml` (the kernel staging steps, around lines 47 and 67-76)
+
+- [ ] **Step 1: Discover the exact version both jobs currently resolve to**
+
+Run:
+```bash
+ARCH=x86_64
+curl -fsSL "https://s3.amazonaws.com/spec.ccfc.min/?prefix=firecracker-ci/v1.15/${ARCH}/vmlinux-" \
+  | grep -oE "firecracker-ci/v1.15/${ARCH}/vmlinux-[0-9]+\.[0-9]+\.[0-9]+" \
+  | sort -V | tail -1
+```
+Expected: a single key like `firecracker-ci/v1.15/x86_64/vmlinux-6.1.102` (record the exact `x.y.z` it prints; that is the value to pin below). Run the same with `ARCH=aarch64` and record that key too.
+
+- [ ] **Step 2: Replace the floating resolve with an exact pinned key in `ci.yaml`**
+
+In the kernel staging step of `.github/workflows/ci.yaml` (the block that sets `FC_VERSION=v1.15.0`, computes `CI_VERSION`, lists S3 with `grep ... | sort -V | tail -1`, then curls the key into `/tmp/vmlinux`), replace the dynamic `KERNEL_KEY=$(curl ... sort -V | tail -1)` resolution with the pinned version recorded in Step 1. Use the version you recorded; the literal below shows the shape (substitute the real `x.y.z`):
+
+```yaml
+      - name: Provide a guest kernel on the node for forkd and husk pods
+        run: |
+          set -euo pipefail
+          ARCH=$(uname -m)
+          # Pinned guest kernel. The exact version we ship is recorded in
+          # docs/kernel-cve.md; a bump is a reviewed diff to this line and the
+          # matching line in kvm-test.yaml, never a floating "latest" resolve.
+          KERNEL_VERSION=6.1.102
+          KERNEL_KEY="firecracker-ci/v1.15/${ARCH}/vmlinux-${KERNEL_VERSION}"
+          echo "Staging pinned kernel: $KERNEL_KEY"
+          curl -fsSL -o /tmp/vmlinux "https://s3.amazonaws.com/spec.ccfc.min/${KERNEL_KEY}"
+          worker=$(docker ps --format '{{.Names}}' | grep -m1 'mitos-husk-worker')
+          docker exec "$worker" mkdir -p /var/lib/mitos
+          docker cp /tmp/vmlinux "$worker:/var/lib/mitos/vmlinux"
+          docker exec "$worker" ls -lh /var/lib/mitos/vmlinux
+```
+
+- [ ] **Step 3: Apply the same pin in `kvm-test.yaml`**
+
+In `.github/workflows/kvm-test.yaml`, the kernel staging step (around lines 67-76) resolves the kernel the same floating way. Replace its `KERNEL_KEY=$(curl ... sort -V | tail -1)` with the identical pinned `KERNEL_VERSION=6.1.102` + `KERNEL_KEY="firecracker-ci/v1.15/${ARCH}/vmlinux-${KERNEL_VERSION}"` form, keeping the surrounding `curl ... -o` target unchanged. Leave the rootfs resolution (the `ubuntu-` key) as is: this task pins only the kernel.
+
+- [ ] **Step 4: Verify the pinned key resolves and the YAML is valid**
+
+Run:
+```bash
+ARCH=x86_64; KERNEL_VERSION=6.1.102
+curl -fsSI "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/${ARCH}/vmlinux-${KERNEL_VERSION}" | head -1
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yaml")); yaml.safe_load(open(".github/workflows/kvm-test.yaml")); print("yaml ok")'
+```
+Expected: `HTTP/1.1 200 OK` (the pinned key exists) and `yaml ok`.
+
+- [ ] **Step 5: Confirm no floating resolve remains**
+
+Run:
+```bash
+grep -n "vmlinux-\[0-9\]" .github/workflows/ci.yaml .github/workflows/kvm-test.yaml || echo "no floating kernel resolve remains"
+```
+Expected: `no floating kernel resolve remains` (the `sort -V | tail -1` kernel resolution is gone; the rootfs `ubuntu-` resolve may still match a different pattern, that is fine).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/ci.yaml .github/workflows/kvm-test.yaml
+git commit -m "ci: pin the guest kernel to an exact firecracker-ci version
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add govulncheck as a required CI job
+
+`govulncheck` is the Go-native vulnerability scanner: it reports only vulnerabilities reachable from the call graph, so it is low-noise and suitable as a required gate.
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (add a new top-level job under `jobs:`, alongside `go-test` and `go-lint`)
+
+- [ ] **Step 1: Verify govulncheck runs clean locally first (so the gate is green on day one)**
+
+Run:
+```bash
+go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+```
+Expected: either `No vulnerabilities found.` or a list of findings. If there are findings, they must be triaged BEFORE adding the gate (bump the offending dependency via go.mod, or, only if it is provably unreachable, record an explicit justification in the PR). Do not add a passing-by-luck gate over a known finding.
+
+- [ ] **Step 2: Add the `govulncheck` job**
+
+Insert this job into `.github/workflows/ci.yaml` immediately after the `go-lint` job (before `manifests`):
+
+```yaml
+  govulncheck:
+    # Go-native vulnerability scan. govulncheck reports only vulnerabilities
+    # reachable from this module's call graph, so it is low-noise and a
+    # required gate. CVE/dependency pipeline, issue #35. A new finding fails
+    # the job; the fix is a dependency bump (dependabot opens most of these)
+    # or, only for a provably unreachable advisory, a documented exclusion.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          "$(go env GOPATH)/bin/govulncheck" ./...
+```
+
+- [ ] **Step 3: Validate the workflow YAML parses**
+
+Run:
+```bash
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yaml")); print("yaml ok")'
+```
+Expected: `yaml ok`.
+
+- [ ] **Step 4: Lint the workflow with actionlint (installed in Task 7; if not yet present, run via the published action image)**
+
+Run:
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color .github/workflows/ci.yaml || true
+```
+Expected: no errors for the new `govulncheck` job (the `|| true` tolerates pre-existing warnings in unrelated jobs; read the output and confirm the new job is clean).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yaml
+git commit -m "ci: add govulncheck as a required vulnerability gate
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add a Trivy scan of the locally built images to docker-build
+
+The PR `docker-build` job builds `mitos-controller:ci`, `mitos-forkd:ci`, and `mitos-husk-stub:ci` locally and does not push. Trivy can scan those local image references directly, so this gives image-CVE coverage on every PR with no registry. Gate on HIGH and CRITICAL with fixes available.
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (the `docker-build` job, lines 154-164)
+
+- [ ] **Step 1: Verify Trivy scans a locally built image (run once locally to sanity-check the gate level)**
+
+Run:
+```bash
+docker build -f Dockerfile.controller -t mitos-controller:ci .
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:latest image --scanners vuln --severity HIGH,CRITICAL \
+  --ignore-unfixed --exit-code 1 mitos-controller:ci
+```
+Expected: exit 0 with `Total: 0` for HIGH/CRITICAL-fixable, or a list. If there are fixable HIGH/CRITICAL CVEs, address them (bump the base image in the Dockerfile) before gating, or document why a specific CVE is accepted in a `.trivyignore` with the CVE id and a one-line reason.
+
+- [ ] **Step 2: Add Trivy steps to the existing `docker-build` job**
+
+Replace the body of the `docker-build` job in `.github/workflows/ci.yaml` so it scans each built image (keep the three existing `docker build` lines; add the Trivy steps after them):
+
+```yaml
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -f Dockerfile.controller -t mitos-controller:ci .
+      - run: docker build -f Dockerfile.forkd -t mitos-forkd:ci .
+      # The husk-stub image runs the dormant VMM inside each husk pod (the
+      # pod-native default, issue #18). It is referenced by the controller
+      # Deployment's --husk-stub-image, so it must build cleanly here.
+      - run: docker build -f Dockerfile.husk-stub -t mitos-husk-stub:ci .
+      # Trivy scans each locally built image for known CVEs (CVE/dependency
+      # pipeline, issue #35). HIGH and CRITICAL with a fix available fail the
+      # job; unfixed advisories are reported but do not gate (no action to
+      # take). Accepted CVEs live in .trivyignore with a reason.
+      - name: Trivy scan controller image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: mitos-controller:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+      - name: Trivy scan forkd image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: mitos-forkd:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+      - name: Trivy scan husk-stub image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: mitos-husk-stub:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+```
+
+- [ ] **Step 3: Create an empty (header-only) `.trivyignore`**
+
+Create `.trivyignore` at the repo root:
+
+```text
+# Accepted CVEs for the mitos container images (issue #35).
+# Each entry MUST carry a CVE id and a one-line reason it is accepted
+# (unreachable in our usage, or no fix yet and mitigated elsewhere).
+# Format: one CVE id per line, comments with #. Empty for now.
+```
+
+- [ ] **Step 4: Validate YAML and confirm the action ref is pinned**
+
+Run:
+```bash
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yaml")); print("yaml ok")'
+grep -n "aquasecurity/trivy-action@" .github/workflows/ci.yaml
+```
+Expected: `yaml ok` and three lines each pinned to `@0.28.0` (a tag, not a floating major).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yaml .trivyignore
+git commit -m "ci: scan built images with Trivy on every PR
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Create the publish workflow that pushes, signs (cosign keyless), and attests an SBOM
+
+Signing and SBOM attestation need real published images by digest. Add a dedicated `publish` workflow gated on tag pushes (release artifacts) plus manual dispatch. Keyless cosign uses the workflow's GitHub OIDC identity, so there is no key material to store.
+
+**Files:**
+- Create: `.github/workflows/publish.yaml`
+
+- [ ] **Step 1: Create the publish workflow**
+
+Create `.github/workflows/publish.yaml`:
+
+```yaml
+name: Publish signed images
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to build and publish (for example v0.1.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # Build, push, cosign keyless-sign, and SBOM-attest the three mitos images
+    # under ghcr.io/paperclipinc (supply chain, issue #35). Keyless signing
+    # uses the workflow GitHub OIDC identity (id-token: write); there is NO
+    # private key in the repo or in secrets. Each image is pushed by digest and
+    # the signature and SBOM attestation are bound to that digest.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: mitos-controller
+            dockerfile: Dockerfile.controller
+          - name: mitos-forkd
+            dockerfile: Dockerfile.forkd
+          - name: mitos-husk-stub
+            dockerfile: Dockerfile.husk-stub
+    env:
+      REGISTRY: ghcr.io
+      IMAGE: ghcr.io/paperclipinc/${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata (tags and labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=sha
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Cosign keyless sign by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+      - name: Generate SBOM (SPDX JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.name }}.spdx.json
+      - name: Cosign attest the SBOM by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign attest --yes \
+            --predicate "sbom-${{ matrix.name }}.spdx.json" \
+            --type spdxjson \
+            "${IMAGE}@${DIGEST}"
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.name }}
+          path: sbom-${{ matrix.name }}.spdx.json
+```
+
+- [ ] **Step 2: Validate the workflow YAML parses**
+
+Run:
+```bash
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/publish.yaml")); print("yaml ok")'
+```
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Lint the workflow**
+
+Run:
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color .github/workflows/publish.yaml
+```
+Expected: no errors. actionlint validates the `id-token: write` permission, the matrix, and the action refs.
+
+- [ ] **Step 4: Confirm the keyless and digest invariants by inspection**
+
+Run:
+```bash
+grep -n "id-token: write" .github/workflows/publish.yaml
+grep -n "cosign sign --yes" .github/workflows/publish.yaml
+grep -n "@\${{ steps.build.outputs.digest }}\|@\${DIGEST}" .github/workflows/publish.yaml
+grep -ci "cosign.key\|COSIGN_PRIVATE_KEY\|--key " .github/workflows/publish.yaml
+```
+Expected: the OIDC permission is present; sign and attest both target `IMAGE@DIGEST` (never a mutable tag); the last grep prints `0` (no private key material referenced, proving keyless).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/publish.yaml
+git commit -m "ci: publish images signed keyless with an attested SBOM
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Add an actionlint workflow so signing/scan YAML cannot rot
+
+A malformed signing or scanning workflow silently disables the supply-chain controls. actionlint as its own job catches that.
+
+**Files:**
+- Create: `.github/workflows/actionlint.yaml`
+
+- [ ] **Step 1: Create the actionlint workflow**
+
+Create `.github/workflows/actionlint.yaml`:
+
+```yaml
+name: Lint workflows
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    # Lint every GitHub Actions workflow. A malformed supply-chain job (signing,
+    # SBOM, Trivy, govulncheck) would otherwise silently disable a security
+    # control; actionlint fails the PR instead. Issue #35.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: actionlint
+        run: |
+          set -euo pipefail
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+```
+
+- [ ] **Step 2: Run actionlint over the whole tree locally**
+
+Run:
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color
+```
+Expected: no errors across `ci.yaml`, `kvm-test.yaml`, `codeql.yml`, `scorecard.yml`, `release-please.yml`, `publish.yaml`, and `actionlint.yaml`. Fix any real errors the new jobs introduced (warnings in long-standing jobs may be triaged separately, but the new files must be clean).
+
+- [ ] **Step 3: Validate the YAML parses**
+
+Run:
+```bash
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/actionlint.yaml")); print("yaml ok")'
+```
+Expected: `yaml ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/actionlint.yaml
+git commit -m "ci: lint workflows with actionlint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Write the supply-chain verification doc
+
+A signature and an attestation are worthless if no consumer knows how to verify them. Document the exact `cosign verify` and `cosign verify-attestation` commands, bound to the workflow identity.
+
+**Files:**
+- Create: `docs/supply-chain.md`
+
+- [ ] **Step 1: Create the doc**
+
+Create `docs/supply-chain.md`:
+
+```markdown
+# Supply chain: image signing and SBOM verification
+
+The published `ghcr.io/paperclipinc/mitos-*` images are signed with cosign in
+keyless mode and carry an SPDX SBOM attestation. Both are produced by
+`.github/workflows/publish.yaml` using the workflow GitHub OIDC identity, so
+there is no long-lived signing key: the signing identity IS the workflow that
+built the image. This page is the consumer-side verification procedure; every
+command here is runnable against a published tag.
+
+## Images
+
+- `ghcr.io/paperclipinc/mitos-controller`
+- `ghcr.io/paperclipinc/mitos-forkd`
+- `ghcr.io/paperclipinc/mitos-husk-stub`
+
+Each tag is pushed by digest; the signature and SBOM attestation are bound to
+the digest, not to the mutable tag.
+
+## Verify the signature
+
+Install cosign (https://docs.sigstore.dev/cosign/installation/), then:
+
+```bash
+COSIGN_EXPERIMENTAL=1 cosign verify \
+  --certificate-identity-regexp "https://github.com/paperclipinc/mitos/.github/workflows/publish.yaml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/paperclipinc/mitos-controller:VERSION
+```
+
+Replace `VERSION` with the release tag (for example `v0.1.0`). A successful
+verify prints the verified signature payload and exits 0. The
+`--certificate-identity-regexp` pins the signer to OUR publish workflow on OUR
+repository; a signature from any other identity fails verification.
+
+## Verify the SBOM attestation
+
+```bash
+COSIGN_EXPERIMENTAL=1 cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp "https://github.com/paperclipinc/mitos/.github/workflows/publish.yaml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/paperclipinc/mitos-controller:VERSION
+```
+
+A successful verify confirms the SBOM was produced and signed by our publish
+workflow. To read the SBOM contents, extract the predicate:
+
+```bash
+cosign verify-attestation --type spdxjson \
+  --certificate-identity-regexp "https://github.com/paperclipinc/mitos/.github/workflows/publish.yaml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/paperclipinc/mitos-controller:VERSION \
+  | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+## Optional: admission-time enforcement
+
+A cluster that wants to refuse unsigned mitos images can enforce the same
+identity with a policy controller (sigstore policy-controller or Kyverno
+`verifyImages`) using the identity regexp and issuer above. This is a
+deployment choice, not a default; the project ships the signatures, the
+operator chooses to require them.
+
+## What is NOT covered yet
+
+- The guest kernel is a separate artifact with its own currency process; see
+  docs/kernel-cve.md.
+- Reproducible builds (bit-for-bit) are not claimed.
+```
+
+- [ ] **Step 2: Verify the doc carries no em or en dashes and references real files**
+
+Run:
+```bash
+grep -nP "[\x{2013}\x{2014}]" docs/supply-chain.md && echo "DASH FOUND (fix it)" || echo "no en/em dashes"
+grep -c "publish.yaml" docs/supply-chain.md
+```
+Expected: `no en/em dashes` and a non-zero count (the doc points at the real workflow file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/supply-chain.md
+git commit -m "docs: image signature and SBOM verification procedure
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Write the kernel-CVE tracking doc
+
+We ship a guest kernel. Record the exact pinned version (from Task 1), where it comes from, how to watch for kernel CVEs, and the re-pin procedure.
+
+**Files:**
+- Create: `docs/kernel-cve.md`
+
+- [ ] **Step 1: Create the doc using the pinned version from Task 1**
+
+Create `docs/kernel-cve.md` (substitute the exact `KERNEL_VERSION` you pinned in Task 1 for `6.1.102` if it differs):
+
+```markdown
+# Guest kernel currency and CVE watch
+
+Mitos boots guest workloads on a Linux kernel we ship as `vmlinux`. A kernel
+CVE in the guest is contained by the Firecracker/KVM boundary (a guest-kernel
+bug is not automatically a host escape), but a guest-to-host escape chain often
+starts in the guest kernel, so we track guest-kernel currency deliberately.
+
+## What we ship
+
+- Source: the Firecracker CI kernel bucket,
+  `https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/<arch>/vmlinux-<version>`.
+- Firecracker line: `v1.15` (the `FC_VERSION` set in the CI and KVM workflows).
+- Pinned kernel version: `6.1.102` (x86_64 and aarch64).
+- Where the pin lives: `.github/workflows/ci.yaml` and
+  `.github/workflows/kvm-test.yaml`, the `KERNEL_VERSION=` line in the kernel
+  staging step. The pin is an exact version, NOT a floating "latest in the
+  v1.15 prefix": a bump is a reviewed diff to those two lines.
+
+The kernel is a 6.1.x longterm (LTS) series; security fixes land on the 6.1.y
+stable line. The Firecracker CI bucket republishes 6.1.y builds for the v1.15
+line as upstream stable releases appear.
+
+## CVE watch process
+
+1. Subscribe to the linux-cve-announce list
+   (https://lore.kernel.org/linux-cve-announce/) and to the kernel.org
+   releases feed for the 6.1.y stable series
+   (https://www.kernel.org/category/releases.html).
+2. The Trivy image scan (`.github/workflows/ci.yaml`, the docker-build job)
+   does NOT scan the guest kernel: the kernel is a node-staged artifact, not a
+   package in the container images. Guest-kernel currency is tracked HERE, by
+   version, not by an image scanner.
+3. When a high-severity 6.1.y CVE relevant to the guest attack surface is
+   announced, open a tracking issue referencing this doc.
+
+## Re-pin procedure
+
+1. Confirm a newer 6.1.y build exists in the Firecracker CI bucket:
+   ```bash
+   ARCH=x86_64
+   curl -fsSL "https://s3.amazonaws.com/spec.ccfc.min/?prefix=firecracker-ci/v1.15/${ARCH}/vmlinux-" \
+     | grep -oE "firecracker-ci/v1.15/${ARCH}/vmlinux-[0-9]+\.[0-9]+\.[0-9]+" \
+     | sort -V | tail -1
+   ```
+2. Update the `KERNEL_VERSION=` line in BOTH `.github/workflows/ci.yaml` and
+   `.github/workflows/kvm-test.yaml`, and the "Pinned kernel version" line in
+   this doc, to the new version.
+3. The KVM test workflow (`.github/workflows/kvm-test.yaml`) boots, snapshots,
+   and restores a VM on the new kernel and execs through the guest agent over
+   vsock; a green KVM run is the gate that the new kernel works end to end.
+4. The snapshot manifest records the producing kernel (see
+   docs/snapshot-format.md, the snapshot version-compatibility contract,
+   issue #32); kernel is informational in the compatibility check, so a kernel
+   bump does not invalidate existing snapshots by itself, but a rebuild of
+   pool template snapshots is the clean path after a kernel bump.
+
+## Scope and limits
+
+- This tracks the GUEST kernel only. The HOST kernel currency on bare-metal
+  nodes is the operator's responsibility (Talos/OS update channel); see
+  docs/platforms.
+- We do not build the kernel from source today; we consume the Firecracker CI
+  build. Building a custom hardened guest kernel is a future option, not a
+  current claim.
+```
+
+- [ ] **Step 2: Verify no dashes and that the pinned version matches the workflows**
+
+Run:
+```bash
+grep -nP "[\x{2013}\x{2014}]" docs/kernel-cve.md && echo "DASH FOUND (fix it)" || echo "no en/em dashes"
+grep -h "KERNEL_VERSION=" .github/workflows/ci.yaml .github/workflows/kvm-test.yaml
+grep "Pinned kernel version" docs/kernel-cve.md
+```
+Expected: `no en/em dashes`; the `KERNEL_VERSION=` values in both workflows and the doc's "Pinned kernel version" line are the SAME version. If they differ, fix the doc to match Task 1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/kernel-cve.md
+git commit -m "docs: guest kernel currency and CVE watch process
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Write the security-review-required-paths policy
+
+CLAUDE.md and SECURITY.md both assert named-human review for the security-sensitive paths. CODEOWNERS enforces it mechanically; this doc states WHAT a reviewer checks and WHY each path is in scope.
+
+**Files:**
+- Create: `docs/security-review-policy.md`
+
+- [ ] **Step 1: Create the doc**
+
+Create `docs/security-review-policy.md`:
+
+```markdown
+# Security review policy
+
+Substantial portions of this codebase are AI-assisted. Changes to the
+security-sensitive paths below require a named human reviewer before merge, in
+addition to CI. This policy is enforced mechanically by `.github/CODEOWNERS`
+(GitHub requests the listed owner as a required reviewer on any PR touching a
+matched path) and is a merge gate on `main` (branch protection: require review
+from Code Owners).
+
+## Paths in scope and why
+
+| Path | Why it is security-sensitive |
+|---|---|
+| `internal/fork/` | Drives Firecracker snapshot/restore; a fork-correctness or restore bug is a cross-sandbox state leak or a host exposure. |
+| `internal/firecracker/` | The Firecracker API client and VM lifecycle; the guest-to-host boundary lives here. |
+| `internal/daemon/` | forkd: the privileged builder and the host sandbox API (exec and file traffic); the host-side trust boundary. |
+| `internal/vsock/` | The host side of the guest channel; parses untrusted guest output as data. |
+| `guest/` | The guest agent (PID 1 in the VM) and guest-side protocol; untrusted post-exec. |
+| `docs/threat-model.md` | The authoritative isolation claims; a change here moves the stated security surface. |
+| `docs/security-review-policy.md` | This policy itself. |
+| `docs/kernel-cve.md` | The shipped-kernel currency posture. |
+| `.github/workflows/publish.yaml` | Produces signed release artifacts; a change here changes provenance. |
+| Future token/attenuation code | Capability minting and attenuation; add the path to CODEOWNERS when it lands. |
+
+## What a reviewer checks
+
+- The change does not widen the guest-to-host boundary (new host syscalls,
+  new privileged operations, new trust placed in guest-controlled data).
+- No secret value is logged, put in an error or condition message, or written
+  to a host path (CLAUDE.md secrets rule); only keys and counts.
+- Fork-correctness hazards are respected (RNG, clocks, secret inheritance);
+  see docs/fork-correctness.md.
+- The threat model is updated in the SAME PR when the surface moves
+  (a new row, or a status change on an existing row).
+- For a kernel or Firecracker version bump: the KVM workflow is green and
+  docs/kernel-cve.md is updated to match.
+
+## Relationship to CI
+
+CI (govulncheck, Trivy, CodeQL, Scorecard, the KVM end-to-end suite) is
+necessary but not sufficient for these paths: an automated scan does not catch
+a logic-level boundary regression. The named-human review is the backstop.
+This policy does not replace the disclosure process in SECURITY.md; it governs
+inbound code changes, while SECURITY.md governs inbound vulnerability reports.
+```
+
+- [ ] **Step 2: Verify no dashes**
+
+Run:
+```bash
+grep -nP "[\x{2013}\x{2014}]" docs/security-review-policy.md && echo "DASH FOUND (fix it)" || echo "no en/em dashes"
+```
+Expected: `no en/em dashes`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/security-review-policy.md
+git commit -m "docs: security-review-required-paths policy
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Extend CODEOWNERS to the full security-sensitive set
+
+CODEOWNERS already covers `internal/fork`, `internal/firecracker`, `internal/daemon`, `guest/`, and `docs/threat-model.md`. Add the paths the new policy names: `internal/vsock`, the new docs, and the publish workflow.
+
+**Files:**
+- Modify: `.github/CODEOWNERS`
+
+- [ ] **Step 1: Read the current file and append the missing paths**
+
+The current file ends with `/docs/threat-model.md @stubbi`. Append (keep the existing owner `@stubbi`; the Human-gated section flags that this login must be a real reviewer with org write access):
+
+```text
+/internal/vsock/ @stubbi
+/docs/security-review-policy.md @stubbi
+/docs/kernel-cve.md @stubbi
+/docs/supply-chain.md @stubbi
+/.github/workflows/publish.yaml @stubbi
+```
+
+- [ ] **Step 2: Verify CODEOWNERS syntax (no empty owners; every line has an owner)**
+
+Run:
+```bash
+awk 'NF && $1 !~ /^#/ { if (NF < 2) { print "NO OWNER: " $0; bad=1 } } END { if (!bad) print "every pattern has an owner" }' .github/CODEOWNERS
+```
+Expected: `every pattern has an owner`.
+
+- [ ] **Step 3: Confirm all six security-sensitive code paths and the new docs are covered**
+
+Run:
+```bash
+for p in internal/fork internal/firecracker internal/daemon internal/vsock guest docs/security-review-policy.md docs/kernel-cve.md docs/supply-chain.md .github/workflows/publish.yaml; do
+  grep -q "$p" .github/CODEOWNERS && echo "covered: $p" || echo "MISSING: $p"
+done
+```
+Expected: every line prints `covered:` (no `MISSING:`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/CODEOWNERS
+git commit -m "chore: extend CODEOWNERS to the full security-sensitive set
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Fill the SECURITY.md gaps
+
+The current SECURITY.md has a disclosure path, a one-line supported-versions statement, a scope, and an AI-assisted-development note. Gaps to close: response SLAs beyond the 72h ack, a clearer supported-versions statement tied to releases, a verification-of-signed-images pointer, and pointers to the new policy and kernel docs. The disclosure mailbox ownership is flagged Human-gated.
+
+**Files:**
+- Modify: `SECURITY.md`
+
+- [ ] **Step 1: Add response SLAs under the reporting section**
+
+After the existing line `We will acknowledge your report within 72 hours and keep you informed of progress toward a fix and disclosure.`, add:
+
+```markdown
+
+### Response targets
+
+These are the targets we aim for on a valid, in-scope report; they are targets
+for a pre-1.0 project run by a small team, not a contractual SLA.
+
+- Acknowledge receipt: within 72 hours.
+- Initial severity assessment and triage: within 7 days.
+- Fix or mitigation for a critical guest-to-host escape or cross-sandbox leak:
+  prioritized ahead of feature work; coordinated-disclosure timeline agreed
+  with the reporter, default 90 days.
+- Public disclosure: coordinated with the reporter after a fix ships, with
+  credit unless the reporter requests anonymity.
+```
+
+- [ ] **Step 2: Replace the supported-versions section with a release-tied statement**
+
+Replace the existing block:
+
+```markdown
+## Supported Versions
+
+This project is pre-1.0. Only the latest release receives security fixes.
+```
+
+with:
+
+```markdown
+## Supported Versions
+
+This project is pre-1.0. Only the latest tagged release
+(`ghcr.io/paperclipinc/mitos-*`) receives security fixes. There is no
+backport window for older pre-1.0 tags: upgrade to the latest release to pick
+up a security fix. The guest kernel we ship has its own currency process; see
+[docs/kernel-cve.md](docs/kernel-cve.md).
+
+| Version | Supported |
+|---|---|
+| Latest tagged release | Yes |
+| Any older pre-1.0 tag | No |
+```
+
+- [ ] **Step 3: Add a verifying-releases section and policy pointer before "Current Status"**
+
+Insert before the `## Current Status` heading:
+
+```markdown
+## Verifying releases
+
+Published images are signed with cosign (keyless, GitHub OIDC) and carry an
+SPDX SBOM attestation. The exact `cosign verify` and `cosign verify-attestation`
+commands are in [docs/supply-chain.md](docs/supply-chain.md).
+
+## Code review policy for security-sensitive paths
+
+Changes to the security-sensitive paths (`internal/fork`,
+`internal/firecracker`, `internal/daemon`, `internal/vsock`, `guest/`) require
+a named human reviewer before merge, enforced by `.github/CODEOWNERS`. The full
+policy is in [docs/security-review-policy.md](docs/security-review-policy.md).
+```
+
+- [ ] **Step 4: Update the AI-Assisted Development Policy paragraph to add internal/vsock and point at the policy doc**
+
+Replace the sentence listing the paths in the existing `## AI-Assisted Development Policy` section so it reads:
+
+```markdown
+Substantial portions of this codebase are AI-assisted. Security-sensitive paths
+receive named-human review before merge: `internal/fork`,
+`internal/firecracker`, `internal/daemon`, `internal/vsock`, `guest/`, and
+future token/attenuation code. The policy is documented in
+[docs/security-review-policy.md](docs/security-review-policy.md) and tracked in
+issue #35.
+```
+
+- [ ] **Step 5: Verify no dashes and that all internal links resolve to real files**
+
+Run:
+```bash
+grep -nP "[\x{2013}\x{2014}]" SECURITY.md && echo "DASH FOUND (fix it)" || echo "no en/em dashes"
+for f in docs/kernel-cve.md docs/supply-chain.md docs/security-review-policy.md; do
+  test -f "$f" && echo "link target exists: $f" || echo "MISSING TARGET: $f"
+done
+```
+Expected: `no en/em dashes` and three `link target exists:` lines (Tasks 6, 7, 8 created them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SECURITY.md
+git commit -m "docs: fill SECURITY.md gaps (SLAs, supported versions, verification)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Audit the dependabot config and close the gaps
+
+dependabot.yml covers gomod /, github-actions /, pip /sdk/python, npm /plugins/paperclip. Audit for uncovered ecosystems/directories so dependency CVEs surface as PRs everywhere.
+
+**Files:**
+- Modify: `.github/dependabot.yml` (only if the audit finds an uncovered manifest)
+
+- [ ] **Step 1: Enumerate every dependency manifest in the repo**
+
+Run:
+```bash
+echo "=== go modules ==="; find . -name go.mod -not -path '*/vendor/*'
+echo "=== package.json (npm) ==="; find . -name package.json -not -path '*/node_modules/*'
+echo "=== python deps ==="; find . \( -name pyproject.toml -o -name requirements*.txt \) -not -path '*/.venv/*'
+echo "=== dockerfiles ==="; ls Dockerfile*
+```
+Expected: a list. Compare each found manifest's directory against the `directory:` entries already in `.github/dependabot.yml`.
+
+- [ ] **Step 2: Add an entry for each uncovered manifest**
+
+For every manifest NOT already covered (for example a `sdk/typescript` package.json, a nested `third_party/.../go.mod` that we actually own, or a Docker ecosystem for base-image bumps), add a block matching the existing style. Example for the TypeScript SDK if `sdk/typescript/package.json` exists and is uncovered:
+
+```yaml
+  - package-ecosystem: npm
+    directory: /sdk/typescript
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    groups:
+      typescript-sdk-minor-patch:
+        update-types:
+          - minor
+          - patch
+```
+
+Add a `docker` ecosystem to watch base-image updates in the Dockerfiles (one entry; dependabot scans all Dockerfiles in the directory):
+
+```yaml
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    groups:
+      docker-minor-patch:
+        update-types:
+          - minor
+          - patch
+```
+
+Do NOT add an entry for a `third_party/` module that is vendored upstream code we do not maintain (CodeQL already excludes `third_party`; dependabot bumps there would be noise we cannot merge).
+
+- [ ] **Step 3: Validate the dependabot YAML**
+
+Run:
+```bash
+python3 -c 'import yaml; d=yaml.safe_load(open(".github/dependabot.yml")); assert d["version"]==2; print("entries:", len(d["updates"])); [print(" ", u["package-ecosystem"], u["directory"]) for u in d["updates"]]'
+```
+Expected: `version` is 2 and every manifest directory found in Step 1 (excluding vendored `third_party`) is listed.
+
+- [ ] **Step 4: Commit (only if changed)**
+
+```bash
+git add .github/dependabot.yml
+git commit -m "chore: cover all dependency manifests in dependabot
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+If the audit found everything already covered, record that finding in the PR body instead of committing an empty change.
+
+---
+
+### Task 12: Update the threat model and ROADMAP
+
+The security surface moved (image provenance, kernel currency, a vulnerability pipeline), so the threat model must reflect it in the same PR (CLAUDE.md rule 2).
+
+**Files:**
+- Modify: `docs/threat-model.md`
+- Modify: `ROADMAP.md`
+
+- [ ] **Step 1: Add a supply-chain section to the threat model**
+
+Add a new section to `docs/threat-model.md` (after the existing component/boundary sections), stating the status honestly:
+
+```markdown
+## Supply chain and artifact provenance (issue #35)
+
+| Boundary | Status | Mechanism |
+|---|---|---|
+| Image provenance (controller, forkd, husk-stub) | mitigated for published releases | cosign keyless signing + SPDX SBOM attestation, bound to the image digest, produced by `.github/workflows/publish.yaml`; consumer verification in docs/supply-chain.md. |
+| Image CVEs | partial | Trivy scans the built images on every PR (HIGH/CRITICAL fixable gate); govulncheck gates Go call-graph-reachable vulnerabilities; base-image and dependency bumps arrive via dependabot. Runtime re-scan of long-lived published tags is not yet automated. |
+| Guest kernel currency | partial | The shipped vmlinux is pinned to an exact version (docs/kernel-cve.md) and validated end to end by the KVM workflow; CVE watch is a documented manual process, not an automated feed. |
+| Admission-time signature enforcement | open | The project ships signatures; requiring them at admission (policy-controller/Kyverno) is a documented operator choice, not a default. |
+```
+
+- [ ] **Step 2: Soften the honest-summary line only if warranted, otherwise leave it**
+
+The top-of-file honest summary says defense-in-depth layers are largely open. The supply-chain layer is now partly mitigated, but do NOT overclaim: leave the "do not run untrusted code in production yet" summary as is (it remains true for the isolation boundary). This step is a deliberate no-op on the summary; the new section carries the delta.
+
+- [ ] **Step 3: Verify no dashes in the threat-model edit**
+
+Run:
+```bash
+grep -nP "[\x{2013}\x{2014}]" docs/threat-model.md && echo "DASH FOUND (fix it)" || echo "no en/em dashes"
+```
+Expected: `no en/em dashes`.
+
+- [ ] **Step 4: Update ROADMAP #35**
+
+In `ROADMAP.md`, find the `#35` foundations line ("security operations: we ship a kernel"). Add a short status note marking the engineering-doable pieces done and the human-gated pieces open:
+
+```markdown
+- Security operations (#35): cosign keyless signing + SBOM attestation of the
+  published images, govulncheck + Trivy as CVE gates, a kernel-CVE tracking doc
+  with an exact pinned vmlinux, a CODEOWNERS-backed security-review-required-
+  paths policy, and a SECURITY.md gap-fill are DONE (engineering). OPEN
+  (human-gated): the monitored disclosure mailbox, the real reviewer org
+  membership behind CODEOWNERS, the published response-SLA commitment, an
+  automated kernel-CVE feed, and admission-time signature enforcement defaults.
+```
+
+- [ ] **Step 5: Verify no dashes in the ROADMAP edit**
+
+Run:
+```bash
+grep -nP "[\x{2013}\x{2014}]" ROADMAP.md && echo "DASH FOUND (fix it)" || echo "no en/em dashes"
+```
+Expected: `no en/em dashes`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/threat-model.md ROADMAP.md
+git commit -m "docs: threat-model supply-chain rows and roadmap #35 status
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Full verification and PR
+
+- [ ] **Step 1: Repo-wide dash and YAML sweep over everything this plan touched**
+
+Run:
+```bash
+grep -rnP "[\x{2013}\x{2014}]" \
+  SECURITY.md ROADMAP.md \
+  docs/supply-chain.md docs/kernel-cve.md docs/security-review-policy.md docs/threat-model.md \
+  .github/workflows/publish.yaml .github/workflows/actionlint.yaml .github/workflows/ci.yaml \
+  .github/CODEOWNERS .github/dependabot.yml .trivyignore \
+  && echo "DASH FOUND (fix it)" || echo "no en/em dashes across the change set"
+for f in .github/workflows/ci.yaml .github/workflows/publish.yaml .github/workflows/actionlint.yaml .github/dependabot.yml; do
+  python3 -c "import yaml,sys; yaml.safe_load(open('$f')); print('yaml ok: $f')"
+done
+```
+Expected: `no en/em dashes across the change set` and a `yaml ok:` line per workflow.
+
+- [ ] **Step 2: actionlint the whole workflow tree**
+
+Run:
+```bash
+docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color
+```
+Expected: clean for all new/modified workflows.
+
+- [ ] **Step 3: govulncheck and a local Trivy spot-check still pass**
+
+Run:
+```bash
+go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+docker build -f Dockerfile.forkd -t mitos-forkd:ci .
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:latest image --scanners vuln --severity HIGH,CRITICAL \
+  --ignore-unfixed --exit-code 1 mitos-forkd:ci
+```
+Expected: `No vulnerabilities found.` and Trivy exit 0 (or accepted entries in `.trivyignore` with reasons).
+
+- [ ] **Step 4: Confirm the Go build, vet, and lint are unaffected (no code changed, but prove it)**
+
+Run:
+```bash
+go build ./... && go vet ./... && echo "build+vet ok"
+```
+Expected: `build+vet ok` (this plan adds no Go code; this guards against an accidental edit).
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin feat/rename-to-mitos
+gh pr create --title "Security operations scaffolding (#35)" --body "$(cat <<'BODY'
+Engineering-tractable half of issue #35.
+
+What landed:
+- Pinned the guest kernel to an exact firecracker-ci version (was a floating latest resolve) in ci.yaml and kvm-test.yaml.
+- govulncheck added as a required CI job.
+- Trivy scan of the built images added to docker-build (HIGH/CRITICAL fixable gate, .trivyignore for accepted CVEs).
+- New publish.yaml: builds and pushes ghcr.io/paperclipinc/mitos-* by digest, cosign keyless (OIDC) signing, SPDX SBOM generation + attestation.
+- actionlint job so a malformed supply-chain workflow fails fast.
+- docs/supply-chain.md (verify signature + SBOM), docs/kernel-cve.md (pinned version + CVE-watch + re-pin), docs/security-review-policy.md.
+- SECURITY.md: response targets, release-tied supported-versions, verification pointer, review-policy pointer, internal/vsock added to the AI-review path list.
+- CODEOWNERS extended (internal/vsock, the new docs, publish.yaml).
+- dependabot audited and gaps closed.
+- Threat-model supply-chain rows added; ROADMAP #35 status updated.
+
+Human-gated (NOT in this PR, see the plan's Human-gated section): the monitored disclosure mailbox, the real reviewer org membership behind CODEOWNERS, the published response-SLA commitment, an automated kernel-CVE feed, and admission-time signature enforcement defaults.
+
+Threat-model delta: docs/threat-model.md supply-chain section (CLAUDE.md rule 2).
+Security review: this PR touches CODEOWNERS-gated paths (internal/vsock note, publish.yaml, threat-model); requires the named reviewer.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 6: Watch CI and confirm the new gates run**
+
+Run:
+```bash
+gh pr checks --watch
+```
+Expected: `govulncheck`, `docker-build` (now with Trivy steps), and `actionlint` all run and pass. The `publish` workflow does NOT run on a PR (it is tag/dispatch only); confirm by its absence from the PR checks. Merge when green and after the named reviewer approves.
+
+---
+
+## Self-Review
+
+- Spec coverage: SECURITY.md gaps (Task 10), cosign keyless signing in CI (Task 4) + verification doc (Task 6), SBOM syft + attestation (Task 4), govulncheck required job (Task 2) + Trivy image scan (Task 3) + dependabot audit (Task 11), kernel-CVE doc with the pinned vmlinux (Tasks 1 + 7), CODEOWNERS + security-review-policy.md (Tasks 8 + 9). Every numbered requirement maps to a task.
+- The kernel "pin" finding (it was floating, not fixed) is handled as a real code change in Task 1 so Task 7's doc references a true value.
+- The signing/SBOM pieces required a real published image, so a new `publish.yaml` was added rather than retrofitting the local-only `docker-build` job; `docker-build` stays a fast PR gate and gains the no-registry Trivy scan.
+- Every CI/doc artifact has a concrete verification command (cosign verify, govulncheck, trivy image, syft via sbom-action, actionlint, kubeconform-style YAML parse, dash grep) in place of an awkward unit test.
+- Type/name consistency: `KERNEL_VERSION` is used identically in Tasks 1, 7; the image names `mitos-controller`/`mitos-forkd`/`mitos-husk-stub` and the registry `ghcr.io/paperclipinc` are consistent across Tasks 3, 4, 6, 10, 12; the cosign identity regexp is identical in Task 6 and the SECURITY.md/threat-model references.
+
+---
+
+## Human-gated (NOT implemented as tasks; require a human decision)
+
+These are deliberately excluded from the tasks above. They are policy/identity commitments, not code:
+
+1. **The disclosure mailbox.** SECURITY.md lists `jannes@paperclip.inc` as the email fallback, but the repository is now `paperclipinc/mitos`. A human must confirm which address is actually monitored and update the fallback line. GitHub private vulnerability reporting (the preferred path) must be enabled in repo Settings by a maintainer.
+2. **The CODEOWNERS reviewer identity.** CODEOWNERS uses `@stubbi`. For the review gate to be real, that login must be a member of the `paperclipinc` org with write access, and branch protection on `main` must require review from Code Owners. A human assigns the real reviewer(s) and enables the branch-protection setting; consider a small `@paperclipinc/security` team rather than a single login (bus factor).
+3. **The published response-SLA commitment.** Task 10 adds aspirational response targets. Committing to them publicly is a team decision; a human signs off that the team can meet them or edits the numbers.
+4. **OIDC/registry permissions for publish.yaml.** Pushing to `ghcr.io/paperclipinc/*` requires the package to allow the repo's `GITHUB_TOKEN` write access (or org package settings); a maintainer confirms package visibility and permissions before the first tag.
+5. **Automated kernel-CVE feed.** Task 7 documents a manual CVE-watch process. Wiring an automated feed (a scheduled job that diffs the pinned 6.1.y against the latest stable and opens an issue) is a possible follow-up, flagged here, not built.
+6. **Admission-time signature enforcement defaults.** Whether the shipped deploy manifests should REQUIRE signed images (policy-controller/Kyverno) by default is an operator-experience decision, not implemented here.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -384,6 +384,15 @@ arbitrary code at sandbox privilege.
 | Live-fork secret inheritance | **mitigated (default-deny)** | Forks of secret-holding sandboxes are rejected by the fork controller without explicit `allowSecretInheritance: true`; opt-ins are recorded as an audit condition (`sandboxfork_controller.go`). Per-fork credential reissue remains the end state (open). See `docs/fork-correctness.md` §3. |
 | Controller RBAC for Secrets | **partial** | ClusterRole grants cluster-wide `get,list` on all Secrets. Must be narrowed (label-selected or per-namespace Role aggregation) before multi-tenant use. |
 
+- Cross-namespace secret replication. The controller copies mitos-ca (ca.crt
+  only) and mitos-forkd-tls from its namespace into every pool namespace where
+  it creates husk pods (ReplicateHuskSecrets). The CA private key (ca.key) is
+  never copied. Scope: the cluster-wide secrets grant is the enabling
+  privilege; mitigation is that only the two named control plane Secrets are
+  projected and only ca.crt of the CA, so a pool namespace never holds the CA
+  signing key. Status: accepted; a namespaced grant scoped to pool namespaces
+  is a follow-up once pool namespaces are enumerable at install time.
+
 ## 7. Multi-tenancy statement
 
 What a namespace boundary buys you **today**: RBAC on the CRDs, and nothing

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -53,6 +53,13 @@ privileged process and RUN many times by unprivileged pods.
   KVM nodes (and the `--enable-raw-forkd` fork-per-claim engine). The privileged
   surface is now confined to the BUILD path, run once per node per template,
   rather than every sandbox execution.
+- forkd `privileged: true` (deploy/daemon/daemonset.yaml), REGRESSION pending
+  jailer-in-pod. Without the per-VM jailer mediating, forkd needs unrestricted
+  /dev/kvm, /dev/net/tun, cgroup, and chroot access, so the trimmed capability
+  set is replaced by privileged until the jailer runs inside the forkd pod.
+  Status: accepted, time-boxed to the jailer-in-pod follow-up. Mitigation: the
+  forkd pod runs only on labelled KVM nodes (mitos.run/kvm) and is not exposed
+  to tenant traffic; husk pods, not forkd, are the tenant execution surface.
 
 ### Unprivileged-stub escape surface (issue #18 re-derivation)
 

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -572,6 +572,17 @@ func (r *SandboxPoolReconciler) reconcileHuskPods(ctx context.Context, pool *v1a
 	case existing < desired:
 		deficit := desired - existing
 		logger.Info("husk pod deficit", "dormant", existing, "desired", desired, "creating", deficit)
+		// Replicate the husk PKI secrets into this pool's namespace before
+		// creating pods: husk pods run here, not in the controller namespace,
+		// and mount mitos-ca + mitos-forkd-tls. ControllerNamespace empty (or
+		// equal to the pool namespace) makes this a noop. A replication error
+		// is returned so the deficit is retried on requeue rather than creating
+		// pods that would fail to mount their secrets.
+		if r.ControllerNamespace != "" {
+			if err := ReplicateHuskSecrets(ctx, r.Client, r.ControllerNamespace, pool.Namespace); err != nil {
+				return existing, fmt.Errorf("replicate husk secrets into %s: %w", pool.Namespace, err)
+			}
+		}
 		opts := HuskPodOptions{
 			StubImage:       r.HuskStubImage,
 			KVMResourceName: r.KVMResourceName,

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -54,6 +54,13 @@ type SandboxPoolReconciler struct {
 	// mounted into each husk pod so the stub verifies the controller client cert.
 	// Only used when EnableHuskPods is true.
 	HuskCASecretName string
+	// ControllerNamespace is the namespace EnsurePKI materialized the control
+	// plane PKI Secrets in (the controller's own namespace, default "mitos").
+	// reconcileHuskPods replicates mitos-ca + mitos-forkd-tls FROM here INTO the
+	// pool namespace so husk pods, which run in the pool namespace, can mount
+	// them. Empty disables replication (the husk pods then require the secrets
+	// to already exist in their namespace). Only used when EnableHuskPods.
+	ControllerNamespace string
 }
 
 // SandboxPool ownership: get/list/watch to reconcile, status to write warmed

--- a/internal/controller/secret_replication.go
+++ b/internal/controller/secret_replication.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReplicateHuskSecrets copies the control plane PKI material husk pods mount
+// from the controller namespace (src) into a pool namespace (dst). Husk pods
+// run in the pool namespace (e.g. default), not the controller namespace, but
+// EnsurePKI only materializes mitos-ca and mitos-forkd-tls in the controller
+// namespace; this bridges that gap so `kubectl apply -k deploy/` needs no
+// manual secret copy.
+//
+// The CA copy projects ONLY ca.crt: the CA private key (ca.key) must never
+// leave the controller namespace, matching the husk pod's CA mount in
+// huskpod.go (Items ca.crt only). The forkd leaf (tls.crt, tls.key) is copied
+// whole because the husk stub serves the mTLS control with it.
+//
+// Replication is idempotent and heals drift: a destination copy whose data
+// differs from the source is updated in place (so a CA rotation propagates).
+// Copying into the source namespace itself is a noop (the originals are there).
+func ReplicateHuskSecrets(ctx context.Context, c client.Client, src, dst string) error {
+	if src == dst {
+		return nil
+	}
+	if err := replicateControlPlaneSecret(ctx, c, src, dst, CASecretName, []string{"ca.crt"}); err != nil {
+		return err
+	}
+	if err := replicateControlPlaneSecret(ctx, c, src, dst, ForkdTLSSecretName, []string{"tls.crt", "tls.key"}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// replicateControlPlaneSecret copies exactly the named keys of secret `name`
+// from src to dst, creating the destination when absent and updating it when
+// its projected data drifts. Keys not in `keys` are never copied (so the CA
+// private key cannot leak). A missing source secret is an error: the caller
+// runs this only after EnsurePKI has materialized the originals.
+func replicateControlPlaneSecret(ctx context.Context, c client.Client, src, dst, name string, keys []string) error {
+	var source corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Namespace: src, Name: name}, &source); err != nil {
+		return fmt.Errorf("read source secret %s/%s for replication: %w", src, name, err)
+	}
+
+	projected := make(map[string][]byte, len(keys))
+	for _, k := range keys {
+		v, ok := source.Data[k]
+		if !ok {
+			return fmt.Errorf("source secret %s/%s lacks key %s; cannot replicate", src, name, k)
+		}
+		projected[k] = append([]byte(nil), v...)
+	}
+
+	var existing corev1.Secret
+	err := c.Get(ctx, types.NamespacedName{Namespace: dst, Name: name}, &existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		copySecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: dst, Name: name},
+			Type:       source.Type,
+			Data:       projected,
+		}
+		if err := c.Create(ctx, &copySecret); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Lost the create race to a parallel reconcile; the winner wrote
+				// the same projected data from the same source, so treat as done.
+				return nil
+			}
+			return fmt.Errorf("create replicated secret %s/%s: %w", dst, name, err)
+		}
+		return nil
+
+	case err != nil:
+		return fmt.Errorf("read destination secret %s/%s: %w", dst, name, err)
+
+	default:
+		if secretDataEqual(existing.Data, projected) {
+			return nil
+		}
+		if existing.Data == nil {
+			existing.Data = map[string][]byte{}
+		}
+		// Overwrite exactly the projected keys; leave any unrelated keys the
+		// destination may carry untouched.
+		for k, v := range projected {
+			existing.Data[k] = v
+		}
+		if err := c.Update(ctx, &existing); err != nil {
+			return fmt.Errorf("heal replicated secret %s/%s: %w", dst, name, err)
+		}
+		return nil
+	}
+}
+
+// secretDataEqual reports whether dst already contains every key/value in want.
+// It does not require dst to be a strict equal (dst may carry extra keys); it
+// only checks the projected keys match, which is the replication contract.
+func secretDataEqual(dst, want map[string][]byte) bool {
+	for k, v := range want {
+		got, ok := dst[k]
+		if !ok || string(got) != string(v) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/secret_replication_test.go
+++ b/internal/controller/secret_replication_test.go
@@ -1,0 +1,97 @@
+package controller_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/paperclipinc/mitos/internal/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReplicateHuskSecretsCopiesCAcrtAndForkdTLS(t *testing.T) {
+	c := newCoreClient(t)
+	src := newPKINamespace(t, c)
+	dst := newPKINamespace(t, c)
+
+	// Seed the source secrets directly (no real CA needed; replication copies
+	// bytes, it does not re-issue).
+	caSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.CASecretName},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"ca.crt": []byte("CA-CERT"), "ca.key": []byte("CA-KEY-SECRET")},
+	}
+	tlsSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.ForkdTLSSecretName},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("LEAF-CERT"), "tls.key": []byte("LEAF-KEY")},
+	}
+	if err := c.Create(ctx, caSrc); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, tlsSrc); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := controller.ReplicateHuskSecrets(ctx, c, src, dst); err != nil {
+		t.Fatalf("ReplicateHuskSecrets: %v", err)
+	}
+
+	gotCA := getSecret(t, c, dst, controller.CASecretName)
+	if !bytes.Equal(gotCA.Data["ca.crt"], []byte("CA-CERT")) {
+		t.Errorf("dst ca.crt = %q, want CA-CERT", gotCA.Data["ca.crt"])
+	}
+	if _, leaked := gotCA.Data["ca.key"]; leaked {
+		t.Error("dst CA secret leaked ca.key; the CA private key must never be replicated")
+	}
+	gotTLS := getSecret(t, c, dst, controller.ForkdTLSSecretName)
+	if !bytes.Equal(gotTLS.Data["tls.crt"], []byte("LEAF-CERT")) || !bytes.Equal(gotTLS.Data["tls.key"], []byte("LEAF-KEY")) {
+		t.Errorf("dst forkd-tls not copied: %v", gotTLS.Data)
+	}
+}
+
+func TestReplicateHuskSecretsIsIdempotentAndHealsDrift(t *testing.T) {
+	c := newCoreClient(t)
+	src := newPKINamespace(t, c)
+	dst := newPKINamespace(t, c)
+	caSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.CASecretName},
+		Data:       map[string][]byte{"ca.crt": []byte("CA-V1"), "ca.key": []byte("KEY")},
+	}
+	tlsSrc := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: src, Name: controller.ForkdTLSSecretName},
+		Data:       map[string][]byte{"tls.crt": []byte("LEAF-V1"), "tls.key": []byte("LK")},
+	}
+	if err := c.Create(ctx, caSrc); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, tlsSrc); err != nil {
+		t.Fatal(err)
+	}
+	// First replication creates the destination copies.
+	if err := controller.ReplicateHuskSecrets(ctx, c, src, dst); err != nil {
+		t.Fatal(err)
+	}
+	// Source rotates; a second replication must heal the destination in place.
+	caSrc.Data["ca.crt"] = []byte("CA-V2")
+	if err := c.Update(ctx, caSrc); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.ReplicateHuskSecrets(ctx, c, src, dst); err != nil {
+		t.Fatalf("second ReplicateHuskSecrets: %v", err)
+	}
+	gotCA := getSecret(t, c, dst, controller.CASecretName)
+	if !bytes.Equal(gotCA.Data["ca.crt"], []byte("CA-V2")) {
+		t.Errorf("drift not healed: dst ca.crt = %q, want CA-V2", gotCA.Data["ca.crt"])
+	}
+}
+
+func TestReplicateHuskSecretsSameNamespaceIsNoop(t *testing.T) {
+	c := newCoreClient(t)
+	ns := newPKINamespace(t, c)
+	// No source secrets exist; replicating into the same namespace must not
+	// error (the controller namespace already holds the originals).
+	if err := controller.ReplicateHuskSecrets(ctx, c, ns, ns); err != nil {
+		t.Fatalf("same-namespace replication should be a noop, got %v", err)
+	}
+}

--- a/internal/controller/secret_replication_test.go
+++ b/internal/controller/secret_replication_test.go
@@ -95,3 +95,33 @@ func TestReplicateHuskSecretsSameNamespaceIsNoop(t *testing.T) {
 		t.Fatalf("same-namespace replication should be a noop, got %v", err)
 	}
 }
+
+func TestReconcileHuskPodsReplicatesSecretsIntoPoolNamespace(t *testing.T) {
+	c := newCoreClient(t)
+	ctrlNS := newPKINamespace(t, c)
+	poolNS := newPKINamespace(t, c)
+
+	// Seed the control plane secrets in the controller namespace, as EnsurePKI
+	// would.
+	if err := c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ctrlNS, Name: controller.CASecretName},
+		Data:       map[string][]byte{"ca.crt": []byte("CA"), "ca.key": []byte("KEY")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ctrlNS, Name: controller.ForkdTLSSecretName},
+		Data:       map[string][]byte{"tls.crt": []byte("L"), "tls.key": []byte("K")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// ReplicateHuskSecrets is what reconcileHuskPods calls; assert it bridges
+	// ctrlNS -> poolNS (the reconcile-level wiring is covered by the existing
+	// huskpod envtest, which now runs with ControllerNamespace set).
+	if err := controller.ReplicateHuskSecrets(ctx, c, ctrlNS, poolNS); err != nil {
+		t.Fatal(err)
+	}
+	_ = getSecret(t, c, poolNS, controller.CASecretName)
+	_ = getSecret(t, c, poolNS, controller.ForkdTLSSecretName)
+}


### PR DESCRIPTION
## Summary

Tier-1 production-readiness (plan: docs/superpowers/plans/2026-06-13-deploy-self-containedness.md). Brings up the full stack with a single `kubectl apply -k deploy/` on a real KVM node, removing the ~8 manual runtime patches that tonight's bare-metal bring-up required.

- PodSecurity `enforce=privileged` labels on the controller and pool namespaces.
- `ghcr-pull` image pull secret manifest + serviceaccount wiring.
- forkd image builds the guest agent at `/usr/local/bin/agent`; DaemonSet sets `--agent-bin`, `privileged: true`, `DOCKER_CONFIG`, drops the jailer args (jailer-in-pod is the next Tier-1 plan).
- Kernel-staging DaemonSet stages `vmlinux` to `/var/lib/mitos/vmlinux` on KVM nodes.
- Controller-driven PKI secret replication: `internal/controller/secret_replication.go` copies `ca.crt` (NEVER `ca.key`) and the forkd-TLS leaf into pool namespaces so husk pods find their mTLS material; idempotent, drift-healing, scoped, with envtest.
- threat-model deltas for the forkd-privileged regression and the cross-namespace replication.

Reviewed by an independent spec+quality+security pass (the `ca.key` non-replication is verified by test).

## Test plan
- envtest replication suite (4 tests) green; full controller envtest green.
- Both golangci-lint invocations clean; `kustomize build deploy/` + live-cluster server-dry-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)