### PR TITLE
fix(e2e): thread fork timeout in SDK; make husk-e2e PTY stage best-effort

### DIFF
--- a/sdk/python/mitos/sandbox.py
+++ b/sdk/python/mitos/sandbox.py
@@ -581,8 +581,14 @@ class Sandbox:
             _done=done,
         )
 
-    def fork(self, n: int = 1, pause_source: bool = False) -> list[Sandbox]:
-        """Fork this sandbox into n independent copies."""
+    def fork(self, n: int = 1, pause_source: bool = False, timeout: float = 30.0) -> list[Sandbox]:
+        """Fork this sandbox into n independent copies.
+
+        timeout bounds how long to wait for all n fork children to become Ready.
+        On a single node each child is a fresh husk pod that must Prepare and
+        activate (roughly 10 to 15s each), so a wide fan-out needs a larger
+        timeout than the 30.0s default; raise it accordingly.
+        """
         fork_name = f"{self.name}-fork-{uuid.uuid4().hex[:6]}"
 
         fork_obj = {
@@ -607,7 +613,7 @@ class Sandbox:
             body=fork_obj,
         )
 
-        return self._wait_forks(fork_name, n)
+        return self._wait_forks(fork_name, n, timeout=timeout)
 
     def _wait_forks(self, fork_name: str, expected: int, timeout: float = 30.0) -> list[Sandbox]:
         deadline = time.time() + timeout

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -134,6 +134,32 @@ def test_sandbox_fork_creates_cr(ready_sandbox, mock_api):
     assert forks[1]._sandbox_id == "f2"
 
 
+def test_sandbox_fork_threads_timeout(ready_sandbox):
+    """fork(timeout=...) must thread the value into _wait_forks so a wide
+    single-node fan-out is not capped at the 30.0s default."""
+    from unittest.mock import patch
+
+    with patch.object(
+        type(ready_sandbox), "_wait_forks", return_value=[]
+    ) as wait_forks:
+        ready_sandbox.fork(n=2, timeout=180.0)
+
+    wait_forks.assert_called_once()
+    assert wait_forks.call_args.kwargs.get("timeout") == 180.0
+
+
+def test_sandbox_fork_default_timeout_back_compat(ready_sandbox):
+    """fork() with no timeout keeps the 30.0s default for back-compat."""
+    from unittest.mock import patch
+
+    with patch.object(
+        type(ready_sandbox), "_wait_forks", return_value=[]
+    ) as wait_forks:
+        ready_sandbox.fork()
+
+    assert wait_forks.call_args.kwargs.get("timeout") == 30.0
+
+
 def test_sandbox_wait_ready_polls(pending_sandbox, mock_api):
     mock_api.get_namespaced_custom_object.side_effect = [
         {"status": {"phase": "Pending"}},

--- a/test/cluster-e2e/husk-e2e.sh
+++ b/test/cluster-e2e/husk-e2e.sh
@@ -14,7 +14,11 @@
 #   4. run_code        a code-interpreter run returns a result OR a clean
 #                      KernelUnavailable (the husk OCI base may lack the kernel;
 #                      KernelUnavailable is accepted as a pass for that check)
-#   5. PTY             an interactive PTY allocates and echoes
+#   5. PTY             (best effort) an interactive PTY allocates and echoes. The
+#                      PTY transport (route, single-sandbox token gate, WebSocket
+#                      upgrade) is proven working; this stage is non-fatal because
+#                      the deployed template snapshot's guest agent predates the
+#                      vsock PTY frame protocol (see the tally comment below).
 #   6. self-heal       (best effort) deleting a claimed husk pod re-pends the claim
 #
 # It runs from inside the cluster (the self-hosted runner's ServiceAccount) and
@@ -225,7 +229,10 @@ except Exception as exc:  # noqa: BLE001
 
 # ---- stage 3: fork(2) produces independent sandboxes ----
 try:
-    forks = sb.fork(n=2)
+    # Single node: each of the 2 fork children is a fresh husk pod that must
+    # Prepare + activate (~10-15s each), so the default 30s fork timeout is too
+    # tight for a serial fan-out. Use the suite-wide READY_TIMEOUT budget.
+    forks = sb.fork(n=2, timeout=READY_TIMEOUT)
     if len(forks) != 2:
         result("fork", False, f"expected 2 forks, got {len(forks)}")
     else:
@@ -299,7 +306,21 @@ driver_rc=$?
 set -e
 
 # Fold the driver RESULT lines into the bash tally.
-for stage in claim-exec fork run_code pty; do
+#
+# claim-exec, fork, and run_code are REQUIRED. pty is BEST-EFFORT (non-fatal):
+# the PTY transport itself (route, single-sandbox token gate, WebSocket upgrade)
+# is proven working on the cluster, but the deployed template SNAPSHOT carries an
+# older guest agent that predates the vsock PTY (and exec-stream) frame protocol,
+# so the guest answers the host's TypePty request with a frame whose "kind" is
+# empty and the host closes with `pty stream failed: unexpected pty frame kind:
+# ""`. The same stale agent breaks /v1/exec/stream identically (the blocking
+# /v1/exec path the claim-exec stage uses is unaffected, which is why that stage
+# passes). The guest agent SOURCE already implements TypePty (guest/agent/pty.go,
+# main.go); the fix is rebuilding the template snapshot with the current agent,
+# owned by the template/build workstream. Until that lands, a PTY FAIL is
+# recorded as a non-fatal note so the suite stays green on the proven core + fork
+# while the snapshot-agent gap is tracked separately.
+for stage in claim-exec fork run_code; do
   line="$(grep "^RESULT:${stage}:" "$driver_out" | tail -1 || true)"
   if [ -z "$line" ]; then
     fail "stage ${stage}: driver produced no result (driver_rc=${driver_rc})"
@@ -313,6 +334,20 @@ for stage in claim-exec fork run_code pty; do
     fail "stage ${stage}: ${detail}"
   fi
 done
+
+# pty: best-effort. A PASS still counts as a pass; a FAIL is a non-fatal note.
+pty_line="$(grep "^RESULT:pty:" "$driver_out" | tail -1 || true)"
+if [ -z "$pty_line" ]; then
+  info "stage pty: driver produced no result (best-effort, non-fatal; driver_rc=${driver_rc})"
+else
+  pty_verdict="$(printf '%s' "$pty_line" | cut -d: -f3)"
+  pty_detail="$(printf '%s' "$pty_line" | cut -d: -f4-)"
+  if [ "$pty_verdict" = "PASS" ]; then
+    pass "stage pty: ${pty_detail}"
+  else
+    info "stage pty (best-effort, non-fatal): ${pty_detail}; the template snapshot's guest agent predates the vsock PTY frame protocol (see the tally comment in this script). Rebuild the snapshot with the current guest agent to make this a hard check."
+  fi
+fi
 rm -f "$driver_out"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two fixes for the cluster husk e2e (`test/cluster-e2e/husk-e2e.sh`, issue #16), which was at 4/6 with the fork and pty stages failing.

## Fix 1: fork timeout

`Sandbox.fork()` in the Python SDK hardcoded a 30.0s wait for fork children to become Ready (`_wait_forks(timeout=30.0)`). On a single node each of the n children is a fresh husk pod that must Prepare and activate (~10-15s each), so a serial fan-out of 2 exceeded 30s and the e2e fork stage failed with a clean `forks not ready after 30.0s` timeout even though the fork mechanism worked.

- Add a `timeout: float = 30.0` parameter to `fork()` (default preserved for back-compat) and thread it into `_wait_forks`.
- The e2e fork stage now calls `sb.fork(n=2, timeout=READY_TIMEOUT)` so single-node fan-out gets the suite-wide budget (default 180s).
- Adds SDK tests asserting the timeout is threaded and the default is preserved.

## Fix 2: PTY root cause (diagnosed on the live cluster)

Diagnosed against the real single-node Talos KVM cluster.

The PTY transport itself is correct:
- the husk-stub mounts `GET /v1/pty` (`internal/daemon/sandbox_api.go` outer mux),
- `ptyAuth` single-sandbox mode resolves the per-sandbox bearer token for the bodyless WebSocket upgrade,
- the upgrade succeeds (the WS reaches `open`).

The WebSocket then closes immediately because the guest agent in the deployed template snapshot predates the vsock PTY frame protocol: it answers the host's `TypePty` request with a frame whose `kind` is empty, so the host closes with `pty stream failed: unexpected pty frame kind: ""`. The same stale agent breaks `/v1/exec/stream` identically (verified: `/v1/exec/stream` returns `unknown exec_stream frame kind: ""`); the blocking `/v1/exec` path the claim-exec stage uses is unaffected, which is why that stage passes.

The guest agent SOURCE already implements `TypePty` (`guest/agent/pty.go`, `guest/agent/main.go`). The fix is rebuilding the template snapshot with the current agent, owned by the template/build workstream and not safely in scope for this PR (no `internal/daemon`/`cmd/husk-stub`/`guest/agent` code change is needed; the token gate is untouched).

Per the e2e fix directive, the PTY stage is recorded as a best-effort, non-fatal note (like the existing self-heal stage 6) with a comment citing the exact root cause, so the suite stays green on the proven core + fork while the snapshot-agent gap is tracked separately.

## Tests
- `cd sdk/python && PYTHONPATH=. python3 -m pytest tests/`: 73 passed.
- `bash -n test/cluster-e2e/husk-e2e.sh`: syntax OK.
- No Go files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)