### PR TITLE
fix(sdk): lazy-import optional async websockets; e2e tests the checked-out SDK

### DIFF
--- a/sdk/python/mitos/pty.py
+++ b/sdk/python/mitos/pty.py
@@ -6,8 +6,12 @@ import json
 import threading
 from typing import Callable, Optional
 
-import websockets  # the async websockets package
 from websocket import WebSocketApp  # from the websocket-client package
+
+# NOTE: the async 'websockets' package is an OPTIONAL extra (mitos[async]); it is
+# imported lazily inside AsyncPtyHandle.connect so that importing this module (and
+# therefore mitos.sandbox) never fails when only the synchronous path is used and
+# the extra is not installed.
 
 
 class PtyHandle:
@@ -121,6 +125,13 @@ class AsyncPtyHandle:
         on_data: Callable[[bytes], None],
     ) -> "AsyncPtyHandle":
         headers = [("Authorization", f"Bearer {token}")] if token else []
+        try:
+            import websockets  # the async package, the mitos[async] extra
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "the async PTY requires the 'websockets' package; install mitos[async]. "
+                "The synchronous pty.create() path needs only websocket-client."
+            ) from exc
         ws = await websockets.connect(
             url,
             additional_headers=headers,

--- a/test/cluster-e2e/husk-e2e.sh
+++ b/test/cluster-e2e/husk-e2e.sh
@@ -165,11 +165,29 @@ echo "--- stages 2-5: claim, exec, fork, run_code, PTY (SDK driver) ---"
 
 driver_out="$(mktemp)"
 set +e
+
+# Install the SDK from the CHECKED-OUT commit into a fresh venv and run the
+# driver with it, rather than the SDK baked into the runner image. This means
+# the e2e always tests THIS commit's SDK, and the runner image never needs a
+# rebuild when the SDK changes. The workspace venv is writable by the runner
+# uid (the baked /opt/mitos-venv may not be). The sync driver needs only the
+# SDK's runtime deps (httpx, websocket-client); the async 'websockets' extra is
+# not required (and is lazy-imported by the SDK).
+DRIVER_PY="python3"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if [ -d "${REPO_ROOT}/sdk/python" ]; then
+  echo "--- installing the checked-out SDK into a fresh venv ---"
+  python3 -m venv /tmp/e2e-sdk-venv
+  /tmp/e2e-sdk-venv/bin/pip install --quiet --upgrade pip >/dev/null 2>&1 || true
+  /tmp/e2e-sdk-venv/bin/pip install --quiet "${REPO_ROOT}/sdk/python"
+  DRIVER_PY="/tmp/e2e-sdk-venv/bin/python"
+fi
+
 INCLUSTER="false"
 [ -z "${KUBECONFIG:-}" ] && INCLUSTER="true"
 MITOS_NS="$NAMESPACE" MITOS_POOL="$POOL" MITOS_CLAIM="$CLAIM" \
 MITOS_INCLUSTER="$INCLUSTER" MITOS_READY_TIMEOUT="$READY_TIMEOUT" \
-python3 - <<'PYEOF' | tee "$driver_out"
+"$DRIVER_PY" - <<'PYEOF' | tee "$driver_out"
 import os
 import sys
 import time


### PR DESCRIPTION
Standing cluster-e2e caught a real SDK packaging bug: mitos/pty.py imported the OPTIONAL async websockets package at module top level, so importing mitos.sandbox crashed (ModuleNotFoundError) wherever only websocket-client (the sync runtime dep) was installed, breaking ALL SDK use. Lazy-import websockets inside AsyncPtyHandle.connect (clear error if the mitos[async] extra is missing); the sync pty path needs only websocket-client. Also: the cluster-e2e driver now installs the checked-out SDK into a fresh venv, so it tests this commit's SDK and the runner image never needs a rebuild on an SDK change. SDK tests pass (16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)