### PR TITLE
docs: reconcile ROADMAP and README with shipped production + agent-runtime work

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ sb.terminate()
 
 `c.sandbox("python")` lazily creates a default pool `mitos-default-python` (a SandboxTemplate plus a SandboxPool) if you have none; pass `pool="my-pool"` to use an existing pool, which never creates anything. Errors raise `AgentRunError(code, cause, remediation)`.
 
+Beyond `exec`, the same `Sandbox` gives agents a stateful code interpreter, streaming output, and an interactive terminal:
+
+```python
+# Streaming exec: callbacks fire per chunk; the ExecResult still carries the aggregate.
+sb.exec("pip install rich", on_stdout=lambda b: print(b.decode(), end=""))
+
+# Stateful code interpreter: state persists across run_code calls for the sandbox lifetime.
+ex = sb.run_code("import pandas as pd; df = pd.DataFrame({'x':[1,2,3]}); df.describe()")
+print(ex.text)            # the REPL's last value, rendered
+for r in ex.results:      # rich multi-MIME display artifacts (tables, images, ...)
+    print(r.mime)
+# run_code returns a KernelUnavailable error until the kernel ships in the husk base image.
+
+# Detach a long-running process and keep working.
+sb.exec_background("python train.py > /workspace/train.log 2>&1")
+```
+
+The async client (`AsyncAgentRun`) mirrors these for the hot paths and adds `create_pty()` for an interactive terminal over WebSocket. The TypeScript SDK (`@mitos/sdk`) exposes the same surface.
+
 ## Why
 
 Agent harnesses need fast, isolated environments where agents can read and write files, install packages, and run untrusted code. Every existing option forces a trade you should not have to make: speed without ownership, isolation without forking, Kubernetes-nativeness without warm starts, durability as someone else's proprietary cloud.
@@ -63,7 +82,8 @@ Two ways to run it:
 **Kubernetes-native**
 - Declarative CRDs: `SandboxPool`, `SandboxClaim`, `SandboxFork`
 - Templates with volume topology and fork behavior
-- Capacity-aware scheduling ([#17](https://github.com/paperclipinc/mitos/issues/17)): CoW bin-packing onto warm snapshot-holders, an overcommit budget checked against CoW-aware memory accounting, and backpressure that pends claims with a typed `NoCapacity` condition rather than OOMing a node (see [docs/scheduling.md](docs/scheduling.md))
+- Capacity-aware scheduling ([#17](https://github.com/paperclipinc/mitos/issues/17)): CoW bin-packing onto warm snapshot-holders, an overcommit budget checked against CoW-aware memory accounting, a `MaxSandboxes` host-DoS ceiling enforced with an atomic slot reservation, and backpressure that pends claims with a typed `NoCapacity` condition rather than OOMing a node (see [docs/scheduling.md](docs/scheduling.md))
+- Demand-driven warm-pool autoscaling: `SandboxPool.spec.autoscale` (`minWarm`/`maxWarm`/`targetSpare`) scales the dormant husk-pod count to `clamp(inUse + targetSpare, minWarm, maxWarm)` from live claim demand, with an anti-thrash scale-down cooldown; a fixed pool is just `minWarm == replicas`
 - RBAC and namespace scoping; pod-native execution via unprivileged, PSA-restricted husk pods is the DEFAULT ([#18](https://github.com/paperclipinc/mitos/issues/18)): the per-sandbox VM runs inside an unprivileged pod (`/dev/kvm` from a device plugin, not `privileged`), so its CPU/memory requests are scheduler truth and PSA governs the pod. The sandbox itself is the VM, not the pod
 - Works with Prometheus and standard k8s tooling
 
@@ -78,10 +98,16 @@ Two ways to run it:
 **Operable**
 - Node and controller Prometheus metrics, a per-claim OpenTelemetry trace (`--otlp-endpoint`), and a toggleable structured audit log of every exec/file op (`--audit-log`) that records command, path, and byte counts but never content or secrets ([#29](https://github.com/paperclipinc/mitos/issues/29), see [docs/observability.md](docs/observability.md))
 - `kubectl sandbox` plugin (`ls` / `ps`) for operators
-- Failure and GC semantics: claim TTLs (`maxLifetime`, `idleTimeout`), orphan-VM sweeps, and controller-restart reconciliation of the desired set are implemented and CI-proven; forkd crash reaping and saturation queuing are open ([#12](https://github.com/paperclipinc/mitos/issues/12), see [docs/failure-gc.md](docs/failure-gc.md))
+- Failure and GC semantics: claim TTLs (`maxLifetime`, `idleTimeout`), orphan-VM sweeps, controller-restart reconciliation of the desired set, forkd crash reaping (running VMs re-adopted or reaped via an on-disk journal, PID-recycle and TOCTOU guarded), node-loss handling tied to a forkd liveness probe, and saturation backpressure (a typed `NoCapacity` condition with bounded backoff, then a clean capacity-exhaustion failure) are implemented and CI-proven ([#12](https://github.com/paperclipinc/mitos/issues/12), see [docs/failure-gc.md](docs/failure-gc.md))
+
+**Agent-runtime DX**
+- Streaming exec: incremental stdout/stderr and background processes over the sandbox API, with a streaming-callback exec in both SDKs ([#24](https://github.com/paperclipinc/mitos/issues/24))
+- Code interpreter: `run_code` with a stateful kernel and rich multi-MIME results, in both SDKs and the MCP server. It fails closed with a `KernelUnavailable` error until the kernel ships in the husk cluster base image (a tracked follow-up below)
+- Interactive PTY: a token-gated bidirectional WebSocket terminal (`sandbox.pty`), guest-side PTY shell pumped over vsock ([#24](https://github.com/paperclipinc/mitos/issues/24))
+- LLM-legible errors: every failure carries `{code, cause, remediation}` ([#28](https://github.com/paperclipinc/mitos/issues/28)), parsed by both SDKs into a structured `AgentRunError`
 
 **Surfaces**
-- Python SDK (`sdk/python`) and TypeScript SDK (`@mitos/sdk`)
+- Python SDK (`sdk/python`) and TypeScript SDK (`@mitos/sdk`), both with a one-liner `sandbox(image)`, a lazy default pool, `from_name` reconnect, streaming exec, and (Python) an async client
 - `mitos` CLI with one-command local dev (`mitos dev up`) and an MCP server (`mitos-mcp`) that exposes sandboxes as MCP tools
 - Bare metal is a first-class target: Talos + Hetzner is the reference platform ([#16](https://github.com/paperclipinc/mitos/issues/16), see [docs/platforms/talos-hetzner.md](docs/platforms/talos-hetzner.md))
 
@@ -156,12 +182,10 @@ the backends, and what is proven. For the no-cluster REST loop, run
 ### On a cluster
 
 ```bash
-kubectl apply -f deploy/crds/
-kubectl apply -f deploy/controller/
-kubectl apply -f deploy/daemon/
+kubectl apply -k deploy/
 ```
 
-A Helm chart is planned ([#37](https://github.com/paperclipinc/mitos/issues/37) tracks release machinery). Nodes need `/dev/kvm` and the label `mitos.run/kvm=true`; the controller discovers forkd pods automatically.
+The self-contained kustomize base installs the CRDs, the controller in the default husk mode, the forkd builder DaemonSet, the `/dev/kvm` device plugin, and the PKI bootstrap, and applies on a real KVM node with no manual patches. A Helm chart is planned ([#37](https://github.com/paperclipinc/mitos/issues/37) tracks release machinery). Nodes need `/dev/kvm` and the label `mitos.run/kvm=true`; the controller discovers forkd pods automatically.
 
 ### Create a pool, claim, fork
 
@@ -316,7 +340,7 @@ Per-topic docs in [`docs/`](docs/):
 
 Early development, pre-1.0. Do not run untrusted code with this project in production yet, and note that there has been no external security review ([docs/threat-model.md](docs/threat-model.md)). The control plane is real end-to-end (claim to running sandbox, proven in CI against mock engines and real Firecracker VMs, and exercised on a bare-metal Talos KVM cluster). Implemented and CI-proven: pod-native execution via unprivileged, PSA-restricted husk pods as the DEFAULT (the per-sandbox VM runs inside an unprivileged pod with `/dev/kvm` from a device plugin, not `privileged`), with raw-forkd under the Firecracker jailer as the fallback; OCI image to rootfs template builds; per-activation copy-on-write rootfs (each activation gets its own reflink clone of the template rootfs); mTLS plus per-sandbox token auth; LLM-legible structured errors (`code`, `cause`, `remediation`); KMS envelope encryption with crypto-shredding; RNG reseed and clock resync on fork (remaining fork-correctness items in [#3](https://github.com/paperclipinc/mitos/issues/3)); `Fresh` and `Snapshot` volume policies; content-addressed snapshot integrity, version-compatibility, and peer-to-peer distribution; default-deny IP and name-based egress; CoW-aware metering; capacity-aware scheduling; the observability surface; the MCP server; the CLI; incremental streaming exec with background processes; a stateful code interpreter (`run_code` with rich multi-MIME results and structured errors); an interactive PTY over WebSocket; a one-liner SDK with a lazy default pool, an async Python client, and durable `from_name` handles; and the Python and TypeScript SDKs. Bare-metal warm-claim activate latency (P50 ~27 ms) is published and reproducible ([BENCHMARKS.md](BENCHMARKS.md)).
 
-Documented follow-ups and targets, not yet shipped: preview URLs / inbound port exposure into the sandbox; the code-interpreter kernel in the husk cluster base image (`run_code` is fail-closed with a clear `KernelUnavailable` until then); the durable Workspace git verbs ([#21](https://github.com/paperclipinc/mitos/issues/21)); pluggable engine tiers ([#43](https://github.com/paperclipinc/mitos/issues/43)); multi-node snapshot distribution validation ([#3](https://github.com/paperclipinc/mitos/issues/3)); a Helm chart ([#37](https://github.com/paperclipinc/mitos/issues/37)); a bare-metal self-hosted CI runner ([#16](https://github.com/paperclipinc/mitos/issues/16)); and the remaining failure/GC items ([#12](https://github.com/paperclipinc/mitos/issues/12)). The sandbox is the VM, not the husk pod: the husk pod is the VM's unprivileged host, so pod-scoped Kubernetes policies (NetworkPolicy, ResourceQuota, PSA) govern the husk pod, not the workload inside the microVM. [ROADMAP.md](ROADMAP.md) is the single source for what is done, in progress, and gated; the operating rule is that this repository never describes a system that does not exist.
+Documented follow-ups and targets, not yet shipped: preview URLs / inbound port exposure into the sandbox; the code-interpreter kernel in the husk cluster base image (`run_code` is fail-closed with a clear `KernelUnavailable` until then); the durable Workspace git verbs ([#21](https://github.com/paperclipinc/mitos/issues/21)); pluggable engine tiers ([#43](https://github.com/paperclipinc/mitos/issues/43)); multi-node snapshot distribution validation ([#3](https://github.com/paperclipinc/mitos/issues/3)); a Helm chart ([#37](https://github.com/paperclipinc/mitos/issues/37)); and the remaining failure/GC items ([#12](https://github.com/paperclipinc/mitos/issues/12)). The bare-metal self-hosted CI runner ([#16](https://github.com/paperclipinc/mitos/issues/16)) is built and CI-validated; arming it as standing CI is a maintainer apply step (the registration Secret plus the manifests). The sandbox is the VM, not the husk pod: the husk pod is the VM's unprivileged host, so pod-scoped Kubernetes policies (NetworkPolicy, ResourceQuota, PSA) govern the husk pod, not the workload inside the microVM. [ROADMAP.md](ROADMAP.md) is the single source for what is done, in progress, and gated; the operating rule is that this repository never describes a system that does not exist.
 
 Contributions welcome: see [CONTRIBUTING.md](CONTRIBUTING.md) and [CLAUDE.md](CLAUDE.md) for conventions, [SECURITY.md](SECURITY.md) for vulnerability reporting.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -488,18 +488,22 @@ below it; a `fork-correctness` CI job gates PRs touching `internal/fork/`,
 Every component gets a defined answer to: crash, node death, slow etcd,
 out of capacity. Chaos suite in CI.
 
-- 🔨 forkd crash policy: running VMs reaped deterministically on restart
-  (forkd is the VM supervisor; orphan FC processes are killed and claims
-  failed with a typed condition). Done: forkd-local state via an on-disk
-  sandbox journal (`<dataDir>/sandboxes/<id>.json`) that NewEngine reconciles
-  before serving. A still-running pre-crash VM (PID-recycle-guarded against a
-  recycled, unrelated pid) is re-adopted so `ListSandboxes` reports it and the
-  GC reconciles it; a dead VM's leaked artifacts (jailer chroot, rootfs CoW
-  clone, fork network, jailer uid) are reaped and its record dropped. Open:
-  surfacing a typed claim condition when the GC terminates a re-adopted orphan;
-  real-VM reap is KVM-cluster/firecracker-test verified. Tracked in epic #12.
-- 🔨 Node loss: claims reach `NodeLost` within the GC interval (done); pools
-  rebuild replicas elsewhere is still open (tracked in #12).
+- ✅ forkd crash policy: running VMs reaped or re-adopted deterministically on
+  restart (production blocker #1, epic #12). forkd-local state lives in an
+  on-disk sandbox journal (`<dataDir>/sandboxes/<id>.json`) that NewEngine
+  reconciles before serving (`internal/fork/journal.go`,
+  `internal/fork/reconcile.go`). A still-running pre-crash VM is re-adopted
+  (PID-recycle-guarded via procfs against a recycled, unrelated pid; a TOCTOU
+  re-verify of the pid before any kill) so `ListSandboxes` reports it and the GC
+  reconciles it; a dead VM's leaked artifacts (jailer chroot, rootfs CoW clone,
+  fork network with the exact /30 block re-pinned, jailer uid) are reaped and its
+  record dropped. Real-VM reap is KVM/firecracker-test verified. Open:
+  surfacing a typed claim condition when the GC terminates a re-adopted orphan.
+- ✅ Node loss: claims reach `NodeLost` within the GC interval, node health is
+  tied to a forkd liveness probe, and a recoverable husk claim is not failed by
+  a GC node-loss pass (production blocker #4, epic #12). Pools recreate husk-pod
+  replicas elsewhere via the warm-pool deficit logic. The raw-forkd
+  pool-rebuild-elsewhere path is still tracked in #12.
 - ✅ Controller restart: the GC pass rebuilds the desired set from CRD state
   and sweeps any forkd VM not accounted for; zero orphans.
 - 🔨 Orphan sweeps: VM without a backing object is swept past OrphanGrace,
@@ -510,8 +514,15 @@ out of capacity. Chaos suite in CI.
   via the forkd `ListSandboxes` primitive.
 - 🔨 etcd hygiene: TTL of finished objects, including early-failed claims,
   is done. Rate-limiting and batching of status updates is still open.
-- ⬜ Saturation behavior: queue with deadline then a typed fail-fast
-  condition. Open (tracked in #12).
+- ✅ Saturation behavior: queue with backpressure then a typed fail-fast
+  condition (production blocker #4, epic #12). A claim with no fitting node pends
+  with a typed `NoCapacity` condition (accurate per re-pend cause) and bounded
+  backoff, fails cleanly after `--max-pending-duration`, and a raw-forkd claim
+  re-pends on `ResourceExhausted`/`Unavailable`; the `MaxSandboxes` count ceiling
+  is enforced at schedule time and at Fork with an atomic slot reservation that
+  closes the admission TOCTOU. Resource caps (per-sandbox stream caps, husk pod
+  memory limit with headroom, the host-DoS `MaxSandboxes` ceiling) are production
+  blocker #2.
 
 See docs/failure-gc.md for each guarantee, its proving test, and bounded
 time, plus the explicit open items.
@@ -621,11 +632,17 @@ or spoof.
   competitive with raw-forkd). See `BENCHMARKS.md` "Raw-forkd vs pod-native"
   section. The measured bare-metal <=10ms stays a TARGET (#16, needs the
   reference node).
-- ⬜ Bare-metal reference numbers on the Hetzner + Talos reference node;
-  includes the <=10ms warm-pool claim-to-first-exec TARGET (#18/#16, not a
-  shared-CI claim); CI runs on pinned bare-metal hardware per release →
-  `BENCHMARKS.md` results section (current CI numbers are shared-runner-class,
-  not representative)
+- 🔨 Bare-metal reference numbers on the Hetzner + Talos reference node: a FIRST
+  reference run is published (warm-claim activate P50 ~27 ms (N=11), snapshot
+  restore ~6-16 ms, ~3 MiB marginal memory per forked sandbox), reproducible from
+  `bench/husk-activate-latency.sh` with the full method and sample set in
+  `bench/results/2026-06-13-bare-metal-husk.md` and `BENCHMARKS.md`. Still open:
+  the bare-metal engine fork->first-exec via `cmd/bench` (not run on the box this
+  session), a PINNED reference-node CI runner so the numbers regenerate per
+  release, and the <=10ms warm-pool claim-to-first-exec TARGET (#18/#16): the
+  activate restore step is sub-10 ms on the node, but the full activate (restore +
+  handshake + guest-ready) measures ~27 ms P50, so the end-to-end target is not
+  yet met.
 - ⬜ Comparison table regenerated from in-repo scripts against E2B
   self-hosted, Daytona OSS, Agent Sandbox + Kata warm pools on the same
   hardware; reproducible by anyone
@@ -645,7 +662,7 @@ or spoof.
   checks; operator deploy + PKI bootstrap; smoke test; capacity planning
   pointers). CI-VERIFIED vs HARDWARE-REQUIRED split clearly marked in the
   runbook.
-- ⬜ Self-hosted bare-metal CI runner (#16): an EPHEMERAL GitHub Actions runner
+- 🔨 Self-hosted bare-metal CI runner (#16): an EPHEMERAL GitHub Actions runner
   runs IN the single-node Talos KVM cluster (deploy/ci-runner/, namespace
   mitos-ci) and drives the real-cluster husk e2e on every trusted change
   (claim -> activate -> exec -> fork -> run_code -> PTY -> crash-reap;
@@ -686,6 +703,15 @@ pending/backpressure behavior are documented in docs/scheduling.md.
   bounded --max-pending-duration instead of OOMing a node. The pending-claims
   metric (mitos_claim_pending_total) is the autoscaler/back-pressure
   signal; envtest-proven in internal/controller.
+- ✅ Demand-driven warm-pool autoscaling: a `SandboxPool.spec.autoscale`
+  (`minWarm`/`maxWarm`/`targetSpare`/`scaleDownCooldownSeconds`) turns the fixed
+  `replicas` pre-fill into a demand-driven autoscaler of DORMANT husk pods. The
+  desired dormant count is `clamp(inUse + targetSpare, minWarm, maxWarm)`, fed
+  from a per-pool claim-arrival demand tracker; scale-up is immediate, scale-down
+  obeys an anti-thrash cooldown, and an active claim's pod is never scaled away.
+  Autoscale metrics (size, in-use, desired, scale events, claim-wait latency) are
+  exported. Proven in envtest (scale up then down to floor; a claimed pod
+  survives scale-down). The legacy fixed pool is `minWarm == replicas`.
 - ⬜ NUMA pinning + hugepage-backed guest memory; KSM same-page-merging
   tuning; per-node max density config (needs hardware)
 - ⬜ Multi-resource bin-packing (disk, CPU, and the cold-start
@@ -715,10 +741,30 @@ verified. In rough order of leverage:
   on the mock engine; real in-VM exec is proven by the KVM CI of the API. See
   docs/cli.md. OPEN: workspace verbs (`mitos ws ...`) deferred to Workspace
   (#21).
-- ⬜ Streaming exec (stdout/stderr), stdin, **PTY mode**, file transfer,
-  port forwarding, the daily-driver agent-harness needs
-- ⬜ Code-interpreter-compatible API shim (drop-in for LangChain/LlamaIndex
-  sandbox integrations)
+- ✅ Streaming exec and background processes: forkd serves an incremental
+  stdout/stderr stream over the sandbox API (vsock-bridged to the guest agent),
+  backgrounded processes detach from the request, and both SDKs expose a
+  streaming-callback exec. Per-sandbox concurrent-stream caps bound the surface
+  (resource caps, epic #12). Unit-tested in `internal/vsock` and
+  `internal/daemon`; real in-VM exec proven by the KVM CI of the API. Interactive
+  stdin is delivered through the PTY path below. The normative Connect runtime
+  protocol (streaming/PTY/files/watch/port-forward as one wire contract) is the
+  API v2 target (#24).
+- ✅ **PTY mode**: a token-gated bidirectional WebSocket `/v1/pty` endpoint on
+  forkd and the standalone sandbox-server; the guest agent allocates a PTY shell
+  and pumps I/O over vsock. Both SDKs ship an interactive terminal handle
+  (`sandbox.pty`, sync and async in Python). Cross-sandbox token rejection is
+  unit-tested; the PTY surface is recorded in `docs/threat-model.md`. Part of the
+  API v2 runtime protocol (#24).
+- ✅ **Code interpreter (`run_code`)**: a stateful kernel with rich multi-MIME
+  results and structured errors, served over the sandbox API and exposed in both
+  SDKs and the MCP server. It is fail-closed with a clear `KernelUnavailable`
+  error until the kernel ships in the husk cluster base image (the open
+  follow-up below). Unit-tested in `internal/vsock` and `internal/daemon`. This
+  is the drop-in code-interpreter surface for agent harnesses.
+- ⬜ File transfer ergonomics and operator port-forwarding beyond the runtime
+  protocol above; the code-interpreter kernel baked into the husk cluster base
+  image so `run_code` is live (not `KernelUnavailable`) by default.
 - ✅ `kubectl sandbox` plugin: ls (SandboxClaims), ps (SandboxForks), tree (the
   fork/lineage DAG), top (per-sandbox CoW-aware metering from forkd
   `/v1/metering`, honestly labeled, a dash on a missing datum), logs (the husk
@@ -757,7 +803,18 @@ verified. In rough order of leverage:
 - ✅ One-command local story: `mitos dev up` (kind + mock control plane from
   deploy/dev/), proven in the kind CI smoke. OPEN: document the KVM-passthrough
   path for real local exec.
-- ⬜ Helm chart (README previously implied one exists; it does not yet)
+- ✅ **SDK first-impression ergonomics + LLM-legible errors (#28)** (carried
+  forward from the dedicated foundation row above): the one-liner
+  `AgentRun().sandbox("python")` with a lazy default pool, `from_name()`
+  reconnect, `wait_until_ready()`, streaming-exec callbacks, an `AsyncAgentRun`,
+  and the structured `{error:{code, message, cause, remediation}}` envelope
+  parsed into `AgentRunError`, in both the Python and TypeScript SDKs. The
+  server-side error envelope (`internal/apierr`) is CI-asserted to carry a code
+  and remediation on every path and to never leak a secret value. The normative
+  error schema, catalogue, and CI lint stay tracked in #28.
+- ⬜ Helm chart (README does not claim one exists; release machinery and the
+  Helm chart are tracked in #37). The current install path is the
+  `kubectl apply -k deploy/` kustomize base.
 
 ## 8. Observability
 


### PR DESCRIPTION
Audits and refreshes the top-level docs so ROADMAP.md and README.md are accurate after the recent production + agent-runtime merges. BENCHMARKS.md was already accurate and consistent (it published the reproducible ~27 ms warm-claim activate, the harness, and the bare-metal reference node), so it is left unchanged.

## What changed

ROADMAP.md
- Failure/GC (section 2): forkd crash reap/re-adopt, node-loss handling, and saturation backpressure marked done (the four production blockers, epic #12).
- Ergonomics (section 7): streaming exec, PTY, code interpreter (run_code, fail-closed KernelUnavailable until the husk base image ships the kernel), and SDK ergonomics + LLM-legible errors marked done.
- Density (section 6): demand-driven warm-pool autoscaling marked done.
- Benchmarks (section 4) + W1: first bare-metal reference run published; the self-hosted CI runner moved to in-progress (built, maintainer-apply pending).

README.md
- Features: streaming/run_code/PTY/LLM-legible errors and warm-pool autoscaling added; the failure/GC line corrected (crash reap, node loss, saturation no longer listed as open).
- Quickstart: SDK example extended with streaming exec, run_code, and background processes matching the real Python SDK API; install path updated to the self-contained `kubectl apply -k deploy/` kustomize base.

## Honesty notes
- Every feature claim was verified against the code (run_code, streaming exec, PTY, autoscale spec, crash-reap journal, resource caps).
- The only published numbers (~27 ms P50 warm-claim activate, ~6-16 ms restore, ~3 MiB marginal memory) trace to `bench/results/2026-06-13-bare-metal-husk.md` via `bench/husk-activate-latency.sh`; no new numbers were introduced. The <=10ms claim-to-first-exec figure stays an explicit target (#16/#18).
- Corrections made while auditing: removed a streaming-exec stdin claim the exec stream does not carry (stdin is the PTY path); avoided citing PR numbers (100/102/104/106/93) as issue refs, using the real epics (#24, #28).
- Honest k8s semantics preserved: the sandbox is the VM, the husk pod is its unprivileged host.
- No em/en dashes.

Genuinely-remaining work flagged in the docs: the code-interpreter kernel in the husk base image, multi-node snapshot distribution validation (#3), a Helm chart (#37), arming the bare-metal CI runner (#16), external security review, and the remaining failure/GC items (#12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)