### PR TITLE
ci(cluster-e2e): GHCR_WRITE_TOKEN PAT fallback for the e2e image push

### DIFF
--- a/.github/workflows/cluster-e2e.yaml
+++ b/.github/workflows/cluster-e2e.yaml
@@ -96,8 +96,13 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a maintainer PAT with write:packages (repo secret
+          # GHCR_WRITE_TOKEN) when present; this is the deterministic path if the
+          # org restricts the default GITHUB_TOKEN from writing org packages or
+          # the package Actions-access grant is not Write. Falls back to
+          # GITHUB_TOKEN (which works once the package grants this repo Write).
+          username: ${{ secrets.GHCR_WRITE_USER || github.actor }}
+          password: ${{ secrets.GHCR_WRITE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Build and push the e2e image for this commit
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
The cluster-e2e build-images push is denied (write_package) with the default GITHUB_TOKEN even after a package Actions-access grant, which indicates an org policy on the default token or a Read-only grant. This makes the GHCR login prefer a maintainer PAT (repo secret GHCR_WRITE_TOKEN, write:packages) when present, falling back to GITHUB_TOKEN. Deterministic regardless of org package policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)