### PR TITLE
feat(husk): live SandboxFork on the husk pod-native default path

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -474,11 +474,21 @@ type ForkInfo struct {
 }
 
 type SandboxForkStatus struct {
-	ReadyForks     int32              `json:"readyForks"`
-	TotalForks     int32              `json:"totalForks"`
-	Forks          []ForkInfo         `json:"forks,omitempty"`
-	CheckpointTime *metav1.Time       `json:"checkpointTime,omitempty"`
-	Conditions     []metav1.Condition `json:"conditions,omitempty"`
+	ReadyForks int32      `json:"readyForks"`
+	TotalForks int32      `json:"totalForks"`
+	Forks      []ForkInfo `json:"forks,omitempty"`
+	// ForkSnapshotTaken records that the husk fork snapshot of the source VM has
+	// already been written for this SandboxFork. It guards the snapshot op so it
+	// runs EXACTLY ONCE across reconcile passes: children take several passes to
+	// reach Ready, and re-snapshotting on each pass would re-pause the source and
+	// overwrite the fork mem/vmstate, so a child activated in a later pass would
+	// restore a newer source memory state than an earlier child (an incoherent
+	// fork set). Once true, subsequent passes reuse the existing snapshot and only
+	// reconcile child readiness. Persisting it in status keeps the guard correct
+	// across a controller restart mid-fork (the source is never re-paused).
+	ForkSnapshotTaken bool               `json:"forkSnapshotTaken,omitempty"`
+	CheckpointTime    *metav1.Time       `json:"checkpointTime,omitempty"`
+	Conditions        []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -227,13 +227,15 @@ func main() {
 	// snapshot it) is the SAME config EnsurePKI returns; it is assigned below
 	// after bootstrap, exactly like the claim reconciler.
 	forkReconciler := &controller.SandboxForkReconciler{
-		Client:          mgr.GetClient(),
-		NodeRegistry:    nodeRegistry,
-		EnableHuskPods:  enableHuskPods,
-		HuskControlPort: huskControlPort,
-		HuskStubImage:   huskStubImage,
-		DataDir:         huskDataDir,
-		KVMResourceName: "mitos.run/kvm",
+		Client:            mgr.GetClient(),
+		NodeRegistry:      nodeRegistry,
+		EnableHuskPods:    enableHuskPods,
+		HuskControlPort:   huskControlPort,
+		HuskStubImage:     huskStubImage,
+		DataDir:           huskDataDir,
+		KVMResourceName:   "mitos.run/kvm",
+		HuskTLSSecretName: controller.ForkdTLSSecretName,
+		HuskCASecretName:  controller.CASecretName,
 	}
 	if err := forkReconciler.SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "SandboxFork")

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -222,10 +222,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := (&controller.SandboxForkReconciler{
-		Client:       mgr.GetClient(),
-		NodeRegistry: nodeRegistry,
-	}).SetupWithManager(mgr); err != nil {
+	// The fork reconciler holds the husk fork fields. Its HuskTLS (the controller
+	// client mTLS config used to dial a source husk pod's network control to
+	// snapshot it) is the SAME config EnsurePKI returns; it is assigned below
+	// after bootstrap, exactly like the claim reconciler.
+	forkReconciler := &controller.SandboxForkReconciler{
+		Client:          mgr.GetClient(),
+		NodeRegistry:    nodeRegistry,
+		EnableHuskPods:  enableHuskPods,
+		HuskControlPort: huskControlPort,
+		HuskStubImage:   huskStubImage,
+		DataDir:         huskDataDir,
+		KVMResourceName: "mitos.run/kvm",
+	}
+	if err := forkReconciler.SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "SandboxFork")
 		os.Exit(1)
 	}
@@ -278,6 +288,7 @@ func main() {
 		discovery.TLS = tlsConf
 		// The husk control channel uses the SAME controller client config.
 		claimReconciler.HuskTLS = tlsConf
+		forkReconciler.HuskTLS = tlsConf
 		logger.Info("PKI bootstrap complete; dialing forkd with mTLS", "namespace", discoveryNamespace)
 	}
 

--- a/cmd/husk-stub/main.go
+++ b/cmd/husk-stub/main.go
@@ -160,6 +160,8 @@ func run() error {
 		vcpus           = flag.Int("vcpus", 1, "guest vCPU count")
 		memMiB          = flag.Int("mem-mib", 512, "guest memory in MiB")
 		activate        = flag.Bool("activate", false, "act as a control CLIENT: connect to --control-socket (or --control-addr over mTLS), send one activate request for --snapshot-dir, print the result, and exit (spawns no VMM)")
+		forkSnapshot    = flag.Bool("fork-snapshot", false, "act as a control CLIENT: connect to --control-addr over mTLS, send one fork-snapshot op for --fork-id writing into the source pod's forks dir, print the result, and exit (spawns no VMM)")
+		forkID          = flag.String("fork-id", "", "fork-snapshot client mode: the node-local fork id (the forks dir leaf the source stub writes the snapshot under)")
 		controlAddr     = flag.String("control-addr", "", "activate client mode: TCP address (host:port) of a husk pod's mTLS NETWORK control to activate over; uses ActivateHuskPod and requires --tls-cert/--tls-key/--tls-ca. Mutually exclusive with --control-socket")
 		snapshotDir     = flag.String("snapshot-dir", "", "activate client mode: the template snapshot directory (expects snapshot/{mem,vmstate} layout) to activate")
 		secretFile      = flag.String("secret-file", "", "activate client mode: path to a KEY=VALUE secret file (one per line) delivered to the guest; values are never logged")
@@ -207,6 +209,49 @@ func run() error {
 			return runNetworkActivateClient(*controlAddr, *snapshotDir, *expectedDigest, *tlsCert, *tlsKey, *tlsCA, envFlag.orNil(), secrets, token)
 		}
 		return runActivateClient(*controlSocket, *snapshotDir, *expectedDigest, envFlag.orNil(), secrets, token)
+	}
+
+	if *forkSnapshot {
+		if *controlAddr == "" {
+			return fmt.Errorf("--fork-snapshot requires --control-addr")
+		}
+		if *forkID == "" {
+			return fmt.Errorf("--fork-snapshot requires --fork-id")
+		}
+		if *tlsCert == "" || *tlsKey == "" || *tlsCA == "" {
+			return fmt.Errorf("--fork-snapshot requires --tls-cert, --tls-key, and --tls-ca")
+		}
+		certPEM, err := os.ReadFile(*tlsCert)
+		if err != nil {
+			return fmt.Errorf("read --tls-cert: %w", err)
+		}
+		keyPEM, err := os.ReadFile(*tlsKey)
+		if err != nil {
+			return fmt.Errorf("read --tls-key: %w", err)
+		}
+		caPEM, err := os.ReadFile(*tlsCA)
+		if err != nil {
+			return fmt.Errorf("read --tls-ca: %w", err)
+		}
+		tlsConf, err := pki.ClientTLSConfig(certPEM, keyPEM, caPEM)
+		if err != nil {
+			return fmt.Errorf("build controller client TLS config: %w", err)
+		}
+		res, err := controller.ForkSnapshotOnHusk(context.Background(), *controlAddr, tlsConf, husk.ForkSnapshotRequest{
+			ForkID:      *forkID,
+			SnapshotDir: filepath.Join("/var/lib/mitos/forks", *forkID),
+		})
+		if err != nil {
+			return fmt.Errorf("fork-snapshot over network control: %w", err)
+		}
+		enc := json.NewEncoder(os.Stdout)
+		if err := enc.Encode(res); err != nil {
+			return fmt.Errorf("encode fork-snapshot result: %w", err)
+		}
+		if !res.OK {
+			return fmt.Errorf("fork-snapshot failed: %s", res.Error)
+		}
+		return nil
 	}
 
 	if *workdir == "" {

--- a/cmd/husk-stub/main.go
+++ b/cmd/husk-stub/main.go
@@ -173,6 +173,7 @@ func run() error {
 		rootfsCoWDir    = flag.String("rootfs-cow-dir", "", "directory on the SAME node filesystem as the template rootfs where this activation's copy-on-write rootfs clone is written (reflink where supported, full copy otherwise). Empty keeps the prior behavior of writing the shared template rootfs in place. A content address, not a secret")
 		templateRootfs  = flag.String("template-rootfs", "", "host path of the template rootfs.ext4 to clone per activation. Empty (with --rootfs-cow-dir) disables the per-activation clone")
 		vmID            = flag.String("vm-id", huskSandboxID, "the per-pod VM id. It scopes this pod's per-activation rootfs CoW clone path (<rootfs-cow-dir>/<vm-id>/rootfs.ext4), so two husk pods sharing the node CoW hostPath never collide on, overwrite, or delete each other's clone. The controller passes the pod name (downward API metadata.name); empty falls back to the legacy fixed id. A node-local identifier, not a secret")
+		forksDir        = flag.String("forks-dir", "", "directory the node forks dir is mounted at, where a fork-snapshot op writes <forks-dir>/<fork-id>/{mem,vmstate}. When set, the serving stub confines fork-snapshot and remove-fork-snapshot writes to within it (fail-closed: a request naming a path outside it is refused). Empty leaves the prior behavior (the request's snapshot dir is used as-is). A node-local path, not a secret")
 	)
 	var envFlag, secretFlag kvFlag
 	flag.Var(&envFlag, "env", "activate client mode: repeatable KEY=VALUE guest env var")
@@ -367,6 +368,9 @@ func run() error {
 		// shared-rootfs behavior.
 		RootfsTemplatePath: *templateRootfs,
 		RootfsCoWDir:       *rootfsCoWDir,
+		// The node forks dir this pod mounts: the serving stub confines
+		// fork-snapshot / remove-fork-snapshot writes to within it (fail-closed).
+		ForksDir: *forksDir,
 	})
 
 	fmt.Fprintln(os.Stderr, "husk-stub: preparing dormant VMM")

--- a/cmd/husk-stub/main_test.go
+++ b/cmd/husk-stub/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestServingArgsAreAllDefined is the regression guard for the husk fork
+// regression: the controller's husk pod builder appends --forks-dir (and the
+// other serving flags) to the husk-stub container args, but the flag was never
+// defined here, so flag.Parse rejected it with "flag provided but not defined:
+// -forks-dir" and the pod crash-looped. That broke BOTH warm-pool prepare and
+// claim activation (no dormant pod ever came up).
+//
+// This test builds the husk-stub binary and runs it with the exact serving args
+// the controller emits, asserting it gets PAST flag parsing (it then fails later
+// for an unrelated reason, e.g. no firecracker binary, which is fine). A flag the
+// controller emits that this binary does not define would fail flag parsing and
+// is the bug we are guarding against.
+func TestServingArgsAreAllDefined(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "husk-stub")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build husk-stub: %v\n%s", err, out)
+	}
+
+	// The serving args the controller's buildHuskPod emits for a husk pod (see
+	// internal/controller/huskpod.go). The values are placeholders; only that the
+	// FLAGS are recognized matters here.
+	args := []string{
+		"--firecracker", "/usr/local/bin/firecracker",
+		"--kernel", "/var/lib/mitos/kernel/vmlinux",
+		"--workdir", "/run/husk/vm",
+		"--control-listen", ":9443",
+		"--sandbox-listen", ":9091",
+		"--tls-cert", "/etc/husk/tls/tls.crt",
+		"--tls-key", "/etc/husk/tls/tls.key",
+		"--tls-ca", "/etc/husk/ca/ca.crt",
+		"--vm-id", "test-pod",
+		"--manifest", "/var/lib/mitos/manifests/deadbeef",
+		"--snapshot-dir", "/var/lib/mitos/snapshot",
+		"--expected-digest", "deadbeef",
+		"--rootfs-cow-dir", "/var/lib/mitos/husk-rootfs",
+		"--template-rootfs", "/var/lib/mitos/templates/t/rootfs.ext4",
+		"--forks-dir", "/var/lib/mitos/forks",
+	}
+
+	out, _ := exec.Command(bin, args...).CombinedOutput()
+	// flag.ExitOnError prints this exact prefix and exits 2 when a flag the
+	// controller emits is not defined here. The fix is to define every such flag.
+	if strings.Contains(string(out), "flag provided but not defined") {
+		t.Fatalf("husk-stub rejected a controller-emitted serving flag (the husk fork regression):\n%s", out)
+	}
+}

--- a/deploy/crds/mitos.run_sandboxforks.yaml
+++ b/deploy/crds/mitos.run_sandboxforks.yaml
@@ -151,6 +151,18 @@ spec:
                   - type
                   type: object
                 type: array
+              forkSnapshotTaken:
+                description: |-
+                  ForkSnapshotTaken records that the husk fork snapshot of the source VM has
+                  already been written for this SandboxFork. It guards the snapshot op so it
+                  runs EXACTLY ONCE across reconcile passes: children take several passes to
+                  reach Ready, and re-snapshotting on each pass would re-pause the source and
+                  overwrite the fork mem/vmstate, so a child activated in a later pass would
+                  restore a newer source memory state than an earlier child (an incoherent
+                  fork set). Once true, subsequent passes reuse the existing snapshot and only
+                  reconcile child readiness. Persisting it in status keeps the guard correct
+                  across a controller restart mid-fork (the source is never re-paused).
+                type: boolean
               forks:
                 items:
                   properties:

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -29,6 +29,23 @@ clock within 2s of the runner, and a delivered env var plus secret readable in
 each guest with the secret value absent from the host-side logs. See
 [docs/husk-pods.md](husk-pods.md).
 
+### Husk fork children
+
+A husk live fork (`internal/controller/sandboxfork_controller.go` `reconcileHuskFork`)
+produces children by SNAPSHOTTING the source pod's running VM (the husk stub
+`ForkSnapshot` op: pause, Full snapshot to `<dataDir>/forks/<fork-id>/{mem,vmstate}`,
+resume unless `pauseSource`) and ACTIVATING each child husk pod from that fork
+snapshot. Each child activates through the SAME `Activate` path a warm pod uses,
+so it runs the identical RNG-reseed + clock-step `NotifyForked` fork-correctness
+handshake (`internal/husk` `productionNotifier` -> `guest/agent/notifyforked.go`
+`handleNotifyForked`): every child reseeds its kernel CRNG with fresh host entropy
+and steps its wall clock, and a child whose guest does not report `ReseededRNG` is
+left unserved (fail closed). So a husk fork child is NOT a CRNG/clock clone of the
+source or its siblings; it inherits exactly the per-fork reseed an engine fork
+gets. Each child is its own husk pod + VM + per-activation rootfs CoW clone, so
+guest writes never cross between children or back to the source. The Python-level
+PRNG caveat in section 1 applies to husk fork children identically.
+
 ## 1. RNG and entropy after restore
 
 Every VM restored from the same snapshot wakes up with byte-identical kernel

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -46,6 +46,31 @@ gets. Each child is its own husk pod + VM + per-activation rootfs CoW clone, so
 guest writes never cross between children or back to the source. The Python-level
 PRNG caveat in section 1 applies to husk fork children identically.
 
+Memory/disk consistency (the disk half of the fork). The fork snapshot's
+`vmstate` is baked against the SOURCE sandbox's rootfs (`path_on_host`), so a
+restored child's guest memory (page cache, ext4 superblock, in-flight metadata)
+reflects the SOURCE disk, not the pristine template disk. The child's
+per-activation rootfs CoW clone is therefore made from the SOURCE pod's live
+rootfs (`<dataDir>/husk-rootfs/<source-pod-name>/rootfs.ext4`, threaded as
+`HuskPodOptions.ForkSourceRootfsPath` and passed to the stub as
+`--template-rootfs`), NOT the template rootfs. Cloning from the template instead
+would rebind the child to a disk that does not match its restored memory: any
+data the source wrote since boot would be lost in children and the
+cached-vs-on-disk mismatch could corrupt the child fs. This mirrors the raw-forkd
+`ForkRunning` path, which threads `source.rootfsPath` into the fork so memory and
+disk stay consistent. The clone is still per-child (keyed by the child pod name),
+so children remain independent; only the clone SOURCE is the source rootfs.
+Verified by `internal/controller` `TestBuildHuskPodForkChildClonesFromSourceRootfs`.
+
+Single coherent fork point. The source VM is snapshotted EXACTLY ONCE per
+`SandboxFork` (guarded by `Status.ForkSnapshotTaken`, persisted so it survives a
+controller restart mid-fork). Children take several reconcile passes to reach
+Ready; re-snapshotting on each pass would re-pause the source and overwrite the
+fork `mem`/`vmstate`, so a child activated in a later pass would restore a NEWER
+source memory state than an earlier child and the N children would not share one
+fork point. Verified by `internal/controller`
+`TestHuskForkSnapshotTakenExactlyOnce`.
+
 ## 1. RNG and entropy after restore
 
 Every VM restored from the same snapshot wakes up with byte-identical kernel

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -201,6 +201,34 @@ A SEPARATE follow-up (a per-node verify cache so the second dormant pod on a nod
 skips the ~680 MiB re-hash) WILL touch the integrity gate and must land with its
 own threat-model delta; it is intentionally out of scope here.
 
+### Husk fork snapshot (live fork on the husk path)
+
+A `SandboxFork` of a husk-backed source drives a `ForkSnapshot` control op against
+the SOURCE husk pod's stub over the SAME mTLS channel as activate (authorized to
+the controller identity only: `internal/husk.ServeTLS` plus
+`AuthorizeControllerIdentity`; the op rides the same op-dispatched channel that
+delivers secrets on activate). The op carries NO secrets (a fork id and a
+node-local snapshot path). The stub pauses the running VM, writes a Full
+Firecracker snapshot to a node hostPath `<dataDir>/forks/<fork-id>` (read-write
+only to the source pod that owns the VM; read-only to the child pods on the SAME
+node), then resumes the source unless `pauseSource`. The fork snapshot is a LIVE,
+EPHEMERAL artifact created by a trusted node-local stub and consumed by child
+stubs on the same node within the same trust boundary; it is NOT content-addressed,
+so the children activate it with verify disabled (`--allow-unverified-snapshots`),
+the same posture a pre-digest pool uses. This is acceptable because the artifact
+is root-owned, never tenant-writable, and re-hashing would gate on a digest that
+does not exist for a live fork. The child still runs the full fail-closed RNG/clock
+reseed handshake (see `docs/fork-correctness.md`, husk fork children). Per-child
+independence: each child is its own husk pod + dormant VMM + per-activation rootfs
+CoW clone, so guest writes never cross between children or back to the source; the
+children share only the read-only fork snapshot mem+vmstate as a restore image,
+exactly as warm pods share the template snapshot. Each child mints its OWN bearer
+token (the source's token never opens a child). Lifecycle: the fork snapshot is
+owned by the `SandboxFork` and removed by its finalizer (`RemoveForkSnapshot` op)
+on delete; the child pods are owner-ref'd to the fork and reaped by Kubernetes GC.
+Residual: a compromised controller can drive a fork-snapshot of any husk pod it
+can reach, the same residual already stated for activate (Surface 2).
+
 **Surface 4: the DEVICE `/dev/kvm`.** KVM access is injected by the device plugin
 (`cmd/kvm-device-plugin`, `internal/deviceplugin`): the pod requests
 `mitos.run/kvm` like any extended resource and the kubelet bind-mounts

--- a/internal/controller/huskclient.go
+++ b/internal/controller/huskclient.go
@@ -41,12 +41,83 @@ func ActivateHuskPod(ctx context.Context, addr string, tlsConf *tls.Config, req 
 		_ = conn.SetDeadline(deadline)
 	}
 
+	if err := husk.WriteControlOp(conn, husk.OpActivate); err != nil {
+		return husk.ActivateResult{}, fmt.Errorf("send activate op to %s: %w", addr, err)
+	}
 	if err := husk.WriteRequest(conn, req); err != nil {
 		return husk.ActivateResult{}, fmt.Errorf("send activate request to %s: %w", addr, err)
 	}
 	res, err := husk.ReadResult(conn)
 	if err != nil {
 		return husk.ActivateResult{}, fmt.Errorf("read activate result from %s: %w", addr, err)
+	}
+	return res, nil
+}
+
+// ForkSnapshotOnHusk dials a husk stub's network control at addr over mTLS and
+// runs the fork-snapshot op: it asks the stub holding the SOURCE sandbox's
+// running VM to pause it, write a Full snapshot to req.SnapshotDir, and resume
+// it (unless req.PauseSource). The resulting node-local snapshot is the restore
+// image the controller activates child husk pods from. req carries NO secrets
+// (a fork id and a snapshot path); the channel is still mTLS because the same
+// control surface delivers secrets on activate and must not accept an
+// unauthenticated peer for any op.
+//
+// A nil tlsConf is refused so the control surface is never driven unauthenticated.
+func ForkSnapshotOnHusk(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+	if tlsConf == nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("fork-snapshot on husk %s: refusing to drive the control channel unauthenticated", addr)
+	}
+	dialer := &tls.Dialer{Config: tlsConf}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("dial husk control %s: %w", addr, err)
+	}
+	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if err := husk.WriteControlOp(conn, husk.OpForkSnapshot); err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("send fork-snapshot op to %s: %w", addr, err)
+	}
+	if err := husk.WriteForkSnapshotRequest(conn, req); err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("send fork-snapshot request to %s: %w", addr, err)
+	}
+	res, err := husk.ReadForkSnapshotResult(conn)
+	if err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("read fork-snapshot result from %s: %w", addr, err)
+	}
+	return res, nil
+}
+
+// RemoveForkSnapshotOnHusk dials the source husk stub and asks it to delete a
+// fork snapshot dir it previously created (the GC counterpart of
+// ForkSnapshotOnHusk). It is best-effort from the caller's perspective: the
+// SandboxFork finalizer logs but does not block deletion on a transient failure,
+// because the dir is reclaimed when the source pod is itself recycled. A nil
+// tlsConf is refused.
+func RemoveForkSnapshotOnHusk(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+	if tlsConf == nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("remove fork-snapshot on husk %s: refusing to drive the control channel unauthenticated", addr)
+	}
+	dialer := &tls.Dialer{Config: tlsConf}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("dial husk control %s: %w", addr, err)
+	}
+	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if err := husk.WriteControlOp(conn, husk.OpRemoveForkSnapshot); err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("send remove-fork-snapshot op to %s: %w", addr, err)
+	}
+	if err := husk.WriteRemoveForkSnapshotRequest(conn, req); err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("send remove-fork-snapshot request to %s: %w", addr, err)
+	}
+	res, err := husk.ReadForkSnapshotResult(conn)
+	if err != nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("read remove-fork-snapshot result from %s: %w", addr, err)
 	}
 	return res, nil
 }

--- a/internal/controller/huskclient_test.go
+++ b/internal/controller/huskclient_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -112,15 +113,32 @@ func (s *fakeHuskServer) handle(conn net.Conn) {
 	if err := husk.AuthorizeControllerIdentity(&state); err != nil {
 		return
 	}
-	req, err := husk.ReadRequest(conn)
+	br := bufio.NewReader(conn)
+	op, err := husk.ReadControlOp(br)
 	if err != nil {
 		return
 	}
-	s.mu.Lock()
-	s.calls++
-	s.gotSecret = req.Secrets["API_KEY"]
-	s.mu.Unlock()
-	_ = husk.WriteResult(conn, husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock", LatencyMs: 1.5})
+	switch op {
+	case husk.OpForkSnapshot:
+		req, rerr := husk.ReadForkSnapshotRequestReader(br)
+		if rerr != nil {
+			return
+		}
+		s.mu.Lock()
+		s.calls++
+		s.mu.Unlock()
+		_ = husk.WriteForkSnapshotResult(conn, husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir, LatencyMs: 2.0})
+	default:
+		req, rerr := husk.ReadActivateRequestReader(br)
+		if rerr != nil {
+			return
+		}
+		s.mu.Lock()
+		s.calls++
+		s.gotSecret = req.Secrets["API_KEY"]
+		s.mu.Unlock()
+		_ = husk.WriteResult(conn, husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock", LatencyMs: 1.5})
+	}
 }
 
 func TestActivateHuskPodRoundTrip(t *testing.T) {
@@ -144,6 +162,33 @@ func TestActivateHuskPodRoundTrip(t *testing.T) {
 	defer s.mu.Unlock()
 	if s.gotSecret != "s3cr3t-value" {
 		t.Fatalf("husk did not receive the secret over mTLS")
+	}
+}
+
+func TestForkSnapshotOnHuskRoundTrip(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newFakeHuskServer(t, p)
+	defer s.stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: "/var/lib/mitos/snapshot",
+		PauseSource: true,
+	})
+	if err != nil {
+		t.Fatalf("ForkSnapshotOnHusk: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+func TestForkSnapshotOnHuskRefusesWithoutTLS(t *testing.T) {
+	_, err := ForkSnapshotOnHusk(context.Background(), "127.0.0.1:1", nil, husk.ForkSnapshotRequest{ForkID: "f", SnapshotDir: "/d"})
+	if err == nil {
+		t.Fatalf("ForkSnapshotOnHusk must refuse a nil TLS config")
 	}
 }
 

--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -13,6 +13,7 @@ package controller_test
 import (
 	"context"
 	"crypto/tls"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -257,5 +258,169 @@ func TestHuskForkRemovesSnapshotOnDelete(t *testing.T) {
 	case <-removeCalls:
 	case <-time.After(15 * time.Second):
 		t.Fatalf("remove-fork-snapshot was not called on delete")
+	}
+}
+
+// TestHuskForkChildPodHasFullHuskShape is the regression for the live KVM crash
+// "husk-stub: read --tls-cert: open /etc/husk/tls/tls.crt: no such file or
+// directory": the fork child pod the controller emits must carry EVERYTHING a
+// warm husk pod carries (the husk PKI mTLS Secret volumes, the kernel, forks, and
+// writable rootfs-CoW hostPaths, the kvm device resource, the POD_NAME downward
+// API, and the locked-down securityContext), so the child stub finds its TLS
+// material and all the files it activates from. The previous bug threaded the
+// fork-specific opts but DROPPED TLSSecretName/CASecretName, so buildHuskPod
+// skipped the TLS/CA volumes and the child crash-looped. This drives the real
+// controller opts path (not a direct buildForkChildPod call), so it catches the
+// wiring, not just the builder.
+func TestHuskForkChildPodHasFullHuskShape(t *testing.T) {
+	srcPod := makeDormantHuskPod(t, "pool-shape", "10.0.0.9")
+	makeForkSourceClaim(t, "src-claim-shape", "pool-shape", srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/x"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shape-1",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxForkSpec{SourceRef: v1alpha1.LocalObjectReference{Name: "src-claim-shape"}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	// Wait for the controller to emit the child pod (forcing it Ready so the
+	// reconcile keeps progressing).
+	var child corev1.Pod
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("shape-1"))
+		for i := range pods.Items {
+			forceHuskPodReady(t, &pods.Items[i])
+		}
+		if len(pods.Items) == 0 {
+			return false
+		}
+		child = pods.Items[0]
+		return true
+	})
+
+	// Index the pod's volumes and the stub container's mounts.
+	vols := map[string]corev1.Volume{}
+	for _, v := range child.Spec.Volumes {
+		vols[v.Name] = v
+	}
+	var stub corev1.Container
+	for i := range child.Spec.Containers {
+		if child.Spec.Containers[i].Name == "husk-stub" {
+			stub = child.Spec.Containers[i]
+		}
+	}
+	if stub.Name == "" {
+		t.Fatalf("fork child has no husk-stub container: %+v", child.Spec.Containers)
+	}
+	mounts := map[string]corev1.VolumeMount{}
+	for _, m := range stub.VolumeMounts {
+		mounts[m.Name] = m
+	}
+
+	// The husk PKI TLS Secret volumes + mounts (the crash). The leaf Secret backs
+	// /etc/husk/tls (tls.crt + tls.key); the CA Secret backs /etc/husk/ca (ca.crt).
+	tlsVol, ok := vols["husk-tls"]
+	if !ok || tlsVol.Secret == nil || tlsVol.Secret.SecretName != "mitos-forkd-tls" {
+		t.Fatalf("fork child missing husk-tls leaf Secret volume (mitos-forkd-tls): %+v", child.Spec.Volumes)
+	}
+	if m, ok := mounts["husk-tls"]; !ok || !m.ReadOnly || m.MountPath != "/etc/husk/tls" {
+		t.Fatalf("fork child husk-tls mount missing/wrong (want RO /etc/husk/tls): %+v", mounts)
+	}
+	caVol, ok := vols["husk-ca"]
+	if !ok || caVol.Secret == nil || caVol.Secret.SecretName != "mitos-ca" {
+		t.Fatalf("fork child missing husk-ca Secret volume (mitos-ca): %+v", child.Spec.Volumes)
+	}
+	if m, ok := mounts["husk-ca"]; !ok || !m.ReadOnly || m.MountPath != "/etc/husk/ca" {
+		t.Fatalf("fork child husk-ca mount missing/wrong (want RO /etc/husk/ca): %+v", mounts)
+	}
+
+	// The kernel hostPath + mount.
+	if _, ok := vols["kernel"]; !ok {
+		t.Fatalf("fork child missing kernel hostPath volume: %+v", child.Spec.Volumes)
+	}
+	if m, ok := mounts["kernel"]; !ok || m.MountPath != "/var/lib/mitos/kernel/vmlinux" {
+		t.Fatalf("fork child kernel mount missing/wrong: %+v", mounts)
+	}
+
+	// The forks hostPath dir (read-write so the child can itself be re-forked).
+	if _, ok := vols["husk-forks"]; !ok {
+		t.Fatalf("fork child missing husk-forks hostPath volume: %+v", child.Spec.Volumes)
+	}
+	if m, ok := mounts["husk-forks"]; !ok || m.ReadOnly {
+		t.Fatalf("fork child husk-forks mount missing or read-only: %+v", mounts)
+	}
+
+	// The writable per-activation rootfs-CoW hostPath dir (the child writes its
+	// own clone here, so it must NOT be read-only).
+	if _, ok := vols["husk-rootfs-cow"]; !ok {
+		t.Fatalf("fork child missing husk-rootfs-cow hostPath volume: %+v", child.Spec.Volumes)
+	}
+	if m, ok := mounts["husk-rootfs-cow"]; !ok || m.ReadOnly {
+		t.Fatalf("fork child husk-rootfs-cow mount missing or read-only (child writes its CoW clone): %+v", mounts)
+	}
+
+	// The fork snapshot mount itself (read-only), pointing at the fork snapshot.
+	if m, ok := mounts["snapshot"]; !ok || !m.ReadOnly {
+		t.Fatalf("fork child snapshot mount missing or not read-only: %+v", mounts)
+	}
+
+	// The kvm device resource: request == limit == 1.
+	req := stub.Resources.Requests[corev1.ResourceName("mitos.run/kvm")]
+	lim := stub.Resources.Limits[corev1.ResourceName("mitos.run/kvm")]
+	if req.Value() != 1 || lim.Value() != 1 {
+		t.Fatalf("fork child kvm device resource not 1/1: req=%s lim=%s", req.String(), lim.String())
+	}
+
+	// POD_NAME downward API (scopes the per-pod CoW clone path).
+	var hasPodName bool
+	for _, e := range stub.Env {
+		if e.Name == "POD_NAME" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil && e.ValueFrom.FieldRef.FieldPath == "metadata.name" {
+			hasPodName = true
+		}
+	}
+	if !hasPodName {
+		t.Fatalf("fork child missing POD_NAME downward API env: %+v", stub.Env)
+	}
+
+	// SecurityContext: same lockdown as a warm pod (no privilege, no escalation,
+	// drop ALL caps, RuntimeDefault seccomp).
+	sc := stub.SecurityContext
+	if sc == nil || sc.Privileged == nil || *sc.Privileged {
+		t.Fatalf("fork child must not be privileged: %+v", sc)
+	}
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Fatalf("fork child must deny privilege escalation: %+v", sc)
+	}
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("fork child must drop ALL caps: %+v", sc.Capabilities)
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("fork child must use RuntimeDefault seccomp: %+v", sc.SeccompProfile)
+	}
+
+	// Fork-specific bits remain: pinned to the source node, and --template-rootfs
+	// (the CoW clone source) is the SOURCE pod's live rootfs, not the template's.
+	if child.Spec.Affinity == nil || child.Spec.Affinity.NodeAffinity == nil {
+		t.Fatalf("fork child must be pinned to the source node via affinity")
+	}
+	args := strings.Join(stub.Args, " ")
+	if !strings.Contains(args, "--template-rootfs /var/lib/mitos/husk-rootfs/"+srcPod.Name+"/rootfs.ext4") {
+		t.Fatalf("fork child --template-rootfs must be the source pod rootfs; args=%v", stub.Args)
 	}
 }

--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -205,6 +205,88 @@ func TestHuskForkSnapshotTakenExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestHuskForkNeverOverCreatesChildren is the regression for the live KVM
+// over-creation bug: a SandboxFork with Replicas=2 driven through MANY reconcile
+// passes while its children stay NOT Ready must create EXACTLY 2 child pods, never
+// 3+. The old loop derived child names from (TotalForks + i) and the iteration
+// count from (Replicas - ReadyForks); once a child became Ready mid-loop it bumped
+// TotalForks, shifting the next index to a NEW name (fork-2, fork-3, ...) so
+// ensureForkChildPod created an EXTRA pod instead of reusing a slot, overcommitting
+// the single node. The fixed-slot loop uses stable names ("<fork>-fork-<i>" for i
+// in [0, Replicas)) so the child count can never exceed Replicas. Children are kept
+// pending across passes here to exercise the many-pass path that produced fork-2.
+func TestHuskForkNeverOverCreatesChildren(t *testing.T) {
+	srcPod := makeDormantHuskPod(t, "pool-noover", "10.0.0.11")
+	makeForkSourceClaim(t, "src-claim-noover", "pool-noover", srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "noover-1",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxForkSpec{SourceRef: v1alpha1.LocalObjectReference{Name: "src-claim-noover"}, Replicas: 2},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	// Wait until both slots exist, then let many requeue passes elapse with the
+	// children deliberately LEFT not-Ready (forceHuskPodReady is never called), so
+	// the reconciler runs the full slot loop repeatedly.
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("noover-1"))
+		return len(pods.Items) >= 2
+	})
+	time.Sleep(3 * time.Second)
+
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren("noover-1")); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(pods.Items) != 2 {
+		names := make([]string, 0, len(pods.Items))
+		for i := range pods.Items {
+			names = append(names, pods.Items[i].Name)
+		}
+		t.Fatalf("expected EXACTLY 2 child pods for Replicas=2, got %d: %v", len(pods.Items), names)
+	}
+
+	// Now drive them Ready and confirm the fork completes at exactly 2, still
+	// without spawning a third pod.
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var p corev1.PodList
+		_ = k8sClient.List(ctx, &p, listForkChildren("noover-1"))
+		for i := range p.Items {
+			forceHuskPodReady(t, &p.Items[i])
+		}
+		var got v1alpha1.SandboxFork
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "noover-1", Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyForks == 2
+	})
+
+	var after corev1.PodList
+	if err := k8sClient.List(ctx, &after, listForkChildren("noover-1")); err != nil {
+		t.Fatalf("list children after ready: %v", err)
+	}
+	if len(after.Items) != 2 {
+		t.Fatalf("expected EXACTLY 2 child pods after completion, got %d", len(after.Items))
+	}
+}
+
 func TestHuskForkRemovesSnapshotOnDelete(t *testing.T) {
 	srcPod := makeDormantHuskPod(t, "pool-hd", "10.0.0.6")
 	makeForkSourceClaim(t, "src-claim-d", "pool-hd", srcPod)

--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -1,0 +1,187 @@
+package controller_test
+
+// Envtest coverage for the husk-pod live fork path (live SandboxFork on the husk
+// pod-native path). With EnableHuskPods a husk-backed source claim forked with
+// replicas=N snapshots the source pod's running VM once and activates N child
+// husk pods from that fork snapshot, each reaching Ready through the same
+// warm-pod Activate path (which runs the fail-closed RNG/clock reseed handshake).
+//
+// envtest has no kubelet, so the test forces each created child Running+Ready and
+// drives the fork-snapshot / activate / remove transports through the suite's
+// swappable fakes (setForkSnapshotter / setForkActivator / setForkSnapshotRemover).
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/controller"
+	"github.com/paperclipinc/mitos/internal/husk"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// forceHuskPodReady forces a husk pod Running+Ready with its PodIP set, so the
+// husk fork reconciler can dial it (envtest has no kubelet to do this).
+func forceHuskPodReady(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
+	var got corev1.Pod
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &got); err != nil {
+		t.Fatalf("get pod %s: %v", pod.Name, err)
+	}
+	if got.Status.Phase == corev1.PodRunning && got.Status.PodIP != "" {
+		return
+	}
+	got.Status.Phase = corev1.PodRunning
+	if got.Status.PodIP == "" {
+		got.Status.PodIP = "10.0.1.1"
+	}
+	got.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	if err := k8sClient.Status().Update(ctx, &got); err != nil {
+		t.Fatalf("force pod %s ready: %v", pod.Name, err)
+	}
+}
+
+// listForkChildren matches the husk pods owned by a fork.
+func listForkChildren(forkName string) client.ListOption {
+	return client.MatchingLabels{"mitos.run/fork": forkName}
+}
+
+// waitUntilForkReady polls cond until true or the deadline elapses.
+func waitUntilForkReady(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", d)
+}
+
+// makeForkSourceClaim creates a Ready husk-backed source claim pointing at srcPod.
+func makeForkSourceClaim(t *testing.T, name, poolName string, srcPod *corev1.Pod) *v1alpha1.SandboxClaim {
+	t.Helper()
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       v1alpha1.SandboxClaimSpec{PoolRef: v1alpha1.LocalObjectReference{Name: poolName}},
+	}
+	if err := k8sClient.Create(ctx, claim); err != nil {
+		t.Fatalf("create claim: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, claim) })
+	claim.Status.Phase = v1alpha1.SandboxReady
+	claim.Status.Node = srcPod.Spec.NodeName
+	claim.Status.SandboxID = srcPod.Name
+	if err := k8sClient.Status().Update(ctx, claim); err != nil {
+		t.Fatalf("update claim status: %v", err)
+	}
+	return claim
+}
+
+func TestHuskForkProducesReadyChildren(t *testing.T) {
+	srcPod := makeDormantHuskPod(t, "pool-hf", "10.0.0.5")
+	makeForkSourceClaim(t, "src-claim", "pool-hf", srcPod)
+
+	var snapCalls int
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		snapCalls++
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hf-1",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxForkSpec{SourceRef: v1alpha1.LocalObjectReference{Name: "src-claim"}, Replicas: 2},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("hf-1"))
+		for i := range pods.Items {
+			forceHuskPodReady(t, &pods.Items[i])
+		}
+		var got v1alpha1.SandboxFork
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "hf-1", Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyForks == 2
+	})
+
+	if snapCalls < 1 {
+		t.Fatalf("expected at least one fork-snapshot call, got %d", snapCalls)
+	}
+}
+
+func TestHuskForkRemovesSnapshotOnDelete(t *testing.T) {
+	srcPod := makeDormantHuskPod(t, "pool-hd", "10.0.0.6")
+	makeForkSourceClaim(t, "src-claim-d", "pool-hd", srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/x"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	removeCalls := make(chan struct{}, 4)
+	setForkSnapshotRemover(func(_ context.Context, _ string, _ *tls.Config, _ husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		select {
+		case removeCalls <- struct{}{}:
+		default:
+		}
+		return husk.ForkSnapshotResult{OK: true}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotRemover(nil) })
+
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hd-1",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxForkSpec{SourceRef: v1alpha1.LocalObjectReference{Name: "src-claim-d"}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("hd-1"))
+		for i := range pods.Items {
+			forceHuskPodReady(t, &pods.Items[i])
+		}
+		var got v1alpha1.SandboxFork
+		_ = k8sClient.Get(ctx, types.NamespacedName{Name: "hd-1", Namespace: "default"}, &got)
+		return got.Status.ReadyForks == 1
+	})
+
+	if err := k8sClient.Delete(ctx, fork); err != nil {
+		t.Fatalf("delete fork: %v", err)
+	}
+	select {
+	case <-removeCalls:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("remove-fork-snapshot was not called on delete")
+	}
+}

--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -13,6 +13,7 @@ package controller_test
 import (
 	"context"
 	"crypto/tls"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -127,6 +128,79 @@ func TestHuskForkProducesReadyChildren(t *testing.T) {
 
 	if snapCalls < 1 {
 		t.Fatalf("expected at least one fork-snapshot call, got %d", snapCalls)
+	}
+}
+
+// TestHuskForkSnapshotTakenExactlyOnce is the BUG 2 regression: the fork
+// snapshot must be taken EXACTLY ONCE for a SandboxFork and reused for all
+// children across reconcile passes. Children take several passes to reach Ready;
+// re-snapshotting on each pass re-pauses the source and overwrites the fork
+// mem/vmstate, so a child activated in a later pass would restore a NEWER source
+// memory state than an earlier child: the N children would not be a coherent
+// single fork point. The children are deliberately NOT forced Ready until after
+// several reconcile passes have elapsed, so the bug (per-pass re-snapshot) would
+// show snapCalls > 1.
+func TestHuskForkSnapshotTakenExactlyOnce(t *testing.T) {
+	srcPod := makeDormantHuskPod(t, "pool-once", "10.0.0.7")
+	makeForkSourceClaim(t, "src-claim-once", "pool-once", srcPod)
+
+	var snapCalls int32
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		atomic.AddInt32(&snapCalls, 1)
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hf-once",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxForkSpec{SourceRef: v1alpha1.LocalObjectReference{Name: "src-claim-once"}, Replicas: 2},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	// Wait for the child pods to be created (this guarantees the snapshot op has
+	// run at least once) WITHOUT forcing them Ready, so the reconciler requeues
+	// repeatedly with children pending. A per-pass re-snapshot would bump
+	// snapCalls above 1 during this window.
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("hf-once"))
+		return len(pods.Items) == 2
+	})
+	// Let several requeue passes elapse with children still pending.
+	time.Sleep(3 * time.Second)
+
+	if got := atomic.LoadInt32(&snapCalls); got != 1 {
+		t.Fatalf("fork snapshot must be taken exactly once across passes; got %d calls", got)
+	}
+
+	// Now drive the children Ready and confirm the fork still completes WITHOUT
+	// any further snapshot calls (reuse of the single snapshot).
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("hf-once"))
+		for i := range pods.Items {
+			forceHuskPodReady(t, &pods.Items[i])
+		}
+		var got v1alpha1.SandboxFork
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "hf-once", Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyForks == 2
+	})
+
+	if got := atomic.LoadInt32(&snapCalls); got != 1 {
+		t.Fatalf("fork snapshot re-taken after children came Ready; got %d calls, want 1", got)
 	}
 }
 

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -52,6 +53,12 @@ const (
 	// huskClaimLabel marks a husk pod as claimed by a specific SandboxClaim.
 	// Selection skips any pod carrying it: one claim activates one husk pod.
 	huskClaimLabel = "mitos.run/claim"
+
+	// huskForkLabel marks a husk pod as a fork CHILD and carries the owning
+	// SandboxFork name, so a reconcile can list exactly this fork's children and
+	// they are never counted as warm-pool slots (the pool selector requires
+	// huskPoolLabel, which fork children do not carry).
+	huskForkLabel = "mitos.run/fork"
 
 	// huskKVMNodeLabel is the node label the KVM device plugin / node bootstrap
 	// sets on a node that has /dev/kvm (deploy/talos). A husk pod is pinned to
@@ -696,7 +703,43 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 	// when the pool is deleted. c.Scheme() is the manager scheme (it carries
 	// core/v1 and mitos.run/v1alpha1). An error here means the scheme is
 	// missing a type and is a programming error; the caller logs and skips.
-	_ = controllerutil.SetControllerReference(pool, pod, r.Scheme())
+	// buildForkChildPod reuses this shape with a Client-less throwaway reconciler
+	// and sets its OWN owner ref (to the SandboxFork) afterward, so skip the
+	// pool owner ref when no Client (hence no scheme) is available.
+	if r.Client != nil {
+		_ = controllerutil.SetControllerReference(pool, pod, r.Scheme())
+	}
+	return pod
+}
+
+// buildForkChildPod builds a husk pod that activates from a fork snapshot. It
+// reuses the same pod shape buildHuskPod emits (buildHuskPod needs a pool for
+// GenerateName/namespace; a fork child is owned by the SandboxFork, not a pool),
+// then rewrites the ownership, labels, and name for the fork. The pod is pinned
+// to the source node (opts.ForkSourceNode) and activates from
+// <DataDir>/forks/<ForkSnapshotID> (opts.ForkSnapshotID), both set by the caller.
+func buildForkChildPod(fork *v1alpha1.SandboxFork, childName string, opts HuskPodOptions, scheme *runtime.Scheme) *corev1.Pod {
+	// buildHuskPod only reads r.Scheme() (for the owner ref we overwrite) and the
+	// opts, so a zero reconciler is sufficient to build the spec. A synthetic pool
+	// carrier supplies GenerateName/namespace; ownership and labels are overwritten
+	// below.
+	r := &SandboxPoolReconciler{}
+	carrier := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: fork.Name, Namespace: fork.Namespace}}
+	pod := r.buildHuskPod(carrier, &v1alpha1.SandboxTemplate{}, opts)
+
+	// Rewrite identity: owned by the SandboxFork (GC with it), labeled as a fork
+	// child (never a warm-pool slot), deterministic name so re-reconcile is
+	// idempotent.
+	pod.OwnerReferences = nil
+	pod.GenerateName = ""
+	pod.Name = childName
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	delete(pod.Labels, huskPoolLabel)
+	pod.Labels[huskLabel] = "true"
+	pod.Labels[huskForkLabel] = fork.Name
+	_ = controllerutil.SetControllerReference(fork, pod, scheme)
 	return pod
 }
 

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -120,6 +120,17 @@ const (
 // claim reconciler threads this into the activate request.
 const HuskSnapshotDir = huskSnapshotMountPath
 
+// huskSourceRootfsInPodPath returns the IN-POD path a fork child clones the
+// SOURCE sandbox's live rootfs from. The source pod wrote its own per-activation
+// rootfs clone at <huskRootfsCoWMountPath>/<source-pod-name>/rootfs.ext4 under
+// the shared husk-rootfs hostPath dir; the fork child mounts that SAME dir, so
+// the source pod's rootfs is visible to it at this path. This is the rootfs the
+// fork snapshot's vmstate was baked against, so the child's CoW clone source
+// must be it (not the pristine template rootfs).
+func huskSourceRootfsInPodPath(sourcePodName string) string {
+	return filepath.Join(huskRootfsCoWMountPath, sourcePodName, "rootfs.ext4")
+}
+
 // HuskPodOptions configures the husk pod spec the controller emits.
 type HuskPodOptions struct {
 	// StubImage is the container image that runs cmd/husk-stub.
@@ -164,6 +175,21 @@ type HuskPodOptions struct {
 	// source sandbox's node). Required when ForkSnapshotID is set, since the fork
 	// snapshot is a node-local hostPath that exists only on that node.
 	ForkSourceNode string
+	// ForkSourceRootfsPath, set on a FORK CHILD, is the IN-POD path of the SOURCE
+	// sandbox's live rootfs that the child's per-activation CoW clone is made from.
+	// It is the source pod's own per-activation rootfs clone, exposed to the child
+	// through the shared husk-rootfs hostPath dir at
+	// <huskRootfsCoWMountPath>/<source-pod-name>/rootfs.ext4. This is load-bearing
+	// for fork correctness: the fork snapshot's vmstate was baked against the
+	// SOURCE's rootfs (path_on_host), so the child's restored guest memory (page
+	// cache, ext4 superblock, in-flight metadata) reflects the SOURCE disk. Cloning
+	// from the PRISTINE TEMPLATE rootfs instead (the bug) rebinds the child to a
+	// disk that does not match its memory: any data the source wrote since boot is
+	// lost and the cached-vs-on-disk mismatch can corrupt the child fs. When set,
+	// it replaces the template rootfs as the clone SOURCE; each child still writes
+	// its OWN per-activation clone (independence), only the clone source changes.
+	// Empty (a warm pod, not a fork child) clones from the template rootfs.
+	ForkSourceRootfsPath string
 	// SnapshotNodes is the set of node hostnames the pool has materialized the
 	// template snapshot on (the registry's NodesWithTemplate). When non-empty the
 	// husk pod carries a nodeAffinity pinning it to exactly these nodes, so its
@@ -532,13 +558,25 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 		})
 		mounts = append(mounts, corev1.VolumeMount{Name: "husk-rootfs-cow", MountPath: huskRootfsCoWMountPath})
 
-		// Tell the stub where to clone from (the in-pod template rootfs at its baked
+		// The clone SOURCE for this pod's per-activation rootfs CoW. A WARM pod
+		// clones from the template rootfs (a fresh boot-time disk). A FORK CHILD
+		// must clone from the SOURCE sandbox's LIVE rootfs instead: the fork
+		// snapshot's vmstate was baked against the source's rootfs, so the child's
+		// restored guest memory reflects the SOURCE disk; cloning from the template
+		// would rebind the child to a disk that does not match its memory (silent
+		// data divergence / fs corruption). ForkSourceRootfsPath is the in-pod path
+		// of the source pod's rootfs (exposed through the shared husk-rootfs dir).
+		cloneSourceRootfs := filepath.Join(templateDir, "rootfs.ext4")
+		if opts.ForkSourceRootfsPath != "" {
+			cloneSourceRootfs = opts.ForkSourceRootfsPath
+		}
+		// Tell the stub where to clone from (the clone source rootfs at its in-pod
 		// path) and to (the writable CoW dir). At Prepare the stub reflink-clones the
-		// template rootfs to a per-pod file under the CoW dir and at Activate rebinds
-		// the rootfs drive to it, so concurrent activations never share a rootfs.
+		// source rootfs to a per-pod file under the CoW dir and at Activate rebinds
+		// the rootfs drive to it, so each activation gets its OWN rootfs clone.
 		args = append(args,
 			"--rootfs-cow-dir", huskRootfsCoWMountPath,
-			"--template-rootfs", filepath.Join(templateDir, "rootfs.ext4"),
+			"--template-rootfs", cloneSourceRootfs,
 		)
 	}
 

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -100,6 +100,12 @@ const (
 	// reflink-capable filesystem (a full copy fallback otherwise). Each activation
 	// writes its own clone under here, never the shared read-only template rootfs.
 	huskRootfsCoWMountPath = "/var/lib/mitos/husk-rootfs"
+
+	// huskForksMountPath is the in-pod path the node forks DIRECTORY is mounted at
+	// (read-write for a source pod that may be forked; the child's read-only
+	// snapshot mount points at a subdir of the node forks dir instead). The stub
+	// writes <huskForksMountPath>/<fork-id>/{mem,vmstate} on a fork-snapshot op.
+	huskForksMountPath = "/var/lib/mitos/forks"
 )
 
 // HuskSnapshotDir is the in-pod path the husk stub treats as ActivateRequest
@@ -141,6 +147,16 @@ type HuskPodOptions struct {
 	// separate from the leaf so the CA private key never reaches the husk pod,
 	// mirroring the forkd DaemonSet's /etc/forkd/ca split. Empty means no CA mount.
 	CASecretName string
+	// ForkSnapshotID, when set, makes this a FORK CHILD pod: it activates from
+	// the node fork snapshot <DataDir>/forks/<ForkSnapshotID> instead of the
+	// template snapshot. The fork snapshot was written by the source sandbox's
+	// husk stub (the fork-snapshot control op). It is a node-local id, not a
+	// secret.
+	ForkSnapshotID string
+	// ForkSourceNode pins a fork child to the node holding the fork snapshot (the
+	// source sandbox's node). Required when ForkSnapshotID is set, since the fork
+	// snapshot is a node-local hostPath that exists only on that node.
+	ForkSourceNode string
 	// SnapshotNodes is the set of node hostnames the pool has materialized the
 	// template snapshot on (the registry's NodesWithTemplate). When non-empty the
 	// husk pod carries a nodeAffinity pinning it to exactly these nodes, so its
@@ -323,7 +339,15 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 	// fall back to the development escape hatch so the warm pool still activates;
 	// the stub logs this loudly. The manifest mount itself is added in the snapshot
 	// block below (it shares the snapshot placement requirement).
-	if opts.ExpectedDigest != "" {
+	if opts.ForkSnapshotID != "" {
+		// Fork child: the fork snapshot is a LIVE, node-local artifact created by
+		// the source stub and consumed by child stubs on the SAME node within the
+		// same trust boundary. It is NOT content-addressed (re-hashing would gate
+		// on a digest that does not exist for a live fork), so the child activates
+		// it with verify disabled, the same posture a pre-digest pool uses. The
+		// child still runs the full fail-closed RNG/clock reseed handshake.
+		args = append(args, "--allow-unverified-snapshots")
+	} else if opts.ExpectedDigest != "" {
 		args = append(args, "--manifest", filepath.Join(huskManifestDirMountPath, opts.ExpectedDigest))
 		// Pass the snapshot dir + expected digest so the dormant pod verifies the
 		// snapshot (the ~680 MiB re-hash) during Prepare, off the claim's Activate
@@ -380,11 +404,38 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 		// CAS manifest digest before loading (fail-closed), so an empty or wrong
 		// snapshot is rejected at activation, not silently run.
 		hostType := corev1.HostPathDirectoryOrCreate
+
+		// The node forks dir, mounted READ-WRITE so this pod's stub can write a
+		// fork snapshot of its running VM (<forks>/<fork-id>/{mem,vmstate}) when
+		// the controller drives a fork-snapshot op against it. Co-located with the
+		// template dir on the SAME node filesystem so a child's read-only mount of
+		// a subdir resolves and any CoW stays on one filesystem.
+		volumes = append(volumes, corev1.Volume{
+			Name: "husk-forks",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: filepath.Join(dataDir, "forks"),
+					Type: &hostType,
+				},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{Name: "husk-forks", MountPath: huskForksMountPath})
+		// Tell the stub where to write fork snapshots so a fork-snapshot op writes
+		// inside the mounted node forks dir.
+		args = append(args, "--forks-dir", huskForksMountPath)
+
+		// The snapshot SOURCE path. A warm pod activates from the template's
+		// snapshot subdir; a FORK CHILD activates from the node fork snapshot
+		// <dataDir>/forks/<fork-id> instead (mounted at the SAME in-pod path).
+		snapshotHostPath := filepath.Join(dataDir, "templates", opts.SnapshotID, "snapshot")
+		if opts.ForkSnapshotID != "" {
+			snapshotHostPath = filepath.Join(dataDir, "forks", opts.ForkSnapshotID)
+		}
 		volumes = append(volumes, corev1.Volume{
 			Name: "snapshot",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: filepath.Join(dataDir, "templates", opts.SnapshotID, "snapshot"),
+					Path: snapshotHostPath,
 					Type: &hostType,
 				},
 			},
@@ -503,6 +554,24 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 							Key:      hostnameNodeLabel,
 							Operator: corev1.NodeSelectorOpIn,
 							Values:   nodes,
+						}},
+					}},
+				},
+			},
+		}
+	}
+	// A fork child can only run where its fork snapshot exists (the source node's
+	// node-local hostPath), so pin it to exactly that node. This takes precedence
+	// over SnapshotNodes; a fork child never sets SnapshotNodes.
+	if opts.ForkSourceNode != "" {
+		affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      hostnameNodeLabel,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{opts.ForkSourceNode},
 						}},
 					}},
 				},

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -873,3 +873,25 @@ func TestBuildHuskPodForkChildActivatesFromForkSnapshot(t *testing.T) {
 		t.Fatalf("fork child must be pinned to the source node via affinity")
 	}
 }
+
+func TestBuildForkChildPodOwnedByFork(t *testing.T) {
+	fork := &v1alpha1.SandboxFork{ObjectMeta: metav1.ObjectMeta{Name: "f1", Namespace: "default", UID: "uid-f1"}}
+	pod := controller.BuildForkChildPodForTest(fork, "child-0", controller.HuskPodOptions{
+		StubImage:      "img",
+		SnapshotID:     "tmpl-a",
+		DataDir:        "/data",
+		ForkSnapshotID: "f1",
+		ForkSourceNode: "kvm-node-1",
+	}, scheme)
+
+	owner := metav1.GetControllerOf(pod)
+	if owner == nil || owner.UID != "uid-f1" {
+		t.Fatalf("fork child not owned by the SandboxFork: %+v", owner)
+	}
+	if pod.Labels["mitos.run/fork"] != "f1" {
+		t.Fatalf("fork child missing fork label, labels=%+v", pod.Labels)
+	}
+	if _, ok := pod.Labels["mitos.run/pool"]; ok {
+		t.Fatalf("fork child must NOT carry the pool warm-slot label, labels=%+v", pod.Labels)
+	}
+}

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -874,6 +874,52 @@ func TestBuildHuskPodForkChildActivatesFromForkSnapshot(t *testing.T) {
 	}
 }
 
+// TestBuildHuskPodForkChildClonesFromSourceRootfs is the BUG 1 regression: a
+// fork child restores the SOURCE's live fork snapshot, whose vmstate was baked
+// against the SOURCE's rootfs. Its per-activation CoW clone MUST therefore be
+// sourced from the SOURCE pod's rootfs, not the pristine template rootfs;
+// otherwise the child's guest memory (page cache, ext4 superblock) reflects the
+// source disk while the block device is the template disk: silent divergence /
+// fs corruption. The controller threads the source pod's in-pod rootfs path
+// through ForkSourceRootfsPath; --template-rootfs (the clone SOURCE) must be it.
+func TestBuildHuskPodForkChildClonesFromSourceRootfs(t *testing.T) {
+	r := &controller.SandboxPoolReconciler{Client: k8sClient}
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"}}
+	tmpl := &v1alpha1.SandboxTemplate{}
+	srcRootfs := filepath.Join("/var/lib/mitos", "husk-rootfs", "src-pod-xyz", "rootfs.ext4")
+	pod := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{
+		StubImage:            "img",
+		SnapshotID:           "tmpl-a",
+		DataDir:              "/data",
+		ForkSnapshotID:       "fork-1",
+		ForkSourceNode:       "kvm-node-1",
+		ForkSourceRootfsPath: srcRootfs,
+	})
+
+	var container corev1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == "husk-stub" {
+			container = pod.Spec.Containers[i]
+		}
+	}
+	args := strings.Join(container.Args, " ")
+	// The clone SOURCE must be the SOURCE pod's rootfs, not the template's.
+	if !strings.Contains(args, "--template-rootfs "+srcRootfs) {
+		t.Fatalf("fork child --template-rootfs must be the source rootfs %q; args=%v", srcRootfs, container.Args)
+	}
+	// And it must NOT clone from the pristine template rootfs (the bug).
+	templateRootfs := filepath.Join("/data", "templates", "tmpl-a", "rootfs.ext4")
+	if strings.Contains(args, "--template-rootfs "+templateRootfs) {
+		t.Fatalf("fork child must NOT clone from the template rootfs %q (source/disk divergence); args=%v", templateRootfs, container.Args)
+	}
+	// Each child still gets its OWN per-activation CoW clone (independence):
+	// the CoW DEST dir is still the per-pod writable dir.
+	const cowMountPath = "/var/lib/mitos/husk-rootfs"
+	if !strings.Contains(args, "--rootfs-cow-dir "+cowMountPath) {
+		t.Errorf("fork child must still write its own per-activation clone under %q; args=%v", cowMountPath, container.Args)
+	}
+}
+
 func TestBuildForkChildPodOwnedByFork(t *testing.T) {
 	fork := &v1alpha1.SandboxFork{ObjectMeta: metav1.ObjectMeta{Name: "f1", Namespace: "default", UID: "uid-f1"}}
 	pod := controller.BuildForkChildPodForTest(fork, "child-0", controller.HuskPodOptions{

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -828,3 +828,48 @@ func TestReconcileHuskPodsFlagOffCreatesNone(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 	}
 }
+
+func TestBuildHuskPodMountsForksDir(t *testing.T) {
+	r := &controller.SandboxPoolReconciler{Client: k8sClient}
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"}}
+	tmpl := &v1alpha1.SandboxTemplate{}
+	pod := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{StubImage: "img", SnapshotID: "tmpl-a", DataDir: "/data"})
+
+	var found bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "husk-forks" && v.HostPath != nil && v.HostPath.Path == "/data/forks" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("husk pod missing the read-write forks hostPath volume; volumes=%+v", pod.Spec.Volumes)
+	}
+}
+
+func TestBuildHuskPodForkChildActivatesFromForkSnapshot(t *testing.T) {
+	r := &controller.SandboxPoolReconciler{Client: k8sClient}
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"}}
+	tmpl := &v1alpha1.SandboxTemplate{}
+	pod := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{
+		StubImage:      "img",
+		SnapshotID:     "tmpl-a",
+		DataDir:        "/data",
+		ForkSnapshotID: "fork-1",
+		ForkSourceNode: "kvm-node-1",
+	})
+
+	// The snapshot mount must point at the FORK snapshot dir, not the template's.
+	var snapPath string
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "snapshot" && v.HostPath != nil {
+			snapPath = v.HostPath.Path
+		}
+	}
+	if snapPath != "/data/forks/fork-1" {
+		t.Fatalf("fork child snapshot mount = %q, want /data/forks/fork-1", snapPath)
+	}
+	// The child is pinned to the source node.
+	if pod.Spec.Affinity == nil {
+		t.Fatalf("fork child must be pinned to the source node via affinity")
+	}
+}

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -55,6 +55,15 @@ type SandboxForkReconciler struct {
 	HuskStubImage   string
 	DataDir         string
 	KVMResourceName string
+	// HuskTLSSecretName / HuskCASecretName are the husk PKI Secrets every husk
+	// pod mounts for its mTLS control channel: the leaf (tls.crt, tls.key) at
+	// /etc/husk/tls and the CA (ca.crt) at /etc/husk/ca. They are the SAME
+	// Secrets the warm-pool reconciler threads into HuskPodOptions; a fork child
+	// is a husk pod and its stub reads --tls-cert/--tls-key/--tls-ca from these
+	// mounts at start, so both MUST be set or the child crash-loops on the first
+	// missing PEM (open /etc/husk/tls/tls.crt: no such file or directory).
+	HuskTLSSecretName string
+	HuskCASecretName  string
 
 	// forkSnapshot / activate / removeForkSnapshot are the husk control seams.
 	// Nil defaults to ForkSnapshotOnHusk / ActivateHuskPod / RemoveForkSnapshotOnHusk.
@@ -357,6 +366,13 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 		DataDir:         r.DataDir,
 		ForkSnapshotID:  forkID,
 		ForkSourceNode:  source.Status.Node,
+		// The husk PKI Secrets the child stub mounts for its --control-listen mTLS
+		// channel (leaf at /etc/husk/tls, CA at /etc/husk/ca). buildHuskPod only
+		// adds the TLS/CA volumes when these are set; omitting them (the previous
+		// bug) leaves the child without its TLS material and the stub crash-loops
+		// reading --tls-cert. They are the SAME Secrets the warm-pool path uses.
+		TLSSecretName: r.HuskTLSSecretName,
+		CASecretName:  r.HuskCASecretName,
 		// BUG 1 fix: the child's per-activation rootfs CoW clone must be sourced
 		// from the SOURCE sandbox's live rootfs (the disk the fork snapshot's
 		// vmstate was baked against), NOT the pristine template rootfs. The source

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -381,19 +381,52 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 		ForkSourceRootfsPath: huskSourceRootfsInPodPath(source.Status.SandboxID),
 	}
 
-	needed := fork.Spec.Replicas - fork.Status.ReadyForks
-	for i := int32(0); i < needed; i++ {
-		childName := fmt.Sprintf("%s-fork-%d", fork.Name, fork.Status.TotalForks+i)
+	// Fixed-slot, idempotent child set. The child pods are EXACTLY Replicas, with
+	// STABLE names ("<fork>-fork-<i>" for i in [0, Replicas)) that never change
+	// across reconcile passes. The previous count-driven loop derived the name from
+	// (TotalForks + i) and the iteration count from (Replicas - ReadyForks): once a
+	// child in a pass became Ready it bumped TotalForks mid-loop, so the next i
+	// produced a NEW name (fork-2, fork-3, ...) and ensureForkChildPod created an
+	// EXTRA pod instead of reusing an existing slot, overcommitting the node. With
+	// fixed names the number of child pods can never exceed Replicas regardless of
+	// how many passes run or how slowly children become Ready: ensureForkChildPod
+	// is get-or-create by the stable name, so each slot maps to exactly one pod.
+	//
+	// ReadyForks is recomputed from scratch each pass (counting Ready slots) rather
+	// than incremented, so a slow or transient child does not permanently inflate
+	// the count.
+	//
+	// A slot already recorded Ready (and so already activated with its token Secret
+	// written) is carried forward as-is and NOT re-activated: re-activating a live
+	// child VM each pass would mint a fresh token and thrash the restored VM.
+	recorded := make(map[string]v1alpha1.ForkInfo, len(fork.Status.Forks))
+	for _, f := range fork.Status.Forks {
+		recorded[f.Name] = f
+	}
 
-		// Create the child pod if absent (idempotent across requeues).
+	var ready int32
+	var forks []v1alpha1.ForkInfo
+	for i := int32(0); i < fork.Spec.Replicas; i++ {
+		childName := fmt.Sprintf("%s-fork-%d", fork.Name, i)
+
+		// Get-or-create the child pod for this slot (idempotent by the stable name).
 		child, err := r.ensureForkChildPod(ctx, fork, childName, opts)
 		if err != nil {
 			logger.Error(err, "create fork child pod failed", "child", childName)
 			continue
 		}
-		// The child must be Running+Ready before it can be activated.
+
+		// Already activated in a prior pass: carry the recorded info forward and
+		// skip re-activation (idempotent per slot).
+		if info, ok := recorded[childName]; ok {
+			forks = append(forks, info)
+			ready++
+			continue
+		}
+
+		// The child must be Running+Ready before it can be activated. Not ready yet:
+		// requeue this slot next pass WITHOUT creating any extra pod.
 		if child.Status.PodIP == "" || !huskPodReady(child) {
-			// Not ready yet; requeue and try again next pass.
 			continue
 		}
 
@@ -422,16 +455,18 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 			continue
 		}
 
-		fork.Status.Forks = append(fork.Status.Forks, v1alpha1.ForkInfo{
+		forks = append(forks, v1alpha1.ForkInfo{
 			Name:      childName,
 			SandboxID: child.Name,
 			Endpoint:  endpoint,
 			Node:      child.Spec.NodeName,
 			Phase:     v1alpha1.SandboxReady,
 		})
-		fork.Status.ReadyForks++
-		fork.Status.TotalForks++
+		ready++
 	}
+	fork.Status.Forks = forks
+	fork.Status.ReadyForks = ready
+	fork.Status.TotalForks = ready
 
 	now := metav1.Now()
 	fork.Status.CheckpointTime = &now

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -2,20 +2,72 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
+	"path/filepath"
+	"strconv"
 	"time"
 
 	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/husk"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+// huskForkSnapshotter is the controller->husk fork-snapshot transport seam. Nil
+// defaults to ForkSnapshotOnHusk; tests inject a fake.
+type huskForkSnapshotter func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error)
+
+// huskForkSnapshotRemover is the controller->husk remove-fork-snapshot seam. Nil
+// defaults to RemoveForkSnapshotOnHusk; tests inject a fake.
+type huskForkSnapshotRemover func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error)
+
+// huskForkFinalizer guards a husk fork so its node-local fork snapshot is
+// removed from the source pod before the SandboxFork object is deleted.
+const huskForkFinalizer = "mitos.run/husk-fork-snapshot"
 
 type SandboxForkReconciler struct {
 	client.Client
 	NodeRegistry *NodeRegistry
+
+	// EnableHuskPods selects the husk fork path: snapshot the source husk pod's
+	// running VM, then create + activate N child husk pods from that fork
+	// snapshot. Off (default in this struct's zero value) keeps the raw-forkd
+	// ForkRunning path unchanged.
+	EnableHuskPods bool
+	// HuskTLS is the controller client mTLS config used to dial a husk stub's
+	// control channel (the SAME config the claim reconciler uses). Required when
+	// EnableHuskPods is true.
+	HuskTLS *tls.Config
+	// HuskControlPort / HuskSandboxPort default to HuskControlPort / huskSandboxPort.
+	HuskControlPort int
+	HuskSandboxPort int
+	// HuskStubImage / DataDir / KVMResourceName configure the fork child pods.
+	HuskStubImage   string
+	DataDir         string
+	KVMResourceName string
+
+	// forkSnapshot / activate / removeForkSnapshot are the husk control seams.
+	// Nil defaults to ForkSnapshotOnHusk / ActivateHuskPod / RemoveForkSnapshotOnHusk.
+	// Tests inject fakes.
+	forkSnapshot       huskForkSnapshotter
+	activate           huskActivator
+	removeForkSnapshot huskForkSnapshotRemover
+
+	// eventFilter / controllerName optionally restrict which forks this reconciler
+	// watches and name the controller, so a raw and a husk fork reconciler can
+	// share one manager in tests. Production leaves them unset.
+	eventFilter    predicate.Predicate
+	controllerName string
 }
 
 // SandboxFork ownership: get/list/watch to reconcile, update to write
@@ -32,6 +84,22 @@ func (r *SandboxForkReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	var fork v1alpha1.SandboxFork
 	if err := r.Get(ctx, req.NamespacedName, &fork); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Husk fork deletion + finalizer handling MUST come before the terminal and
+	// already-satisfied short-circuits below: a fork being deleted (or one that
+	// has reached its replicas) still needs its node-local fork snapshot GC'd.
+	if r.EnableHuskPods {
+		if !fork.DeletionTimestamp.IsZero() {
+			return r.finalizeHuskFork(ctx, &fork)
+		}
+		if !controllerutil.ContainsFinalizer(&fork, huskForkFinalizer) {
+			controllerutil.AddFinalizer(&fork, huskForkFinalizer)
+			if err := r.Update(ctx, &fork); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// A rejected fork is terminal: never reconcile it again.
@@ -91,6 +159,14 @@ func (r *SandboxForkReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if source.Status.Phase != v1alpha1.SandboxReady {
 		logger.Info("source sandbox not ready, waiting", "source", source.Name, "phase", source.Status.Phase)
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+
+	// Husk fork path: the source VM is owned by the source husk pod's stub, not
+	// forkd's engine, so the only way to live-fork it is for the owning stub to
+	// snapshot it and N child husk pods to restore that snapshot. The raw-forkd
+	// ForkRunning path below is left unchanged for the non-husk default.
+	if r.EnableHuskPods {
+		return r.reconcileHuskFork(ctx, &fork, &source)
 	}
 
 	// Find the node running the source sandbox. A live/standard fork is pinned
@@ -192,6 +268,231 @@ func (r *SandboxForkReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
+// huskForksInPodDir is the in-pod path a husk stub writes a fork snapshot to for
+// forkID; it matches the --forks-dir mount the pod builder set (huskForksMountPath).
+func huskForksInPodDir(forkID string) string { return filepath.Join(huskForksMountPath, forkID) }
+
+// reconcileHuskFork forks a husk-backed source: it snapshots the source pod's
+// running VM ONCE (fork-snapshot control op), then creates and activates N child
+// husk pods from the fork snapshot, recording each Ready child in the fork
+// status. It is the husk analog of the forkd ForkRunning loop. The fork snapshot
+// is node-local and shared read-only by the children on the same node, while each
+// child gets its own pod + VM + per-activation rootfs CoW clone (independence) and
+// runs the same fail-closed RNG/clock reseed handshake a warm pod does.
+func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1alpha1.SandboxFork, source *v1alpha1.SandboxClaim) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Resolve the source husk pod: a husk claim records Status.SandboxID = pod
+	// name and Status.Node = the pod's node.
+	srcPod, err := r.findHuskPod(ctx, fork.Namespace, source.Status.SandboxID)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+	if srcPod.Status.PodIP == "" {
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+
+	controlPort := r.HuskControlPort
+	if controlPort == 0 {
+		controlPort = HuskControlPort
+	}
+	sandboxPort := r.HuskSandboxPort
+	if sandboxPort == 0 {
+		sandboxPort = huskSandboxPort
+	}
+	forkSnap := r.forkSnapshot
+	if forkSnap == nil {
+		forkSnap = ForkSnapshotOnHusk
+	}
+	activate := r.activate
+	if activate == nil {
+		activate = ActivateHuskPod
+	}
+
+	// One fork snapshot per SandboxFork, keyed by the fork name. Idempotent: a
+	// re-reconcile that already snapshotted re-runs the op (CreateSnapshot
+	// overwrites), which is cheap and keeps the path simple; the children share
+	// the same fork snapshot dir read-only.
+	forkID := fork.Name
+	srcAddr := net.JoinHostPort(srcPod.Status.PodIP, strconv.Itoa(controlPort))
+	snapCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	// The source stub writes the snapshot inside its OWN in-pod forks dir mount
+	// (huskForksMountPath/<fork-id>); the child reads the same node dir mounted
+	// read-only at HuskSnapshotDir.
+	snapRes, err := forkSnap(snapCtx, srcAddr, r.HuskTLS, husk.ForkSnapshotRequest{
+		ForkID:      forkID,
+		SnapshotDir: huskForksInPodDir(forkID),
+		PauseSource: fork.Spec.PauseSource,
+	})
+	if err != nil || !snapRes.OK {
+		msg := "fork snapshot did not complete"
+		if err != nil {
+			msg = fmt.Sprintf("fork snapshot transport error: %v", err)
+		} else if snapRes.Error != "" {
+			msg = "fork snapshot failed: " + snapRes.Error
+		}
+		logger.Info("husk fork snapshot failed, requeueing", "source", srcPod.Name, "detail", msg)
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+	}
+
+	opts := HuskPodOptions{
+		StubImage:       r.HuskStubImage,
+		KVMResourceName: r.KVMResourceName,
+		SnapshotID:      source.Spec.PoolRef.Name, // template id, for resource/kernel mounts
+		DataDir:         r.DataDir,
+		ForkSnapshotID:  forkID,
+		ForkSourceNode:  source.Status.Node,
+	}
+
+	needed := fork.Spec.Replicas - fork.Status.ReadyForks
+	for i := int32(0); i < needed; i++ {
+		childName := fmt.Sprintf("%s-fork-%d", fork.Name, fork.Status.TotalForks+i)
+
+		// Create the child pod if absent (idempotent across requeues).
+		child, err := r.ensureForkChildPod(ctx, fork, childName, opts)
+		if err != nil {
+			logger.Error(err, "create fork child pod failed", "child", childName)
+			continue
+		}
+		// The child must be Running+Ready before it can be activated.
+		if child.Status.PodIP == "" || !huskPodReady(child) {
+			// Not ready yet; requeue and try again next pass.
+			continue
+		}
+
+		apiToken, err := mintAPIToken()
+		if err != nil {
+			logger.Error(err, "token minting failed", "child", childName)
+			continue
+		}
+
+		addr := net.JoinHostPort(child.Status.PodIP, strconv.Itoa(controlPort))
+		actRes, err := activate(ctx, addr, r.HuskTLS, husk.ActivateRequest{
+			// The child reads the FORK snapshot here (its <dataDir>/forks/<fork-id>
+			// hostPath is mounted at HuskSnapshotDir). No ExpectedDigest: the fork
+			// snapshot is node-local, not content-addressed.
+			SnapshotDir: HuskSnapshotDir,
+			Token:       apiToken,
+		})
+		if err != nil || !actRes.OK {
+			logger.Info("fork child activation failed, will retry", "child", childName)
+			continue
+		}
+
+		endpoint := net.JoinHostPort(child.Status.PodIP, strconv.Itoa(sandboxPort))
+		if err := ensureSandboxTokenSecret(ctx, r.Client, fork, childName+tokenSecretSuffix, apiToken, endpoint); err != nil {
+			logger.Error(err, "token secret write failed", "child", childName)
+			continue
+		}
+
+		fork.Status.Forks = append(fork.Status.Forks, v1alpha1.ForkInfo{
+			Name:      childName,
+			SandboxID: child.Name,
+			Endpoint:  endpoint,
+			Node:      child.Spec.NodeName,
+			Phase:     v1alpha1.SandboxReady,
+		})
+		fork.Status.ReadyForks++
+		fork.Status.TotalForks++
+	}
+
+	now := metav1.Now()
+	fork.Status.CheckpointTime = &now
+	setCondition(&fork.Status.Conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             conditionStatus(fork.Status.ReadyForks >= fork.Spec.Replicas),
+		LastTransitionTime: now,
+		Reason:             "ForksCreated",
+		Message:            fmt.Sprintf("%d/%d husk forks ready", fork.Status.ReadyForks, fork.Spec.Replicas),
+	})
+	if err := r.Status().Update(ctx, fork); err != nil {
+		return ctrl.Result{}, err
+	}
+	if fork.Status.ReadyForks < fork.Spec.Replicas {
+		// Children still coming up; requeue to drive them Ready.
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// findHuskPod returns the husk pod named name in ns (a husk claim's
+// Status.SandboxID is the pod name). It returns an error when not found so the
+// caller can requeue.
+func (r *SandboxForkReconciler) findHuskPod(ctx context.Context, ns, name string) (*corev1.Pod, error) {
+	var pod corev1.Pod
+	if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &pod); err != nil {
+		return nil, fmt.Errorf("get source husk pod %s/%s: %w", ns, name, err)
+	}
+	return &pod, nil
+}
+
+// ensureForkChildPod creates the fork child pod if it does not exist and returns
+// the current pod object. Idempotent across requeues (a child already created is
+// fetched and returned).
+func (r *SandboxForkReconciler) ensureForkChildPod(ctx context.Context, fork *v1alpha1.SandboxFork, name string, opts HuskPodOptions) (*corev1.Pod, error) {
+	var existing corev1.Pod
+	err := r.Get(ctx, client.ObjectKey{Namespace: fork.Namespace, Name: name}, &existing)
+	if err == nil {
+		return &existing, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("get fork child pod %s: %w", name, err)
+	}
+	pod := buildForkChildPod(fork, name, opts, r.Scheme())
+	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("create fork child pod %s: %w", name, err)
+	}
+	// Re-get so the caller sees the server object (with any defaults applied).
+	if err := r.Get(ctx, client.ObjectKey{Namespace: fork.Namespace, Name: name}, &existing); err != nil {
+		return nil, fmt.Errorf("re-get fork child pod %s: %w", name, err)
+	}
+	return &existing, nil
+}
+
+// finalizeHuskFork removes the node-local fork snapshot from the source husk pod
+// (best effort) and clears the finalizer so deletion proceeds. The child pods are
+// owner-ref'd to the fork and reaped by Kubernetes GC; only the snapshot dir
+// needs explicit cleanup. A transport failure does not block deletion: the dir is
+// reclaimed when the source pod is recycled.
+func (r *SandboxForkReconciler) finalizeHuskFork(ctx context.Context, fork *v1alpha1.SandboxFork) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	if !controllerutil.ContainsFinalizer(fork, huskForkFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	remove := r.removeForkSnapshot
+	if remove == nil {
+		remove = RemoveForkSnapshotOnHusk
+	}
+
+	// Resolve the source pod to dial; if it is gone the snapshot went with it.
+	var source v1alpha1.SandboxClaim
+	if err := r.Get(ctx, client.ObjectKey{Namespace: fork.Namespace, Name: fork.Spec.SourceRef.Name}, &source); err == nil && source.Status.SandboxID != "" {
+		if srcPod, err := r.findHuskPod(ctx, fork.Namespace, source.Status.SandboxID); err == nil && srcPod.Status.PodIP != "" {
+			controlPort := r.HuskControlPort
+			if controlPort == 0 {
+				controlPort = HuskControlPort
+			}
+			addr := net.JoinHostPort(srcPod.Status.PodIP, strconv.Itoa(controlPort))
+			rmCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+			if _, err := remove(rmCtx, addr, r.HuskTLS, husk.RemoveForkSnapshotRequest{
+				ForkID:      fork.Name,
+				SnapshotDir: huskForksInPodDir(fork.Name),
+			}); err != nil {
+				logger.Info("remove fork snapshot failed; proceeding with delete", "fork", fork.Name, "detail", err.Error())
+			}
+		}
+	}
+
+	controllerutil.RemoveFinalizer(fork, huskForkFinalizer)
+	if err := r.Update(ctx, fork); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
 type forkRunningResult struct {
 	SandboxID    string
 	Endpoint     string
@@ -199,8 +500,18 @@ type forkRunningResult struct {
 	CheckpointMs float64
 }
 
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
 func (r *SandboxForkReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.SandboxFork{}).
-		Complete(r)
+	b := ctrl.NewControllerManagedBy(mgr)
+	if r.eventFilter != nil {
+		b = b.For(&v1alpha1.SandboxFork{}, builder.WithPredicates(r.eventFilter))
+	} else {
+		b = b.For(&v1alpha1.SandboxFork{})
+	}
+	// The husk fork path owns child husk pods (created + GC'd with the fork).
+	b = b.Owns(&corev1.Pod{})
+	if r.controllerName != "" {
+		b = b.Named(r.controllerName)
+	}
+	return b.Complete(r)
 }

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -309,31 +309,45 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 		activate = ActivateHuskPod
 	}
 
-	// One fork snapshot per SandboxFork, keyed by the fork name. Idempotent: a
-	// re-reconcile that already snapshotted re-runs the op (CreateSnapshot
-	// overwrites), which is cheap and keeps the path simple; the children share
-	// the same fork snapshot dir read-only.
+	// One fork snapshot per SandboxFork, keyed by the fork name, taken EXACTLY
+	// ONCE and reused for every child across reconcile passes. Children take
+	// several passes to reach Ready; re-snapshotting on each pass would re-pause
+	// the source and OVERWRITE the fork mem/vmstate, so a child activated in a
+	// later pass would restore a NEWER source memory state than an earlier child:
+	// the N children would not be a coherent single fork point. The guard is the
+	// persisted Status.ForkSnapshotTaken flag, so it survives a controller restart
+	// mid-fork (the source is never re-paused once the snapshot exists).
 	forkID := fork.Name
-	srcAddr := net.JoinHostPort(srcPod.Status.PodIP, strconv.Itoa(controlPort))
-	snapCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-	// The source stub writes the snapshot inside its OWN in-pod forks dir mount
-	// (huskForksMountPath/<fork-id>); the child reads the same node dir mounted
-	// read-only at HuskSnapshotDir.
-	snapRes, err := forkSnap(snapCtx, srcAddr, r.HuskTLS, husk.ForkSnapshotRequest{
-		ForkID:      forkID,
-		SnapshotDir: huskForksInPodDir(forkID),
-		PauseSource: fork.Spec.PauseSource,
-	})
-	if err != nil || !snapRes.OK {
-		msg := "fork snapshot did not complete"
-		if err != nil {
-			msg = fmt.Sprintf("fork snapshot transport error: %v", err)
-		} else if snapRes.Error != "" {
-			msg = "fork snapshot failed: " + snapRes.Error
+	if !fork.Status.ForkSnapshotTaken {
+		srcAddr := net.JoinHostPort(srcPod.Status.PodIP, strconv.Itoa(controlPort))
+		snapCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+		// The source stub writes the snapshot inside its OWN in-pod forks dir mount
+		// (huskForksMountPath/<fork-id>); the child reads the same node dir mounted
+		// read-only at HuskSnapshotDir.
+		snapRes, err := forkSnap(snapCtx, srcAddr, r.HuskTLS, husk.ForkSnapshotRequest{
+			ForkID:      forkID,
+			SnapshotDir: huskForksInPodDir(forkID),
+			PauseSource: fork.Spec.PauseSource,
+		})
+		if err != nil || !snapRes.OK {
+			msg := "fork snapshot did not complete"
+			if err != nil {
+				msg = fmt.Sprintf("fork snapshot transport error: %v", err)
+			} else if snapRes.Error != "" {
+				msg = "fork snapshot failed: " + snapRes.Error
+			}
+			logger.Info("husk fork snapshot failed, requeueing", "source", srcPod.Name, "detail", msg)
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		logger.Info("husk fork snapshot failed, requeueing", "source", srcPod.Name, "detail", msg)
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		// Record the snapshot was taken BEFORE creating any child, so a crash
+		// between here and the child loop does not re-snapshot (re-pause) the
+		// source on the next pass. The children always re-read the same fork
+		// snapshot dir, so persisting the flag first is safe.
+		fork.Status.ForkSnapshotTaken = true
+		if err := r.Status().Update(ctx, fork); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	opts := HuskPodOptions{
@@ -343,6 +357,12 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 		DataDir:         r.DataDir,
 		ForkSnapshotID:  forkID,
 		ForkSourceNode:  source.Status.Node,
+		// BUG 1 fix: the child's per-activation rootfs CoW clone must be sourced
+		// from the SOURCE sandbox's live rootfs (the disk the fork snapshot's
+		// vmstate was baked against), NOT the pristine template rootfs. The source
+		// pod name is its Status.SandboxID; its rootfs is visible to the child
+		// through the shared husk-rootfs hostPath dir.
+		ForkSourceRootfsPath: huskSourceRootfsInPodPath(source.Status.SandboxID),
 	}
 
 	needed := fork.Spec.Replicas - fork.Status.ReadyForks

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -556,12 +556,14 @@ func TestMain(m *testing.M) {
 	// A husk-enabled fork reconciler that handles ONLY husk-fork-test forks, with
 	// swappable fork-snapshot / activate / remove seams.
 	huskFork := &controller.SandboxForkReconciler{
-		Client:         mgr.GetClient(),
-		NodeRegistry:   nodeRegistry,
-		EnableHuskPods: true,
-		HuskTLS:        &tls.Config{}, //nolint:gosec // test stub; fakes ignore it
-		HuskStubImage:  "mitos-husk-stub:test",
-		DataDir:        "/var/lib/mitos",
+		Client:            mgr.GetClient(),
+		NodeRegistry:      nodeRegistry,
+		EnableHuskPods:    true,
+		HuskTLS:           &tls.Config{}, //nolint:gosec // test stub; fakes ignore it
+		HuskStubImage:     "mitos-husk-stub:test",
+		DataDir:           "/var/lib/mitos",
+		HuskTLSSecretName: controller.ForkdTLSSecretName,
+		HuskCASecretName:  controller.CASecretName,
 	}
 	huskFork.OnlyForkLabel(controller.HuskForkTestLabel)
 	huskFork.SetForkSnapshotForTest(func(c context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -132,6 +132,13 @@ var (
 	huskTestCheckpointerMu sync.Mutex
 	huskTestCheckpointer   func(ctx context.Context, claim *v1alpha1.SandboxClaim, pod *corev1.Pod) (bool, error)
 
+	// forkSnapshotterMu guards the swappable husk fork-snapshot / activator /
+	// remover seams the suite's husk-enabled fork reconciler dials through.
+	forkSnapshotterMu   sync.Mutex
+	forkSnapshotter     func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error)
+	forkActivator       func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error)
+	forkSnapshotRemover func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error)
+
 	// wsTransferMu guards the swappable workspace hydrate/dehydrate fakes the
 	// suite's raw claim reconciler drives. Tests set them via setWSTransfer.
 	wsTransferMu sync.Mutex
@@ -287,6 +294,63 @@ func currentHuskTestActivator() func(ctx context.Context, addr string, tlsConf *
 		}
 	}
 	return huskTestActivator
+}
+
+// setForkSnapshotter / currentForkSnapshotter swap the fork-snapshot seam the
+// suite's husk fork reconciler dials through.
+func setForkSnapshotter(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error)) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	forkSnapshotter = fn
+}
+
+func currentForkSnapshotter() func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	if forkSnapshotter == nil {
+		return func(context.Context, string, *tls.Config, husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+			return husk.ForkSnapshotResult{OK: false, Error: "no fork snapshotter installed"}, nil
+		}
+	}
+	return forkSnapshotter
+}
+
+// setForkActivator / currentForkActivator swap the activate seam the suite's
+// husk fork reconciler dials through.
+func setForkActivator(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error)) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	forkActivator = fn
+}
+
+func currentForkActivator() func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	if forkActivator == nil {
+		return func(context.Context, string, *tls.Config, husk.ActivateRequest) (husk.ActivateResult, error) {
+			return husk.ActivateResult{OK: false, Error: "no fork activator installed"}, nil
+		}
+	}
+	return forkActivator
+}
+
+// setForkSnapshotRemover / currentForkSnapshotRemover swap the remove-fork-snapshot
+// seam the suite's husk fork reconciler dials through on delete.
+func setForkSnapshotRemover(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error)) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	forkSnapshotRemover = fn
+}
+
+func currentForkSnapshotRemover() func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	if forkSnapshotRemover == nil {
+		return func(context.Context, string, *tls.Config, husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+			return husk.ForkSnapshotResult{OK: true}, nil
+		}
+	}
+	return forkSnapshotRemover
 }
 
 // syncBuffer is a concurrency-safe io.Writer that accumulates everything
@@ -478,10 +542,40 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	_ = (&controller.SandboxForkReconciler{
+	// The raw-forkd fork reconciler handles forks WITHOUT the husk-fork label, so
+	// it does not fight the husk fork reconciler over the same object.
+	rawFork := &controller.SandboxForkReconciler{
 		Client:       mgr.GetClient(),
 		NodeRegistry: nodeRegistry,
-	}).SetupWithManager(mgr)
+	}
+	rawFork.SkipForkLabel(controller.HuskForkTestLabel)
+	if err := rawFork.SetupWithManager(mgr); err != nil {
+		panic(err)
+	}
+
+	// A husk-enabled fork reconciler that handles ONLY husk-fork-test forks, with
+	// swappable fork-snapshot / activate / remove seams.
+	huskFork := &controller.SandboxForkReconciler{
+		Client:         mgr.GetClient(),
+		NodeRegistry:   nodeRegistry,
+		EnableHuskPods: true,
+		HuskTLS:        &tls.Config{}, //nolint:gosec // test stub; fakes ignore it
+		HuskStubImage:  "mitos-husk-stub:test",
+		DataDir:        "/var/lib/mitos",
+	}
+	huskFork.OnlyForkLabel(controller.HuskForkTestLabel)
+	huskFork.SetForkSnapshotForTest(func(c context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return currentForkSnapshotter()(c, addr, tlsConf, req)
+	})
+	huskFork.SetActivateForTest(func(c context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error) {
+		return currentForkActivator()(c, addr, tlsConf, req)
+	})
+	huskFork.SetForkSnapshotRemoverForTest(func(c context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return currentForkSnapshotRemover()(c, addr, tlsConf, req)
+	})
+	if err := huskFork.SetupWithManager(mgr); err != nil {
+		panic(err)
+	}
 
 	// The Workspace reconciler (W4): manages the revision DAG, retention,
 	// lineage, and head/revisions/resumable status. Core, not behind any flag.

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -42,6 +43,12 @@ func TraceIDAnnotationsForTest(ctx context.Context) map[string]string {
 // package so the husk pod spec can be unit-tested.
 func (r *SandboxPoolReconciler) BuildHuskPodForTest(pool *v1alpha1.SandboxPool, template *v1alpha1.SandboxTemplate, opts HuskPodOptions) *corev1.Pod {
 	return r.buildHuskPod(pool, template, opts)
+}
+
+// BuildForkChildPodForTest exposes buildForkChildPod to the external
+// controller_test package so the fork child pod spec can be unit-tested.
+func BuildForkChildPodForTest(fork *v1alpha1.SandboxFork, childName string, opts HuskPodOptions, scheme *runtime.Scheme) *corev1.Pod {
+	return buildForkChildPod(fork, childName, opts, scheme)
 }
 
 // HuskTestClaimLabel marks a claim as owned by the husk-activation tests. The

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -51,11 +51,49 @@ func BuildForkChildPodForTest(fork *v1alpha1.SandboxFork, childName string, opts
 	return buildForkChildPod(fork, childName, opts, scheme)
 }
 
+// SetForkSnapshotForTest installs the fork-snapshot seam (tests only).
+func (r *SandboxForkReconciler) SetForkSnapshotForTest(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error)) {
+	r.forkSnapshot = fn
+}
+
+// SetActivateForTest installs the activate seam on the fork reconciler (tests only).
+func (r *SandboxForkReconciler) SetActivateForTest(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error)) {
+	r.activate = fn
+}
+
+// SetForkSnapshotRemoverForTest installs the remove seam (tests only).
+func (r *SandboxForkReconciler) SetForkSnapshotRemoverForTest(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error)) {
+	r.removeForkSnapshot = fn
+}
+
+// SkipForkLabel restricts the fork reconciler to forks WITHOUT the given label;
+// only used by the test harness so a raw and a husk fork reconciler can share one
+// manager.
+func (r *SandboxForkReconciler) SkipForkLabel(label string) {
+	r.eventFilter = predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetLabels()[label] == ""
+	})
+	r.controllerName = "sandboxfork-raw"
+}
+
+// OnlyForkLabel restricts the fork reconciler to forks WITH the given label.
+func (r *SandboxForkReconciler) OnlyForkLabel(label string) {
+	r.eventFilter = predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetLabels()[label] != ""
+	})
+	r.controllerName = "sandboxfork-husk"
+}
+
 // HuskTestClaimLabel marks a claim as owned by the husk-activation tests. The
 // suite registers the raw claim reconciler to SKIP these (so it does not fight a
 // manually driven husk reconciler over the same object) and a husk-enabled
 // reconciler to handle ONLY these.
 const HuskTestClaimLabel = "mitos.run/husk-test"
+
+// HuskForkTestLabel marks a SandboxFork as owned by the husk-fork tests. The
+// suite registers the raw fork reconciler to SKIP these and a husk-enabled fork
+// reconciler to handle ONLY these.
+const HuskForkTestLabel = "mitos.run/husk-fork-test"
 
 // SkipLabel restricts this reconciler to claims WITHOUT the given label; only
 // used by the test harness so a raw and a husk reconciler can share one manager.

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -100,6 +100,91 @@ func ReadResult(r io.Reader) (ActivateResult, error) {
 	return res, err
 }
 
+// ControlOp discriminates the control message that follows it on the wire, so
+// one mTLS control channel can serve activate, fork-snapshot, and
+// remove-fork-snapshot. The op line is written BEFORE the request line. The
+// zero value (an absent op line) is OpActivate, so the existing activate client
+// that writes an ActivateRequest directly stays wire-compatible.
+type ControlOp struct {
+	Op string `json:"op"`
+}
+
+const (
+	// OpActivate loads a snapshot into a dormant VMM (the default).
+	OpActivate = "activate"
+	// OpForkSnapshot snapshots the running VM this stub holds.
+	OpForkSnapshot = "fork-snapshot"
+	// OpRemoveForkSnapshot deletes a previously created fork snapshot dir.
+	OpRemoveForkSnapshot = "remove-fork-snapshot"
+)
+
+// WriteControlOp writes the op envelope line that precedes a request.
+func WriteControlOp(w io.Writer, op string) error {
+	return writeLine(w, ControlOp{Op: op})
+}
+
+// ReadControlOp reads the op envelope line. An absent op defaults to OpActivate
+// so a caller can pair it with the request read on the same connection.
+func ReadControlOp(r *bufio.Reader) (string, error) {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return "", fmt.Errorf("read control op: %w", err)
+	}
+	var op ControlOp
+	if err := json.Unmarshal(line, &op); err != nil {
+		return "", fmt.Errorf("decode control op: %w", err)
+	}
+	if op.Op == "" {
+		op.Op = OpActivate
+	}
+	return op.Op, nil
+}
+
+// readActivateRequest decodes one ActivateRequest line from a shared reader.
+func readActivateRequest(r *bufio.Reader) (ActivateRequest, error) {
+	var req ActivateRequest
+	err := readLineReader(r, &req)
+	return req, err
+}
+
+func readForkSnapshotRequest(r *bufio.Reader) (ForkSnapshotRequest, error) {
+	var req ForkSnapshotRequest
+	err := readLineReader(r, &req)
+	return req, err
+}
+
+func readRemoveForkSnapshotRequest(r *bufio.Reader) (RemoveForkSnapshotRequest, error) {
+	var req RemoveForkSnapshotRequest
+	err := readLineReader(r, &req)
+	return req, err
+}
+
+// ReadActivateRequestReader decodes one ActivateRequest from a shared reader.
+// Exported for the controller-side client and tests that pipeline op + request
+// on one connection.
+func ReadActivateRequestReader(r *bufio.Reader) (ActivateRequest, error) {
+	return readActivateRequest(r)
+}
+
+// ReadForkSnapshotRequestReader decodes one ForkSnapshotRequest from a shared reader.
+func ReadForkSnapshotRequestReader(r *bufio.Reader) (ForkSnapshotRequest, error) {
+	return readForkSnapshotRequest(r)
+}
+
+// readLineReader decodes one newline-delimited JSON value from a shared reader,
+// so multiple reads on one connection (op then request) do not each buffer the
+// whole stream the way a per-call bufio.Scanner would.
+func readLineReader(r *bufio.Reader, v interface{}) error {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return fmt.Errorf("read control message: %w", err)
+	}
+	if err := json.Unmarshal(line, v); err != nil {
+		return fmt.Errorf("decode control message: %w", err)
+	}
+	return nil
+}
+
 // ForkSnapshotRequest asks a husk stub holding a RUNNING (active) VM to snapshot
 // that VM in place: pause it, write a Full Firecracker snapshot to SnapshotDir
 // (mem + vmstate, the same layout the fork engine and the activate path use),

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -100,6 +100,80 @@ func ReadResult(r io.Reader) (ActivateResult, error) {
 	return res, err
 }
 
+// ForkSnapshotRequest asks a husk stub holding a RUNNING (active) VM to snapshot
+// that VM in place: pause it, write a Full Firecracker snapshot to SnapshotDir
+// (mem + vmstate, the same layout the fork engine and the activate path use),
+// then resume it unless PauseSource is set. The result snapshot is the restore
+// image the controller activates N independent CHILD husk pods from, so a husk
+// sandbox can be live-forked even though forkd's engine does not own its VM.
+//
+// ForkID is the node-local fork identifier the controller mints (the SandboxFork
+// child group); it is a content/address-like value, never a secret, and is the
+// directory leaf under the node forks dir. SnapshotDir is the in-pod path the
+// node forks dir is mounted at for THIS fork; the stub writes SnapshotDir/mem
+// and SnapshotDir/vmstate.
+type ForkSnapshotRequest struct {
+	ForkID      string `json:"fork_id"`
+	SnapshotDir string `json:"snapshot_dir"`
+	PauseSource bool   `json:"pause_source,omitempty"`
+}
+
+// ForkSnapshotResult is the control reply for a ForkSnapshot op. OK is true only
+// when the VM paused, the snapshot was written, and (unless PauseSource) the VM
+// resumed. SnapshotDir echoes where the snapshot was written (it carries no
+// secret). Error carries actionable remediation text when OK is false; it never
+// carries secrets.
+type ForkSnapshotResult struct {
+	OK          bool    `json:"ok"`
+	SnapshotDir string  `json:"snapshot_dir,omitempty"`
+	LatencyMs   float64 `json:"latency_ms"`
+	Error       string  `json:"error,omitempty"`
+}
+
+// RemoveForkSnapshotRequest asks the source stub to delete a fork snapshot dir it
+// previously created. The controller sends it when the SandboxFork is deleted so
+// the node-local fork snapshot does not outlive its owner.
+type RemoveForkSnapshotRequest struct {
+	ForkID      string `json:"fork_id"`
+	SnapshotDir string `json:"snapshot_dir"`
+}
+
+// WriteForkSnapshotRequest writes a ForkSnapshotRequest as one JSON line.
+func WriteForkSnapshotRequest(w io.Writer, req ForkSnapshotRequest) error {
+	return writeLine(w, req)
+}
+
+// ReadForkSnapshotRequest reads one line-delimited ForkSnapshotRequest.
+func ReadForkSnapshotRequest(r io.Reader) (ForkSnapshotRequest, error) {
+	var req ForkSnapshotRequest
+	err := readLine(r, &req)
+	return req, err
+}
+
+// WriteForkSnapshotResult writes a ForkSnapshotResult as one JSON line.
+func WriteForkSnapshotResult(w io.Writer, res ForkSnapshotResult) error {
+	return writeLine(w, res)
+}
+
+// ReadForkSnapshotResult reads one line-delimited ForkSnapshotResult.
+func ReadForkSnapshotResult(r io.Reader) (ForkSnapshotResult, error) {
+	var res ForkSnapshotResult
+	err := readLine(r, &res)
+	return res, err
+}
+
+// WriteRemoveForkSnapshotRequest writes a RemoveForkSnapshotRequest as one JSON line.
+func WriteRemoveForkSnapshotRequest(w io.Writer, req RemoveForkSnapshotRequest) error {
+	return writeLine(w, req)
+}
+
+// ReadRemoveForkSnapshotRequest reads one line-delimited RemoveForkSnapshotRequest.
+func ReadRemoveForkSnapshotRequest(r io.Reader) (RemoveForkSnapshotRequest, error) {
+	var req RemoveForkSnapshotRequest
+	err := readLine(r, &req)
+	return req, err
+}
+
 func writeLine(w io.Writer, v interface{}) error {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/internal/husk/control_test.go
+++ b/internal/husk/control_test.go
@@ -80,3 +80,33 @@ func TestActivateResultErrorRoundTrip(t *testing.T) {
 		t.Fatalf("error result mismatch: got %+v want %+v", got, want)
 	}
 }
+
+func TestForkSnapshotRequestRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	want := ForkSnapshotRequest{ForkID: "fork-1", SnapshotDir: "/var/lib/mitos/forks/fork-1", PauseSource: true}
+	if err := WriteForkSnapshotRequest(&buf, want); err != nil {
+		t.Fatalf("WriteForkSnapshotRequest: %v", err)
+	}
+	got, err := ReadForkSnapshotRequest(&buf)
+	if err != nil {
+		t.Fatalf("ReadForkSnapshotRequest: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip mismatch: got %+v want %+v", got, want)
+	}
+}
+
+func TestForkSnapshotResultRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	want := ForkSnapshotResult{OK: true, SnapshotDir: "/var/lib/mitos/forks/fork-1", LatencyMs: 12.5}
+	if err := WriteForkSnapshotResult(&buf, want); err != nil {
+		t.Fatalf("WriteForkSnapshotResult: %v", err)
+	}
+	got, err := ReadForkSnapshotResult(&buf)
+	if err != nil {
+		t.Fatalf("ReadForkSnapshotResult: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip mismatch: got %+v want %+v", got, want)
+	}
+}

--- a/internal/husk/forksnapshot_test.go
+++ b/internal/husk/forksnapshot_test.go
@@ -79,3 +79,37 @@ func TestForkSnapshotFailClosedOnSnapshotError(t *testing.T) {
 		t.Fatalf("snapshot error must fail closed: err=%v res=%+v", err, res)
 	}
 }
+
+func TestForkSnapshotConfinedToForksDir(t *testing.T) {
+	forks := t.TempDir()
+	f := &fakeVMM{}
+	s := &Stub{state: StateActive, vm: f, forksDir: forks}
+
+	// A dir WITHIN the configured forks dir is accepted.
+	inside := filepath.Join(forks, "fork-1")
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{ForkID: "fork-1", SnapshotDir: inside})
+	if err != nil || !res.OK {
+		t.Fatalf("fork snapshot inside forks dir must succeed: err=%v res=%+v", err, res)
+	}
+
+	// A dir OUTSIDE the forks dir (here a traversal escape) is refused fail-closed
+	// and the VM is never paused.
+	f2 := &fakeVMM{}
+	s2 := &Stub{state: StateActive, vm: f2, forksDir: forks}
+	escape := filepath.Join(forks, "..", "escape")
+	res2, err2 := s2.ForkSnapshot(context.Background(), ForkSnapshotRequest{ForkID: "x", SnapshotDir: escape})
+	if err2 == nil || res2.OK {
+		t.Fatalf("fork snapshot outside forks dir must fail closed: err=%v res=%+v", err2, res2)
+	}
+	if f2.paused {
+		t.Fatalf("an out-of-bounds fork snapshot must not pause the VM")
+	}
+}
+
+func TestRemoveForkSnapshotConfinedToForksDir(t *testing.T) {
+	forks := t.TempDir()
+	s := &Stub{state: StateActive, vm: &fakeVMM{}, forksDir: forks}
+	if err := s.RemoveForkSnapshot(ForkSnapshotRequest{SnapshotDir: filepath.Join(forks, "..", "escape")}); err == nil {
+		t.Fatalf("remove fork snapshot outside forks dir must be refused")
+	}
+}

--- a/internal/husk/forksnapshot_test.go
+++ b/internal/husk/forksnapshot_test.go
@@ -1,0 +1,81 @@
+package husk
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// activeStubWithFake returns a Stub already in StateActive holding the given fake
+// vmm, so ForkSnapshot can be exercised without a real Activate. It uses the same
+// fake vmm type the stub_test.go uses.
+func activeStubWithFake(f *fakeVMM) *Stub {
+	return &Stub{state: StateActive, vm: f}
+}
+
+func TestForkSnapshotPausesSnapshotsResumes(t *testing.T) {
+	f := &fakeVMM{}
+	s := activeStubWithFake(f)
+
+	dir := t.TempDir()
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: dir,
+		PauseSource: false,
+	})
+	if err != nil {
+		t.Fatalf("ForkSnapshot: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("ForkSnapshot not OK: %+v", res)
+	}
+	if !f.paused {
+		t.Fatalf("source VM was not paused before snapshot")
+	}
+	if !f.resumed {
+		t.Fatalf("source VM was not resumed after snapshot (PauseSource=false)")
+	}
+	if f.snapMem != filepath.Join(dir, "mem") || f.snapState != filepath.Join(dir, "vmstate") {
+		t.Fatalf("snapshot written to wrong paths: mem=%s state=%s", f.snapMem, f.snapState)
+	}
+	if s.State() != StateActive {
+		t.Fatalf("stub must remain active after fork snapshot, got %s", s.State())
+	}
+}
+
+func TestForkSnapshotHonorsPauseSource(t *testing.T) {
+	f := &fakeVMM{}
+	s := activeStubWithFake(f)
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: t.TempDir(),
+		PauseSource: true,
+	})
+	if err != nil || !res.OK {
+		t.Fatalf("ForkSnapshot: err=%v res=%+v", err, res)
+	}
+	if !f.paused {
+		t.Fatalf("source VM was not paused")
+	}
+	if f.resumed {
+		t.Fatalf("PauseSource=true must leave the source paused, but it was resumed")
+	}
+}
+
+func TestForkSnapshotRequiresActiveState(t *testing.T) {
+	f := &fakeVMM{}
+	s := &Stub{state: StateDormant, vm: f}
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{ForkID: "f", SnapshotDir: t.TempDir()})
+	if err == nil || res.OK {
+		t.Fatalf("ForkSnapshot must refuse a non-active stub: err=%v res=%+v", err, res)
+	}
+}
+
+func TestForkSnapshotFailClosedOnSnapshotError(t *testing.T) {
+	f := &fakeVMM{snapErr: errSnap}
+	s := activeStubWithFake(f)
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{ForkID: "f", SnapshotDir: t.TempDir()})
+	if err == nil || res.OK {
+		t.Fatalf("snapshot error must fail closed: err=%v res=%+v", err, res)
+	}
+}

--- a/internal/husk/netcontrol.go
+++ b/internal/husk/netcontrol.go
@@ -1,6 +1,7 @@
 package husk
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -122,13 +123,48 @@ func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize 
 		return
 	}
 
-	req, err := ReadRequest(conn)
+	br := bufio.NewReader(conn)
+	op, err := ReadControlOp(br)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "husk control: read activate request: %v\n", err)
+		fmt.Fprintf(os.Stderr, "husk control: read control op: %v\n", err)
 		return
 	}
-	res, _ := stub.Activate(ctx, req)
-	if werr := WriteResult(conn, res); werr != nil {
-		fmt.Fprintf(os.Stderr, "husk control: write activate result: %v\n", werr)
+	switch op {
+	case OpActivate:
+		req, rerr := readActivateRequest(br)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: read activate request: %v\n", rerr)
+			return
+		}
+		res, _ := stub.Activate(ctx, req)
+		if werr := WriteResult(conn, res); werr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: write activate result: %v\n", werr)
+		}
+	case OpForkSnapshot:
+		req, rerr := readForkSnapshotRequest(br)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: read fork-snapshot request: %v\n", rerr)
+			return
+		}
+		res, _ := stub.ForkSnapshot(ctx, req)
+		if werr := WriteForkSnapshotResult(conn, res); werr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: write fork-snapshot result: %v\n", werr)
+		}
+	case OpRemoveForkSnapshot:
+		req, rerr := readRemoveForkSnapshotRequest(br)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: read remove-fork-snapshot request: %v\n", rerr)
+			return
+		}
+		rmErr := stub.RemoveForkSnapshot(ForkSnapshotRequest{ForkID: req.ForkID, SnapshotDir: req.SnapshotDir})
+		out := ForkSnapshotResult{OK: rmErr == nil, SnapshotDir: req.SnapshotDir}
+		if rmErr != nil {
+			out.Error = rmErr.Error()
+		}
+		if werr := WriteForkSnapshotResult(conn, out); werr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: write remove-fork-snapshot result: %v\n", werr)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "husk control: unknown control op %q\n", op)
 	}
 }

--- a/internal/husk/netcontrol_test.go
+++ b/internal/husk/netcontrol_test.go
@@ -105,6 +105,9 @@ func activateClient(t *testing.T, addr string, clientConf *tls.Config, req Activ
 		return ActivateResult{}, err
 	}
 	defer conn.Close()
+	if err := WriteControlOp(conn, OpActivate); err != nil {
+		return ActivateResult{}, err
+	}
 	if err := WriteRequest(conn, req); err != nil {
 		return ActivateResult{}, err
 	}
@@ -142,6 +145,44 @@ func TestServeTLSControllerRoundTrip(t *testing.T) {
 	}
 	if n.gotReq[0].Secrets["API_KEY"] != "s3cr3t-value" {
 		t.Fatalf("stub did not receive the secret")
+	}
+}
+
+func TestServeTLSDispatchesForkSnapshot(t *testing.T) {
+	// A serving stub holding an ACTIVE fake VM answers a fork-snapshot op over the
+	// mTLS control channel: it pauses, snapshots, resumes, and replies OK.
+	p := newNetTestPKI(t)
+	f := &fakeVMM{}
+	stub := &Stub{state: StateActive, vm: f}
+
+	addr, stop := startServer(t, stub, p)
+	defer stop()
+
+	dir := t.TempDir()
+	dialer := &tls.Dialer{Config: p.clientConf(t, p.ctrlCert)}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := WriteControlOp(conn, OpForkSnapshot); err != nil {
+		t.Fatalf("WriteControlOp: %v", err)
+	}
+	if err := WriteForkSnapshotRequest(conn, ForkSnapshotRequest{ForkID: "fork-1", SnapshotDir: dir}); err != nil {
+		t.Fatalf("WriteForkSnapshotRequest: %v", err)
+	}
+	res, err := ReadForkSnapshotResult(conn)
+	if err != nil {
+		t.Fatalf("ReadForkSnapshotResult: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("fork-snapshot op not OK: %+v", res)
+	}
+	if !f.paused {
+		t.Fatalf("source VM not paused via the control channel")
 	}
 }
 

--- a/internal/husk/sandbox_api_test.go
+++ b/internal/husk/sandbox_api_test.go
@@ -88,10 +88,12 @@ type pathVMM struct {
 func (m *pathVMM) LoadSnapshotWithOverrides(_, _ string, _ bool, _ []firecracker.NetworkOverride) error {
 	return nil
 }
-func (m *pathVMM) VsockHostPath(string) string  { return m.vsockPath }
-func (m *pathVMM) PatchDrive(_, _ string) error { return nil }
-func (m *pathVMM) Resume() error                { return nil }
-func (m *pathVMM) Close() error                 { return nil }
+func (m *pathVMM) VsockHostPath(string) string      { return m.vsockPath }
+func (m *pathVMM) PatchDrive(_, _ string) error     { return nil }
+func (m *pathVMM) Resume() error                    { return nil }
+func (m *pathVMM) Pause() error                     { return nil }
+func (m *pathVMM) CreateSnapshot(_, _ string) error { return nil }
+func (m *pathVMM) Close() error                     { return nil }
 
 func postHuskExec(t *testing.T, url, sandbox, bearer string) (int, string) {
 	t.Helper()

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -73,6 +73,15 @@ type vmm interface {
 	// The husk activate path calls it AFTER the rootfs drive rebind so the guest
 	// resumes already bound to its own per-activation rootfs clone.
 	Resume() error
+	// Pause transitions the loaded/running VM to Paused (PATCH /vm Paused). The
+	// fork-snapshot op pauses the source VM before CreateSnapshot, which requires
+	// a paused VM, then resumes it (unless the fork asked to keep it paused).
+	Pause() error
+	// CreateSnapshot writes a Full Firecracker snapshot of the PAUSED VM: the
+	// guest memory to memPath and the device/vm state to snapshotPath. The
+	// fork-snapshot op writes the source VM's snapshot here so child husk pods can
+	// restore independent copies of it.
+	CreateSnapshot(memPath, snapshotPath string) error
 	// Close tears the VMM down.
 	Close() error
 }

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -264,6 +265,14 @@ type Options struct {
 	// seam (volume.Backend.ReflinkCopy, which is FICLONE with a full-copy
 	// fallback). Tests inject a fake.
 	Reflink reflinker
+	// ForksDir is the node forks directory mounted into this pod. When set, the
+	// fork-snapshot and remove-fork-snapshot control ops confine their writes to
+	// within it (fail-closed: a request naming a SnapshotDir outside it is
+	// refused), so the control channel can never be steered to write or delete a
+	// path outside the mounted forks dir. Empty disables the check (the request's
+	// SnapshotDir is used as-is, the prior behavior). A node-local path, not a
+	// secret.
+	ForksDir string
 }
 
 // DefaultReadyTimeout bounds how long Activate waits for the guest agent to
@@ -297,6 +306,10 @@ type Stub struct {
 	reflink            reflinker
 	rootfsClonePath    string
 
+	// forksDir confines fork-snapshot / remove-fork-snapshot writes to within it
+	// when set; empty disables the check.
+	forksDir string
+
 	mu              sync.Mutex
 	state           State
 	vm              vmm
@@ -323,6 +336,7 @@ func New(cfg firecracker.VMConfig, opts Options) *Stub {
 		rootfsTemplatePath: opts.RootfsTemplatePath,
 		rootfsCoWDir:       opts.RootfsCoWDir,
 		reflink:            opts.Reflink,
+		forksDir:           opts.ForksDir,
 	}
 	if s.start == nil {
 		s.start = productionStarter
@@ -592,6 +606,9 @@ func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkS
 		return ForkSnapshotResult{OK: false, Error: "fork-snapshot: empty snapshot dir"},
 			fmt.Errorf("husk: fork-snapshot: empty snapshot dir")
 	}
+	if err := s.confineToForksDir(req.SnapshotDir); err != nil {
+		return ForkSnapshotResult{OK: false, Error: err.Error()}, err
+	}
 
 	memFile := filepath.Join(req.SnapshotDir, "mem")
 	vmStateFile := filepath.Join(req.SnapshotDir, "vmstate")
@@ -641,8 +658,29 @@ func (s *Stub) RemoveForkSnapshot(req ForkSnapshotRequest) error {
 	if req.SnapshotDir == "" {
 		return fmt.Errorf("husk: remove fork snapshot: empty snapshot dir")
 	}
+	if err := s.confineToForksDir(req.SnapshotDir); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(req.SnapshotDir); err != nil {
 		return fmt.Errorf("husk: remove fork snapshot %s: %w", req.SnapshotDir, err)
+	}
+	return nil
+}
+
+// confineToForksDir refuses a fork-snapshot / remove-fork-snapshot SnapshotDir
+// that resolves outside the configured forks dir, so the control channel can
+// never be steered to write or delete a path outside the mounted node forks dir.
+// It is a fail-closed defense-in-depth gate; when no forks dir is configured
+// (the empty default) it permits any dir, preserving the prior behavior. The dir
+// carries no secret, so it is safe to name in the error.
+func (s *Stub) confineToForksDir(dir string) error {
+	if s.forksDir == "" {
+		return nil
+	}
+	base := filepath.Clean(s.forksDir)
+	target := filepath.Clean(dir)
+	if target != base && !strings.HasPrefix(target, base+string(filepath.Separator)) {
+		return fmt.Errorf("husk: fork snapshot dir %q is outside the configured forks dir %q", dir, s.forksDir)
 	}
 	return nil
 }

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -561,6 +561,92 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 	}, nil
 }
 
+// ForkSnapshot snapshots the CURRENTLY RUNNING VM this stub holds, in place, so
+// the controller can restore N independent child husk pods from it. It is the
+// husk analog of the fork engine's ForkRunning: the source VM is owned by THIS
+// husk pod's stub (not forkd's engine), so the only way to live-fork it is for
+// the owning stub to snapshot it.
+//
+// It pauses the VM (CreateSnapshot requires a paused VM), writes a Full snapshot
+// to req.SnapshotDir/{mem,vmstate} (the same layout Activate reads), then resumes
+// it UNLESS req.PauseSource is set, in which case it leaves the source paused.
+// The stub stays StateActive throughout: it still owns its one VM.
+//
+// FAIL CLOSED: it requires StateActive (else error, no snapshot); a pause,
+// snapshot-create, or resume failure returns OK=false plus an error. On a
+// snapshot failure it still attempts to resume the source so a transient
+// snapshot error does not leave a live sandbox frozen. The fork id and snapshot
+// paths carry no secrets.
+func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkSnapshotResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state != StateActive {
+		return ForkSnapshotResult{OK: false, Error: fmt.Sprintf("fork-snapshot in state %s: must be active", s.state)},
+			fmt.Errorf("husk: fork-snapshot in state %s: must be active", s.state)
+	}
+	if err := ctx.Err(); err != nil {
+		return ForkSnapshotResult{OK: false, Error: err.Error()}, err
+	}
+	if req.SnapshotDir == "" {
+		return ForkSnapshotResult{OK: false, Error: "fork-snapshot: empty snapshot dir"},
+			fmt.Errorf("husk: fork-snapshot: empty snapshot dir")
+	}
+
+	memFile := filepath.Join(req.SnapshotDir, "mem")
+	vmStateFile := filepath.Join(req.SnapshotDir, "vmstate")
+	if err := os.MkdirAll(req.SnapshotDir, 0o755); err != nil {
+		werr := fmt.Errorf("husk: create fork snapshot dir %s: %w", req.SnapshotDir, err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	start := time.Now()
+
+	if err := s.vm.Pause(); err != nil {
+		werr := fmt.Errorf("husk: pause source VM for fork snapshot: %w", err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	if err := s.vm.CreateSnapshot(memFile, vmStateFile); err != nil {
+		// Best effort: resume the source so a transient snapshot error does not
+		// leave a tenant's live sandbox frozen. The resume error is reported only
+		// if the snapshot itself succeeded; here the snapshot already failed.
+		_ = s.vm.Resume()
+		werr := fmt.Errorf("husk: create fork snapshot in %s: %w", req.SnapshotDir, err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	// Resume the source UNLESS the fork asked to keep it paused. PauseSource
+	// trades a brief source interruption for a colder, quiescent snapshot.
+	if !req.PauseSource {
+		if err := s.vm.Resume(); err != nil {
+			werr := fmt.Errorf("husk: resume source VM after fork snapshot: %w", err)
+			return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+
+	latency := time.Since(start)
+	return ForkSnapshotResult{
+		OK:          true,
+		SnapshotDir: req.SnapshotDir,
+		LatencyMs:   float64(latency.Microseconds()) / 1000.0,
+	}, nil
+}
+
+// RemoveForkSnapshot deletes a fork snapshot dir this stub previously created. It
+// is the GC counterpart of ForkSnapshot: the controller calls it when the owning
+// SandboxFork is deleted so the node-local snapshot does not outlive its owner.
+// It does not touch the VM and is safe in any state. The path carries no secret.
+func (s *Stub) RemoveForkSnapshot(req ForkSnapshotRequest) error {
+	if req.SnapshotDir == "" {
+		return fmt.Errorf("husk: remove fork snapshot: empty snapshot dir")
+	}
+	if err := os.RemoveAll(req.SnapshotDir); err != nil {
+		return fmt.Errorf("husk: remove fork snapshot %s: %w", req.SnapshotDir, err)
+	}
+	return nil
+}
+
 // Serve accepts control connections on ln and dispatches each to Activate,
 // replying with the ActivateResult.
 //

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -38,11 +38,24 @@ type fakeVMM struct {
 
 	resumeCalls int
 	resumeErr   error
+	resumed     bool
+
+	// paused / pauseErr / snapMem / snapState / snapErr support the fork-snapshot
+	// op: ForkSnapshot pauses the source VM, writes a Full snapshot, then resumes.
+	paused    bool
+	pauseErr  error
+	snapMem   string
+	snapState string
+	snapErr   error
 
 	// callOrder records the activate-time VMM call sequence ("load", "patch",
 	// "resume") so a test can assert load(resume=false) -> PatchDrive -> Resume.
 	callOrder []string
 }
+
+// errSnap is a scripted CreateSnapshot failure used by the fork-snapshot
+// fail-closed tests.
+var errSnap = errors.New("snap boom")
 
 func (f *fakeVMM) LoadSnapshotWithOverrides(mem, snapshot string, resume bool, overrides []firecracker.NetworkOverride) error {
 	f.mu.Lock()
@@ -75,6 +88,7 @@ func (f *fakeVMM) Resume() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.resumeCalls++
+	f.resumed = true
 	f.callOrder = append(f.callOrder, "resume")
 	return f.resumeErr
 }
@@ -84,6 +98,29 @@ func (f *fakeVMM) Close() error {
 	defer f.mu.Unlock()
 	f.closed = true
 	return nil
+}
+
+func (f *fakeVMM) Pause() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.paused = true
+	f.callOrder = append(f.callOrder, "pause")
+	return f.pauseErr
+}
+
+func (f *fakeVMM) CreateSnapshot(memPath, snapshotPath string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.snapMem = memPath
+	f.snapState = snapshotPath
+	f.callOrder = append(f.callOrder, "snapshot")
+	return f.snapErr
+}
+
+func TestVMMInterfaceHasForkSnapshotMethods(t *testing.T) {
+	// Compile-time proof the fake vmm satisfies the extended interface (Pause +
+	// CreateSnapshot), so the fork-snapshot op can drive it in a unit test.
+	var _ vmm = (*fakeVMM)(nil)
 }
 
 // fakeNotifier records the fork-correctness handshake arguments and returns a


### PR DESCRIPTION
Implements live fork on the husk default (previously raw-forkd only; the standing cluster-e2e caught that husk fork produced no Ready children). The source husk-stub snapshots its running VM (pause + CreateSnapshot), N child husk pods restore it (CoW) via the existing Activate path so RNG-reseed + clock-step (fork-correctness) apply, each child independent (own VM + per-activation rootfs CoW clone from the SOURCE rootfs + own bearer token). Snapshot taken once; fork-snapshot GC on delete. Raw-forkd ForkRunning unchanged.

SECURITY-SENSITIVE (per-tenant fork state): reviewed for child independence (no cross-child write bleed), per-child token gate, fork-correctness reseed, source fail-closed. A review-caught CRITICAL (child cloned template instead of source rootfs -> memory/disk divergence) is fixed. Verified on real KVM via the cluster-e2e fork stage.

Plan: docs/superpowers/plans/2026-06-14-husk-fork.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)