### PR TITLE
ci(publish): GHCR_WRITE_TOKEN fallback for the release image push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,8 +44,13 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a maintainer PAT with write:packages (repo secret
+          # GHCR_WRITE_TOKEN) when present; the default GITHUB_TOKEN is denied
+          # write_package on the org ghcr packages, so the release image push
+          # fails without it. Falls back to GITHUB_TOKEN once the packages grant
+          # this repo Write. Same pattern as .github/workflows/cluster-e2e.yaml.
+          username: ${{ secrets.GHCR_WRITE_USER || github.actor }}
+          password: ${{ secrets.GHCR_WRITE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Image metadata (tags and labels)
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Apply the same ghcr PAT fallback used by cluster-e2e to publish.yaml, so cutting v0.3.0 can push+sign+attest the three images (GITHUB_TOKEN is denied write_package on the org packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)