### PR TITLE
docs(threat-model): record the jailer-in-pod decision (unprivileged husk pods stay)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -53,13 +53,22 @@ privileged process and RUN many times by unprivileged pods.
   KVM nodes (and the `--enable-raw-forkd` fork-per-claim engine). The privileged
   surface is now confined to the BUILD path, run once per node per template,
   rather than every sandbox execution.
-- forkd `privileged: true` (deploy/daemon/daemonset.yaml), REGRESSION pending
-  jailer-in-pod. Without the per-VM jailer mediating, forkd needs unrestricted
-  /dev/kvm, /dev/net/tun, cgroup, and chroot access, so the trimmed capability
-  set is replaced by privileged until the jailer runs inside the forkd pod.
-  Status: accepted, time-boxed to the jailer-in-pod follow-up. Mitigation: the
-  forkd pod runs only on labelled KVM nodes (mitos.run/kvm) and is not exposed
-  to tenant traffic; husk pods, not forkd, are the tenant execution surface.
+- forkd `privileged: true` (deploy/daemon/daemonset.yaml). forkd is the per-node
+  BUILDER and the raw-forkd fallback: building a snapshot runs the jailer (which
+  needs unrestricted /dev/kvm, /dev/net/tun, cgroup, and chroot setup), so forkd
+  runs privileged. Status: accepted by design. Mitigation: the forkd pod runs
+  only on labelled KVM nodes (mitos.run/kvm), is one-per-node (not one-per-
+  sandbox), and is not exposed to tenant traffic; husk pods, not forkd, are the
+  tenant execution surface.
+- The per-VM Firecracker jailer is deliberately NOT run inside the husk pod.
+  jailer-in-pod was implemented and VERIFIED achievable on real KVM (branch
+  feat/jailer-in-pod, closed PR #96), but it requires the full 9-cap jailer set,
+  Unconfined seccomp, and a writable exec+dev hostPath chroot, which makes EVERY
+  husk pod privileged-class and breaks the PSA-restricted model. It is declined:
+  the jailer isolates many VMs sharing one process (raw-forkd), but in the husk
+  model each pod runs exactly ONE VM, so the pod itself is the per-VM boundary
+  (its own uid, netns, cgroup, PSA-restricted securityContext). Per-VM isolation
+  comes from one-VM-per-unprivileged-pod plus the microVM, not an in-pod jailer.
 
 ### Unprivileged-stub escape surface (issue #18 re-derivation)
 


### PR DESCRIPTION
## Summary

In-pod verification on real KVM (closed PR #96) proved jailer-in-pod is achievable but requires making every husk pod privileged-class (full 9-cap jailer set + Unconfined seccomp + writable exec/dev hostPath chroot), breaking the PSA-restricted model that is #18's core value.

Decision: keep husk pods unprivileged + PSA-restricted; do NOT run the jailer in-pod. In the husk model each pod runs exactly one VM, so the pod itself is the per-VM boundary; the jailer (designed for many-VMs-per-process in raw-forkd) is redundant here and would trade one privileged builder per node for one privileged pod per sandbox. Per-VM isolation = one-VM-per-unprivileged-pod + the microVM.

This reframes the forkd-privileged note (accepted by design, not "regression pending jailer-in-pod") and records the decision so the unjailed-VMM-in-an-unprivileged-pod is understood as intentional, not a gap. Verified e2e on the live cluster: unprivileged husk pod (drop ALL, RuntimeDefault, no jailer), claim Ready in ~410 ms with a ~32 ms activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)