### PR TITLE
Production blocker #4: saturation + node-loss hardening (count-aware scheduling, husk node-loss, node liveness)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -289,6 +289,9 @@ func main() {
 	if err := mgr.Add(&controller.GarbageCollector{
 		Client:   mgr.GetClient(),
 		Registry: nodeRegistry,
+		// In husk mode node-loss recovery is owned by the husk re-pend path; the
+		// GC must not terminally-fail a recoverable husk-backed claim.
+		EnableHuskPods: enableHuskPods,
 	}); err != nil {
 		logger.Error(err, "unable to add garbage collector")
 		os.Exit(1)

--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -100,17 +100,46 @@ bootstrap window where state is lost.
   fresh `GarbageCollector` with no prior state against live forkd VMs
   (`TestGCSweepsOrphanVMs`, `TestGCLiveClaimByNameNotSwept`).
 
-### NodeLost: a claim on a lost node reaches a terminal phase
+### Node health: liveness, not just last-seen
 
-A Ready claim whose node is no longer a healthy registered node is transitioned
-to the terminal `Failed` phase with a `NodeLost` reason and `FinishedAt` stamped.
-The node is gone, so there is nothing to terminate; the GC only stamps state. The
-orphan sweep and NodeLost never fight: the sweep visits only healthy nodes, so a
-claim on a lost node is never swept. A claim on a still-healthy node is untouched.
+A node is schedulable only while it is healthy. Health requires BOTH a recent
+heartbeat (the 2-minute last-seen TTL on `LastHeartbeat`) AND a live forkd: a
+node whose forkd liveness probe (the discovery `GetCapacity` call, every 15s)
+fails `probeFailureThreshold` (3) times in a row is marked unhealthy and dropped
+from `SelectNode`, even with a fresh heartbeat. This closes the gap where a pod
+stays `Running` while forkd is hung or the host is dead: previously such a node
+stayed healthy and schedulable for the full 2-minute TTL on stale capacity. The
+threshold absorbs a transient single-probe blip (no flapping); at the 15s
+interval, 3 failures is roughly 45s before the node leaves the schedulable set,
+well inside the heartbeat TTL.
 
-- Bound: within one `Interval` of the node going unhealthy or leaving the
-  registry.
-- Proving tests: `TestGCMarksNodeLost`, `TestGCLeavesHealthyNodeClaim`.
+- Bound: roughly `probeFailureThreshold * discovery interval` (about 45s) before
+  a hung forkd's node is dropped from scheduling.
+- Proving tests: `TestNodeUnhealthyAfterProbeFailureThreshold`,
+  `TestSyncPodsDropsNodeOnRepeatedProbeFailure`.
+
+### NodeLost: a raw-forkd claim on a lost node reaches a terminal phase
+
+In RAW-FORKD mode, a Ready claim whose node is no longer a healthy registered
+node is transitioned to the terminal `Failed` phase with a `NodeLost` reason and
+`FinishedAt` stamped. The node is gone, so there is nothing to terminate; the GC
+only stamps state. The ephemeral VM died with the node and there is no recovery,
+so failing the claim (and letting the TTL pass reap it) is correct. The orphan
+sweep and NodeLost never fight: the sweep visits only healthy nodes, so a claim
+on a lost node is never swept. A claim on a still-healthy node is untouched.
+
+In HUSK mode, `markNodeLost` is a no-op: a Ready husk-backed claim recovers from
+node loss by RE-PENDING onto a replacement dormant slot (owned by
+`checkHuskPodLost` and the husk pod watch, which the warm pool self-heals). The
+GC must not race that re-pend into a terminal `Failed`, so it skips the
+node-lost-fail entirely in husk mode. The GC carries `EnableHuskPods` from the
+controller run mode to make this decision.
+
+- Bound: raw mode fails within one `Interval` of the node going unhealthy or
+  leaving the registry; husk mode re-pends on the pod event (or the claim's own
+  requeue).
+- Proving tests: `TestGCMarksNodeLost`, `TestGCLeavesHealthyNodeClaim`,
+  `TestGCInHuskModeDoesNotFailNodeLostClaim`.
 
 ### TTL hygiene: finished objects are deleted, including early-failed claims
 

--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -138,6 +138,14 @@ controller run mode to make this decision.
 - Bound: raw mode fails within one `Interval` of the node going unhealthy or
   leaving the registry; husk mode re-pends on the pod event (or the claim's own
   requeue).
+- Husk hard-node-loss latency is cluster-dependent, not a mitos GC interval. Husk
+  node-loss recovery fires immediately on a pod delete or `DeletionTimestamp`
+  event. But a HARD host loss where the pod object lingers `Running` with no
+  `DeletionTimestamp` is bounded by the cluster's own unreachable-pod eviction
+  setting (the `node.kubernetes.io/unreachable` taint toleration, k8s default
+  about 5 minutes), since no pod event fires until the cluster evicts the pod.
+  Operators wanting faster husk node-loss recovery should tune the unreachable
+  toleration or the pod-eviction timeout; mitos cannot shorten it.
 - Proving tests: `TestGCMarksNodeLost`, `TestGCLeavesHealthyNodeClaim`,
   `TestGCInHuskModeDoesNotFailNodeLostClaim`.
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -56,11 +56,24 @@ depends on whether the node is already warm for `T`:
 Both estimates come from the node's own per-template capacity record when it has
 one, then from any node that has forked `T`, then from a configured default
 (256 MiB shared, 8 MiB unique) so an unknown template is never treated as free.
-A node admits a fork only when its projected cost fits its remaining budget:
+A node admits a fork only when it is below its sandbox-count ceiling AND its
+projected cost fits its remaining budget:
 
 ```
-projectedCost(node, T) <= budget(node) - MemoryUsed(node)
+ActiveSandboxes(node) < MaxSandboxes(node)   # count ceiling (MaxSandboxes 0 = unlimited)
+projectedCost(node, T) <= budget(node) - MemoryUsed(node)   # memory headroom
 ```
+
+### Sandbox-count ceiling
+
+forkd enforces a per-node `MaxSandboxes` cap (the host-DoS ceiling, PR #110):
+`engine.Fork` past it returns gRPC `ResourceExhausted`. Both `ActiveSandboxes`
+and `MaxSandboxes` arrive on the capacity heartbeat, so the scheduler also
+enforces the cap at SCHEDULE time: a node where `MaxSandboxes > 0` and
+`ActiveSandboxes >= MaxSandboxes` does not admit, so a full node is not selected
+and the node-side `ResourceExhausted` reject becomes a rare race (the window
+between `SelectNode` and the `Fork` RPC) rather than the primary path to the cap.
+`MaxSandboxes` 0 (unset, e.g. the mock engine) imposes no count ceiling.
 
 ## The bin-packing policy
 
@@ -122,6 +135,15 @@ The claim reconciler then:
 A claim that becomes admittable before the deadline (a node frees memory or a
 new node joins) proceeds to `Restoring` as usual, and the pending stamp is
 cleared so a later shortage starts a fresh clock.
+
+The same `NoCapacity` machinery also catches the schedule-time race on the
+RAW-FORKD path: when `SelectNode` picks a node but the `Fork` RPC is rejected
+with `ResourceExhausted` (the node filled to its `MaxSandboxes` cap in the
+window after selection) or `Unavailable` (the node went away mid-fork), the
+claim RE-PENDS through `reconcileNoCapacity` instead of failing terminally, so
+it retries on a node with headroom and only fails after the bounded wait. A
+`NotFound` keeps its own snapshot-not-yet-on-node retry; any other forkd error
+still fails the claim. (The husk path does not use the `Fork` RPC.)
 
 A claim that stays capacity-pending longer than `--max-pending-duration`
 (default 5m) FAILS cleanly: `Phase = Failed`, a `Ready=False` condition with

--- a/internal/controller/capacity_admission_envtest_test.go
+++ b/internal/controller/capacity_admission_envtest_test.go
@@ -7,6 +7,9 @@ import (
 
 	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
 	"github.com/paperclipinc/mitos/internal/controller"
+	"github.com/paperclipinc/mitos/internal/fork"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -174,6 +177,73 @@ func TestClaimFailsAfterBoundedPendingWait(t *testing.T) {
 	}
 	if got := counterValue(t, "mitos_claim_errors_total", map[string]string{"pool": "cap2-pool", "reason": "capacity"}); got <= errBefore {
 		t.Fatalf("claim_errors_total{pool=cap2-pool,reason=capacity} = %v, want > %v", got, errBefore)
+	}
+}
+
+// TestClaimRePendsOnForkdResourceExhausted drives the schedule-time race: the
+// node admits the fork (ample memory headroom) and SelectNode picks it, but the
+// forkd Fork RPC rejects with ResourceExhausted (the node filled to its
+// MaxSandboxes between selection and the RPC, PR #110). The claim must RE-PEND
+// with a NoCapacity condition (bounded retry), NOT fail terminally: another
+// node, or this one once it drains, can still take the fork.
+func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
+	stop, engine, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "cap-node-3", "cap3-tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+
+	// The node has memory headroom so admits() selects it; the forkd Fork RPC is
+	// what rejects, exactly the race the schedule-time count check cannot close.
+	testRegistry.SetNodeMemory("cap-node-3", 16*gib, 0)
+	engine.ForkErr = fork.ErrAtCapacity // -> gRPC ResourceExhausted
+
+	makeCapacityFixture(t, "cap3")
+
+	pending := waitForPhase(t, "cap3", v1alpha1.SandboxPending, 15*time.Second)
+	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
+	if cond == nil || cond.Reason != "NoCapacity" {
+		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatalf("NoCapacity Ready condition status = %q, want False", cond.Status)
+	}
+	if pending.Status.Phase == v1alpha1.SandboxFailed {
+		t.Fatal("claim must NOT be Failed on a forkd ResourceExhausted reject")
+	}
+
+	// Clearing the reject lets a later reconcile place the claim and go Ready,
+	// proving the re-pend was recoverable (not a dead end).
+	engine.ForkErr = nil
+	ready := waitForPhase(t, "cap3", v1alpha1.SandboxReady, 15*time.Second)
+	if ready.Status.Node != "cap-node-3" {
+		t.Fatalf("ready node = %q, want cap-node-3", ready.Status.Node)
+	}
+}
+
+// TestClaimRePendsOnForkdUnavailable drives the node-died-mid-fork race: the
+// forkd Fork RPC fails with Unavailable (the node went away between selection
+// and the RPC). Like ResourceExhausted, the claim must RE-PEND (NoCapacity), not
+// fail terminally, so it retries on a healthy node.
+func TestClaimRePendsOnForkdUnavailable(t *testing.T) {
+	stop, engine, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "cap-node-4", "cap4-tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+
+	testRegistry.SetNodeMemory("cap-node-4", 16*gib, 0)
+	engine.ForkErr = status.Error(codes.Unavailable, "node draining")
+
+	makeCapacityFixture(t, "cap4")
+
+	pending := waitForPhase(t, "cap4", v1alpha1.SandboxPending, 15*time.Second)
+	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
+	if cond == nil || cond.Reason != "NoCapacity" {
+		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)
+	}
+	if pending.Status.Phase == v1alpha1.SandboxFailed {
+		t.Fatal("claim must NOT be Failed on a forkd Unavailable reject")
 	}
 }
 

--- a/internal/controller/capacity_admission_envtest_test.go
+++ b/internal/controller/capacity_admission_envtest_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -211,6 +212,14 @@ func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
 	if pending.Status.Phase == v1alpha1.SandboxFailed {
 		t.Fatal("claim must NOT be Failed on a forkd ResourceExhausted reject")
 	}
+	// The message must reflect the count-ceiling cause, NOT the memory-overcommit
+	// cause (issue #28: accurate, actionable remediation per cause).
+	if strings.Contains(cond.Message, "memory capacity") {
+		t.Fatalf("count-ceiling re-pend message must not claim memory capacity: %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "sandbox-count") {
+		t.Fatalf("count-ceiling re-pend message must name the per-node sandbox-count limit: %q", cond.Message)
+	}
 
 	// Clearing the reject lets a later reconcile place the claim and go Ready,
 	// proving the re-pend was recoverable (not a dead end).
@@ -244,6 +253,14 @@ func TestClaimRePendsOnForkdUnavailable(t *testing.T) {
 	}
 	if pending.Status.Phase == v1alpha1.SandboxFailed {
 		t.Fatal("claim must NOT be Failed on a forkd Unavailable reject")
+	}
+	// The message must reflect the node-unreachable cause, NOT the
+	// memory-overcommit cause (issue #28).
+	if strings.Contains(cond.Message, "memory capacity") {
+		t.Fatalf("node-unreachable re-pend message must not claim memory capacity: %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "unreachable") {
+		t.Fatalf("node-unreachable re-pend message must name the unreachable node: %q", cond.Message)
 	}
 }
 

--- a/internal/controller/forkd_client.go
+++ b/internal/controller/forkd_client.go
@@ -16,8 +16,24 @@ import (
 
 // isNotFound reports whether err (possibly wrapped) carries gRPC NotFound.
 func isNotFound(err error) bool {
+	return hasGRPCCode(err, codes.NotFound)
+}
+
+// isRetryableCapacity reports whether err (possibly wrapped) carries a forkd
+// Fork rejection that should re-pend the claim rather than fail it terminally:
+// ResourceExhausted (the node hit its MaxSandboxes count cap, PR #110, a
+// schedule-time race) or Unavailable (the node went away mid-fork). Both are
+// transient from the claim's view: another node, or this one once it drains,
+// can take the fork, so the claim routes to the bounded NoCapacity re-pend.
+func isRetryableCapacity(err error) bool {
+	return hasGRPCCode(err, codes.ResourceExhausted) || hasGRPCCode(err, codes.Unavailable)
+}
+
+// hasGRPCCode reports whether err (possibly wrapped) carries the given gRPC
+// status code anywhere in its unwrap chain.
+func hasGRPCCode(err error, code codes.Code) bool {
 	for e := err; e != nil; e = errors.Unwrap(e) {
-		if s, ok := status.FromError(e); ok && s.Code() == codes.NotFound {
+		if s, ok := status.FromError(e); ok && s.Code() == code {
 			return true
 		}
 	}

--- a/internal/controller/forkd_client_test.go
+++ b/internal/controller/forkd_client_test.go
@@ -181,6 +181,26 @@ func TestIsNotFound(t *testing.T) {
 	}
 }
 
+func TestIsRetryableCapacity(t *testing.T) {
+	for _, code := range []codes.Code{codes.ResourceExhausted, codes.Unavailable} {
+		wrapped := fmt.Errorf("forkd fork on n1: %w", status.Error(code, "boom"))
+		if !isRetryableCapacity(wrapped) {
+			t.Fatalf("wrapped %s should be retryable-capacity", code)
+		}
+	}
+	// NotFound is the snapshot-not-yet-on-node path, handled separately.
+	if isRetryableCapacity(fmt.Errorf("wrap: %w", status.Error(codes.NotFound, "missing"))) {
+		t.Fatal("NotFound is not a retryable-capacity error")
+	}
+	// A hard internal error must still fail the claim.
+	if isRetryableCapacity(fmt.Errorf("wrap: %w", status.Error(codes.Internal, "boom"))) {
+		t.Fatal("Internal is not a retryable-capacity error")
+	}
+	if isRetryableCapacity(fmt.Errorf("plain error")) {
+		t.Fatal("plain error is not a retryable-capacity error")
+	}
+}
+
 func TestPoolSnapshotAccounting(t *testing.T) {
 	addrWith, _ := startFakeForkd(t, "py-tmpl")
 	addrWithout, engineWithout := startFakeForkd(t)

--- a/internal/controller/forkd_discovery.go
+++ b/internal/controller/forkd_discovery.go
@@ -82,6 +82,7 @@ func (d *ForkdDiscovery) sync(ctx context.Context) {
 
 // syncPods registers every running forkd pod and refreshes its capacity.
 func (d *ForkdDiscovery) syncPods(ctx context.Context, pods []corev1.Pod) {
+	logger := log.FromContext(ctx).WithName("forkd-discovery")
 	for _, pod := range pods {
 		info, ok := NodeInfoFromPod(pod, d.GRPCPort, d.HTTPPort, d.CASPort)
 		if !ok {
@@ -91,7 +92,17 @@ func (d *ForkdDiscovery) syncPods(ctx context.Context, pods []corev1.Pod) {
 		// Populate capacity before the registry ever sees the struct;
 		// registered NodeInfo fields are read under the registry's RLock and
 		// must never be mutated afterwards outside it.
-		d.refreshCapacity(ctx, info)
+		probeOK := d.refreshCapacity(ctx, info)
+		// Tie health to the LIVENESS probe: a failed GetCapacity (forkd hung or
+		// host dead while the pod is still Running) increments the consecutive
+		// failure count carried across re-registers; a success resets it. A node
+		// past the threshold is dropped from scheduling by isHealthy.
+		if probeOK {
+			info.probeFailures = 0
+		} else {
+			info.probeFailures = d.Registry.priorProbeFailures(info.Name) + 1
+			logger.Info("forkd liveness probe failed", "node", info.Name, "consecutiveFailures", info.probeFailures, "threshold", probeFailureThreshold)
+		}
 		d.Registry.Register(info)
 	}
 }
@@ -99,22 +110,24 @@ func (d *ForkdDiscovery) syncPods(ctx context.Context, pods []corev1.Pod) {
 // refreshCapacity fills template/capacity fields via forkd's GetCapacity,
 // dialing the node directly (the node is not registered yet; the registry
 // must only ever see fully-populated NodeInfo structs; see AddTemplate's
-// locking contract).
-func (d *ForkdDiscovery) refreshCapacity(ctx context.Context, info *NodeInfo) {
+// locking contract). It returns whether the probe SUCCEEDED: a failed probe is
+// the liveness signal the caller uses to mark a node unhealthy, so a hung forkd
+// (pod still Running) is not registered as schedulable on stale capacity.
+func (d *ForkdDiscovery) refreshCapacity(ctx context.Context, info *NodeInfo) bool {
 	creds := insecure.NewCredentials()
 	if d.TLS != nil {
 		creds = credentials.NewTLS(d.TLS)
 	}
 	conn, err := grpc.NewClient(info.Endpoint, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		return
+		return false
 	}
 	defer conn.Close()
 	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	resp, err := forkdpb.NewForkDaemonClient(conn).GetCapacity(cctx, &forkdpb.GetCapacityRequest{})
 	if err != nil {
-		return
+		return false
 	}
 	info.ActiveSandboxes = resp.ActiveSandboxes
 	info.MaxSandboxes = resp.MaxSandboxes
@@ -136,6 +149,7 @@ func (d *ForkdDiscovery) refreshCapacity(ctx context.Context, info *NodeInfo) {
 		}
 		info.TemplateEstimates = estimates
 	}
+	return true
 }
 
 // NodeInfoFromPod maps a forkd pod to a NodeInfo. Returns false when the pod

--- a/internal/controller/forkd_discovery_test.go
+++ b/internal/controller/forkd_discovery_test.go
@@ -98,3 +98,46 @@ func TestSyncPodsRegistersAndRefreshesCapacity(t *testing.T) {
 		t.Fatal("maxSandboxes not refreshed from GetCapacity")
 	}
 }
+
+// TestSyncPodsDropsNodeOnRepeatedProbeFailure drives the liveness signal: a pod
+// is Running (so NodeInfoFromPod registers it) but its forkd GetCapacity probe
+// always fails (the endpoint is dead, simulating a hung forkd or a dead host
+// whose pod is still Running). After probeFailureThreshold consecutive failures
+// the node is unhealthy and excluded from SelectNode; a single failure does not
+// flap it out.
+func TestSyncPodsDropsNodeOnRepeatedProbeFailure(t *testing.T) {
+	registry := NewNodeRegistry()
+	// Point the derived Endpoint at a closed port so every GetCapacity dial/RPC
+	// fails. Use a short bounded timeout via the discovery's own 5s call timeout.
+	d := &ForkdDiscovery{
+		Registry: registry,
+		GRPCPort: 1, // 127.0.0.1:1 refuses connections
+		HTTPPort: 2,
+	}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "forkd-dead",
+			Labels: map[string]string{"app.kubernetes.io/component": "forkd"},
+		},
+		Spec:   corev1.PodSpec{NodeName: "dead-worker"},
+		Status: corev1.PodStatus{PodIP: "127.0.0.1", Phase: corev1.PodRunning},
+	}
+
+	// First sync: one probe failure. Below the threshold, the node is still
+	// healthy (a single blip must not flap it out).
+	d.syncPods(context.Background(), []corev1.Pod{pod})
+	if !registry.NodeHealthy("dead-worker") {
+		t.Fatal("a single probe failure must not mark the node unhealthy")
+	}
+
+	// Keep syncing until the consecutive-failure count crosses the threshold.
+	for i := 1; i < probeFailureThreshold; i++ {
+		d.syncPods(context.Background(), []corev1.Pod{pod})
+	}
+	if registry.NodeHealthy("dead-worker") {
+		t.Fatalf("after %d consecutive probe failures the node must be unhealthy", probeFailureThreshold)
+	}
+	if _, err := registry.SelectNode("", ""); err == nil {
+		t.Fatal("SelectNode must not place onto a node failing its liveness probe")
+	}
+}

--- a/internal/controller/gc.go
+++ b/internal/controller/gc.go
@@ -31,6 +31,15 @@ type GarbageCollector struct {
 	// DefaultTTLSeconds is the TTL applied to a finished claim that does not set
 	// spec.ttlSecondsAfterFinished. Default 600s.
 	DefaultTTLSeconds int32
+	// EnableHuskPods mirrors the controller run mode. In husk mode a Ready claim
+	// is backed by a husk pod, and node-loss recovery is owned by
+	// checkHuskPodLost + the husk pod watch, which RE-PEND the claim onto a
+	// replacement dormant slot (the warm pool self-heals). The GC must NOT
+	// terminally-fail such a claim: a GC pass winning the race against the
+	// re-pend would defeat the husk self-heal. When set, markNodeLost is a no-op.
+	// In raw-forkd mode (false) a lost node means the ephemeral VM is gone with
+	// no recovery, so the claim is correctly failed (and the GC TTL reaps it).
+	EnableHuskPods bool
 }
 
 func (g *GarbageCollector) Start(ctx context.Context) error {
@@ -203,7 +212,15 @@ func (g *GarbageCollector) sweepOrphans(ctx context.Context, logger logr.Logger,
 // claim is, for every consumer, just a failed claim with a specific reason.
 // The node is gone, so there is nothing to terminate; we only stamp state,
 // bounded by the GC interval.
+//
+// In husk mode this is a no-op: a Ready husk-backed claim recovers from node
+// loss by re-pending onto a replacement dormant slot (checkHuskPodLost + the
+// husk pod watch own that path). Failing it here would race that re-pend into a
+// terminal state and defeat the husk self-heal.
 func (g *GarbageCollector) markNodeLost(ctx context.Context, logger logr.Logger, claims []v1alpha1.SandboxClaim) {
+	if g.EnableHuskPods {
+		return
+	}
 	for i := range claims {
 		c := &claims[i]
 		if c.Status.Phase != v1alpha1.SandboxReady {

--- a/internal/controller/node_registry.go
+++ b/internal/controller/node_registry.go
@@ -58,11 +58,27 @@ type NodeInfo struct {
 	// scheduler uses it to project the marginal memory cost of placing a fork.
 	TemplateEstimates map[string]TemplateCapacity
 	LastHeartbeat     time.Time
+	// probeFailures is the number of CONSECUTIVE forkd liveness probes
+	// (GetCapacity) that have failed for this node. Discovery resets it to 0 on a
+	// successful probe and increments it on a failure (carried across the
+	// every-15s re-register). A node at or above probeFailureThreshold is treated
+	// as unhealthy and dropped from scheduling even while its pod is still
+	// Running: a hung forkd or a dead host whose pod has not yet been observed
+	// gone must not keep receiving forks. A single failure does NOT flap a node
+	// out (the threshold absorbs a transient blip).
+	probeFailures int
 	// TLS, when set, overrides the registry-level TLS config for dials to
 	// this node; lets tests run mixed TLS/insecure fleets in one registry.
 	TLS  *tls.Config
 	conn *grpc.ClientConn
 }
+
+// probeFailureThreshold is the number of CONSECUTIVE failed liveness probes
+// after which a node is treated as unhealthy. Set above 1 so a single transient
+// probe blip does not flap a node out of the schedulable set; at the every-15s
+// discovery interval, three failures means roughly 45s of an unreachable forkd
+// before the node is dropped, well inside the 2-minute heartbeat TTL.
+const probeFailureThreshold = 3
 
 // TemplateCapacity is the controller-side mirror of the forkd proto
 // TemplateCapacity: the per-template memory estimate the scheduler bin-packs
@@ -460,8 +476,30 @@ func (r *NodeRegistry) PruneStale(maxAge time.Duration) int {
 	return pruned
 }
 
+// isHealthy reports whether the node is schedulable. Health requires BOTH a
+// recent heartbeat (the 2-minute last-seen TTL) AND a live forkd: a node whose
+// liveness probe (GetCapacity) has failed probeFailureThreshold times in a row
+// is unhealthy even with a fresh heartbeat, since its pod can still be Running
+// while forkd is hung or its host is dead. This ties health to a LIVENESS
+// signal, not just last-seen, so a hung forkd cannot stay schedulable.
 func (n *NodeInfo) isHealthy() bool {
+	if n.probeFailures >= probeFailureThreshold {
+		return false
+	}
 	return time.Since(n.LastHeartbeat) < 2*time.Minute
+}
+
+// priorProbeFailures returns the consecutive-probe-failure count currently
+// recorded for the named node, or 0 when the node is not registered. Discovery
+// uses it to carry the count across the every-15s re-register (which replaces
+// the whole NodeInfo struct).
+func (r *NodeRegistry) priorProbeFailures(name string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if node, ok := r.nodes[name]; ok {
+		return node.probeFailures
+	}
+	return 0
 }
 
 func (n *NodeInfo) hasSnapshot(id string) bool {

--- a/internal/controller/node_registry_test.go
+++ b/internal/controller/node_registry_test.go
@@ -61,6 +61,36 @@ func TestRegisterCarriesConnectionForward(t *testing.T) {
 	}
 }
 
+// TestNodeUnhealthyAfterProbeFailureThreshold asserts a node whose liveness
+// probe (forkd GetCapacity) has failed at least probeFailureThreshold times in a
+// row is treated as unhealthy and dropped from SelectNode, even though its
+// heartbeat is fresh (its pod is still Running, but forkd is hung or the host
+// died). A single failure must NOT flap the node out.
+func TestNodeUnhealthyAfterProbeFailureThreshold(t *testing.T) {
+	r := NewNodeRegistry()
+	node := &NodeInfo{Name: "n1", Endpoint: "10.0.0.1:9090", LastHeartbeat: time.Now()}
+
+	// One failure short of the threshold: still healthy (no single-blip flap).
+	node.probeFailures = probeFailureThreshold - 1
+	r.Register(node)
+	if !r.NodeHealthy("n1") {
+		t.Fatalf("node with %d/%d probe failures must still be healthy", node.probeFailures, probeFailureThreshold)
+	}
+	if _, err := r.SelectNode("", ""); err != nil {
+		t.Fatalf("SelectNode below threshold: %v", err)
+	}
+
+	// At the threshold: unhealthy, dropped from scheduling.
+	node = &NodeInfo{Name: "n1", Endpoint: "10.0.0.1:9090", LastHeartbeat: time.Now(), probeFailures: probeFailureThreshold}
+	r.Register(node)
+	if r.NodeHealthy("n1") {
+		t.Fatal("node at the probe-failure threshold must be unhealthy")
+	}
+	if _, err := r.SelectNode("", ""); err == nil {
+		t.Fatal("SelectNode must not place onto a node failing its liveness probe")
+	}
+}
+
 func TestNodesWithTemplate(t *testing.T) {
 	r := NewNodeRegistry()
 	r.Register(&NodeInfo{Name: "a", TemplateIDs: []string{"py"}})

--- a/internal/controller/nodelost_test.go
+++ b/internal/controller/nodelost_test.go
@@ -89,6 +89,44 @@ func TestGCMarksNodeLost(t *testing.T) {
 	}
 }
 
+// TestGCInHuskModeDoesNotFailNodeLostClaim asserts that in husk mode the GC
+// does NOT terminally-fail a Ready claim whose node is lost. Husk node-loss is
+// owned by checkHuskPodLost + the husk pod watch, which RE-PEND the claim onto a
+// replacement dormant slot. A GC pass winning the race and flipping the claim to
+// terminal Failed/NodeLost would defeat the husk self-heal, so the GC skips the
+// node-lost-fail entirely when EnableHuskPods is set.
+func TestGCInHuskModeDoesNotFailNodeLostClaim(t *testing.T) {
+	stop, _, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "nl-node-3", "nl3-tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped := false
+	defer func() {
+		if !stopped {
+			stop()
+		}
+	}()
+
+	makeReadyClaim(t, "nl3", "nl-node-3")
+
+	// The node leaves the registry.
+	stop()
+	stopped = true
+
+	// A GC in husk mode must leave the claim Ready: the husk re-pend path owns
+	// node-loss recovery, not the GC.
+	gc := &controller.GarbageCollector{Client: k8sClient, Registry: testRegistry, EnableHuskPods: true}
+	gc.RunOnce(ctx)
+
+	var got v1alpha1.SandboxClaim
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "nl3-claim", Namespace: "default"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Phase == v1alpha1.SandboxFailed {
+		t.Fatalf("husk-mode GC must NOT flip a node-lost claim to Failed; phase = %q", got.Status.Phase)
+	}
+}
+
 func TestGCLeavesHealthyNodeClaim(t *testing.T) {
 	stop, _, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "nl-node-2", "nl2-tmpl")
 	if err != nil {

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/paperclipinc/mitos/internal/vsock"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -795,6 +796,11 @@ func (r *SandboxClaimReconciler) reconcileNoCapacity(ctx context.Context, claim 
 	waited := now.Sub(pendingSince)
 	maxWait := r.maxPendingDuration()
 
+	// Derive an accurate, cause-specific condition and remediation (issue #28).
+	// reconcileNoCapacity now fronts three distinct re-pend causes, and the
+	// memory-overcommit wording is only correct for one of them.
+	causeClause, remediation := noCapacityCauseText(cause)
+
 	// Bounded fail: capacity never freed within the allowed wait. Surface an
 	// actionable terminal error and stamp FinishedAt so the GC TTL pass reaps it.
 	if waited >= maxWait {
@@ -808,8 +814,8 @@ func (r *SandboxClaimReconciler) reconcileNoCapacity(ctx context.Context, claim 
 			LastTransitionTime: finished,
 			Reason:             "CapacityExhausted",
 			Message: fmt.Sprintf(
-				"no node had memory capacity under the overcommit policy for %s (waited past the %s bound); scale out forkd nodes or raise the overcommit factor, then recreate the claim",
-				waited.Round(time.Second), maxWait,
+				"%s for %s (waited past the %s bound); %s, then recreate the claim",
+				causeClause, waited.Round(time.Second), maxWait, remediation,
 			),
 		})
 		_ = r.Status().Update(ctx, claim)
@@ -826,13 +832,38 @@ func (r *SandboxClaimReconciler) reconcileNoCapacity(ctx context.Context, claim 
 		LastTransitionTime: metav1.NewTime(now),
 		Reason:             "NoCapacity",
 		Message: fmt.Sprintf(
-			"no node has memory capacity under the overcommit policy; the claim will retry (waited %s of %s), scale out nodes or raise the overcommit factor",
-			waited.Round(time.Second), maxWait,
+			"%s; the claim will retry (waited %s of %s), %s",
+			causeClause, waited.Round(time.Second), maxWait, remediation,
 		),
 	})
 	// Best-effort status write; the return below requeues regardless.
 	_ = r.Status().Update(ctx, claim)
 	return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
+}
+
+// noCapacityCauseText maps a re-pend cause to an accurate condition clause and
+// an actionable remediation (issue #28: LLM-legible errors). reconcileNoCapacity
+// fronts three distinct causes, only one of which is the memory-overcommit
+// shortage; surfacing the memory wording for the count-ceiling or
+// node-unreachable causes would be misleading. The returned clause carries no
+// secret values.
+func noCapacityCauseText(cause error) (clause, remediation string) {
+	switch {
+	case hasGRPCCode(cause, codes.ResourceExhausted):
+		// The selected node hit its per-node MaxSandboxes count ceiling between
+		// placement and the Fork RPC (the --max-sandbox cap, a schedule-time race).
+		return "the selected node reached its per-node sandbox-count limit (--max-sandbox)",
+			"add forkd nodes or raise the per-node --max-sandbox limit"
+	case hasGRPCCode(cause, codes.Unavailable):
+		// The selected node went unreachable between placement and the Fork RPC.
+		return "the selected node is unreachable (it left or died mid-fork)",
+			"the claim retries on a healthy node; add forkd nodes if the cluster is down"
+	default:
+		// scheduler ErrNoCapacity: no node admits the fork under the memory
+		// overcommit policy. This is the original wording.
+		return "no node has memory capacity under the overcommit policy",
+			"scale out forkd nodes or raise the overcommit factor"
+	}
 }
 
 // clearPendingSince removes the capacity-pending stamp from the claim's

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -484,6 +484,17 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			_ = r.Status().Update(ctx, &claim)
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
+		// The node rejected the fork on its sandbox-count cap (ResourceExhausted,
+		// PR #110) or went away mid-fork (Unavailable). Both are transient: the
+		// claim was placed onto a node that filled or died between SelectNode and
+		// the Fork RPC (a schedule-time race the count-admission check shrinks but
+		// cannot eliminate). Re-pend through the bounded NoCapacity machinery
+		// instead of failing terminally, so the claim retries on a node with
+		// headroom and only fails after the bounded wait.
+		if isRetryableCapacity(err) {
+			logger.Info("node rejected fork (capacity/unavailable), re-pending", "node", node.Name, "error", err.Error())
+			return r.reconcileNoCapacity(ctx, &claim, err)
+		}
 		logger.Error(err, "fork failed", "node", node.Name)
 		recordClaimError(claim.Spec.PoolRef.Name, "fork")
 		now := metav1.Now()

--- a/internal/controller/scheduler.go
+++ b/internal/controller/scheduler.go
@@ -100,10 +100,25 @@ func (r *NodeRegistry) projectedCost(node *NodeInfo, templateID string) int64 {
 	return shared + unique
 }
 
-// admits reports whether node can take a fork of templateID: its known budget
-// has room for the projected cost. Nodes with an unknown budget (MemoryTotal 0)
-// always admit (dev/mock). Caller must hold at least the read lock.
+// atSandboxCeiling reports whether the node has reached its forkd-side sandbox
+// COUNT cap (MaxSandboxes, PR #110): MaxSandboxes > 0 AND ActiveSandboxes is at
+// or above it. MaxSandboxes 0 means the cap is unset/unlimited (e.g. the mock
+// engine) and never blocks scheduling. Enforcing this at schedule time keeps the
+// node-side ResourceExhausted reject a rare race, not the primary path to the
+// cap.
+func (n *NodeInfo) atSandboxCeiling() bool {
+	return n.MaxSandboxes > 0 && n.ActiveSandboxes >= n.MaxSandboxes
+}
+
+// admits reports whether node can take a fork of templateID: it is below its
+// sandbox-count ceiling AND its known memory budget has room for the projected
+// cost. Nodes with an unknown budget (MemoryTotal 0) admit on memory (dev/mock)
+// but are still subject to the count ceiling. Caller must hold at least the read
+// lock.
 func (r *NodeRegistry) admits(node *NodeInfo, templateID string) bool {
+	if node.atSandboxCeiling() {
+		return false
+	}
 	avail, known := r.available(node)
 	if !known {
 		return true

--- a/internal/controller/scheduler_test.go
+++ b/internal/controller/scheduler_test.go
@@ -195,6 +195,63 @@ func TestSelectNodeNoNodesDistinctFromNoCapacity(t *testing.T) {
 	}
 }
 
+// TestSelectNodeRejectsNodeAtSandboxCeiling asserts a node that has reached its
+// MaxSandboxes count ceiling is NOT selected, even when it has ample memory.
+// The count ceiling is the forkd-side cap (PR #110): enforcing it at schedule
+// time makes the node-side ResourceExhausted a rare race, not the primary path.
+func TestSelectNodeRejectsNodeAtSandboxCeiling(t *testing.T) {
+	r := NewNodeRegistry()
+	// Plenty of memory, but already at the sandbox-count ceiling.
+	full := warmNode("full", 64*gib, 1*gib, "py", 256*1024*1024, 8*1024*1024, 5)
+	full.MaxSandboxes = 5
+	full.ActiveSandboxes = 5
+	r.Register(full)
+
+	if _, err := r.SelectNode("py", ""); !errors.Is(err, ErrNoCapacity) {
+		t.Fatalf("expected ErrNoCapacity (node at sandbox ceiling), got %v", err)
+	}
+}
+
+// TestSelectNodeSpillsOffSandboxCeilingNode asserts the scheduler spills to a
+// node with count headroom when the densest warm holder is at its ceiling.
+func TestSelectNodeSpillsOffSandboxCeilingNode(t *testing.T) {
+	r := NewNodeRegistry()
+	dense := warmNode("dense", 64*gib, 1*gib, "py", 256*1024*1024, 8*1024*1024, 10)
+	dense.MaxSandboxes = 10
+	dense.ActiveSandboxes = 10 // at ceiling
+	sparse := warmNode("sparse", 64*gib, 1*gib, "py", 256*1024*1024, 8*1024*1024, 2)
+	sparse.MaxSandboxes = 10
+	sparse.ActiveSandboxes = 2 // has headroom
+	r.Register(dense)
+	r.Register(sparse)
+
+	node, err := r.SelectNode("py", "")
+	if err != nil {
+		t.Fatalf("SelectNode: %v", err)
+	}
+	if node.Name != "sparse" {
+		t.Fatalf("got %q want sparse (dense is at the sandbox ceiling)", node.Name)
+	}
+}
+
+// TestSelectNodeZeroMaxSandboxesMeansNoCountCeiling asserts MaxSandboxes 0 (the
+// cap is unset/unlimited, e.g. mock engine) never blocks scheduling on count.
+func TestSelectNodeZeroMaxSandboxesMeansNoCountCeiling(t *testing.T) {
+	r := NewNodeRegistry()
+	n := warmNode("n1", 64*gib, 1*gib, "py", 256*1024*1024, 8*1024*1024, 100)
+	n.MaxSandboxes = 0
+	n.ActiveSandboxes = 100
+	r.Register(n)
+
+	node, err := r.SelectNode("py", "")
+	if err != nil {
+		t.Fatalf("SelectNode: %v", err)
+	}
+	if node.Name != "n1" {
+		t.Fatalf("got %q want n1 (MaxSandboxes 0 means no count ceiling)", node.Name)
+	}
+}
+
 func TestSelectNodeUnknownBudgetTreatedUnlimited(t *testing.T) {
 	r := NewNodeRegistry()
 	// A node reporting MemoryTotal 0 (meminfo unavailable, e.g. darwin/dev)

--- a/internal/fork/mock.go
+++ b/internal/fork/mock.go
@@ -23,6 +23,11 @@ type MockEngine struct {
 	counter   atomic.Int64
 	// Simulated fork latency
 	ForkDelay time.Duration
+	// ForkErr, when set, is returned by every Fork call before any sandbox is
+	// created. Tests use it to simulate a node-side fork rejection (e.g.
+	// fork.ErrAtCapacity -> gRPC ResourceExhausted) without driving the engine
+	// to its real cap. Read under the lock.
+	ForkErr error
 	// PausedSources records source sandbox IDs that were "paused" during ForkRunning.
 	PausedSources []string
 	// terminated records every sandbox ID passed to Terminate, in call order,
@@ -146,8 +151,12 @@ func (e *MockEngine) Fork(snapshotID, sandboxID string, opts ForkOpts) (*ForkRes
 	start := time.Now()
 
 	e.mu.RLock()
+	forkErr := e.ForkErr
 	_, ok := e.findTemplateBySnapshot(snapshotID)
 	e.mu.RUnlock()
+	if forkErr != nil {
+		return nil, forkErr
+	}
 	if !ok {
 		return nil, fmt.Errorf("snapshot %s not found", snapshotID)
 	}


### PR DESCRIPTION
## Summary

The re-scoped blocker #4: now that #110 enforces MaxSandboxes at the engine, this closes the controller-side gaps so the failure/GC semantics (CLAUDE.md principle 4) are sound end to end. Two correctness bugs + one node-liveness hardening.

1. **Count-aware scheduling + retryable-capacity re-pend** (scheduler.go, forkd_client.go, sandboxclaim_controller.go): the scheduler `admits` was MEMORY-ONLY and ignored `MaxSandboxes`, so the count ceiling was enforced only by the node-side reject, which HARD-FAILED a raw-forkd claim. Now `SelectNode` excludes a node at `ActiveSandboxes >= MaxSandboxes`, and a forkd `ResourceExhausted` or `Unavailable` routes to the existing bounded `reconcileNoCapacity` re-pend (NoCapacity condition + MaxPendingDuration cap) instead of failing. Condition messages are now cause-specific (memory / count-cap / node-unreachable) with accurate remediation (issue #28).
2. **markNodeLost gated to raw-forkd** (gc.go, main.go): the GC's node-lost terminal-fail fired in BOTH modes and could race the husk re-pend into a terminal `Failed`, defeating the husk self-heal. It is now a no-op in husk mode (checkHuskPodLost + the pod watch own husk node-loss); raw-forkd still Fails + GC-TTL-reaps. (sweepOrphans/ttlFinished still run in husk mode, so no etcd leak.)
3. **Node liveness signal** (node_registry.go, forkd_discovery.go): health was a 2-min last-seen TTL, so a hung forkd / dead host with a lingering Running pod stayed schedulable. Health now drops a node after 3 consecutive GetCapacity probe failures (~45s), excluding it from SelectNode (conservative: a single blip does not flap it out; a recovered probe resets).

## Verification
- Reviewed (spec + quality): APPROVED, no blockers. Confirmed no husk node-loss recovery gap (the husk hard-host-loss path now follows the k8s unreachable-pod eviction timeline, documented), the re-pend is bounded and does NOT mask hard failures (only ResourceExhausted/Unavailable re-pend; Internal/etc. still fail), the count ceiling has no memory/packing regression, and liveness does not flap or strand live sandboxes. The two LOW review notes (cause-specific messages, husk-latency doc) are fixed.
- Controller envtest (incl. new count-ceiling, ResourceExhausted/Unavailable re-pend, husk-mode markNodeLost no-op, and probe-failure-liveness tests); raw-forkd TestGCMarksNodeLost still passes; both golangci-lint clean.
- docs/failure-gc.md + docs/scheduling.md updated.

With this, all four production blockers from the readiness assessment are cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)