### PR TITLE
ci: deploy forkd at the commit in cluster-e2e

### DIFF
--- a/.github/workflows/cluster-e2e.yaml
+++ b/.github/workflows/cluster-e2e.yaml
@@ -88,6 +88,8 @@ jobs:
             dockerfile: Dockerfile.controller
           - name: mitos-husk-stub
             dockerfile: Dockerfile.husk-stub
+          - name: mitos-forkd
+            dockerfile: Dockerfile.forkd
     env:
       IMAGE: ghcr.io/paperclipinc/${{ matrix.name }}
     steps:
@@ -171,8 +173,29 @@ jobs:
           set -euo pipefail
           CONTROLLER_IMG="${IMAGE_REGISTRY}/mitos-controller:${IMAGE_TAG}"
           HUSK_IMG="${IMAGE_REGISTRY}/mitos-husk-stub:${IMAGE_TAG}"
+          FORKD_IMG="${IMAGE_REGISTRY}/mitos-forkd:${IMAGE_TAG}"
           echo "Deploying controller=${CONTROLLER_IMG}"
           echo "Deploying husk-stub=${HUSK_IMG}"
+          echo "Deploying forkd=${FORKD_IMG}"
+
+          # Update forkd FIRST. forkd is the BUILDER: it builds each template's
+          # snapshot and injects the guest agent into it. The e2e creates a fresh
+          # template in its first stage, so forkd must already run the code under
+          # test before that, otherwise the new template is built with an old
+          # guest agent whose vsock protocol does not match the new husk-stub/SDK.
+          #
+          # Record the current forkd image so teardown can restore it even if a
+          # later step fails.
+          PREV_FORKD_IMG="$(kubectl -n "${MITOS_NAMESPACE}" get daemonset/mitos-forkd \
+            -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          echo "prev_forkd_image=${PREV_FORKD_IMG}" >> "$GITHUB_OUTPUT"
+          echo "Previous forkd image: ${PREV_FORKD_IMG}"
+
+          # Point the forkd DaemonSet at the just-built forkd image and wait for
+          # its rollout to finish before the e2e proceeds.
+          kubectl -n "${MITOS_NAMESPACE}" set image daemonset/mitos-forkd \
+            forkd="${FORKD_IMG}"
+          kubectl -n "${MITOS_NAMESPACE}" rollout status daemonset/mitos-forkd --timeout=180s
 
           # Record the current controller image so teardown can restore it even
           # if a later step fails.
@@ -245,6 +268,16 @@ jobs:
             kubectl -n "${MITOS_NAMESPACE}" rollout status deployment/mitos-controller --timeout=180s
           else
             echo "no previous controller image recorded; leaving controller as-is"
+          fi
+
+          echo "=== teardown: restore the forkd DaemonSet image ==="
+          PREV_FORKD="${{ steps.deploy.outputs.prev_forkd_image }}"
+          if [ -n "${PREV_FORKD}" ]; then
+            kubectl -n "${MITOS_NAMESPACE}" set image daemonset/mitos-forkd \
+              forkd="${PREV_FORKD}"
+            kubectl -n "${MITOS_NAMESPACE}" rollout status daemonset/mitos-forkd --timeout=180s
+          else
+            echo "no previous forkd image recorded; leaving forkd as-is"
           fi
           echo "teardown done"
           exit 0


### PR DESCRIPTION
## Problem

The cluster-e2e deploy-under-test step updated ONLY the controller Deployment image and the controller's `--husk-stub-image` arg. It did NOT update forkd. The forkd DaemonSet (`mitos-forkd`, namespace `mitos`) stayed on `mitos-forkd:latest`, an old pre-streaming-exec release.

forkd is the BUILDER: it builds each template's snapshot and injects the guest agent into it. The e2e creates a fresh template in its first stage, so with an old forkd that template is built with an OLD guest agent that does not speak the streaming-exec frames the NEW `husk-stub:e2e-<sha>`/SDK expects. The husk pod activates and auth passes, but `sb.exec()` fails with `exec failed: unknown exec_stream frame kind: ""`, a guest-agent vs host protocol mismatch.

## Fix

Deploy the whole stack at the commit so forkd's injected agent matches the husk-stub/SDK protocol.

1. **build-images**: add `mitos-forkd` (`Dockerfile.forkd`) to the matrix, pushing `ghcr.io/paperclipinc/mitos-forkd:e2e-<sha>`.
2. **deploy step**: record the current forkd image (`prev_forkd_image`), set the `mitos-forkd` DaemonSet (container `forkd`) to `e2e-<sha>`, and `rollout status` it with `--timeout=180s` BEFORE the controller update and before the e2e creates its fresh template.
3. **teardown** (`if: always()`): restore the forkd DaemonSet image from `prev_forkd_image`, best-effort, never masking the real exit code.

## Confirmed from deploy/daemon/daemonset.yaml

- DaemonSet name: `mitos-forkd`
- Container name: `forkd`

## Verification

- `actionlint .github/workflows/cluster-e2e.yaml` is clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` parses.
- No em/en dashes.
- Security gating unchanged: the build-images and cluster-husk-e2e job `if:` (fork-PR exclusion), the `cluster` environment, and `permissions` are untouched. The forkd build is just another matrix entry on the already-gated build-images job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)