### PR TITLE
fix(ci-runner): grant runner daemonsets get/patch for forkd deploy-under-test

### DIFF
--- a/deploy/ci-runner/rbac.yaml
+++ b/deploy/ci-runner/rbac.yaml
@@ -146,6 +146,11 @@ rules:
       - apps
     resources:
       - deployments
+      # The husk e2e also deploys-under-test the forkd DaemonSet (the builder
+      # that injects the guest agent into each template snapshot), so the agent
+      # matches the commit's exec_stream protocol. get/patch/update + rollout
+      # status only; no create/delete.
+      - daemonsets
     verbs:
       - get
       - list


### PR DESCRIPTION
The e2e deploys forkd (a DaemonSet) under test now; the runner SA needs daemonsets get/patch/update (no create/delete). Least-privilege preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)