### PR TITLE
fix: drop husk-pod reuse so an evicted claim recovers onto a fresh pod

### DIFF
--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -655,28 +655,6 @@ func huskPodReady(p *corev1.Pod) bool {
 // carries the pod's resourceVersion so exactly one wins and the loser gets a 409
 // Conflict and requeues to pick a different dormant pod. A pod is therefore
 // claimed (and activated) by exactly one claim.
-// findClaimedHuskPod returns the husk pod this claim already claimed (the
-// claim-label patch committed on a prior reconcile), so a retrying claim REUSES
-// its pod instead of selecting and claiming a fresh dormant one. Without this,
-// any claim that claims a pod then fails before reaching Ready leaks a pod on
-// every retry, and a refilling warm pool feeds that leak into a runaway that
-// drains the pool. Returns nil when this claim holds no pod yet.
-func (r *SandboxClaimReconciler) findClaimedHuskPod(ctx context.Context, pool *v1alpha1.SandboxPool, claimName string) (*corev1.Pod, error) {
-	var pods corev1.PodList
-	if err := r.List(ctx, &pods,
-		client.InNamespace(pool.Namespace),
-		client.MatchingLabels{huskPoolLabel: pool.Name, huskClaimLabel: claimName},
-	); err != nil {
-		return nil, fmt.Errorf("list claimed husk pods for %s: %w", claimName, err)
-	}
-	for i := range pods.Items {
-		if pods.Items[i].DeletionTimestamp == nil {
-			return &pods.Items[i], nil
-		}
-	}
-	return nil, nil
-}
-
 func (r *SandboxClaimReconciler) selectDormantHuskPod(ctx context.Context, pool *v1alpha1.SandboxPool) (*corev1.Pod, error) {
 	var pods corev1.PodList
 	if err := r.List(ctx, &pods,

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -536,19 +536,14 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *v1alpha1.SandboxClaim, pool *v1alpha1.SandboxPool, template *v1alpha1.SandboxTemplate) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// Reuse the pod this claim already claimed on a prior reconcile (idempotent);
-	// only select + claim a fresh dormant pod when this claim holds none. This
-	// stops a retrying claim from leaking a new pod each pass.
-	pod, err := r.findClaimedHuskPod(ctx, pool, claim.Name)
+	// Select a fresh dormant pod to claim. A pod already claimed by any claim
+	// (including this one on a prior pass) carries the claim label and is skipped
+	// by selectDormantHuskPod, so an evicted claim whose old pod is gone or dying
+	// always moves on to a new dormant pod rather than re-activating the dead one.
+	// Leader election (one active reconciler) is what bounds concurrent claiming.
+	pod, err := r.selectDormantHuskPod(ctx, pool)
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-	reusingPod := pod != nil
-	if pod == nil {
-		pod, err = r.selectDormantHuskPod(ctx, pool)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 	if pod == nil {
 		// No warm husk slot: pend and retry. The pool reconciler is expected to
@@ -613,26 +608,23 @@ func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *
 	// Conflict and must NOT activate this pod (a second tenant on the same VM).
 	// Winning the label patch is the gate to Activate, so a pod is activated by
 	// exactly one claim. On conflict we requeue so the next reconcile picks a
-	// different dormant pod. Skipped when REUSING a pod this claim already holds
-	// (the label is already ours).
-	if !reusingPod {
-		if err := r.markHuskPodClaimed(ctx, pod, claim.Name); err != nil {
-			if apierrors.IsConflict(err) {
-				logger.Info("husk pod claimed concurrently, requeueing to pick another", "pod", pod.Name)
-				claim.Status.Phase = v1alpha1.SandboxPending
-				setCondition(&claim.Status.Conditions, metav1.Condition{
-					Type:               "Ready",
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(r.now()),
-					Reason:             "HuskPodRaced",
-					Message:            "the selected dormant husk pod was claimed by another claim concurrently; the claim will retry and pick a different dormant pod",
-				})
-				_ = r.Status().Update(ctx, claim)
-				return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
-			}
-			logger.Error(err, "mark husk pod claimed failed", "pod", pod.Name)
-			return ctrl.Result{}, err
+	// different dormant pod.
+	if err := r.markHuskPodClaimed(ctx, pod, claim.Name); err != nil {
+		if apierrors.IsConflict(err) {
+			logger.Info("husk pod claimed concurrently, requeueing to pick another", "pod", pod.Name)
+			claim.Status.Phase = v1alpha1.SandboxPending
+			setCondition(&claim.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(r.now()),
+				Reason:             "HuskPodRaced",
+				Message:            "the selected dormant husk pod was claimed by another claim concurrently; the claim will retry and pick a different dormant pod",
+			})
+			_ = r.Status().Update(ctx, claim)
+			return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
 		}
+		logger.Error(err, "mark husk pod claimed failed", "pod", pod.Name)
+		return ctrl.Result{}, err
 	}
 
 	// The recorded snapshot manifest digest the husk stub re-verifies the on-disk


### PR DESCRIPTION
## Summary

The warm-pool reuse helper (`findClaimedHuskPod`, added alongside leader election) made a reconciling claim re-activate the pod it already held. That regressed eviction recovery: when a Ready claim's husk pod is deleted, the claim re-selected the dying-but-still-active pod and looped on `activate in state active: must be dormant` instead of claiming a fresh dormant pod (the `kind-e2e-husk` "Eviction 3" assertion).

The reuse was only defense-in-depth against the multi-pod runaway, and that runaway's real cause (no leader election, two active controllers both claiming) is already fixed. Reverting reuse restores the tested behavior: a claimed pod carries the claim label and is skipped by `selectDormantHuskPod`, so an evicted claim always moves on to a new dormant pod. A pod left claimed by a failed activation is bounded by serial reconciles under leader election and recycled on claim release.

## Test plan
- Full controller envtest suite green; both golangci-lint invocations clean.
- Fixes the kind-e2e-husk Eviction 3 re-pend assertion (also unblocks PR #94 and PR #96, which rebase onto this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)