### PR TITLE
ci(#16): bare-metal self-hosted runner for standing real-cluster husk e2e

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint configuration.
+#
+# Declares the custom self-hosted runner labels so actionlint does not flag them
+# as unknown. These labels are carried by the in-cluster self-hosted GitHub
+# Actions runner (deploy/ci-runner/, issue #16); see docs/ci-runner.md. The
+# cluster-e2e workflow targets them with runs-on: [self-hosted, mitos-cluster].
+self-hosted-runner:
+  labels:
+    - mitos-cluster
+    - kvm

--- a/.github/workflows/cluster-e2e.yaml
+++ b/.github/workflows/cluster-e2e.yaml
@@ -1,0 +1,195 @@
+name: Cluster e2e (self-hosted)
+
+# =============================================================================
+# SECURITY: this workflow runs on a SELF-HOSTED runner that lives INSIDE the
+# maintainer's single-node Talos KVM cluster. That runner can drive the cluster
+# (it has KVM via the husk pods and a scoped ServiceAccount). The repo
+# paperclipinc/mitos is PUBLIC. Therefore this job MUST NEVER execute code from
+# an untrusted fork pull request: a malicious fork PR could otherwise own the
+# cluster.
+#
+# Gating (non-negotiable):
+#   * push to main            post-merge verification of already-reviewed code.
+#   * workflow_dispatch       manual maintainer trigger.
+#   * pull_request            OPT-IN ONLY, and gated by the job-level `if:` to:
+#                               (a) same-repo PRs (head.repo == base repo, i.e.
+#                                   NOT a fork), AND
+#                               (b) a maintainer-applied label `ci-cluster`.
+#                             Combined with the `cluster` GitHub Environment
+#                             (which should require a maintainer approval), this
+#                             means fork-PR code can never reach the runner.
+#
+# A fork PR (head.repo.full_name != github.repository) fails BOTH the same-repo
+# check and the label check, so the job is skipped. Do NOT relax the `if:`.
+# =============================================================================
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      e2e_namespace:
+        description: "Namespace to run the e2e in"
+        required: false
+        default: mitos-e2e
+  # OPT-IN labeled-same-repo-PR path. The `pull_request` event fires for forks
+  # too, but the job-level `if:` below excludes forks AND requires the label, so
+  # a labeled fork PR still cannot run here.
+  pull_request:
+    branches: [main]
+    types: [labeled, synchronize, reopened]
+
+# Least-privilege token: this job only needs to read the repo to check out.
+permissions:
+  contents: read
+
+concurrency:
+  # One cluster e2e at a time; a newer run cancels an in-flight one so the
+  # single-node cluster is never driven by two jobs at once.
+  group: cluster-e2e
+  cancel-in-progress: true
+
+jobs:
+  cluster-husk-e2e:
+    # The self-hosted runner in the cluster. Labels match the runner Deployment
+    # (deploy/ci-runner/deployment.yaml LABELS).
+    runs-on: [self-hosted, mitos-cluster]
+
+    # SECURITY GATE. Run only on trusted triggers:
+    #   * push / workflow_dispatch are inherently maintainer-trusted, OR
+    #   * a pull_request that is BOTH from the same repo (NOT a fork) AND carries
+    #     the maintainer-applied `ci-cluster` label.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'ci-cluster')
+      )
+
+    # The `cluster` Environment should be configured in repo Settings to require
+    # a maintainer approval (a second human gate) and to scope any cluster
+    # secrets. See docs/ci-runner.md.
+    environment: cluster
+
+    # Tight overall budget: a hung husk activation must not pin the cluster.
+    timeout-minutes: 25
+
+    env:
+      # The dedicated e2e namespace (the runner's RBAC blast radius). Override
+      # via the workflow_dispatch input.
+      E2E_NAMESPACE: ${{ github.event.inputs.e2e_namespace || 'mitos-e2e' }}
+      # The control-plane namespace where the controller runs.
+      MITOS_NAMESPACE: mitos
+      # The image tag to deploy under test. On main and dispatch we use the
+      # commit-sha tag the publish/build pipeline pushes to GHCR (type=sha =>
+      # sha-<short>). The full ref is github.sha; GHCR's sha tag is the short
+      # form, computed in the deploy step.
+      IMAGE_REGISTRY: ghcr.io/paperclipinc
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show context (no secrets)
+        run: |
+          set -euo pipefail
+          echo "event: ${{ github.event_name }}"
+          echo "ref: ${{ github.ref }}"
+          echo "sha: ${{ github.sha }}"
+          echo "e2e namespace: ${E2E_NAMESPACE}"
+          kubectl version --client
+          kubectl get nodes -l 'mitos.run/kvm=true' -o wide
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          # The build/publish pipeline tags images type=sha => sha-<7 char>.
+          short="$(echo "${{ github.sha }}" | cut -c1-7)"
+          echo "sha_tag=sha-${short}" >> "$GITHUB_OUTPUT"
+          echo "Resolved image tag: sha-${short}"
+
+      - name: Deploy images under test
+        id: deploy
+        run: |
+          set -euo pipefail
+          CONTROLLER_IMG="${IMAGE_REGISTRY}/mitos-controller:${{ steps.tag.outputs.sha_tag }}"
+          HUSK_IMG="${IMAGE_REGISTRY}/mitos-husk-stub:${{ steps.tag.outputs.sha_tag }}"
+          echo "Deploying controller=${CONTROLLER_IMG}"
+          echo "Deploying husk-stub=${HUSK_IMG}"
+
+          # Record the current controller image so teardown can restore it even
+          # if a later step fails.
+          PREV_IMG="$(kubectl -n "${MITOS_NAMESPACE}" get deployment/mitos-controller \
+            -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          echo "prev_controller_image=${PREV_IMG}" >> "$GITHUB_OUTPUT"
+          echo "Previous controller image: ${PREV_IMG}"
+
+          # Point the controller at the just-built controller image.
+          kubectl -n "${MITOS_NAMESPACE}" set image deployment/mitos-controller \
+            controller="${CONTROLLER_IMG}"
+
+          # Point the controller's --husk-stub-image arg at the just-built husk
+          # image so newly warmed husk pods run the code under test. Append the
+          # arg; argv-last-wins means this overrides the baked default.
+          kubectl -n "${MITOS_NAMESPACE}" patch deployment/mitos-controller --type=json \
+            -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/args/-\",\"value\":\"--husk-stub-image=${HUSK_IMG}\"}]"
+
+          kubectl -n "${MITOS_NAMESPACE}" rollout status deployment/mitos-controller --timeout=300s
+
+      - name: Run the cluster husk e2e
+        run: |
+          set -euo pipefail
+          chmod +x test/cluster-e2e/husk-e2e.sh
+          READY_TIMEOUT=240 test/cluster-e2e/husk-e2e.sh "${E2E_NAMESPACE}"
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "=== controller deployment ==="
+          kubectl -n "${MITOS_NAMESPACE}" describe deployment/mitos-controller
+          echo "=== controller logs ==="
+          kubectl -n "${MITOS_NAMESPACE}" logs deployment/mitos-controller --tail=200 --all-containers
+          echo "=== e2e namespace objects ==="
+          kubectl -n "${E2E_NAMESPACE}" get sandboxpools,sandboxclaims,sandboxforks,pods -o wide
+          echo "=== e2e husk pod logs ==="
+          for p in $(kubectl -n "${E2E_NAMESPACE}" get pods -l 'mitos.run/husk=true' -o name | head -5); do
+            echo "--- ${p} ---"
+            kubectl -n "${E2E_NAMESPACE}" logs "${p}" --tail=80
+          done
+          exit 0
+
+      - name: Teardown (always)
+        if: always()
+        run: |
+          set +e
+          echo "=== teardown: remove e2e objects ==="
+          # The e2e script cleans its own objects on exit; this is the belt-and-
+          # suspenders sweep in case the runner step was cancelled mid-run.
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxforks --all --wait=false
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxclaims --all --wait=false
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxpools --all --wait=false
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxtemplates --all --wait=false
+
+          echo "=== teardown: restore the controller image ==="
+          PREV="${{ steps.deploy.outputs.prev_controller_image }}"
+          if [ -n "${PREV}" ]; then
+            kubectl -n "${MITOS_NAMESPACE}" set image deployment/mitos-controller \
+              controller="${PREV}"
+            # Drop the --husk-stub-image arg we appended (remove the LAST arg).
+            LAST_IDX="$(kubectl -n "${MITOS_NAMESPACE}" get deployment/mitos-controller \
+              -o jsonpath='{.spec.template.spec.containers[0].args}' \
+              | python3 -c 'import sys,json; a=json.load(sys.stdin); print(len(a)-1)' 2>/dev/null)"
+            if [ -n "${LAST_IDX}" ]; then
+              kubectl -n "${MITOS_NAMESPACE}" patch deployment/mitos-controller --type=json \
+                -p="[{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/args/${LAST_IDX}\"}]" \
+                || true
+            fi
+            kubectl -n "${MITOS_NAMESPACE}" rollout status deployment/mitos-controller --timeout=180s
+          else
+            echo "no previous controller image recorded; leaving controller as-is"
+          fi
+          echo "teardown done"
+          exit 0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -645,6 +645,20 @@ or spoof.
   checks; operator deploy + PKI bootstrap; smoke test; capacity planning
   pointers). CI-VERIFIED vs HARDWARE-REQUIRED split clearly marked in the
   runbook.
+- ⬜ Self-hosted bare-metal CI runner (#16): an EPHEMERAL GitHub Actions runner
+  runs IN the single-node Talos KVM cluster (deploy/ci-runner/, namespace
+  mitos-ci) and drives the real-cluster husk e2e on every trusted change
+  (claim -> activate -> exec -> fork -> run_code -> PTY -> crash-reap;
+  test/cluster-e2e/husk-e2e.sh against namespace mitos-e2e), turning the
+  maintainer's manual cluster check into standing CI
+  (.github/workflows/cluster-e2e.yaml). SECURITY: the repo is PUBLIC, so the job
+  is gated to TRUSTED triggers only (push to main + workflow_dispatch by
+  default; an opt-in labeled same-repo-PR path, never forks) and the runner SA
+  is least-privilege (two namespaces, read-only nodes; never cluster-admin).
+  Built and CI-validated (YAML, kustomize, shellcheck); deploy + the maintainer
+  setup steps are in docs/ci-runner.md. Open: the maintainer creates the
+  registration Secret and applies the manifests; the dedicated-test-controller
+  option to drop the production controller-patch grant.
 - ⬜ Evaluate dm-thin / xfs-reflink as alternatives to the btrfs dependency
 - ⬜ Hetzner AX reference BOM: MEASURED density and cost/sandbox-hour on the
   pinned reference node. Needs the hardware; do NOT fabricate numbers.

--- a/deploy/ci-runner/Dockerfile.ci-runner
+++ b/deploy/ci-runner/Dockerfile.ci-runner
@@ -1,0 +1,51 @@
+# Thin self-hosted GitHub Actions runner for the mitos cluster e2e.
+#
+# The base is the OFFICIAL actions-runner image, pinned by version AND digest.
+# We add only what the e2e DRIVES the cluster with: kubectl, git, bash, jq,
+# python3, and the mitos Python SDK. The runner does NOT need docker or KVM:
+# the husk pods do the KVM, the runner only kubectls and speaks the sandbox
+# HTTP API over the in-cluster pod network.
+#
+# SECURITY: keep this image minimal. It runs with a registration token that can
+# add runners to a PUBLIC repo, so every extra tool is extra attack surface.
+#
+# Build + push (maintainer, on a trusted machine):
+#   docker build -f deploy/ci-runner/Dockerfile.ci-runner \
+#     -t ghcr.io/paperclipinc/mitos-ci-runner:<tag> .
+#   docker push ghcr.io/paperclipinc/mitos-ci-runner:<tag>
+# Then pin the deployment.yaml image to the pushed digest.
+
+# Pin the base by digest. Resolve the current digest with:
+#   docker buildx imagetools inspect ghcr.io/actions/actions-runner:2.321.0
+# and replace the placeholder below before building.
+FROM ghcr.io/actions/actions-runner:2.328.0@sha256:db0dcae6d28559e54277755a33aba7d0665f255b3bd2a66cdc5e132712f155e0
+
+USER root
+
+# kubectl: pinned to a version compatible with the cluster (k8s v1.36.x). git,
+# bash, jq, ca-certificates, curl, python3 + venv for the SDK.
+ARG KUBECTL_VERSION=v1.36.1
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        bash \
+        jq \
+        python3 \
+        python3-venv \
+        python3-pip \
+    && curl -fsSL -o /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the mitos Python SDK into a venv on PATH so the e2e can import it.
+# Copy only the SDK so the build does not depend on the whole repo context.
+COPY sdk/python /opt/mitos-sdk
+RUN python3 -m venv /opt/mitos-venv \
+    && /opt/mitos-venv/bin/pip install --no-cache-dir /opt/mitos-sdk
+ENV PATH="/opt/mitos-venv/bin:${PATH}"
+
+USER runner

--- a/deploy/ci-runner/deployment.yaml
+++ b/deploy/ci-runner/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mitos-ci-runner
+  namespace: mitos-ci
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+spec:
+  # Exactly one runner. It is EPHEMERAL (--ephemeral): the GitHub runner exits
+  # after a single job, the pod terminates, and the Deployment restarts it,
+  # which re-registers a FRESH runner using the token from the Secret. A
+  # fresh-per-job runner means no job can leave state behind for the next job,
+  # which matters on a PUBLIC repo. Scale to more replicas only if concurrent
+  # cluster e2e jobs are wanted (each is a distinct ephemeral runner).
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mitos
+      app.kubernetes.io/component: ci-runner
+  # Recreate, not RollingUpdate: an ephemeral runner is a singleton worker, not
+  # a served endpoint, so there is no reason to briefly run two registrations.
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mitos
+        app.kubernetes.io/component: ci-runner
+    spec:
+      serviceAccountName: mitos-ci-runner
+      # The runner only kubectls and speaks HTTP to pod IPs. It needs NO host
+      # access, NO privilege, NO KVM. Restricted-PSS compliant.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # Single runner; if the node is briefly NotReady do not pile up.
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: runner
+          # PIN by digest. Built from deploy/ci-runner/Dockerfile.ci-runner and
+          # pushed by the maintainer; see that file and docs/ci-runner.md. The
+          # :latest tag is a readability placeholder; replace it with an
+          # immutable digest (image@sha256:...) before applying, so a moving tag
+          # cannot swap the runner binary out from under the cluster.
+          image: ghcr.io/paperclipinc/mitos-ci-runner:v1@sha256:3d13de2739d6d6e4d737bff55bea370b1db91d1d055b49b24683ab32aae2aa58
+          imagePullPolicy: IfNotPresent
+          # The official actions-runner entrypoint reads these env vars, runs
+          # config.sh to register, then run.sh. --ephemeral makes it a
+          # single-job runner that re-registers on restart.
+          env:
+            - name: RUNNER_NAME_PREFIX
+              value: mitos-cluster
+            # The repo (NOT org) the runner registers against. Self-hosted on a
+            # PUBLIC repo: fork-PR gating lives in the workflow, see
+            # .github/workflows/cluster-e2e.yaml.
+            - name: REPO_URL
+              value: https://github.com/paperclipinc/mitos
+            - name: RUNNER_SCOPE
+              value: repo
+            # Labels the workflow targets with runs-on: [self-hosted,
+            # mitos-cluster, kvm]. "kvm" advertises that jobs here reach the
+            # KVM-capable husk path (the husk pods do the KVM, not the runner).
+            - name: LABELS
+              value: self-hosted,mitos-cluster,kvm
+            - name: EPHEMERAL
+              value: "true"
+            # Registration token / PAT, supplied by the maintainer-created
+            # Secret. NEVER stored in the repo. The manifest references the
+            # Secret only; see docs/ci-runner.md for how to create it.
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: mitos-ci-runner-token
+                  key: token
+            # Write the runner working tree to the emptyDir, not the read-only
+            # rootfs.
+            - name: RUNNER_WORKDIR
+              value: /home/runner/_work
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: work
+              mountPath: /home/runner/_work
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        # Ephemeral scratch for the checkout and runner work tree; gone with the
+        # pod so no job leaves residue for the next.
+        - name: work
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/deploy/ci-runner/e2e-namespace.yaml
+++ b/deploy/ci-runner/e2e-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mitos-e2e
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-e2e
+    # The husk pods that land here run a dormant Firecracker VMM and request
+    # the mitos.run/kvm device-plugin resource (NOT privileged: true), matching
+    # the production pod-native path. They are scheduled by the controller, not
+    # by the runner. This namespace is the blast-radius boundary for the e2e:
+    # the runner's RBAC can only touch claims/pods/exec HERE.

--- a/deploy/ci-runner/kustomization.yaml
+++ b/deploy/ci-runner/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Self-hosted GitHub Actions runner for the real-cluster husk e2e (issue #16).
+#
+# Apply with: kubectl apply -k deploy/ci-runner/
+#
+# This lays down the mitos-ci namespace (the runner), the mitos-e2e namespace
+# (the e2e blast radius), the runner ServiceAccount, the least-privilege RBAC,
+# and the ephemeral runner Deployment.
+#
+# It deliberately does NOT include the runner registration Secret
+# (mitos-ci-runner-token): no token value lives in the repo. The maintainer
+# creates that Secret out of band before applying; see docs/ci-runner.md.
+#
+# This base is separate from deploy/kustomization.yaml (the control plane) and
+# from deploy/dev/ (the mock dev overlay); it consumes neither.
+resources:
+  - namespace.yaml
+  - e2e-namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - deployment.yaml

--- a/deploy/ci-runner/namespace.yaml
+++ b/deploy/ci-runner/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mitos-ci
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+    # The runner pod is unprivileged (it only kubectls; the husk pods do the
+    # KVM), so it satisfies the restricted Pod Security Standard. We enforce it
+    # here so a future change cannot quietly grant the runner more than it needs.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/deploy/ci-runner/rbac.yaml
+++ b/deploy/ci-runner/rbac.yaml
@@ -1,0 +1,239 @@
+# Least-privilege RBAC for the cluster e2e runner.
+#
+# The runner drives the real-cluster husk e2e: it creates a SandboxPool, claims
+# from it, forks, execs, and reaps, all inside the dedicated mitos-e2e
+# namespace; and it deploys the just-built images by patching the controller in
+# the mitos namespace. Every rule below is justified by a step the e2e actually
+# performs. There is deliberately NO ClusterRole and NO cluster-admin: the two
+# Roles below bound the runner to exactly two namespaces (mitos-e2e and mitos),
+# so a compromised runner cannot reach tenant workloads in other namespaces.
+#
+# SECURITY: this identity is reachable from a self-hosted GitHub Actions runner
+# on a PUBLIC repo. The CI workflow (.github/workflows/cluster-e2e.yaml) gates
+# the job so fork-PR code never runs on it; this RBAC is the second layer: even
+# if untrusted code somehow ran, it could only manipulate the e2e namespace and
+# patch the controller image, not own the cluster.
+---
+# In mitos-e2e: the runner owns the full e2e lifecycle.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mitos-ci-runner-e2e
+  namespace: mitos-e2e
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+rules:
+  # Create the e2e template + pool, claim, and fork; delete them on teardown.
+  # SandboxTemplate is created by the e2e (the pool references it) and read
+  # back, so it carries create/delete here too rather than read-only.
+  - apiGroups:
+      - mitos.run
+    resources:
+      - sandboxtemplates
+      - sandboxpools
+      - sandboxclaims
+      - sandboxforks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # Read the status the controller writes (phase, conditions, endpoint, forks).
+  - apiGroups:
+      - mitos.run
+    resources:
+      - sandboxtemplates/status
+      - sandboxpools/status
+      - sandboxclaims/status
+      - sandboxforks/status
+    verbs:
+      - get
+      - list
+      - watch
+  # Pods: list/get/watch the warm dormant husk pods and the claimed pod; the
+  # self-heal assertion deletes a claimed husk pod to prove the claim re-pends.
+  # The runner does NOT create pods (the controller does); delete is scoped to
+  # the eviction/self-heal probe only.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  # Pod logs for diagnostics on a failed assertion.
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  # exec into a pod IS used by the bench-style fallback path; the primary exec
+  # path is the SDK over the sandbox HTTP API to the pod IP, but kubectl exec is
+  # the diagnostic fallback. Scoped to mitos-e2e pods only.
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  # The Python SDK reads the per-sandbox bearer-token Secret
+  # (<sandbox>-sandbox-token) to authenticate exec/run_code/pty against the
+  # sandbox HTTP API. get/list only; the runner never writes Secrets. Token
+  # VALUES are never logged by the e2e (CLAUDE.md secrets rule).
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+  # The controller replicates the husk PKI Secrets into the pool namespace; the
+  # runner reads services/endpoints only for diagnostics (endpoint resolution
+  # of the sandbox API is via the claim Status.Endpoint pod IP, not a Service).
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mitos-ci-runner-e2e
+  namespace: mitos-e2e
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mitos-ci-runner-e2e
+subjects:
+  - kind: ServiceAccount
+    name: mitos-ci-runner
+    namespace: mitos-ci
+---
+# In mitos: deploy-under-test. The runner reads the controller Deployment and
+# its logs and patches its image/args to the just-built tag, then waits for the
+# rollout. It does NOT get blanket write on the mitos namespace: it can only
+# get/list/watch/patch/update Deployments (to set the image and wait for the
+# rollout), read ReplicaSets/Pods/Pod logs (rollout status + diagnostics), and
+# read the PKI Secrets' existence (get/list, no values logged). It cannot
+# create or delete Deployments, cannot touch Secrets writes, and cannot reach
+# the controller's RBAC.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mitos-ci-runner-deploy
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  # Rollout status reads the managed ReplicaSets; diagnostics read pods + logs.
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  # Confirm the PKI Secrets exist before driving claims (presence + keys only;
+  # values are never read into logs). get/list, no write.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mitos-ci-runner-deploy
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mitos-ci-runner-deploy
+subjects:
+  - kind: ServiceAccount
+    name: mitos-ci-runner
+    namespace: mitos-ci
+---
+# Cluster-scoped READ ONLY: the controller places husk pods on nodes labeled
+# mitos.run/kvm=true and the e2e asserts the node is KVM-capable, so the runner
+# needs to read nodes (get/list). Nodes are cluster-scoped, so this is the one
+# unavoidable ClusterRole; it grants READ on nodes ONLY and binds the same SA.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mitos-ci-runner-nodes-read
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mitos-ci-runner-nodes-read
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mitos-ci-runner-nodes-read
+subjects:
+  - kind: ServiceAccount
+    name: mitos-ci-runner
+    namespace: mitos-ci

--- a/deploy/ci-runner/serviceaccount.yaml
+++ b/deploy/ci-runner/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mitos-ci-runner
+  namespace: mitos-ci
+  labels:
+    app.kubernetes.io/name: mitos
+    app.kubernetes.io/component: ci-runner
+# This is the identity the e2e drives the cluster as. Its RBAC is the e2e blast
+# radius, so it is scoped as tightly as the suite needs and is never bound to
+# cluster-admin. See rbac.yaml for the per-namespace justification of every verb.
+automountServiceAccountToken: true

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -1,0 +1,257 @@
+# Bare-metal CI: the in-cluster self-hosted runner (issue #16)
+
+This turns the maintainer's manual cluster verification into standing CI. A
+self-hosted GitHub Actions runner runs INSIDE the single-node Talos KVM cluster
+and, on every trusted change, drives the REAL-cluster husk end-to-end:
+
+    claim -> activate -> exec -> fork -> run_code -> PTY -> crash-reap
+
+against real KVM on a real Kubernetes cluster. The mock-engine kind e2e and the
+KVM Firecracker job already run on GitHub-hosted runners; this is the missing
+proof that the WHOLE stack (controller + husk pods + guest agent + the sandbox
+HTTP/PTY API) works together on real hardware.
+
+## Architecture
+
+```
+GitHub (paperclipinc/mitos, PUBLIC)
+  |
+  |  trusted trigger only (push to main / workflow_dispatch / labeled same-repo PR)
+  v
+self-hosted runner pod  (namespace mitos-ci, ServiceAccount mitos-ci-runner)
+  |  unprivileged: only kubectls + speaks the sandbox HTTP/PTY API
+  |
+  |  (1) deploy-under-test: kubectl set image controller + husk-stub arg
+  |  (2) run test/cluster-e2e/husk-e2e.sh against namespace mitos-e2e
+  v
+controller (namespace mitos)  ->  husk pods (namespace mitos-e2e, do the KVM)
+  ^                                      |
+  |  Python SDK over the pod network ----+  exec / run_code / fork / PTY
+```
+
+The runner itself does NOT need docker or KVM. The husk pods do the KVM (they
+request the `mitos.run/kvm` device-plugin resource, the production pod-native
+path). The runner only drives the cluster with `kubectl` and talks to each
+claim's sandbox HTTP API over the in-cluster pod network via the mitos Python
+SDK (`in_cluster=True`).
+
+Images are built and pushed to `ghcr.io/paperclipinc/mitos-{controller,husk-stub,...}`
+by the existing `docker-build` / publish pipeline on GitHub-hosted
+`ubuntu-latest`. This job only DEPLOYS those images; it never builds them on the
+runner (building untrusted Dockerfiles on a cluster-attached runner would be a
+security hole).
+
+### Files
+
+| File | Purpose |
+| --- | --- |
+| `deploy/ci-runner/namespace.yaml` | `mitos-ci` namespace (the runner) |
+| `deploy/ci-runner/e2e-namespace.yaml` | `mitos-e2e` namespace (the e2e blast radius) |
+| `deploy/ci-runner/serviceaccount.yaml` | `mitos-ci-runner` ServiceAccount |
+| `deploy/ci-runner/rbac.yaml` | least-privilege Roles + RoleBindings (+ a read-only nodes ClusterRole) |
+| `deploy/ci-runner/deployment.yaml` | the ephemeral runner Deployment |
+| `deploy/ci-runner/Dockerfile.ci-runner` | thin runner image (official base + kubectl/git/jq/python3/SDK) |
+| `deploy/ci-runner/kustomization.yaml` | `kubectl apply -k` base (NO token Secret) |
+| `.github/workflows/cluster-e2e.yaml` | the gated CI job |
+| `test/cluster-e2e/husk-e2e.sh` | the real-cluster husk verification |
+
+## Security model (why fork PRs are excluded)
+
+The repo `paperclipinc/mitos` is PUBLIC. A self-hosted runner attached to the
+cluster is a high-value target: anyone who can run code on it inherits the
+runner's KVM-backed husk path and its cluster RBAC. A malicious fork pull
+request could, if its code ran here, own the cluster. So the job is gated to
+TRUSTED triggers ONLY. There are three independent layers:
+
+1. **Trigger gating (the primary control).** `.github/workflows/cluster-e2e.yaml`
+   runs only on:
+   - `push` to `main` (already-reviewed, merged code), or
+   - `workflow_dispatch` (a maintainer pressing the button), or
+   - a `pull_request` that is BOTH from the same repo (NOT a fork) AND carries
+     the maintainer-applied `ci-cluster` label.
+
+   The job-level `if:` is:
+
+   ```yaml
+   if: >-
+     github.event_name == 'push' ||
+     github.event_name == 'workflow_dispatch' ||
+     (
+       github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'ci-cluster')
+     )
+   ```
+
+   A fork PR has `head.repo.full_name != github.repository`, so it fails the
+   same-repo check; it also cannot carry a maintainer-only label without a
+   maintainer's action. Either way the job is skipped. The default safe baseline
+   is push-to-main + workflow_dispatch; the labeled-same-repo-PR path is OPT-IN.
+
+2. **The `cluster` GitHub Environment (a second human gate).** The job declares
+   `environment: cluster`. Configure that Environment in repo Settings to
+   require a maintainer approval before any run proceeds, so even a trusted
+   trigger waits for a human.
+
+3. **Least-privilege RBAC (blast-radius containment).** Even if untrusted code
+   somehow ran, the runner's ServiceAccount cannot own the cluster. It is bound
+   to exactly two namespaces and one read-only cluster verb:
+   - `mitos-e2e`: full lifecycle of the e2e objects (templates, pools, claims,
+     forks), read/exec/delete pods, read pod logs, read the per-sandbox token
+     Secrets (values never logged), read services/endpoints/events.
+   - `mitos`: read + patch the controller Deployment (deploy-under-test), read
+     ReplicaSets/Pods/Pod logs (rollout + diagnostics), read Secrets presence.
+     It CANNOT create or delete Deployments, write Secrets, or touch the
+     controller's own RBAC.
+   - cluster-scoped: `get/list nodes` ONLY (nodes are cluster-scoped and the
+     e2e checks for a KVM-capable node).
+
+   There is deliberately NO `ClusterRole` granting writes and NO `cluster-admin`.
+
+4. **Ephemeral runner.** The runner is registered with `--ephemeral`: it runs
+   one job, exits, and the Deployment restarts it, re-registering a fresh
+   runner. No job can leave state for the next, and the pod is unprivileged
+   (`runAsNonRoot`, all capabilities dropped, no host mounts, no KVM).
+
+### Trade-off note: deploy-under-test in the live `mitos` namespace
+
+The job patches the controller image in the live `mitos` namespace and restores
+it on teardown (`if: always()`). This grants the runner `patch`/`update` on the
+controller Deployment, which is more than read-only. It is bounded to the
+controller Deployment object only (no Secret writes, no create/delete), and the
+`cluster` Environment approval + trigger gating keep it maintainer-controlled.
+If you prefer zero write access to the production control plane, deploy a
+dedicated test controller instance in a separate namespace and re-point the
+e2e + the RBAC `mitos-ci-runner-deploy` Role at it; that removes the production
+patch grant at the cost of a second controller to maintain.
+
+## One-time maintainer setup
+
+All steps assume your `kubectl` context points at the cluster and you are an
+admin of the GitHub repo.
+
+### 1. Build and push the runner image
+
+The runner image is the official `actions-runner` plus `kubectl`, `git`, `jq`,
+`python3`, and the mitos Python SDK. Build it on a trusted machine and push to
+GHCR:
+
+```bash
+# Resolve and pin the base digest first (edit Dockerfile.ci-runner FROM line):
+docker buildx imagetools inspect ghcr.io/actions/actions-runner:2.321.0
+
+docker build -f deploy/ci-runner/Dockerfile.ci-runner \
+  -t ghcr.io/paperclipinc/mitos-ci-runner:0.1.0 .
+docker push ghcr.io/paperclipinc/mitos-ci-runner:0.1.0
+```
+
+Then pin `deploy/ci-runner/deployment.yaml`'s `image:` to the pushed digest
+(`ghcr.io/paperclipinc/mitos-ci-runner@sha256:...`) so a moving tag cannot swap
+the runner binary.
+
+### 2. Create the runner registration Secret
+
+The runner needs either a repo runner-registration token OR a fine-grained PAT.
+A fine-grained PAT is recommended because the official image can refresh
+short-lived registration tokens from it across ephemeral restarts.
+
+Create a fine-grained PAT at GitHub Settings -> Developer settings ->
+Fine-grained tokens, scoped to the `paperclipinc/mitos` repo with:
+
+- Repository permissions: `Administration: Read and write` (required to
+  register/remove self-hosted runners), `Actions: Read and write`.
+
+Then create the Secret IN the cluster (the token value lives ONLY here, never in
+the repo):
+
+```bash
+kubectl create namespace mitos-ci --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret -n mitos-ci generic mitos-ci-runner-token \
+  --from-literal=token=ghp_your_fine_grained_pat_here
+```
+
+To rotate: re-create the Secret and restart the Deployment
+(`kubectl -n mitos-ci rollout restart deployment/mitos-ci-runner`).
+
+### 3. Apply the runner manifests
+
+```bash
+kubectl apply -k deploy/ci-runner/
+```
+
+This creates the `mitos-ci` and `mitos-e2e` namespaces, the ServiceAccount, the
+least-privilege RBAC, and the ephemeral runner Deployment. It does NOT create
+the token Secret (you did that in step 2).
+
+### 4. Verify the runner registered
+
+```bash
+kubectl -n mitos-ci get pods
+kubectl -n mitos-ci logs deployment/mitos-ci-runner
+```
+
+Then in the GitHub UI: repo Settings -> Actions -> Runners. A runner named
+`mitos-cluster-...` with labels `self-hosted, mitos-cluster, kvm` should appear
+as Idle. (Because it is ephemeral, it appears while idle and is replaced after
+each job.)
+
+### 5. Configure the `cluster` Environment (recommended)
+
+Repo Settings -> Environments -> New environment -> `cluster`. Add yourself (or
+the maintainers) as required reviewers so every cluster e2e run waits for a
+human approval.
+
+### 6. Trigger a run
+
+- Automatic: merge to `main`.
+- Manual: repo Actions -> "Cluster e2e (self-hosted)" -> Run workflow.
+
+### 7. (Optional) the labeled same-repo PR path
+
+To run the cluster e2e on a same-repo (non-fork) PR before merge, a maintainer
+applies the `ci-cluster` label to the PR. Create the label once:
+
+```bash
+gh label create ci-cluster \
+  --description "Run the self-hosted cluster e2e on this same-repo PR" \
+  --color B60205
+```
+
+Fork PRs can NEVER use this path: the `if:` requires
+`head.repo.full_name == github.repository`, which a fork fails, and a fork
+contributor cannot apply a label.
+
+## What the e2e asserts
+
+`test/cluster-e2e/husk-e2e.sh` (run against `mitos-e2e`) checks, with bounded
+waits and a cleanup trap, each printing a `PASS:` / `FAIL:` line:
+
+0. a node labeled `mitos.run/kvm=true` is present.
+1. a `SandboxPool` warms at least one dormant husk pod.
+2. a `SandboxClaim` activates to Ready and `exec("echo ...")` returns the
+   expected stdout with exit 0.
+3. `fork(2)` produces two independent sandboxes (a marker written in one is not
+   visible in the other).
+4. `run_code` returns a result, OR a clean `KernelUnavailable` (the husk OCI
+   base may lack the code-interpreter kernel; per issue #16 a clean
+   `KernelUnavailable` is ACCEPTED as a pass and does NOT fail the suite). A
+   non-`KernelUnavailable` kernel error IS a failure.
+5. a PTY allocates and echoes its input.
+6. (best effort) deleting the claimed husk pod re-pends the claim (the
+   eviction / self-heal path). Inconclusive is non-fatal; a clear regression is
+   surfaced.
+
+On any failure the script dumps pool/claim/pod state and recent husk pod logs.
+Secret VALUES are never logged (CLAUDE.md secrets rule).
+
+## Failure behavior
+
+- The workflow has a 25-minute job timeout, so a hung activation cannot pin the
+  cluster.
+- Teardown runs `if: always()`: it deletes the e2e pool/claims/forks and
+  RESTORES the controller image and args, even if the run failed or was
+  cancelled. The e2e script also cleans its own objects via an EXIT trap.
+- The runner is ephemeral, so a crashed job leaves no residual runner state; the
+  Deployment brings up a fresh one.
+- `concurrency: cluster-e2e` with `cancel-in-progress` ensures the single-node
+  cluster is never driven by two e2e jobs at once.

--- a/test/cluster-e2e/husk-e2e.sh
+++ b/test/cluster-e2e/husk-e2e.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+#
+# husk-e2e.sh
+#
+# The real-cluster husk end-to-end verification (issue #16). This is the
+# standing CI form of the maintainer's manual cluster check: it drives a REAL
+# Kubernetes cluster with a REAL KVM-capable node through the full husk
+# lifecycle and asserts each stage.
+#
+# Stages (each prints a PASS/FAIL line):
+#   1. pool warms      a SandboxPool brings up dormant husk pods
+#   2. claim activates a SandboxClaim reaches Ready and exec returns expected stdout
+#   3. fork(2)         a fork produces independent sandboxes
+#   4. run_code        a code-interpreter run returns a result OR a clean
+#                      KernelUnavailable (the husk OCI base may lack the kernel;
+#                      KernelUnavailable is accepted as a pass for that check)
+#   5. PTY             an interactive PTY allocates and echoes
+#   6. self-heal       (best effort) deleting a claimed husk pod re-pends the claim
+#
+# It runs from inside the cluster (the self-hosted runner's ServiceAccount) and
+# reaches the per-claim sandbox HTTP API over the pod network via the Python
+# SDK (in_cluster=True). CRD lifecycle and the self-heal probe use kubectl.
+#
+# Reuses the warm-dormant-pod wait pattern from bench/husk-activate-latency.sh.
+#
+# Usage:
+#   test/cluster-e2e/husk-e2e.sh [namespace] [kubeconfig]
+#
+#   [namespace]   namespace to run the e2e in (default: mitos-e2e)
+#   [kubeconfig]  optional kubeconfig path; omit to use the in-cluster SA
+#
+# Env knobs:
+#   READY_TIMEOUT   per-stage wait budget, seconds (default 180)
+#   POLL_INTERVAL   poll interval, seconds (default 1)
+#   E2E_IMAGE       template image (default python:3.12-slim)
+#
+set -euo pipefail
+
+NAMESPACE="${1:-mitos-e2e}"
+KUBECONFIG_ARG="${2:-}"
+if [ -n "$KUBECONFIG_ARG" ]; then
+  export KUBECONFIG="$KUBECONFIG_ARG"
+fi
+
+READY_TIMEOUT="${READY_TIMEOUT:-180}"
+POLL_INTERVAL="${POLL_INTERVAL:-1}"
+E2E_IMAGE="${E2E_IMAGE:-python:3.12-slim}"
+
+RUN_ID="$(date +%s)-$$"
+TEMPLATE="e2e-tmpl-${RUN_ID}"
+POOL="e2e-pool-${RUN_ID}"
+CLAIM="e2e-claim-${RUN_ID}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+info() { echo "  $*"; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 1; }
+}
+require kubectl
+require python3
+
+# kubectl in a namespace shorthand.
+k() { kubectl -n "$NAMESPACE" "$@"; }
+
+diagnostics() {
+  echo "=== diagnostics (namespace ${NAMESPACE}) ===" >&2
+  k get sandboxpools,sandboxclaims,sandboxforks -o wide >&2 2>&1 || true
+  k get pods -o wide >&2 2>&1 || true
+  echo "--- claim describe ---" >&2
+  k describe sandboxclaim "$CLAIM" >&2 2>&1 || true
+  echo "--- recent husk pod logs ---" >&2
+  for p in $(k get pods -l 'mitos.run/husk=true' -o name 2>/dev/null | head -3); do
+    echo "--- logs $p ---" >&2
+    k logs "$p" --tail=40 >&2 2>&1 || true
+  done
+}
+
+cleanup() {
+  rc=$?
+  echo "=== teardown ==="
+  # Delete the claim/fork first (releases pods), then the pool, then the
+  # template. Best effort; never let teardown mask the real exit code.
+  k delete sandboxforks --all --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  k delete sandboxclaim "$CLAIM" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  k delete sandboxpool "$POOL" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  k delete sandboxtemplate "$TEMPLATE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  # Sweep any residual claims/forks this run created.
+  k delete sandboxclaims -l "mitos.run/e2e-run=${RUN_ID}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  echo "teardown done"
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "=== mitos cluster husk e2e: ns=${NAMESPACE} image=${E2E_IMAGE} run=${RUN_ID} ==="
+
+# ---------------------------------------------------------------------------
+# Stage 0: KVM node present (the husk path needs a KVM-capable node).
+# ---------------------------------------------------------------------------
+if kubectl get nodes -l 'mitos.run/kvm=true' -o name 2>/dev/null | grep -q node; then
+  pass "a KVM-capable node (mitos.run/kvm=true) is present"
+else
+  fail "no node labeled mitos.run/kvm=true; the husk path cannot warm pods"
+  diagnostics
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 1: a pool warms dormant husk pods.
+# ---------------------------------------------------------------------------
+echo "--- stage 1: pool warms dormant husk pods ---"
+k apply -f - >/dev/null <<EOF
+apiVersion: mitos.run/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: ${TEMPLATE}
+  labels:
+    mitos.run/e2e-run: "${RUN_ID}"
+spec:
+  image: ${E2E_IMAGE}
+  resources:
+    cpu: "1"
+    memory: "512Mi"
+---
+apiVersion: mitos.run/v1alpha1
+kind: SandboxPool
+metadata:
+  name: ${POOL}
+  labels:
+    mitos.run/e2e-run: "${RUN_ID}"
+spec:
+  templateRef:
+    name: ${TEMPLATE}
+  replicas: 2
+EOF
+
+# Wait for at least one dormant warm pod: husk=true, Running, no claim label.
+warm_deadline=$(( $(date +%s) + READY_TIMEOUT ))
+warm_ok=""
+while [ "$(date +%s)" -lt "$warm_deadline" ]; do
+  dormant="$(k get pods -l 'mitos.run/husk=true,!mitos.run/claim' \
+    --field-selector=status.phase=Running -o name 2>/dev/null | head -1 || true)"
+  if [ -n "$dormant" ]; then warm_ok="yes"; break; fi
+  sleep "$POLL_INTERVAL"
+done
+if [ -n "$warm_ok" ]; then
+  pass "pool ${POOL} warmed at least one dormant husk pod"
+else
+  fail "pool ${POOL} did not warm a dormant husk pod within ${READY_TIMEOUT}s"
+  diagnostics
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stages 2-5 are driven by the Python SDK against the sandbox HTTP API over the
+# pod network. The driver prints one RESULT:<stage>:<PASS|FAIL>:<detail> line
+# per stage on stdout; this script folds those into the PASS/FAIL tally so the
+# bash layer stays the single source of truth for the exit code.
+# ---------------------------------------------------------------------------
+echo "--- stages 2-5: claim, exec, fork, run_code, PTY (SDK driver) ---"
+
+driver_out="$(mktemp)"
+set +e
+INCLUSTER="false"
+[ -z "${KUBECONFIG:-}" ] && INCLUSTER="true"
+MITOS_NS="$NAMESPACE" MITOS_POOL="$POOL" MITOS_CLAIM="$CLAIM" \
+MITOS_INCLUSTER="$INCLUSTER" MITOS_READY_TIMEOUT="$READY_TIMEOUT" \
+python3 - <<'PYEOF' | tee "$driver_out"
+import os
+import sys
+import time
+
+from mitos import AgentRun
+
+NS = os.environ["MITOS_NS"]
+POOL = os.environ["MITOS_POOL"]
+CLAIM = os.environ["MITOS_CLAIM"]
+INCLUSTER = os.environ.get("MITOS_INCLUSTER", "true") == "true"
+READY_TIMEOUT = float(os.environ.get("MITOS_READY_TIMEOUT", "180"))
+
+
+def result(stage, ok, detail=""):
+    print(f"RESULT:{stage}:{'PASS' if ok else 'FAIL'}:{detail}", flush=True)
+
+
+run = AgentRun(namespace=NS, in_cluster=INCLUSTER)
+
+# ---- stage 2: claim activates to Ready and exec returns expected stdout ----
+sb = None
+try:
+    sb = run.sandbox(pool=POOL, name=CLAIM)
+    sb.wait_until_ready(timeout=READY_TIMEOUT)
+    res = sb.exec("echo mitos-e2e-ok", timeout=30)
+    out = (res.stdout or "").strip()
+    if res.exit_code == 0 and out == "mitos-e2e-ok":
+        result("claim-exec", True, f"exit=0 stdout={out!r}")
+    else:
+        result("claim-exec", False, f"exit={res.exit_code} stdout={out!r} stderr={res.stderr!r}")
+except Exception as exc:  # noqa: BLE001
+    result("claim-exec", False, f"{type(exc).__name__}: {exc}")
+    # Without a Ready sandbox the remaining stages cannot run; bail.
+    sys.exit(0)
+
+# ---- stage 3: fork(2) produces independent sandboxes ----
+try:
+    forks = sb.fork(n=2)
+    if len(forks) != 2:
+        result("fork", False, f"expected 2 forks, got {len(forks)}")
+    else:
+        # Prove independence: write a distinct marker in each fork and read it
+        # back; the two must not see each other's marker.
+        f0, f1 = forks[0], forks[1]
+        f0.exec("echo fork0 > /tmp/who", timeout=30)
+        f1.exec("echo fork1 > /tmp/who", timeout=30)
+        r0 = f0.exec("cat /tmp/who", timeout=30).stdout.strip()
+        r1 = f1.exec("cat /tmp/who", timeout=30).stdout.strip()
+        if r0 == "fork0" and r1 == "fork1":
+            result("fork", True, f"independent: f0={r0!r} f1={r1!r}")
+        else:
+            result("fork", False, f"not independent: f0={r0!r} f1={r1!r}")
+except Exception as exc:  # noqa: BLE001
+    result("fork", False, f"{type(exc).__name__}: {exc}")
+
+# ---- stage 4: run_code returns a result OR a clean KernelUnavailable ----
+# The husk OCI base may lack the code-interpreter kernel; per issue #16 a clean
+# KernelUnavailable is accepted as a PASS for this check (do not fail the suite).
+try:
+    ex = sb.run_code("print(6 * 7)", timeout=60)
+    if ex.error is not None and "KernelUnavailable" in (ex.error.name or ""):
+        result("run_code", True, "clean KernelUnavailable (accepted: base lacks the kernel)")
+    elif ex.error is not None and "KernelUnavailable" in (ex.error.value or ""):
+        result("run_code", True, "clean KernelUnavailable (accepted: base lacks the kernel)")
+    else:
+        logs = "".join(ex.logs.get("stdout", []))
+        got = (ex.text or logs).strip()
+        if "42" in got:
+            result("run_code", True, f"kernel returned {got!r}")
+        elif ex.error is not None:
+            # A non-KernelUnavailable error is a real failure.
+            result("run_code", False, f"kernel error {ex.error.name!r}: {ex.error.value!r}")
+        else:
+            result("run_code", False, f"no result and no KernelUnavailable; got {got!r}")
+except Exception as exc:  # noqa: BLE001
+    # A transport-level KernelUnavailable can surface as an exception; accept it.
+    msg = f"{type(exc).__name__}: {exc}"
+    if "KernelUnavailable" in msg:
+        result("run_code", True, "clean KernelUnavailable (accepted: base lacks the kernel)")
+    else:
+        result("run_code", False, msg)
+
+# ---- stage 5: a PTY allocates and echoes ----
+try:
+    chunks = []
+    handle = sb.pty.create(on_data=lambda b: chunks.append(b), cols=80, rows=24)
+    handle.send_input(b"echo pty-mitos-e2e\n")
+    # Give the guest a moment to echo, then exit the shell.
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if b"pty-mitos-e2e" in b"".join(chunks):
+            break
+        time.sleep(0.2)
+    handle.send_input(b"exit\n")
+    try:
+        handle.wait(timeout=10)
+    except TypeError:
+        # Older handle.wait() takes no timeout.
+        handle.wait()
+    echoed = b"".join(chunks)
+    if b"pty-mitos-e2e" in echoed:
+        result("pty", True, "PTY allocated and echoed the input")
+    else:
+        result("pty", False, f"PTY did not echo; got {echoed[:120]!r}")
+except Exception as exc:  # noqa: BLE001
+    result("pty", False, f"{type(exc).__name__}: {exc}")
+PYEOF
+driver_rc=$?
+set -e
+
+# Fold the driver RESULT lines into the bash tally.
+for stage in claim-exec fork run_code pty; do
+  line="$(grep "^RESULT:${stage}:" "$driver_out" | tail -1 || true)"
+  if [ -z "$line" ]; then
+    fail "stage ${stage}: driver produced no result (driver_rc=${driver_rc})"
+    continue
+  fi
+  verdict="$(printf '%s' "$line" | cut -d: -f3)"
+  detail="$(printf '%s' "$line" | cut -d: -f4-)"
+  if [ "$verdict" = "PASS" ]; then
+    pass "stage ${stage}: ${detail}"
+  else
+    fail "stage ${stage}: ${detail}"
+  fi
+done
+rm -f "$driver_out"
+
+# ---------------------------------------------------------------------------
+# Stage 6 (best effort): deleting a claimed husk pod re-pends the claim
+# (the eviction / self-heal path). Best effort: if the claim object or its pod
+# cannot be resolved, record a non-fatal note rather than a FAIL.
+# ---------------------------------------------------------------------------
+echo "--- stage 6 (best effort): self-heal re-pends a claim on pod deletion ---"
+self_heal_probe() {
+  # Find the pod backing the claim. The controller labels the activated husk
+  # pod with mitos.run/claim=<claim-name>.
+  pod="$(k get pods -l "mitos.run/claim=${CLAIM}" -o name 2>/dev/null | head -1 || true)"
+  if [ -z "$pod" ]; then
+    info "self-heal: could not resolve the pod for claim ${CLAIM}; skipping (non-fatal)"
+    return 0
+  fi
+  info "self-heal: deleting ${pod} backing claim ${CLAIM}"
+  k delete "$pod" --wait=false >/dev/null 2>&1 || true
+  # The claim should leave Ready (re-pend) then recover to Ready on a new pod,
+  # OR at minimum its Ready condition should flip away from True transiently.
+  deadline=$(( $(date +%s) + READY_TIMEOUT ))
+  saw_repend=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    ready="$(k get sandboxclaim "$CLAIM" \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+    if [ "$ready" != "True" ]; then saw_repend="yes"; break; fi
+    sleep "$POLL_INTERVAL"
+  done
+  if [ -n "$saw_repend" ]; then
+    return 0
+  fi
+  info "self-heal: claim stayed Ready throughout (controller may have re-activated faster than the poll); treating as non-fatal"
+  return 2
+}
+set +e
+self_heal_probe
+sh_rc=$?
+set -e
+if [ "$sh_rc" -eq 0 ]; then
+  pass "self-heal: claim re-pended after its husk pod was deleted"
+else
+  # Best effort: a missed re-pend window is recorded but does NOT fail the suite.
+  echo "NOTE: self-heal probe inconclusive (non-fatal)"
+fi
+
+# ---------------------------------------------------------------------------
+# Verdict.
+# ---------------------------------------------------------------------------
+echo
+echo "=== summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ==="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  diagnostics
+  exit 1
+fi
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## Summary

A self-hosted GitHub Actions runner running IN the single-node Talos KVM cluster, so a new `cluster-e2e` workflow runs the husk e2e (claim -> activate -> exec -> fork -> run_code -> PTY -> crash-reap/self-heal) on REAL KVM and a REAL k8s cluster on every trusted change. This turns the manual cluster verification done throughout the production-readiness work into standing CI: every merge to main is auto-verified on the real engine, not just kind mock + GitHub-hosted nested KVM.

- `deploy/ci-runner/`: the runner Deployment (ephemeral, unprivileged, runAsNonRoot, all caps dropped, no KVM/host mounts; it only drives the cluster via kubectl + the SDK over the pod network) in namespace `mitos-ci`, plus a dedicated `mitos-e2e` namespace, a ServiceAccount, and MINIMAL RBAC (namespaced Roles for the e2e + deploy-under-test; the only ClusterRole grants nodes-read; no cluster-admin). Runner image + base actions-runner both pinned by digest.
- `.github/workflows/cluster-e2e.yaml`: `runs-on: [self-hosted, mitos-cluster]`, 25-min timeout, `permissions: contents:read`, `environment: cluster` (required-reviewer gate), `if: always()` teardown.
- `test/cluster-e2e/husk-e2e.sh`: the real-cluster assertions (KVM node, warm pool, claim activate + exec, fork independence, run_code-or-clean-KernelUnavailable, PTY echo, claimed-pod re-pend).
- `docs/ci-runner.md`: architecture, the security model, and the exact maintainer setup steps.

## SECURITY (the repo is PUBLIC)
A self-hosted runner must never run untrusted fork-PR code (it has KVM + cluster RBAC). The job `if:` allows ONLY: `push` to main, `workflow_dispatch`, or a `pull_request` that is BOTH from the same repo (`head.repo.full_name == github.repository`, so forks are excluded) AND carries a maintainer-applied `ci-cluster` label. Fork PRs fail both checks and are skipped. The `cluster` Environment adds a second human-approval gate. No token value is committed; the maintainer creates the registration Secret out of band.

## Activation (one-time, maintainer; needs repo-admin, which CI cannot self-grant)
The runner image is already built + pushed + digest-pinned. Remaining:
1. Create a fine-grained PAT (Administration + Actions read/write) or a runner registration token.
2. `kubectl create secret -n mitos-ci generic mitos-ci-runner-token --from-literal=token=<token>`
3. `kubectl apply -k deploy/ci-runner/`
4. Configure the `cluster` GitHub Environment with a required reviewer.

Then the runner registers and the e2e runs on every trusted change. Validated: kustomize resolves, workflow + manifests parse, actionlint clean, e2e shellcheck clean, no committed secrets, no em/en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)