### PR TITLE
fix(controller): settle an unplaceable husk claim so kind-e2e-husk re-pend probe goes green

### DIFF
--- a/internal/controller/husk_repend_stamp_test.go
+++ b/internal/controller/husk_repend_stamp_test.go
@@ -1,0 +1,195 @@
+package controller_test
+
+// Regression guard for the kind-e2e-husk re-pend probe ("did not settle Ready on
+// the stamped backing pod"). The probe stamps a husk claim Ready with a merge
+// patch and waits for it to settle. Settling failed because a husk claim that
+// cannot place (its pool has no dormant pod: NoHuskPod) was hot-looping: each
+// reconcile re-asserted the SAME NoHuskPod condition with a FRESH
+// LastTransitionTime, which made the Status().Update a real change, which
+// re-triggered the claim's own watch, which re-reconciled, ad infinitum. That
+// loop of full-object status writes from a stale read clobbered the e2e's
+// externally merge-patched Ready stamp, so the claim never settled.
+//
+// The fix makes setCondition preserve LastTransitionTime when the Status is
+// unchanged, so re-asserting an unchanged condition is a no-op write and the loop
+// terminates. These tests pin both halves: a pending NoHuskPod claim does not
+// churn (no hot loop), and an externally-stamped Ready husk claim with a healthy
+// backing pod stays Ready across reconciles.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestHuskNoPodClaimDoesNotChurn pins the root cause: a husk claim whose pool has
+// no dormant pod pends with NoHuskPod and must SETTLE (a stable resourceVersion),
+// not hot-loop. A hot loop here is what clobbered the e2e's Ready stamp. The claim
+// references an empty pool (replicas 0), exactly the kind-e2e-husk re-pend probe
+// shape, so the controller can never select a pod for it and always takes the
+// NoHuskPod pend path.
+func TestHuskNoPodClaimDoesNotChurn(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "churn-tmpl", Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "churn-pool", Namespace: "default"},
+		Spec: v1alpha1.SandboxPoolSpec{
+			TemplateRef: v1alpha1.LocalObjectReference{Name: "churn-tmpl"},
+			Replicas:    0,
+		},
+	}
+	if err := k8sClient.Create(ctx, template); err != nil {
+		t.Fatal(err)
+	}
+	if err := k8sClient.Create(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "churn-claim",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskTestClaimLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxClaimSpec{PoolRef: v1alpha1.LocalObjectReference{Name: "churn-pool"}},
+	}
+	if err := k8sClient.Create(ctx, claim); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, claim)
+		_ = k8sClient.Delete(ctx, pool)
+		_ = k8sClient.Delete(ctx, template)
+	})
+
+	// Wait for the claim to reach Pending (NoHuskPod).
+	waitClaimPhase(t, claim.Name, func(cl *v1alpha1.SandboxClaim) bool {
+		return cl.Status.Phase == v1alpha1.SandboxPending
+	})
+
+	// Let it settle, then record the resourceVersion and confirm it does NOT keep
+	// advancing: a stable resourceVersion across a sustained window means the
+	// reconcile is not churning the object (no hot loop). The capacity-pending
+	// requeue is 5s, so a healthy reconciler writes nothing in between; a churning
+	// one bumps the resourceVersion many times per second.
+	time.Sleep(2 * time.Second)
+	var first v1alpha1.SandboxClaim
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: "default"}, &first); err != nil {
+		t.Fatalf("get claim: %v", err)
+	}
+	rv := first.ResourceVersion
+	bumps := 0
+	for i := 0; i < 20; i++ {
+		time.Sleep(150 * time.Millisecond)
+		var got v1alpha1.SandboxClaim
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: "default"}, &got); err != nil {
+			t.Fatalf("get claim: %v", err)
+		}
+		if got.ResourceVersion != rv {
+			bumps++
+			rv = got.ResourceVersion
+		}
+	}
+	// One or two bumps from the periodic 5s requeue are tolerable; a hot loop
+	// produces dozens. Allow a small margin, fail on a churn.
+	if bumps > 2 {
+		t.Fatalf("pending NoHuskPod claim churned its status %d times over ~3s (hot loop: each reconcile re-stamped an unchanged condition with a fresh timestamp); this clobbers an external Ready stamp and is the kind-e2e-husk settle regression", bumps)
+	}
+}
+
+// TestHuskClaimStampedReadyStaysReady mirrors the kind-e2e-husk re-pend probe
+// setup: an empty pool (replicas 0) for the claim so the controller can never
+// pick a dormant pod for it, a borrowed dormant husk pod from a different pool
+// labeled with the claim, and the claim status stamped Ready on that pod via a
+// server-side merge patch (the Go analog of `kubectl patch
+// --subresource=status --type=merge`). The controller must leave the Ready claim
+// Ready (its backing pod is healthy) and must not flap it to Restoring/Pending.
+func TestHuskClaimStampedReadyStaysReady(t *testing.T) {
+	emptyTemplate := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "stamp-empty-tmpl", Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+	emptyPool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "stamp-empty-pool", Namespace: "default"},
+		Spec: v1alpha1.SandboxPoolSpec{
+			TemplateRef: v1alpha1.LocalObjectReference{Name: "stamp-empty-tmpl"},
+			Replicas:    0,
+		},
+	}
+	if err := k8sClient.Create(ctx, emptyTemplate); err != nil {
+		t.Fatal(err)
+	}
+	if err := k8sClient.Create(ctx, emptyPool); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, emptyPool)
+		_ = k8sClient.Delete(ctx, emptyTemplate)
+	})
+
+	// A dormant pod in a DIFFERENT pool, borrowed to back the claim. It is labeled
+	// with the claim so checkHuskPodLost keys off it (pool independent).
+	backing := makeDormantHuskPod(t, "stamp-other-pool", "10.9.9.9")
+
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stamp-ready-claim",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskTestClaimLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxClaimSpec{PoolRef: v1alpha1.LocalObjectReference{Name: "stamp-empty-pool"}},
+	}
+	if err := k8sClient.Create(ctx, claim); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, claim) })
+
+	// Borrow the pod (object-level claim commit) then stamp the claim status Ready
+	// on it with a server-side merge patch that always lands on the latest object.
+	backing.Labels["mitos.run/claim"] = claim.Name
+	if err := k8sClient.Update(ctx, backing); err != nil {
+		t.Fatal(err)
+	}
+	stamp := []byte(fmt.Sprintf(
+		`{"status":{"phase":%q,"node":%q,"endpoint":%q,"sandboxID":%q}}`,
+		v1alpha1.SandboxReady, backing.Spec.NodeName, backing.Status.PodIP+":9091", backing.Name,
+	))
+	if err := k8sClient.Status().Patch(ctx, claim, client.RawPatch(types.MergePatchType, stamp)); err != nil {
+		t.Fatalf("stamp claim Ready: %v", err)
+	}
+
+	// The claim must settle Ready on the stamped pod and HOLD it for a sustained
+	// window: the reconcile must not flap it off Ready while the backing pod is
+	// healthy.
+	stableSince := time.Time{}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var got v1alpha1.SandboxClaim
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: "default"}, &got); err != nil {
+			t.Fatalf("get claim: %v", err)
+		}
+		switch got.Status.Phase {
+		case v1alpha1.SandboxReady:
+			if got.Status.SandboxID != backing.Name {
+				t.Fatalf("Ready claim points at sandboxID %q, want the stamped pod %q", got.Status.SandboxID, backing.Name)
+			}
+			if stableSince.IsZero() {
+				stableSince = time.Now()
+			}
+			if time.Since(stableSince) >= 3*time.Second {
+				return // Held Ready for a sustained window: no flap.
+			}
+		default:
+			t.Fatalf("externally-stamped Ready husk claim flapped to phase %q (regression: reconcile destabilized a Ready husk claim with a healthy backing pod)", got.Status.Phase)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("claim never held Ready for a sustained window")
+}

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -396,18 +396,24 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	// Mark as restoring
-	claim.Status.Phase = v1alpha1.SandboxRestoring
-	if err := r.Status().Update(ctx, &claim); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Husk-pod activation path (issue #18, slice 2). When enabled, the claim
 	// activates a dormant warm husk pod in place over the mTLS control channel
 	// instead of SelectNode+forkOnNode. The default (flag off) leaves the
-	// raw-forkd path below unchanged.
+	// raw-forkd path below unchanged. The husk path stamps Restoring itself only
+	// once it has actually selected a dormant pod to activate: a claim that cannot
+	// place (NoHuskPod) must stay Pending and settle, not cycle
+	// Pending -> Restoring -> Pending on every reconcile. That cycle is a hot loop
+	// (each write re-triggers the claim's own watch) whose continuous full-status
+	// writes from a stale read clobber an externally applied status (the husk e2e's
+	// merge-patch Ready stamp), so the claim never settles.
 	if r.EnableHuskPods {
 		return r.reconcileHuskClaim(ctx, &claim, &pool, &template)
+	}
+
+	// Raw-forkd path: mark as restoring before attempting placement.
+	claim.Status.Phase = v1alpha1.SandboxRestoring
+	if err := r.Status().Update(ctx, &claim); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Pick a node with a ready snapshot
@@ -612,19 +618,44 @@ func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *
 	}
 	if pod == nil {
 		// No warm husk slot: pend and retry. The pool reconciler is expected to
-		// scale the warm pool up; this is a transient placement precondition.
+		// scale the warm pool up; this is a transient placement precondition. The
+		// status write is IDEMPOTENT: a claim already Pending with the same
+		// NoHuskPod condition is left untouched, so a re-reconcile of an unplaceable
+		// claim does not bump the object and re-trigger its own watch (a hot loop
+		// whose stale-read full-status writes would clobber an externally applied
+		// status). recordClaimPending is the pending-gauge signal and runs each
+		// pass regardless.
 		logger.Info("no dormant husk pod available, pending", "pool", pool.Name)
-		claim.Status.Phase = v1alpha1.SandboxPending
 		recordClaimPending()
-		setCondition(&claim.Status.Conditions, metav1.Condition{
+		changed := claim.Status.Phase != v1alpha1.SandboxPending ||
+			claim.Status.Endpoint != "" || claim.Status.Node != "" || claim.Status.SandboxID != ""
+		claim.Status.Phase = v1alpha1.SandboxPending
+		claim.Status.Endpoint = ""
+		claim.Status.Node = ""
+		claim.Status.SandboxID = ""
+		if setCondition(&claim.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.NewTime(r.now()),
 			Reason:             "NoHuskPod",
 			Message:            "no warm husk pod is ready in the pool; the claim will retry once the pool scales a dormant slot up",
-		})
-		_ = r.Status().Update(ctx, claim)
+		}) {
+			changed = true
+		}
+		if changed {
+			_ = r.Status().Update(ctx, claim)
+		}
 		return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
+	}
+
+	// A dormant pod is available: mark the claim Restoring before activating it.
+	// This is stamped here (not before pod selection) so a claim that cannot place
+	// stays Pending and settles, never cycling Pending -> Restoring -> Pending.
+	if claim.Status.Phase != v1alpha1.SandboxRestoring {
+		claim.Status.Phase = v1alpha1.SandboxRestoring
+		if err := r.Status().Update(ctx, claim); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Resolve env + secrets (same path as the forkd fork). Secret VALUES live

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -528,14 +528,40 @@ func (r *SandboxPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func setCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
+// setCondition upserts a condition by Type, preserving LastTransitionTime when
+// the condition's Status has not changed (the same semantics as apimachinery's
+// meta.SetStatusCondition). This is load-bearing: a reconcile that re-asserts an
+// unchanged condition (a Pending claim re-pended with the same reason every pass)
+// must NOT stamp a fresh LastTransitionTime, because a fresh timestamp makes the
+// status write a real change, which re-triggers the object's own watch, which
+// re-reconciles, which writes again: a self-sustaining hot loop. Worse, that loop
+// of full Status().Update writes from a stale read clobbers any externally
+// applied status (for example the husk e2e's merge-patch Ready stamp), so the
+// claim never settles. Preserving the timestamp on an unchanged Status makes the
+// re-assert a no-op write, so the loop terminates and external stamps survive.
+func setCondition(conditions *[]metav1.Condition, condition metav1.Condition) bool {
 	for i, c := range *conditions {
 		if c.Type == condition.Type {
+			// Carry the existing transition time forward unless the Status flips,
+			// so an unchanged condition does not churn the object.
+			if c.Status == condition.Status && !c.LastTransitionTime.IsZero() {
+				condition.LastTransitionTime = c.LastTransitionTime
+			}
+			// Report whether anything meaningful changed: an identical re-assert
+			// (same Status, Reason, Message, and carried-forward transition time) is
+			// a no-op, so the caller can skip a status write that would otherwise
+			// re-trigger the object's own watch.
+			unchanged := c.Status == condition.Status &&
+				c.Reason == condition.Reason &&
+				c.Message == condition.Message &&
+				c.ObservedGeneration == condition.ObservedGeneration &&
+				c.LastTransitionTime.Equal(&condition.LastTransitionTime)
 			(*conditions)[i] = condition
-			return
+			return !unchanged
 		}
 	}
 	*conditions = append(*conditions, condition)
+	return true
 }
 
 func conditionStatus(ok bool) metav1.ConditionStatus {


### PR DESCRIPTION
## Problem

The `kind-e2e-husk` job was RED on main: the re-pend probe step failed with
`EVICTION-FAILED: the probe claim did not settle Ready on the stamped backing pod`.
The probe creates a claim against an empty pool (replicas 0), borrows a dormant
husk pod from another pool, labels it claimed, and merge-patches the claim status
Ready on it (the kind cluster has no VMM, so a real husk activation cannot run).
It then waits for the claim to settle Ready before deleting the pod to prove
re-pend. The settle never happened: the claim was observed flapping
Pending/Restoring, never Ready, with sandboxID always empty.

## Root cause

A husk claim whose pool has no dormant pod (NoHuskPod) cycled
Pending -> Restoring -> Pending on every reconcile: the reconcile stamped
Restoring before pod selection (`claim.Status.Phase = SandboxRestoring` +
`Status().Update`), then pended again when `reconcileHuskClaim` found no pod. Each
status write re-triggered the claim's own watch, so the cycle was a self-sustaining
hot loop of full-object `Status().Update` writes from a stale-read claim. Those
full-status writes clobbered the e2e's externally applied merge-patch Ready stamp
(they wrote back the stale Pending phase and an empty sandboxID), so the claim
never settled.

The hot loop predates the recent merges; the W4 workspace merge (#127) added enough
extra reconcile traffic (Workspace + memory-snapshot reconcilers) to make the
clobber reliable, flipping the probe from green to consistently red. Confirmed by
bisection: the repro test passes against the pre-#125 tree and the #125 merge, and
fails at the #127 head.

## Fix

Reconcile-layer, not a test weakening:

- The husk path stamps Restoring only AFTER it has selected a dormant pod to
  activate. A claim that cannot place stays Pending and settles, instead of
  cycling Pending -> Restoring -> Pending.
- The NoHuskPod pend write is idempotent: a claim already Pending with the same
  condition is left untouched, so re-reconciling an unplaceable claim does not bump
  the object or re-trigger its own watch.
- `setCondition` preserves `LastTransitionTime` when a condition's Status is
  unchanged (the apimachinery `meta.SetStatusCondition` semantics) and reports
  whether anything changed, so re-asserting an unchanged condition is a no-op write.

Net effect: an unplaceable husk claim settles Pending (no churn), and an externally
stamped Ready husk claim with a healthy backing pod stays Ready, so the e2e probe's
merge-patch stamp survives and settles. The re-pend on husk pod loss behavior is
NOT weakened.

## Tests

New envtest in `internal/controller`:

- `TestHuskNoPodClaimDoesNotChurn` pins the root cause: a pending NoHuskPod claim
  must not churn its resourceVersion (fails pre-fix with ~20 bumps in 3s).
- `TestHuskClaimStampedReadyStaysReady` mirrors the e2e probe: a merge-patched
  Ready husk claim with a healthy borrowed pod stays Ready across reconciles.

Existing `TestHuskClaimRePendsOnPodLossKill` and
`TestHuskClaimDrainCheckpointRoutesThroughSeam` stay green (re-pend behavior intact).

## Verification

- `go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` clean.
- `go test ./internal/controller/` green (full envtest suite); fork/daemon/vsock
  unit tests green.
- `golangci-lint run` and `GOOS=linux golangci-lint run` both clean.

The real confirmation is `kind-e2e-husk` going green on this PR (it runs on kind in
CI); to be confirmed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)