### PR TITLE
Per-activation rootfs CoW: each husk activation gets its own reflink clone (tenant isolation)

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -934,6 +934,37 @@ jobs:
           echo "  Per-fork volumes proven (Fresh round-trip + Snapshot CoW independence)"
           echo "================================"
 
+      # Per-activation rootfs CoW: exercise volume.ReflinkCopy against a REAL
+      # cp --reflink on a reflink-capable filesystem (btrfs loopback), the same
+      # FICLONE fast path the husk per-activation rootfs clone uses. The test is
+      # build-tagged reflink_integration so the default unit suite (and darwin,
+      # which has no cp --reflink) skips it; here it runs on a btrfs mount where
+      # the reflink fast path is available, and asserts the clone is byte-identical
+      # to the source. On a non-reflink filesystem the production ReflinkCopy logs
+      # the WARNING and falls back to a full copy, so byte-equality holds either way.
+      - name: Per-activation rootfs CoW, reflink clone byte-identical on btrfs
+        timeout-minutes: 5
+        run: |
+          set -e
+          sudo apt-get install -y btrfs-progs
+          REFLINK_ROOT=/mnt/reflink-btrfs
+          REFLINK_IMG=/tmp/mitos-test/reflink-btrfs.img
+          dd if=/dev/zero of=$REFLINK_IMG bs=1M count=512 status=none
+          mkfs.btrfs -q $REFLINK_IMG
+          sudo mkdir -p $REFLINK_ROOT
+          sudo mount -o loop $REFLINK_IMG $REFLINK_ROOT
+          sudo chmod 777 $REFLINK_ROOT
+          echo "Reflink test data dir on btrfs (reflink-capable):"
+          mount | grep "$REFLINK_ROOT"
+          # TMPDIR on the btrfs mount so the test's t.TempDir (src + dst) is
+          # reflink-capable and cp --reflink=always succeeds.
+          TMPDIR=$REFLINK_ROOT go test -tags reflink_integration \
+            ./internal/volume/ -run TestReflinkCopyRealFilesystem -v
+          sudo umount $REFLINK_ROOT || true
+          echo "================================"
+          echo "  Per-activation rootfs CoW reflink proven (byte-identical clone on btrfs)"
+          echo "================================"
+
       # Encryption-at-rest proof (#31) on REAL cryptsetup. This phase drives the
       # REAL internal/storecrypt Manager (cmd/crypt-smoke uses the production
       # DefaultRunner, so the same package code forkd's encryption integration

--- a/cmd/husk-stub/main.go
+++ b/cmd/husk-stub/main.go
@@ -159,6 +159,8 @@ func run() error {
 		manifest        = flag.String("manifest", "", "path to the recorded CAS manifest for the template snapshot. When set, the stub re-verifies the snapshot (digest integrity + snapcompat) against it BEFORE loading, fail-closed (the husk mirror of forkd's verify-on-load gate, issues #9 and #32). The manifest is a content address, not a secret")
 		allowUnverified = flag.Bool("allow-unverified-snapshots", false, "DEVELOPMENT ONLY: skip the activate-time snapshot integrity + compatibility verification, mirroring forkd's --allow-unverified-snapshots. Default false keeps verify enforced; a missing manifest/digest or a failed check then refuses the activate (fail-closed)")
 		expectedDigest  = flag.String("expected-digest", "", "activate client mode: the template's recorded CAS manifest digest, threaded into the ActivateRequest so the serving stub verifies the snapshot against it (a content address, not a secret)")
+		rootfsCoWDir    = flag.String("rootfs-cow-dir", "", "directory on the SAME node filesystem as the template rootfs where this activation's copy-on-write rootfs clone is written (reflink where supported, full copy otherwise). Empty keeps the prior behavior of writing the shared template rootfs in place. A content address, not a secret")
+		templateRootfs  = flag.String("template-rootfs", "", "host path of the template rootfs.ext4 to clone per activation. Empty (with --rootfs-cow-dir) disables the per-activation clone")
 	)
 	var envFlag, secretFlag kvFlag
 	flag.Var(&envFlag, "env", "activate client mode: repeatable KEY=VALUE guest env var")
@@ -277,6 +279,13 @@ func run() error {
 		// so the claim's Activate is just the load + handshake, not the re-hash.
 		PrepareSnapshotDir:    *snapshotDir,
 		PrepareExpectedDigest: *expectedDigest,
+		// Per-activation rootfs CoW: clone the template rootfs to a per-pod file
+		// on a writable co-located volume at Prepare and rebind the rootfs drive
+		// to it at Activate, so concurrent activations of one template never
+		// share or corrupt a single rootfs. Both empty keeps the prior in-place
+		// shared-rootfs behavior.
+		RootfsTemplatePath: *templateRootfs,
+		RootfsCoWDir:       *rootfsCoWDir,
 	})
 
 	fmt.Fprintln(os.Stderr, "husk-stub: preparing dormant VMM")

--- a/cmd/husk-stub/main.go
+++ b/cmd/husk-stub/main.go
@@ -42,6 +42,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -60,6 +61,14 @@ import (
 // so one fixed id is sufficient; the controller addresses the in-pod API by
 // podIP:port, and the per-sandbox bearer token (not the id) is the auth gate.
 const huskSandboxID = "husk"
+
+// huskVMIDPattern is the allowlist the --vm-id flag must satisfy before it is
+// joined into the per-activation rootfs CoW clone path (and handed to
+// firecracker.StartVM, which applies the same constraint). It forbids path
+// separators and traversal sequences, so a per-pod id can never escape the CoW
+// directory. It is intentionally identical to firecracker's internal vmIDPattern
+// (a DNS-1123-compatible allowlist that a Kubernetes pod name satisfies).
+var huskVMIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`)
 
 // kvFlag collects repeatable KEY=VALUE flags into a map. It is used for --env
 // and --secret. The String method NEVER renders the values: a --secret flag's
@@ -161,6 +170,7 @@ func run() error {
 		expectedDigest  = flag.String("expected-digest", "", "activate client mode: the template's recorded CAS manifest digest, threaded into the ActivateRequest so the serving stub verifies the snapshot against it (a content address, not a secret)")
 		rootfsCoWDir    = flag.String("rootfs-cow-dir", "", "directory on the SAME node filesystem as the template rootfs where this activation's copy-on-write rootfs clone is written (reflink where supported, full copy otherwise). Empty keeps the prior behavior of writing the shared template rootfs in place. A content address, not a secret")
 		templateRootfs  = flag.String("template-rootfs", "", "host path of the template rootfs.ext4 to clone per activation. Empty (with --rootfs-cow-dir) disables the per-activation clone")
+		vmID            = flag.String("vm-id", huskSandboxID, "the per-pod VM id. It scopes this pod's per-activation rootfs CoW clone path (<rootfs-cow-dir>/<vm-id>/rootfs.ext4), so two husk pods sharing the node CoW hostPath never collide on, overwrite, or delete each other's clone. The controller passes the pod name (downward API metadata.name); empty falls back to the legacy fixed id. A node-local identifier, not a secret")
 	)
 	var envFlag, secretFlag kvFlag
 	flag.Var(&envFlag, "env", "activate client mode: repeatable KEY=VALUE guest env var")
@@ -228,8 +238,24 @@ func run() error {
 		return fmt.Errorf("create workdir: %w", err)
 	}
 
+	// The VM id is PER-POD: it scopes this pod's per-activation rootfs CoW clone
+	// path (<rootfs-cow-dir>/<id>/rootfs.ext4) so two husk pods that share the
+	// node's CoW hostPath never write, overwrite, or delete the same clone file.
+	// The controller passes the pod name via the downward API; an empty flag
+	// keeps the legacy fixed id (single-pod-per-node assumption). The id is joined
+	// into a filesystem path here and in firecracker.StartVM, so validate it at
+	// this trust boundary up front (the same DNS-1123-compatible allowlist the
+	// firecracker client enforces) rather than relying on call ordering.
+	vmConfigID := *vmID
+	if vmConfigID == "" {
+		vmConfigID = huskSandboxID
+	}
+	if !huskVMIDPattern.MatchString(vmConfigID) {
+		return fmt.Errorf("--vm-id %q is invalid: must match %s", vmConfigID, huskVMIDPattern.String())
+	}
+
 	cfg := firecracker.VMConfig{
-		ID:             "husk",
+		ID:             vmConfigID,
 		FirecrackerBin: *firecrackerBin,
 		WorkDir:        *workdir,
 		KernelPath:     *kernel,

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -164,20 +164,21 @@ refused at activate time on the husk path; and (c) it is a
 BASE IMAGE, not tenant data: tenant secrets are delivered post-restore over the
 control channel (surface 2), never baked into the shared snapshot (section 6).
 Cross-pod isolation of the snapshot mem/vmstate is the read-only property, not a
-per-pod copy. The ROOTFS isolation is now twofold. First, the template dir
-(which holds `rootfs.ext4`) is mounted READ-ONLY into the husk pod
-(`huskpod.go`: the `template` mount is `ReadOnly: true`, like the snapshot,
-kernel, and manifest mounts); the stub only reads the template rootfs to clone
-it, so no husk pod can write through to the shared template at the mount.
-Second, each activation gets its OWN copy-on-write clone of the template rootfs
-on a SEPARATE writable mount: `internal/husk` `Stub.Prepare` reflink-clones
-`<dataDir>/templates/<id>/rootfs.ext4` to a PER-POD file
-`<dataDir>/husk-rootfs/<pod-name>/rootfs.ext4` (the clone path is scoped to the
-per-pod VM id the controller passes via the downward API `metadata.name`, so two
-husk pods sharing the node CoW hostPath never collide on, overwrite, or delete
-each other's clone), and `Stub.Activate` loads the snapshot PAUSED, rebinds the
-baked `rootfs` drive to that clone with `PatchDrive` while the guest is frozen,
-then resumes. So the guest writes only its own clone, never a single block of the
+per-pod copy. The ROOTFS isolation is from a per-activation copy-on-write clone
+rebound while the guest is FROZEN, not from a read-only template mount. The
+template dir (which holds `rootfs.ext4`) is mounted read-write, because
+Firecracker opens the snapshot's baked rootfs path with O_RDWR during
+`/snapshot/load` (a read-only mount fails the load EROFS, verified on real KVM);
+isolation does NOT rely on the mount mode. Each activation gets its OWN clone:
+`internal/husk` `Stub.Prepare` reflink-clones `<dataDir>/templates/<id>/rootfs
+.ext4` to a PER-POD file `<dataDir>/husk-rootfs/<pod-name>/rootfs.ext4` (the clone
+path is scoped to the per-pod VM id the controller passes via the downward API
+`metadata.name`, so two husk pods sharing the node CoW hostPath never collide on,
+overwrite, or delete each other's clone), and `Stub.Activate` loads the snapshot
+PAUSED (`resume=false`), rebinds the baked `rootfs` drive to that clone with
+`PatchDrive` while the guest is frozen, THEN resumes. The template is only OPENED
+(never written) during the paused load and the drive fd is replaced by PatchDrive
+before resume, so the guest writes only its own clone, never a single block of the
 shared template, and concurrent activations of one template never leak one
 tenant's filesystem state into another. The clone is removed on pod teardown
 (`Stub.Close`). Fully pod-native snapshot delivery (a CAS pull into the pod,

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -163,9 +163,18 @@ activate before loading, so a tampered-on-disk or incompatible snapshot is
 refused at activate time on the husk path; and (c) it is a
 BASE IMAGE, not tenant data: tenant secrets are delivered post-restore over the
 control channel (surface 2), never baked into the shared snapshot (section 6).
-Cross-pod isolation of the mount is the read-only property, not a per-pod copy;
-fully pod-native snapshot delivery (a CAS pull into the pod, removing the shared
-hostPath) is a documented follow-up.
+Cross-pod isolation of the snapshot mem/vmstate is the read-only property, not a
+per-pod copy. The ROOTFS, by contrast, is no longer shared read-write: each
+activation gets its OWN copy-on-write clone of the template rootfs
+(`internal/husk` `Stub.Prepare` reflink-clones `<dataDir>/templates/<id>/rootfs.ext4`
+to a per-pod file under the writable `<dataDir>/husk-rootfs` hostPath, and
+`Stub.Activate` rebinds the snapshot's baked `rootfs` drive to that clone with
+`PatchDrive` after load), so concurrent activations of one template never write
+through to a single shared rootfs or leak one tenant's filesystem state into
+another. This closes the prior residual where the template dir (including the
+rootfs) was mounted read-write and shared. The clone is removed on pod teardown
+(`Stub.Close`). Fully pod-native snapshot delivery (a CAS pull into the pod,
+removing the shared read-only mem/vmstate hostPath) remains a documented follow-up.
 
 **Surface 4: the DEVICE `/dev/kvm`.** KVM access is injected by the device plugin
 (`cmd/kvm-device-plugin`, `internal/deviceplugin`): the pod requests

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -164,15 +164,22 @@ refused at activate time on the husk path; and (c) it is a
 BASE IMAGE, not tenant data: tenant secrets are delivered post-restore over the
 control channel (surface 2), never baked into the shared snapshot (section 6).
 Cross-pod isolation of the snapshot mem/vmstate is the read-only property, not a
-per-pod copy. The ROOTFS, by contrast, is no longer shared read-write: each
-activation gets its OWN copy-on-write clone of the template rootfs
-(`internal/husk` `Stub.Prepare` reflink-clones `<dataDir>/templates/<id>/rootfs.ext4`
-to a per-pod file under the writable `<dataDir>/husk-rootfs` hostPath, and
-`Stub.Activate` rebinds the snapshot's baked `rootfs` drive to that clone with
-`PatchDrive` after load), so concurrent activations of one template never write
-through to a single shared rootfs or leak one tenant's filesystem state into
-another. This closes the prior residual where the template dir (including the
-rootfs) was mounted read-write and shared. The clone is removed on pod teardown
+per-pod copy. The ROOTFS isolation is now twofold. First, the template dir
+(which holds `rootfs.ext4`) is mounted READ-ONLY into the husk pod
+(`huskpod.go`: the `template` mount is `ReadOnly: true`, like the snapshot,
+kernel, and manifest mounts); the stub only reads the template rootfs to clone
+it, so no husk pod can write through to the shared template at the mount.
+Second, each activation gets its OWN copy-on-write clone of the template rootfs
+on a SEPARATE writable mount: `internal/husk` `Stub.Prepare` reflink-clones
+`<dataDir>/templates/<id>/rootfs.ext4` to a PER-POD file
+`<dataDir>/husk-rootfs/<pod-name>/rootfs.ext4` (the clone path is scoped to the
+per-pod VM id the controller passes via the downward API `metadata.name`, so two
+husk pods sharing the node CoW hostPath never collide on, overwrite, or delete
+each other's clone), and `Stub.Activate` loads the snapshot PAUSED, rebinds the
+baked `rootfs` drive to that clone with `PatchDrive` while the guest is frozen,
+then resumes. So the guest writes only its own clone, never a single block of the
+shared template, and concurrent activations of one template never leak one
+tenant's filesystem state into another. The clone is removed on pod teardown
 (`Stub.Close`). Fully pod-native snapshot delivery (a CAS pull into the pod,
 removing the shared read-only mem/vmstate hostPath) remains a documented follow-up.
 

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -402,13 +402,17 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 				},
 			},
 		})
-		// READ-ONLY: the stub only READS the template rootfs to reflink-clone it
-		// per activation; it never writes the template dir. Mounting it read-only
-		// (like the snapshot, kernel, and manifest mounts) closes the shared-RW
-		// residual at the mount itself, so no husk pod can write through to the
-		// shared template even if a future code path tried. The per-activation CoW
-		// clone is written to the SEPARATE writable husk-rootfs-cow mount below.
-		mounts = append(mounts, corev1.VolumeMount{Name: "template", MountPath: templateDir, ReadOnly: true})
+		// Mounted READ-WRITE, but the guest never writes the template. Firecracker
+		// opens the snapshot's BAKED rootfs path (this template rootfs.ext4) with
+		// O_RDWR during /snapshot/load, so a read-only mount makes the load fail
+		// EROFS (verified on real KVM). The VM stays PAUSED through load (resume
+		// =false) -> PatchDrive(rootfs -> per-pod clone) -> Resume, so by the time
+		// the guest runs its rootfs is the per-activation CoW clone (the SEPARATE
+		// writable husk-rootfs mount below), never the template. Isolation is from
+		// the rebind-before-resume, not the mount mode: the template is only OPENED
+		// (not written) during the paused load and the fd is replaced by PatchDrive
+		// before resume, so concurrent activations never write the shared template.
+		mounts = append(mounts, corev1.VolumeMount{Name: "template", MountPath: templateDir})
 
 		// The writable per-activation rootfs CoW directory, a sibling of the
 		// template dir under the node data dir so the stub's reflink clone of the

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -93,6 +93,13 @@ const (
 	// a file" / "no such file or directory") even when it exists, while a
 	// directory hostPath mounts cleanly and exposes the file inside it.
 	huskManifestDirMountPath = "/var/lib/mitos/manifests"
+	// huskRootfsCoWMountPath is the in-pod path the writable per-activation rootfs
+	// CoW directory is mounted at. It is a hostPath under the node data dir
+	// (<dataDir>/husk-rootfs), co-located with the template dir on the SAME node
+	// filesystem so the stub's reflink clone of the template rootfs lands on a
+	// reflink-capable filesystem (a full copy fallback otherwise). Each activation
+	// writes its own clone under here, never the shared read-only template rootfs.
+	huskRootfsCoWMountPath = "/var/lib/mitos/husk-rootfs"
 )
 
 // HuskSnapshotDir is the in-pod path the husk stub treats as ActivateRequest
@@ -371,15 +378,11 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 		// one, both sidesteps the Talos single-file hostPath check and exposes the
 		// rootfs at exactly the baked path.
 		//
-		// PRODUCTION FOLLOW-UP (per-activation rootfs CoW): this mounts the shared
-		// template rootfs read-write, so the resumed VM writes into it directly.
-		// That is correct for a warm pool of one dormant pod per snapshot (a single
-		// activation owns the rootfs), but concurrent activations of one snapshot
-		// would share and corrupt it. The fork engine already does the right thing
-		// (reflink/copy the rootfs per fork, then PatchDrive after load); the husk
-		// activation path needs the same: copy templates/<id>/rootfs.ext4 to a
-		// per-activation file on a writable volume and PatchDrive to it after the
-		// snapshot loads. Tracked as the husk-rootfs-CoW follow-up.
+		// The stub then rebinds the rootfs drive to a PER-ACTIVATION copy-on-write
+		// clone (see the husk-rootfs-cow mount below) immediately after load, so the
+		// resumed VM writes its OWN rootfs, never the shared template rootfs:
+		// concurrent activations of one template no longer share or corrupt a single
+		// rootfs. The clone source (this template rootfs) stays effectively read-only.
 		templateDir := filepath.Join(dataDir, "templates", opts.SnapshotID)
 		volumes = append(volumes, corev1.Volume{
 			Name: "template",
@@ -391,6 +394,33 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 			},
 		})
 		mounts = append(mounts, corev1.VolumeMount{Name: "template", MountPath: templateDir})
+
+		// The writable per-activation rootfs CoW directory, a sibling of the
+		// template dir under the node data dir so the stub's reflink clone of the
+		// template rootfs stays on ONE reflink-capable filesystem. Mounted
+		// READ-WRITE (unlike the snapshot and template mounts) because the stub
+		// writes this activation's clone here; an emptyDir would land on a
+		// different filesystem and defeat reflink. DirectoryOrCreate so the dir is
+		// created on first use.
+		volumes = append(volumes, corev1.Volume{
+			Name: "husk-rootfs-cow",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: filepath.Join(dataDir, "husk-rootfs"),
+					Type: &hostType,
+				},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{Name: "husk-rootfs-cow", MountPath: huskRootfsCoWMountPath})
+
+		// Tell the stub where to clone from (the in-pod template rootfs at its baked
+		// path) and to (the writable CoW dir). At Prepare the stub reflink-clones the
+		// template rootfs to a per-pod file under the CoW dir and at Activate rebinds
+		// the rootfs drive to it, so concurrent activations never share a rootfs.
+		args = append(args,
+			"--rootfs-cow-dir", huskRootfsCoWMountPath,
+			"--template-rootfs", filepath.Join(templateDir, "rootfs.ext4"),
+		)
 	}
 
 	// Placement: the dormant VMM needs /dev/kvm (the kvm nodeSelector) AND the

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -263,6 +263,15 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 		"--tls-cert", filepath.Join(huskTLSMountPath, "tls.crt"),
 		"--tls-key", filepath.Join(huskTLSMountPath, "tls.key"),
 		"--tls-ca", filepath.Join(huskCAMountPath, "ca.crt"),
+		// Per-pod VM id from the downward API pod name (set on the container env
+		// below). It scopes this pod's per-activation rootfs CoW clone path
+		// (<rootfs-cow-dir>/<id>/rootfs.ext4), which is written under a node
+		// hostPath shared by EVERY husk pod on the node. Without a per-pod id every
+		// husk pod would clone to the IDENTICAL path and overwrite or delete each
+		// other's live rootfs (cross-pod corruption); the pod name is unique per
+		// node, so each pod gets its own clone. $(POD_NAME) is substituted by the
+		// kubelet from the env var, not the shell.
+		"--vm-id", "$(POD_NAME)",
 	}
 
 	// Snapshot verify gate (fail-closed): when the pool has a recorded template
@@ -393,7 +402,13 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 				},
 			},
 		})
-		mounts = append(mounts, corev1.VolumeMount{Name: "template", MountPath: templateDir})
+		// READ-ONLY: the stub only READS the template rootfs to reflink-clone it
+		// per activation; it never writes the template dir. Mounting it read-only
+		// (like the snapshot, kernel, and manifest mounts) closes the shared-RW
+		// residual at the mount itself, so no husk pod can write through to the
+		// shared template even if a future code path tried. The per-activation CoW
+		// clone is written to the SEPARATE writable husk-rootfs-cow mount below.
+		mounts = append(mounts, corev1.VolumeMount{Name: "template", MountPath: templateDir, ReadOnly: true})
 
 		// The writable per-activation rootfs CoW directory, a sibling of the
 		// template dir under the node data dir so the stub's reflink clone of the
@@ -492,6 +507,20 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 					// snapshot are read-only hostPath mounts. The controller dials
 					// the control port to activate (slice 2).
 					Args: args,
+					// POD_NAME via the downward API: the kubelet substitutes it
+					// into the --vm-id $(POD_NAME) arg above so each husk pod gets
+					// a UNIQUE per-pod VM id. That id scopes the per-activation
+					// rootfs CoW clone path under the shared node hostPath, so two
+					// husk pods on one node never collide on, overwrite, or delete
+					// each other's rootfs clone. The pod name is unique per node.
+					Env: []corev1.EnvVar{{
+						Name: "POD_NAME",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.name",
+							},
+						},
+					}},
 					Ports: []corev1.ContainerPort{{
 						// The activated VM's sandbox HTTP API (exec/files). The
 						// claim's Status.Endpoint is podIP:this, so it must be a

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -442,9 +442,12 @@ func TestBuildHuskPodMountsWritableRootfsCoWDir(t *testing.T) {
 		t.Errorf("args missing --template-rootfs %s: %v", wantTemplateRootfs, container.Args)
 	}
 
-	// The template dir mount (the clone SOURCE) must be READ-ONLY: the stub only
-	// reads it to clone the rootfs, so a writable mount would re-open the shared-RW
-	// residual this fix closes.
+	// The template dir mount is READ-WRITE: Firecracker opens the snapshot's baked
+	// rootfs path (this template rootfs.ext4) with O_RDWR during /snapshot/load, so
+	// a read-only mount makes the load fail EROFS (verified on real KVM). Isolation
+	// is NOT from the mount mode: the VM stays paused through load -> PatchDrive
+	// (rootfs -> per-pod clone) -> resume, so the guest writes only its clone, never
+	// the template. The template is only opened (not written) during the paused load.
 	var tmplMount *corev1.VolumeMount
 	for i := range container.VolumeMounts {
 		if container.VolumeMounts[i].Name == "template" {
@@ -454,8 +457,8 @@ func TestBuildHuskPodMountsWritableRootfsCoWDir(t *testing.T) {
 	if tmplMount == nil {
 		t.Fatal("expected a template volume mount")
 	}
-	if !tmplMount.ReadOnly {
-		t.Error("the template dir mount must be read-only (the stub only reads it to clone the rootfs)")
+	if tmplMount.ReadOnly {
+		t.Error("the template dir mount must be read-write so Firecracker can open the baked rootfs path at load; isolation is from rebind-before-resume, not the mount mode")
 	}
 
 	// The per-pod VM id flows from the downward API pod name: a POD_NAME env from

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -15,6 +15,7 @@ package controller_test
 //     is documented in huskpod.go).
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -381,6 +382,64 @@ func TestBuildHuskPodMountsManifestWhenDigestKnown(t *testing.T) {
 	}
 	if !mounted {
 		t.Error("manifest volume is not mounted into the container")
+	}
+}
+
+func TestBuildHuskPodMountsWritableRootfsCoWDir(t *testing.T) {
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "cow-pool", Namespace: "default", UID: "pool-uid-cow"},
+		Spec:       v1alpha1.SandboxPoolSpec{TemplateRef: v1alpha1.LocalObjectReference{Name: "cow-tmpl"}, Replicas: 1},
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cow-tmpl", Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+
+	r := &controller.SandboxPoolReconciler{Client: k8sClient}
+	pod := r.BuildHuskPodForTest(pool, template, controller.HuskPodOptions{
+		StubImage:  "mitos-husk-stub:test",
+		SnapshotID: "cow-tmpl",
+		DataDir:    "/var/lib/mitos",
+	})
+	container := pod.Spec.Containers[0]
+
+	// The CoW dir hostPath volume must be present and WRITABLE (ReadOnly false),
+	// co-located under the node data dir as a sibling of templates.
+	var cowMount *corev1.VolumeMount
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == "husk-rootfs-cow" {
+			cowMount = &container.VolumeMounts[i]
+		}
+	}
+	if cowMount == nil {
+		t.Fatal("expected a husk-rootfs-cow volume mount")
+	}
+	if cowMount.ReadOnly {
+		t.Error("the rootfs CoW dir must be mounted read-write")
+	}
+
+	var cowVol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == "husk-rootfs-cow" {
+			cowVol = &pod.Spec.Volumes[i]
+		}
+	}
+	if cowVol == nil || cowVol.HostPath == nil {
+		t.Fatal("expected a husk-rootfs-cow hostPath volume")
+	}
+	wantHostPath := filepath.Join("/var/lib/mitos", "husk-rootfs")
+	if cowVol.HostPath.Path != wantHostPath {
+		t.Errorf("CoW hostPath = %q, want %q (sibling of templates under the data dir)", cowVol.HostPath.Path, wantHostPath)
+	}
+
+	// The stub must be told where to clone from and to.
+	args := strings.Join(container.Args, " ")
+	if !strings.Contains(args, "--rootfs-cow-dir "+cowMount.MountPath) {
+		t.Errorf("args missing --rootfs-cow-dir %s: %v", cowMount.MountPath, container.Args)
+	}
+	wantTemplateRootfs := filepath.Join("/var/lib/mitos", "templates", "cow-tmpl", "rootfs.ext4")
+	if !strings.Contains(args, "--template-rootfs "+wantTemplateRootfs) {
+		t.Errorf("args missing --template-rootfs %s: %v", wantTemplateRootfs, container.Args)
 	}
 }
 

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -441,6 +441,42 @@ func TestBuildHuskPodMountsWritableRootfsCoWDir(t *testing.T) {
 	if !strings.Contains(args, "--template-rootfs "+wantTemplateRootfs) {
 		t.Errorf("args missing --template-rootfs %s: %v", wantTemplateRootfs, container.Args)
 	}
+
+	// The template dir mount (the clone SOURCE) must be READ-ONLY: the stub only
+	// reads it to clone the rootfs, so a writable mount would re-open the shared-RW
+	// residual this fix closes.
+	var tmplMount *corev1.VolumeMount
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == "template" {
+			tmplMount = &container.VolumeMounts[i]
+		}
+	}
+	if tmplMount == nil {
+		t.Fatal("expected a template volume mount")
+	}
+	if !tmplMount.ReadOnly {
+		t.Error("the template dir mount must be read-only (the stub only reads it to clone the rootfs)")
+	}
+
+	// The per-pod VM id flows from the downward API pod name: a POD_NAME env from
+	// metadata.name plus --vm-id $(POD_NAME). This scopes the clone path per pod so
+	// two husk pods on one node never collide on the shared CoW hostPath.
+	var podNameEnv *corev1.EnvVar
+	for i := range container.Env {
+		if container.Env[i].Name == "POD_NAME" {
+			podNameEnv = &container.Env[i]
+		}
+	}
+	if podNameEnv == nil {
+		t.Fatal("expected a POD_NAME env var")
+	}
+	if podNameEnv.ValueFrom == nil || podNameEnv.ValueFrom.FieldRef == nil ||
+		podNameEnv.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+		t.Errorf("POD_NAME must come from the downward API metadata.name, got %+v", podNameEnv.ValueFrom)
+	}
+	if !strings.Contains(args, "--vm-id $(POD_NAME)") {
+		t.Errorf("args missing --vm-id $(POD_NAME): %v", container.Args)
+	}
 }
 
 // TestBuildHuskPodEscapeHatchWhenNoDigest proves the fallback: with no recorded

--- a/internal/husk/sandbox_api_test.go
+++ b/internal/husk/sandbox_api_test.go
@@ -88,8 +88,9 @@ type pathVMM struct {
 func (m *pathVMM) LoadSnapshotWithOverrides(_, _ string, _ bool, _ []firecracker.NetworkOverride) error {
 	return nil
 }
-func (m *pathVMM) VsockHostPath(string) string { return m.vsockPath }
-func (m *pathVMM) Close() error                { return nil }
+func (m *pathVMM) VsockHostPath(string) string  { return m.vsockPath }
+func (m *pathVMM) PatchDrive(_, _ string) error { return nil }
+func (m *pathVMM) Close() error                 { return nil }
 
 func postHuskExec(t *testing.T, url, sandbox, bearer string) (int, string) {
 	t.Helper()

--- a/internal/husk/sandbox_api_test.go
+++ b/internal/husk/sandbox_api_test.go
@@ -90,6 +90,7 @@ func (m *pathVMM) LoadSnapshotWithOverrides(_, _ string, _ bool, _ []firecracker
 }
 func (m *pathVMM) VsockHostPath(string) string  { return m.vsockPath }
 func (m *pathVMM) PatchDrive(_, _ string) error { return nil }
+func (m *pathVMM) Resume() error                { return nil }
 func (m *pathVMM) Close() error                 { return nil }
 
 func postHuskExec(t *testing.T, url, sandbox, bearer string) (int, string) {

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -457,6 +457,22 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
 
+	// Rebind the baked "rootfs" drive to THIS activation's CoW clone now that the
+	// snapshot is loaded and resumed, before the guest writes anything. This is the
+	// husk analog of the fork engine's per-fork volume drive rebind: the snapshot
+	// bakes the rootfs block device at path_on_host, and Firecracker supports
+	// updating a drive's path_on_host on a restored+resumed VM (PATCH /drives).
+	// Skipped when no per-activation clone was prepared (the prior shared-rootfs
+	// behavior). Fail closed: a rebind failure means the VM is still pointed at the
+	// shared template rootfs, which is exactly the corruption hazard this prevents,
+	// so do NOT mark active. The drive id and path carry no secrets.
+	if s.rootfsClonePath != "" {
+		if err := s.vm.PatchDrive("rootfs", s.rootfsClonePath); err != nil {
+			werr := fmt.Errorf("husk: rebind rootfs drive to per-activation clone: %w", err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+
 	vsockPath := s.vm.VsockHostPath(firecracker.VsockRelPath)
 	if err := s.ready(vsockPath, s.readyTimeout); err != nil {
 		// Fail closed: the snapshot loaded but the guest never answered, so we

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -593,6 +593,19 @@ func (s *Stub) State() State {
 func (s *Stub) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Best effort: remove this activation's rootfs CoW clone so it does not
+	// outlive the pod. A reflink clone shares extents with the template until
+	// written, so removing it frees only the activation's own divergent blocks.
+	// Path only is logged on failure; the clone carries no secrets. Done before
+	// the vm == nil early return so a clone is reaped even when no VMM is held.
+	if s.rootfsClonePath != "" {
+		if rmErr := os.Remove(s.rootfsClonePath); rmErr != nil && !os.IsNotExist(rmErr) {
+			fmt.Fprintf(os.Stderr, "husk: remove per-activation rootfs clone %s: %v\n", s.rootfsClonePath, rmErr)
+		}
+		s.rootfsClonePath = ""
+	}
+
 	if s.vm == nil {
 		return nil
 	}

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -57,6 +57,11 @@ type vmm interface {
 	LoadSnapshotWithOverrides(mem, snapshot string, resume bool, overrides []firecracker.NetworkOverride) error
 	// VsockHostPath resolves a relative vsock uds_path to its host location.
 	VsockHostPath(rel string) string
+	// PatchDrive rebinds an existing baked drive (by drive id) to a host backing
+	// file via PATCH /drives, after the snapshot is loaded and resumed. The husk
+	// activate path uses it to point the rootfs drive at this activation's CoW
+	// clone, the same rebind the fork engine applies to volume drives.
+	PatchDrive(driveID, pathOnHost string) error
 	// Close tears the VMM down.
 	Close() error
 }

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/paperclipinc/mitos/internal/firecracker"
 	"github.com/paperclipinc/mitos/internal/snapcompat"
+	"github.com/paperclipinc/mitos/internal/volume"
 	"github.com/paperclipinc/mitos/internal/vsock"
 )
 
@@ -125,6 +126,13 @@ func productionNotifier(vsockPath string, generation uint64, entropy []byte, req
 	return nil
 }
 
+// reflinker copies a source file to a destination with copy-on-write semantics
+// (reflink where the filesystem supports it, full copy otherwise). The husk
+// stub clones the template rootfs to a per-activation file through it. The
+// production seam is volume.Backend.ReflinkCopy; tests inject a fake. src and
+// dst carry no secrets.
+type reflinker func(src, dst string) error
+
 // productionStarter wraps firecracker.StartVM. *firecracker.Client satisfies
 // vmm (it has LoadSnapshotWithOverrides, VsockHostPath, and we adapt Kill to
 // Close below).
@@ -223,6 +231,20 @@ type Options struct {
 	// Activate path as before. The values are content addresses, not secrets.
 	PrepareSnapshotDir    string
 	PrepareExpectedDigest string
+	// RootfsTemplatePath and RootfsCoWDir, when both set, give this activation its
+	// OWN copy-on-write clone of the template rootfs instead of writing the shared
+	// template rootfs.ext4 in place. At Prepare the stub reflink-clones
+	// RootfsTemplatePath to <RootfsCoWDir>/<vm id>/rootfs.ext4 (pre-paid, dormant),
+	// and at Activate it rebinds the snapshot's baked "rootfs" drive to that clone
+	// with PatchDrive after the snapshot loads. Both empty keeps the prior behavior
+	// (the resumed VM writes the shared template rootfs). The paths are content
+	// addresses, not secrets.
+	RootfsTemplatePath string
+	RootfsCoWDir       string
+	// Reflink performs the per-activation rootfs clone. Nil uses the production
+	// seam (volume.Backend.ReflinkCopy, which is FICLONE with a full-copy
+	// fallback). Tests inject a fake.
+	Reflink reflinker
 }
 
 // DefaultReadyTimeout bounds how long Activate waits for the guest agent to
@@ -247,6 +269,15 @@ type Stub struct {
 	prepareSnapshotDir    string
 	prepareExpectedDigest string
 
+	// rootfsTemplatePath / rootfsCoWDir configure the per-activation rootfs CoW;
+	// reflink performs the clone; rootfsClonePath records the clone Prepare made so
+	// Activate rebinds the drive to it and Close removes it. Empty rootfsClonePath
+	// means no per-activation rootfs was prepared (prior behavior).
+	rootfsTemplatePath string
+	rootfsCoWDir       string
+	reflink            reflinker
+	rootfsClonePath    string
+
 	mu              sync.Mutex
 	state           State
 	vm              vmm
@@ -269,6 +300,10 @@ func New(cfg firecracker.VMConfig, opts Options) *Stub {
 
 		prepareSnapshotDir:    opts.PrepareSnapshotDir,
 		prepareExpectedDigest: opts.PrepareExpectedDigest,
+
+		rootfsTemplatePath: opts.RootfsTemplatePath,
+		rootfsCoWDir:       opts.RootfsCoWDir,
+		reflink:            opts.Reflink,
 	}
 	if s.start == nil {
 		s.start = productionStarter
@@ -288,6 +323,9 @@ func New(cfg firecracker.VMConfig, opts Options) *Stub {
 	}
 	if s.readyTimeout == 0 {
 		s.readyTimeout = DefaultReadyTimeout
+	}
+	if s.reflink == nil {
+		s.reflink = volume.New("").ReflinkCopy
 	}
 	return s
 }
@@ -330,6 +368,33 @@ func (s *Stub) Prepare(ctx context.Context) error {
 			return fmt.Errorf("husk: prepare-time snapshot verification failed: %w", err)
 		}
 		s.prepareVerified = true
+	}
+
+	// Per-activation rootfs CoW (opt-in): clone the template rootfs to this
+	// activation's OWN file NOW, during the dormant pre-paid window, so the
+	// Activate hot path is only load + handshake (the clone, especially a
+	// full-copy fallback on a non-reflink filesystem, must never land on the hot
+	// path). The clone source is read-only and content-addressed, so a clone taken
+	// here is byte-identical to one taken at Activate. Fail closed: a clone failure
+	// tears the dormant VMM down and keeps the pod out of StateDormant so the pool
+	// never offers it.
+	if s.rootfsTemplatePath != "" && s.rootfsCoWDir != "" {
+		clonePath := filepath.Join(s.rootfsCoWDir, s.cfg.ID, "rootfs.ext4")
+		// Create the clone's parent directory before handing the path to the
+		// reflinker. The production seam (volume.ReflinkCopy) also MkdirAlls
+		// (idempotent), but doing it here keeps the stub the owner of the clone
+		// location so any reflinker, including a test fake, writes to a real dir.
+		if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
+			_ = s.vm.Close()
+			s.vm = nil
+			return fmt.Errorf("husk: create per-activation rootfs dir: %w", err)
+		}
+		if err := s.reflink(s.rootfsTemplatePath, clonePath); err != nil {
+			_ = s.vm.Close()
+			s.vm = nil
+			return fmt.Errorf("husk: clone per-activation rootfs: %w", err)
+		}
+		s.rootfsClonePath = clonePath
 	}
 
 	s.state = StateDormant

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -54,15 +54,25 @@ func (s State) String() string {
 // real Firecracker process or KVM.
 type vmm interface {
 	// LoadSnapshotWithOverrides loads the snapshot mem+vmstate files and (when
-	// resume is true) resumes the VM, remapping NICs per overrides.
+	// resume is true) resumes the VM, remapping NICs per overrides. The husk
+	// activate path loads with resume=false so it can rebind the rootfs drive
+	// (PatchDrive) while the VM is PAUSED, before the guest can write anything,
+	// then resumes explicitly via Resume.
 	LoadSnapshotWithOverrides(mem, snapshot string, resume bool, overrides []firecracker.NetworkOverride) error
 	// VsockHostPath resolves a relative vsock uds_path to its host location.
 	VsockHostPath(rel string) string
 	// PatchDrive rebinds an existing baked drive (by drive id) to a host backing
-	// file via PATCH /drives, after the snapshot is loaded and resumed. The husk
-	// activate path uses it to point the rootfs drive at this activation's CoW
+	// file via PATCH /drives, on the loaded-but-PAUSED restored VM (before Resume)
+	// so the guest never touches the shared template backing. Firecracker's runtime
+	// API controller accepts a drive path_on_host PATCH in the Paused state with no
+	// root-device restriction (verified against the pinned v1.15 rpc_interface). The
+	// husk activate path uses it to point the rootfs drive at this activation's CoW
 	// clone, the same rebind the fork engine applies to volume drives.
 	PatchDrive(driveID, pathOnHost string) error
+	// Resume transitions the loaded VM from Paused to Running (PATCH /vm Resumed).
+	// The husk activate path calls it AFTER the rootfs drive rebind so the guest
+	// resumes already bound to its own per-activation rootfs clone.
+	Resume() error
 	// Close tears the VMM down.
 	Close() error
 }
@@ -450,27 +460,43 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 		}
 	}
 
-	if err := s.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, true, req.NetworkOverrides); err != nil {
+	// Load the snapshot PAUSED (resume=false). The rootfs drive rebind below MUST
+	// happen before the guest runs, and PATCH /drives on the ROOT device of an
+	// already-RESUMED VM both leaves a write window (any writeback between resume
+	// and the rebind hits the SHARED template rootfs) and may be rejected by
+	// Firecracker. Loading paused lets us rebind while the guest is frozen, then
+	// resume explicitly. nil overrides restores exactly as before.
+	if err := s.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, false, req.NetworkOverrides); err != nil {
 		// Fail closed: the snapshot did not load; the VM is not usable. Leave
 		// state dormant so a retry (or teardown) can decide what to do.
 		werr := fmt.Errorf("husk: load snapshot from %s: %w", req.SnapshotDir, err)
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
 
-	// Rebind the baked "rootfs" drive to THIS activation's CoW clone now that the
-	// snapshot is loaded and resumed, before the guest writes anything. This is the
-	// husk analog of the fork engine's per-fork volume drive rebind: the snapshot
-	// bakes the rootfs block device at path_on_host, and Firecracker supports
-	// updating a drive's path_on_host on a restored+resumed VM (PATCH /drives).
+	// Rebind the baked "rootfs" drive to THIS activation's CoW clone while the VM
+	// is still PAUSED (loaded, not yet resumed), so the guest never writes a single
+	// block through the shared template rootfs. This is the husk analog of the fork
+	// engine's per-fork volume drive rebind: the snapshot bakes the rootfs block
+	// device at path_on_host, and Firecracker's runtime API controller accepts a
+	// drive path_on_host PATCH in the Paused state with no root-device restriction.
 	// Skipped when no per-activation clone was prepared (the prior shared-rootfs
 	// behavior). Fail closed: a rebind failure means the VM is still pointed at the
 	// shared template rootfs, which is exactly the corruption hazard this prevents,
-	// so do NOT mark active. The drive id and path carry no secrets.
+	// so do NOT resume or mark active. The drive id and path carry no secrets.
 	if s.rootfsClonePath != "" {
 		if err := s.vm.PatchDrive("rootfs", s.rootfsClonePath); err != nil {
 			werr := fmt.Errorf("husk: rebind rootfs drive to per-activation clone: %w", err)
 			return ActivateResult{OK: false, Error: werr.Error()}, werr
 		}
+	}
+
+	// Resume the VM only AFTER the rootfs drive is rebound, so the guest comes up
+	// already bound to its own per-activation rootfs clone, never the shared
+	// template. Fail closed: if the resume is rejected the VM never runs, so do NOT
+	// mark active.
+	if err := s.vm.Resume(); err != nil {
+		werr := fmt.Errorf("husk: resume VM after rootfs rebind: %w", err)
+		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
 
 	vsockPath := s.vm.VsockHostPath(firecracker.VsockRelPath)

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -657,6 +657,94 @@ func TestPrepareCloneFailureFailsClosed(t *testing.T) {
 	}
 }
 
+func TestActivateRebindsRootfsDriveToClone(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+	vm := &fakeVMM{}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return vm, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       cowDir,
+		Reflink:            func(src, dst string) error { return os.WriteFile(dst, []byte("c"), 0o644) },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: filepath.Join(dir, "snap")})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("activate not OK: %s", res.Error)
+	}
+	if len(vm.patchCalls) != 1 {
+		t.Fatalf("expected exactly 1 PatchDrive call, got %d: %v", len(vm.patchCalls), vm.patchCalls)
+	}
+	if vm.patchCalls[0].driveID != "rootfs" {
+		t.Errorf("rebind drive id = %q, want \"rootfs\"", vm.patchCalls[0].driveID)
+	}
+	wantPath := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
+	if vm.patchCalls[0].path != wantPath {
+		t.Errorf("rebind path = %q, want clone %q", vm.patchCalls[0].path, wantPath)
+	}
+}
+
+func TestActivateNoRebindWhenNoClone(t *testing.T) {
+	vm := &fakeVMM{}
+	s := newTestStub(t, vm, readyOK)
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap"})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("activate not OK: %s", res.Error)
+	}
+	if len(vm.patchCalls) != 0 {
+		t.Errorf("no rootfs clone configured, so no PatchDrive expected, got %v", vm.patchCalls)
+	}
+}
+
+func TestActivateRebindFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	vm := &fakeVMM{patchErr: errors.New("drive busy")}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return vm, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       filepath.Join(dir, "husk-rootfs"),
+		Reflink:            func(src, dst string) error { return os.WriteFile(dst, []byte("c"), 0o644) },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: filepath.Join(dir, "snap")})
+	if err == nil {
+		t.Fatal("expected activate to fail closed on rebind error")
+	}
+	if res.OK {
+		t.Fatal("fail closed: result must not be OK")
+	}
+	if s.State() == StateActive {
+		t.Errorf("state must not be active after a failed rebind, got %s", s.State())
+	}
+}
+
 // TestFakeVMMSatisfiesInterface fails to compile if the vmm interface gains a
 // method fakeVMM does not implement, keeping the fake in lockstep with the seam.
 func TestFakeVMMSatisfiesInterface(t *testing.T) {

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -573,6 +573,90 @@ func TestActivateNeverLogsEntropyOrSecrets(t *testing.T) {
 	}
 }
 
+func TestPrepareClonesRootfsWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "templates", "tmpl", "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(tmplRootfs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmplRootfs, []byte("ROOTFS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+
+	var gotSrc, gotDst string
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       cowDir,
+		Reflink: func(src, dst string) error {
+			gotSrc, gotDst = src, dst
+			return os.WriteFile(dst, []byte("CLONE"), 0o644)
+		},
+	})
+
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if gotSrc != tmplRootfs {
+		t.Errorf("reflink src = %q, want template rootfs %q", gotSrc, tmplRootfs)
+	}
+	wantDst := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
+	if gotDst != wantDst {
+		t.Errorf("reflink dst = %q, want per-activation path %q", gotDst, wantDst)
+	}
+	if _, err := os.Stat(wantDst); err != nil {
+		t.Errorf("clone not written: %v", err)
+	}
+}
+
+func TestPrepareSkipsCloneWhenUnconfigured(t *testing.T) {
+	called := false
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:   func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:   readyOK,
+		Notify:  (&fakeNotifier{}).notify,
+		Verify:  verifyOK,
+		Reflink: func(src, dst string) error { called = true; return nil },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if called {
+		t.Error("reflink must not run when RootfsTemplatePath/RootfsCoWDir are empty")
+	}
+}
+
+func TestPrepareCloneFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	vm := &fakeVMM{}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return vm, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       filepath.Join(dir, "husk-rootfs"),
+		Reflink:            func(src, dst string) error { return errors.New("no space") },
+	})
+	if err := s.Prepare(context.Background()); err == nil {
+		t.Fatal("expected Prepare to fail closed on clone error")
+	}
+	if s.State() == StateDormant {
+		t.Error("state must not be dormant after a failed clone")
+	}
+	if !vm.closed {
+		t.Error("the dormant VMM must be torn down when Prepare fails closed")
+	}
+}
+
 // TestFakeVMMSatisfiesInterface fails to compile if the vmm interface gains a
 // method fakeVMM does not implement, keeping the fake in lockstep with the seam.
 func TestFakeVMMSatisfiesInterface(t *testing.T) {

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -35,6 +35,13 @@ type fakeVMM struct {
 		path    string
 	}
 	patchErr error
+
+	resumeCalls int
+	resumeErr   error
+
+	// callOrder records the activate-time VMM call sequence ("load", "patch",
+	// "resume") so a test can assert load(resume=false) -> PatchDrive -> Resume.
+	callOrder []string
 }
 
 func (f *fakeVMM) LoadSnapshotWithOverrides(mem, snapshot string, resume bool, overrides []firecracker.NetworkOverride) error {
@@ -45,6 +52,7 @@ func (f *fakeVMM) LoadSnapshotWithOverrides(mem, snapshot string, resume bool, o
 	f.gotState = snapshot
 	f.gotResume = resume
 	f.gotOverr = overrides
+	f.callOrder = append(f.callOrder, "load")
 	return f.loadErr
 }
 
@@ -59,7 +67,16 @@ func (f *fakeVMM) PatchDrive(driveID, pathOnHost string) error {
 		driveID string
 		path    string
 	}{driveID, pathOnHost})
+	f.callOrder = append(f.callOrder, "patch")
 	return f.patchErr
+}
+
+func (f *fakeVMM) Resume() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resumeCalls++
+	f.callOrder = append(f.callOrder, "resume")
+	return f.resumeErr
 }
 
 func (f *fakeVMM) Close() error {
@@ -175,8 +192,13 @@ func TestPrepareThenActivateSucceeds(t *testing.T) {
 	if vm.gotState != "/data/templates/tmpl/snapshot/vmstate" {
 		t.Errorf("vmstate path = %q", vm.gotState)
 	}
-	if !vm.gotResume {
-		t.Error("expected resume=true")
+	// The husk path loads PAUSED (resume=false) and resumes explicitly AFTER the
+	// rootfs rebind, so the guest never writes through the shared template.
+	if vm.gotResume {
+		t.Error("expected snapshot load with resume=false (rebind happens while paused)")
+	}
+	if vm.resumeCalls != 1 {
+		t.Errorf("expected exactly 1 explicit Resume call, got %d", vm.resumeCalls)
 	}
 	if len(vm.gotOverr) != 1 || vm.gotOverr[0].HostDevName != "tap-1" {
 		t.Errorf("overrides not threaded through: %+v", vm.gotOverr)
@@ -613,6 +635,52 @@ func TestPrepareClonesRootfsWhenConfigured(t *testing.T) {
 	}
 }
 
+// TestPrepareClonePathScopedToVMID proves the per-activation rootfs clone path
+// is scoped to the (per-pod) VM id: two stubs with DISTINCT ids clone to
+// DISTINCT files under the same CoW dir. This is the cross-pod-corruption fix:
+// the controller passes the pod name as the VM id, so two husk pods sharing the
+// node CoW hostPath never overwrite or delete each other's live rootfs.
+func TestPrepareClonePathScopedToVMID(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("ROOTFS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+
+	clonePathFor := func(vmID string) string {
+		var gotDst string
+		s := New(firecracker.VMConfig{ID: vmID}, Options{
+			Start:              func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+			Ready:              readyOK,
+			Notify:             (&fakeNotifier{}).notify,
+			Verify:             verifyOK,
+			RootfsTemplatePath: tmplRootfs,
+			RootfsCoWDir:       cowDir,
+			Reflink: func(src, dst string) error {
+				gotDst = dst
+				return os.WriteFile(dst, []byte("CLONE"), 0o644)
+			},
+		})
+		if err := s.Prepare(context.Background()); err != nil {
+			t.Fatalf("Prepare(%s): %v", vmID, err)
+		}
+		return gotDst
+	}
+
+	a := clonePathFor("pool-husk-aaaaa")
+	b := clonePathFor("pool-husk-bbbbb")
+	if a == b {
+		t.Fatalf("distinct VM ids must yield distinct clone paths; both = %q", a)
+	}
+	if a != filepath.Join(cowDir, "pool-husk-aaaaa", "rootfs.ext4") {
+		t.Errorf("clone path for first id = %q", a)
+	}
+	if b != filepath.Join(cowDir, "pool-husk-bbbbb", "rootfs.ext4") {
+		t.Errorf("clone path for second id = %q", b)
+	}
+}
+
 func TestPrepareSkipsCloneWhenUnconfigured(t *testing.T) {
 	called := false
 	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
@@ -693,6 +761,47 @@ func TestActivateRebindsRootfsDriveToClone(t *testing.T) {
 	wantPath := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
 	if vm.patchCalls[0].path != wantPath {
 		t.Errorf("rebind path = %q, want clone %q", vm.patchCalls[0].path, wantPath)
+	}
+	// The rootfs rebind MUST happen on the paused VM (resume=false on load) and
+	// BEFORE the explicit Resume, so the guest never writes the shared template.
+	if vm.gotResume {
+		t.Error("snapshot must be loaded with resume=false so the rebind lands while paused")
+	}
+	vm.mu.Lock()
+	order := append([]string(nil), vm.callOrder...)
+	vm.mu.Unlock()
+	want := []string{"load", "patch", "resume"}
+	if len(order) != len(want) {
+		t.Fatalf("VMM call order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("VMM call order = %v, want %v", order, want)
+		}
+	}
+}
+
+// TestActivateResumeFailureFailsClosed proves a Resume rejection after the
+// rootfs rebind fails the activate closed: the VM is never marked active.
+func TestActivateResumeFailureFailsClosed(t *testing.T) {
+	vm := &fakeVMM{resumeErr: errors.New("resume rejected")}
+	s := newTestStub(t, vm, readyOK)
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap"})
+	if err == nil {
+		t.Fatal("expected activate to fail closed on resume error")
+	}
+	if res.OK {
+		t.Fatal("fail closed: result must not be OK when resume is rejected")
+	}
+	if s.State() == StateActive {
+		t.Errorf("state must not be active after a failed resume, got %s", s.State())
+	}
+	// The snapshot loaded (paused) before the resume failed.
+	if vm.loadCalls != 1 {
+		t.Errorf("expected the snapshot to load before resume, got %d loads", vm.loadCalls)
 	}
 }
 

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -751,6 +751,37 @@ func TestFakeVMMSatisfiesInterface(t *testing.T) {
 	var _ vmm = (*fakeVMM)(nil)
 }
 
+func TestCloseRemovesRootfsClone(t *testing.T) {
+	dir := t.TempDir()
+	tmplRootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(tmplRootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cowDir := filepath.Join(dir, "husk-rootfs")
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:              func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:              readyOK,
+		Notify:             (&fakeNotifier{}).notify,
+		Verify:             verifyOK,
+		RootfsTemplatePath: tmplRootfs,
+		RootfsCoWDir:       cowDir,
+		Reflink:            func(src, dst string) error { return os.WriteFile(dst, []byte("c"), 0o644) },
+	})
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	clonePath := filepath.Join(cowDir, "husk-test", "rootfs.ext4")
+	if _, err := os.Stat(clonePath); err != nil {
+		t.Fatalf("clone should exist after Prepare: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(clonePath); !os.IsNotExist(err) {
+		t.Errorf("clone should be removed after Close, stat err = %v", err)
+	}
+}
+
 func TestCloseTearsDownVMM(t *testing.T) {
 	vm := &fakeVMM{}
 	s := newTestStub(t, vm, readyOK)

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -29,6 +29,12 @@ type fakeVMM struct {
 	gotResume bool
 	gotOverr  []firecracker.NetworkOverride
 	closed    bool
+
+	patchCalls []struct {
+		driveID string
+		path    string
+	}
+	patchErr error
 }
 
 func (f *fakeVMM) LoadSnapshotWithOverrides(mem, snapshot string, resume bool, overrides []firecracker.NetworkOverride) error {
@@ -44,6 +50,16 @@ func (f *fakeVMM) LoadSnapshotWithOverrides(mem, snapshot string, resume bool, o
 
 func (f *fakeVMM) VsockHostPath(rel string) string {
 	return filepath.Join("/run/husk", rel)
+}
+
+func (f *fakeVMM) PatchDrive(driveID, pathOnHost string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.patchCalls = append(f.patchCalls, struct {
+		driveID string
+		path    string
+	}{driveID, pathOnHost})
+	return f.patchErr
 }
 
 func (f *fakeVMM) Close() error {
@@ -555,6 +571,12 @@ func TestActivateNeverLogsEntropyOrSecrets(t *testing.T) {
 			t.Fatalf("entropy bytes leaked to stderr (%d-byte form)", len(enc))
 		}
 	}
+}
+
+// TestFakeVMMSatisfiesInterface fails to compile if the vmm interface gains a
+// method fakeVMM does not implement, keeping the fake in lockstep with the seam.
+func TestFakeVMMSatisfiesInterface(t *testing.T) {
+	var _ vmm = (*fakeVMM)(nil)
 }
 
 func TestCloseTearsDownVMM(t *testing.T) {

--- a/internal/volume/backend.go
+++ b/internal/volume/backend.go
@@ -183,30 +183,37 @@ func (b *Backend) Fresh(spec Spec, sandboxID string) (Prepared, error) {
 	return Prepared{Name: spec.Name, HostPath: dst, MountPath: spec.MountPath, ReadOnly: spec.ReadOnly}, nil
 }
 
-// Snapshot reflink-copies sourcePath to a per-fork backing file. It first tries
-// cp --reflink=always for a true copy-on-write clone; on filesystems without
-// reflink support (anything but btrfs/xfs) that fails, so it falls back to
-// cp --reflink=auto, which performs a full copy. A successful fallback logs a
-// warning (CoW was unavailable for this filesystem); a hard failure returns an
-// error.
+// ReflinkCopy copies src to dst with copy-on-write semantics. It first tries
+// cp --reflink=always for a true FICLONE clone (instant, shared extents on
+// btrfs/xfs); on a filesystem without reflink support that fails, so it falls
+// back to cp --reflink=auto, which performs a full byte copy and logs a warning
+// (CoW was unavailable). The destination's parent directory is created if
+// absent. src and dst carry no secrets and are safe to log. This is the single
+// owner of the reflink policy: both per-fork volume Snapshot and the husk
+// per-activation rootfs clone go through it so they cannot drift.
+func (b *Backend) ReflinkCopy(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("reflink copy: mkdir: %w", err)
+	}
+	if err := b.runner([]string{"cp", "--reflink=always", src, dst}); err != nil {
+		fmt.Fprintf(os.Stderr, "volume: WARNING reflink CoW unavailable (filesystem lacks reflink support); falling back to a full copy of %s to %s\n", src, dst)
+		if err := b.runner([]string{"cp", "--reflink=auto", src, dst}); err != nil {
+			return fmt.Errorf("reflink copy %s to %s: %w", src, dst, err)
+		}
+	}
+	return nil
+}
+
+// Snapshot reflink-copies sourcePath to a per-fork backing file via ReflinkCopy,
+// which tries cp --reflink=always for a true copy-on-write clone and falls back
+// to cp --reflink=auto (a full copy) on filesystems without reflink support.
 func (b *Backend) Snapshot(spec Spec, sandboxID, sourcePath string) (Prepared, error) {
 	if err := validateName(spec.Name); err != nil {
 		return Prepared{}, err
 	}
 	dst := b.volumePath(sandboxID, spec.Name)
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return Prepared{}, fmt.Errorf("volume %s: mkdir: %w", spec.Name, err)
-	}
-	err := b.runner([]string{"cp", "--reflink=always", sourcePath, dst})
-	if err != nil {
-		// Reflink unavailable on this filesystem; fall back to a full copy.
-		// Warn so an operator knows this fork did NOT get instant copy-on-write
-		// (the destination is a full byte copy, costing time and space). The
-		// paths carry no secrets and are safe to log.
-		fmt.Fprintf(os.Stderr, "volume: WARNING reflink CoW unavailable for %s (filesystem lacks reflink support); falling back to a full copy of %s to %s\n", spec.Name, sourcePath, dst)
-		if err := b.runner([]string{"cp", "--reflink=auto", sourcePath, dst}); err != nil {
-			return Prepared{}, fmt.Errorf("volume %s: snapshot copy: %w", spec.Name, err)
-		}
+	if err := b.ReflinkCopy(sourcePath, dst); err != nil {
+		return Prepared{}, fmt.Errorf("volume %s: %w", spec.Name, err)
 	}
 	return Prepared{Name: spec.Name, HostPath: dst, MountPath: spec.MountPath, ReadOnly: spec.ReadOnly}, nil
 }

--- a/internal/volume/backend_test.go
+++ b/internal/volume/backend_test.go
@@ -134,6 +134,43 @@ func TestSnapshotFallsBackToReflinkAuto(t *testing.T) {
 	}
 }
 
+func TestReflinkCopyTriesAlwaysThenAuto(t *testing.T) {
+	b, rr := newTestBackend(t)
+	rr.failOn = func(argv []string) bool {
+		return strings.Contains(strings.Join(argv, " "), "--reflink=always")
+	}
+	src := filepath.Join(t.TempDir(), "src.ext4")
+	dst := filepath.Join(t.TempDir(), "dst.ext4")
+
+	if err := b.ReflinkCopy(src, dst); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+	if len(rr.calls) != 2 {
+		t.Fatalf("expected 2 cp calls (always then auto), got %d: %v", len(rr.calls), rr.calls)
+	}
+	if !strings.Contains(strings.Join(rr.calls[0], " "), "--reflink=always") {
+		t.Errorf("first cp should try --reflink=always: %v", rr.calls[0])
+	}
+	if !strings.Contains(strings.Join(rr.calls[1], " "), "--reflink=auto") {
+		t.Errorf("fallback should use --reflink=auto: %v", rr.calls[1])
+	}
+	if rr.calls[1][len(rr.calls[1])-2] != src || rr.calls[1][len(rr.calls[1])-1] != dst {
+		t.Errorf("cp src/dst = %q %q, want %q %q", rr.calls[1][len(rr.calls[1])-2], rr.calls[1][len(rr.calls[1])-1], src, dst)
+	}
+}
+
+func TestReflinkCopyMakesDestDir(t *testing.T) {
+	b, _ := newTestBackend(t)
+	src := filepath.Join(t.TempDir(), "src.ext4")
+	dst := filepath.Join(t.TempDir(), "nested", "dst.ext4")
+	if err := b.ReflinkCopy(src, dst); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(dst)); err != nil {
+		t.Errorf("dest parent dir not created: %v", err)
+	}
+}
+
 func TestShareReturnsSourceReadOnlyNoCopy(t *testing.T) {
 	b, rr := newTestBackend(t)
 	src := "/srv/images/base.ext4"

--- a/internal/volume/reflink_cow_test.go
+++ b/internal/volume/reflink_cow_test.go
@@ -1,0 +1,40 @@
+//go:build reflink_integration
+
+package volume
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReflinkCopyRealFilesystem exercises ReflinkCopy against a real cp on the
+// host filesystem: the destination must be a byte-identical copy of the source.
+// It runs ONLY under the reflink_integration build tag (KVM CI / bare-metal),
+// because cp --reflink does not exist on darwin and the destination filesystem
+// must support FICLONE (XFS/Btrfs) for the fast path; the production
+// ReflinkCopy falls back to a full copy when reflink is unavailable, so the
+// byte-equality assertion holds either way.
+func TestReflinkCopyRealFilesystem(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.ext4")
+	dst := filepath.Join(dir, "sub", "dst.ext4")
+	want := bytes.Repeat([]byte("PAPERCLIP"), 4096) // ~36 KiB of recognizable bytes
+	if err := os.WriteFile(src, want, 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	b := New(dir) // production runner (real cp)
+	if err := b.ReflinkCopy(src, dst); err != nil {
+		t.Fatalf("ReflinkCopy: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("clone is not byte-identical to source: got %d bytes, want %d", len(got), len(want))
+	}
+}


### PR DESCRIPTION
## Summary

Tier-1 production-readiness, the last of five plans (docs/superpowers/plans/2026-06-13-per-activation-rootfs-cow.md). Before this, a husk pod activated against the SHARED template rootfs.ext4, so concurrent tenants activating one template would corrupt + leak across a single rootfs. Now each activation gets its OWN copy-on-write rootfs.

- Extract the reflink CoW policy into `volume.Backend.ReflinkCopy` (FICLONE fast path + full-copy fallback), reused by the Snapshot volume policy and the husk path.
- `Stub.Prepare` reflink-clones the template rootfs to a PER-POD file `<dataDir>/husk-rootfs/<pod-name>/rootfs.ext4` (path scoped to the per-pod VM id via the downward API `metadata.name`, so pods sharing the node CoW hostPath never collide), off the activate hot path.
- `Stub.Activate` loads the snapshot PAUSED (`resume=false`), rebinds the baked rootfs drive to the clone via `PatchDrive` while the guest is frozen, then resumes. The guest writes only its clone, never the template.
- `Stub.Close` removes the per-pod clone (no accumulation).

## Review + verification rigor
An independent security review caught three real isolation defects, all fixed: the clone path used a constant VM id (`"husk"`) so pods collided on one node (now per-pod via `$(POD_NAME)`); the rebind ran AFTER resume (now load-paused -> PatchDrive -> resume, with the Firecracker v1.15 source confirming PATCH /drives is allowed on a paused loaded VM); and the threat-model overstated the isolation. Then real-KVM verification on the live cluster caught a fourth: with the template mounted read-only the load fails EROFS (Firecracker opens the baked rootfs O_RDWR), so the template stays writable and isolation comes from rebind-before-resume.

Verified e2e on the live Talos cluster: two dormant pods with DISTINCT per-pod reflink clones on xfs, the template untouched, and a claim Ready in ~400 ms with the load-paused -> PatchDrive(rootfs) -> Resume sequence in the stub log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)