### PR TITLE
fix(security): fail closed when a forked VM does not reseed its RNG

### DIFF
--- a/cmd/sandbox-server/main.go
+++ b/cmd/sandbox-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/paperclipinc/mitos/internal/apierr"
@@ -31,6 +33,10 @@ type server struct {
 	// to sandboxAPI at construction. Retained so the flag plumbing is observable
 	// without reaching into the daemon package's unexported state.
 	maxStreamsPerSandbox int
+	// forkGeneration is the monotonically increasing fork generation handed to
+	// the guest in each NotifyForked so a guest can tell forks apart. Atomic so
+	// concurrent forks get distinct generations.
+	forkGeneration atomic.Uint64
 }
 
 // newServer builds the standalone server and applies the SandboxAPI policy
@@ -241,22 +247,63 @@ func (s *server) handleFork(w http.ResponseWriter, r *http.Request) {
 		ForkTimeMs: float64(time.Since(start).Microseconds()) / 1000.0,
 	}
 
+	// In real mode, register the vsock connection for exec/files and run the
+	// fork-correctness reseed handshake. A real-mode fork restores a snapshot,
+	// so the guest shares the snapshot's CRNG state with every sibling fork;
+	// without a reseed two forks emit duplicate TLS keys / tokens / nonces. We
+	// FAIL CLOSED, the same policy as forkd and the husk path: if the agent is
+	// unreachable, the notify fails, or the guest reports it did not reseed, the
+	// fork is rejected and never registered. The mock mode has no guest, so it
+	// skips the handshake.
+	if !s.mockMode {
+		vsockPath := fmt.Sprintf("/tmp/sandbox-server/sandboxes/%s/vsock.sock", req.ID)
+		if err := s.sandboxAPI.RegisterSandbox(req.ID, vsockPath); err != nil {
+			// Fail closed: a fork whose guest agent is unreachable cannot reseed.
+			errResp(w, fmt.Sprintf("fork %q: guest agent not connected: %v", req.ID, err), 500)
+			return
+		}
+		s.sandboxAPI.RegisterStreamPath(req.ID, vsockPath)
+		if err := s.reseedFork(req.ID); err != nil {
+			// Fail closed: drop the half-wired sandbox so an un-reseeded VM that
+			// shares CRNG state with its siblings is never served. The error
+			// carries no entropy or secret values.
+			s.sandboxAPI.UnregisterSandbox(req.ID)
+			errResp(w, fmt.Sprintf("fork %q: %v", req.ID, err), 500)
+			return
+		}
+	}
+
 	s.mu.Lock()
 	s.sandboxes[req.ID] = info
 	s.mu.Unlock()
 
-	// In real mode, register the vsock connection for exec/files
-	if !s.mockMode {
-		vsockPath := fmt.Sprintf("/tmp/sandbox-server/sandboxes/%s/vsock.sock", req.ID)
-		if err := s.sandboxAPI.RegisterSandbox(req.ID, vsockPath); err != nil {
-			// Non-fatal: the sandbox exists but exec/files won't work until the agent is reachable.
-			log.Printf("register agent for sandbox %q: %v", req.ID, err)
-		}
-		s.sandboxAPI.RegisterStreamPath(req.ID, vsockPath)
-	}
-
 	log.Printf("fork %q from %q in %.2fms", req.ID, req.Template, info.ForkTimeMs)
 	resp(w, info)
+}
+
+// reseedFork runs the post-restore fork-correctness handshake against a real
+// fork's guest agent: it generates 32 bytes of fresh crypto/rand entropy and a
+// distinct generation, sends them via NotifyForked so the guest reseeds its
+// kernel CRNG and steps its wall clock, and FAILS CLOSED on the reseed result.
+// A nil response or ReseededRNG:false means the guest still shares its siblings'
+// CRNG state, which is incorrect (not merely degraded), so it returns an error
+// and the caller refuses to serve the fork. This mirrors the daemon's
+// notifyForked and the husk productionNotifier. Entropy bytes are never logged;
+// only the boolean reseed result is inspected.
+func (s *server) reseedFork(sandboxID string) error {
+	entropy := make([]byte, 32)
+	if _, err := rand.Read(entropy); err != nil {
+		return fmt.Errorf("generate fork entropy: %w", err)
+	}
+	gen := s.forkGeneration.Add(1)
+	resp, err := s.sandboxAPI.NotifyForked(sandboxID, gen, entropy, nil, nil)
+	if err != nil {
+		return fmt.Errorf("notify guest of fork: %w", err)
+	}
+	if resp == nil || !resp.ReseededRNG {
+		return fmt.Errorf("guest did not reseed its RNG after restore; refusing to serve a fork that shares CRNG state")
+	}
+	return nil
 }
 
 func (s *server) handleListSandboxes(w http.ResponseWriter, r *http.Request) {

--- a/cmd/sandbox-server/main_test.go
+++ b/cmd/sandbox-server/main_test.go
@@ -1,8 +1,19 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/paperclipinc/mitos/internal/vsock"
 )
 
 // TestMaxStreamsPerSandboxFlagDefault verifies the standalone server exposes a
@@ -32,5 +43,133 @@ func TestNewServerPlumbsStreamCap(t *testing.T) {
 	}
 	if s.maxStreamsPerSandbox != want {
 		t.Fatalf("newServer stream cap: got %d want %d", s.maxStreamsPerSandbox, want)
+	}
+}
+
+// fakeAgent listens on sockPath speaking the Firecracker vsock UDS preamble and
+// the JSON agent protocol, recording notify_forked requests. On notify_forked it
+// replies OK:true with a NotifyForkedResponse reporting ReseededRNG=reseeded, so
+// a test can drive both the reseeded-OK and the un-reseeded fail-closed path. No
+// secrets or entropy are ever logged.
+func fakeAgent(t *testing.T, sockPath string, reseeded bool) *[]*vsock.NotifyForkedRequest {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { lis.Close() })
+	var notifies []*vsock.NotifyForkedRequest
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				sc := bufio.NewScanner(c)
+				sc.Buffer(make([]byte, 1<<20), 1<<20)
+				// The standalone server reaches this fake over the unix fallback
+				// (vsock.ConnectUnix), which sends no "CONNECT <port>" preamble:
+				// the JSON request protocol starts immediately.
+				for sc.Scan() {
+					var req vsock.Request
+					if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+						return
+					}
+					if req.Type == vsock.TypeNotifyForked {
+						notifies = append(notifies, req.NotifyForked)
+						out, _ := json.Marshal(vsock.Response{
+							OK:           true,
+							NotifyForked: &vsock.NotifyForkedResponse{ReseededRNG: reseeded},
+						})
+						if _, err := c.Write(append(out, '\n')); err != nil {
+							return
+						}
+						continue
+					}
+					out, _ := json.Marshal(vsock.Response{OK: true})
+					if _, err := c.Write(append(out, '\n')); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return &notifies
+}
+
+// realServerWithAgent builds a real-mode server whose sandboxAPI dials a fake
+// guest agent for sandboxID at the standalone server's fixed vsock path. The
+// real-mode handleFork resolves the vsock UDS under dataDir/sandboxes/<id>;
+// since the path does not exist on disk, the EnableUnixFallback path the
+// standalone server sets routes the dial to the fixed local agent socket.
+func realServerWithAgent(t *testing.T, sandboxID string, reseeded bool) (*server, *[]*vsock.NotifyForkedRequest) {
+	t.Helper()
+	// The standalone server falls back to /tmp/sandbox-agent-52.sock when the
+	// per-sandbox vsock path does not exist, so the fake agent listens there.
+	sock := fmt.Sprintf("/tmp/sandbox-agent-%d.sock", vsock.AgentPort)
+	_ = os.Remove(sock)
+	notifies := fakeAgent(t, sock, reseeded)
+
+	dataDir, err := os.MkdirTemp("/tmp", "sbsrv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dataDir) })
+
+	s := newServer(dataDir, "", false, 16) // real mode
+	s.templates[sandboxID+"-tmpl"] = &templateInfo{ID: sandboxID + "-tmpl", Ready: true}
+	return s, notifies
+}
+
+func forkRequest(t *testing.T, s *server, id, template string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"id": id, "template": template})
+	r := httptest.NewRequest(http.MethodPost, "/v1/fork", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handleFork(w, r)
+	return w
+}
+
+// TestRealModeForkReseedsAndSucceeds proves the standalone server runs the
+// reseed handshake on a real-mode fork and serves the sandbox when the guest
+// reports ReseededRNG:true.
+func TestRealModeForkReseedsAndSucceeds(t *testing.T) {
+	const id = "sb-ok"
+	s, notifies := realServerWithAgent(t, id, true)
+
+	w := forkRequest(t, s, id, id+"-tmpl")
+	if w.Code != http.StatusOK {
+		t.Fatalf("real-mode fork with reseeding guest: status %d, body %s", w.Code, w.Body.String())
+	}
+	if len(*notifies) != 1 {
+		t.Fatalf("expected exactly one notify_forked, got %d", len(*notifies))
+	}
+	if len((*notifies)[0].Entropy) != 32 {
+		t.Errorf("entropy length = %d, want 32", len((*notifies)[0].Entropy))
+	}
+}
+
+// TestRealModeForkFailsClosedWhenGuestDoesNotReseed is the security regression
+// guard: a real-mode fork whose guest reports ReseededRNG:false must FAIL
+// CLOSED. The fork is rejected and the sandbox is not left registered, so an
+// un-reseeded VM that shares CRNG state with its siblings is never served.
+func TestRealModeForkFailsClosedWhenGuestDoesNotReseed(t *testing.T) {
+	const id = "sb-noreseed"
+	s, _ := realServerWithAgent(t, id, false)
+
+	w := forkRequest(t, s, id, id+"-tmpl")
+	if w.Code == http.StatusOK {
+		t.Fatalf("real-mode fork must fail when the guest reports ReseededRNG:false; got 200 body %s", w.Body.String())
+	}
+	s.mu.RLock()
+	_, registered := s.sandboxes[id]
+	s.mu.RUnlock()
+	if registered {
+		t.Fatal("un-reseeded fork must not be left registered")
 	}
 }

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -11,7 +11,7 @@ test missing or incomplete. `done` = implemented + test runs in the
 
 | # | Hazard | Policy | Test | Status |
 |---|--------|--------|------|--------|
-| 1 | Shared RNG state after restore | Reseed CRNG on every fork via host entropy over vsock (NotifyForked); FAIL CLOSED when the guest does not reseed | go: `TestForkNotifiesAgentWithFreshEntropy`, `TestForkGenerationIncrementsAcrossForks`, `TestForkFailsWhenNotifyForkedErrors`; KVM: two forks of one snapshot assert distinct `/dev/urandom` (`URANDOM` lines differ) | **partial; NOT fail-closed off husk (review finding)** (guest reseed + forkd notify done; virtio-rng device attachment NOT wired; KVM proof is guest-only. Fail-closed ONLY on the husk path: `internal/husk` `productionNotifier` checks `resp.ReseededRNG` and leaves the VM unserved on false. On the RAW-FORKD path `internal/daemon/sandbox_api.go` `NotifyForked` DISCARDS the response and never checks `ReseededRNG`, so a guest that signals `ReseededRNG:false` with `OK:true` is served anyway and serves duplicate CRNG output; only a transport `OK:false` fails the fork. The SANDBOX-SERVER real-mode fork does NO reseed handshake at all (`cmd/sandbox-server/main.go` `handleFork`). The go test `internal/daemon/delivery_test.go` only exercises `OK:false`, not `ReseededRNG:false`, so the gap is untested.) |
+| 1 | Shared RNG state after restore | Reseed CRNG on every fork via host entropy over vsock (NotifyForked); FAIL CLOSED on EVERY engine when the guest does not reseed | go: `TestForkNotifiesAgentWithFreshEntropy`, `TestForkGenerationIncrementsAcrossForks`, `TestForkFailsWhenNotifyForkedErrors`, `TestForkFailsWhenGuestDoesNotReseed`, `TestForkRunningFailsWhenGuestDoesNotReseed` (daemon), `TestRealModeForkFailsClosedWhenGuestDoesNotReseed` (sandbox-server); KVM: two forks of one snapshot assert distinct `/dev/urandom` (`URANDOM` lines differ) | **partial** (guest reseed + reseed handshake done; virtio-rng device attachment NOT wired; KVM proof is guest-only. Fail-closed is enforced on ALL engines: the husk path (`internal/husk` `productionNotifier`), the raw-forkd path (`internal/daemon/sandbox_api.go` `NotifyForked` now RETURNS the guest response and `internal/daemon/server.go` `notifyForked` refuses to mark the sandbox Ready when it is nil or reports `ReseededRNG:false`), and sandbox-server real-mode (`cmd/sandbox-server/main.go` `reseedFork`, the same gate). A guest that signals `ReseededRNG:false` with `OK:true` is reaped, not served; a transport `OK:false` and a `ReseededRNG:false` both fail the fork. The `ReseededRNG:false` failure mode is now covered by the go tests listed above. Remaining for `done`: virtio-rng attachment and a KVM end-to-end forkd notify proof.) |
 | 2 | Stale wall clock after restore | kvm-clock resync + agent clock step from host wall clock in NotifyForked | go: `TestForkNotifiesAgentWithFreshEntropy` (carries `HostWallClockNanos`); KVM: each fork `WALLCLOCK_NS` within 2s of the runner clock | **partial** (guest clock step done, 500ms tolerance; KVM proof is guest-only. Review finding: `stepClock` steps only `CLOCK_REALTIME`, NOT `CLOCK_MONOTONIC` (`guest/agent/notifyforked.go`), so timers and deadlines anchored to the monotonic clock across a restore can mis-fire.) |
 | 3 | Secrets duplicated into live forks | Per-fork credential reissue; inheritance requires opt-in | `TestLiveForkOfSecretHolderIsRejectedByDefault`, `TestForkDeliversConfigureToAgent`, KVM `test-agent` configure check | **partial** (default-deny gate + vsock delivery implemented; reissue open) |
 | 4 | Duplicate MAC/IP/TCP state in forks | Fresh NIC identity per fork; parent TCP dead in fork | `TestForkNetworkIdentity` | **open** (guests currently have no NIC at all; see note) |
@@ -23,11 +23,12 @@ The husk-pods activate path (issue #18, `internal/husk`, `cmd/husk-stub`) runs
 the SAME RNG-reseed + clock-step `NotifyForked` handshake as the engine fork
 path (rows 1 and 2), plus env/secret delivery via `Configure` (row 3), on every
 `Activate`. It fails closed: a VM whose guest does not report `ReseededRNG` is
-left unserved. NOTE (review finding): this fail-closed reseed check is enforced
-ONLY on the husk path (`internal/husk` `productionNotifier`). It is NOT enforced
-on the raw-forkd path (`internal/daemon` discards the `NotifyForked` response)
-nor on sandbox-server real-mode (no reseed handshake). The "always strict" claim
-holds for husk only; see row 1. The KVM husk activate-correctness phase proves it by activating
+left unserved. The SAME fail-closed reseed check is now enforced on EVERY engine:
+the husk path (`internal/husk` `productionNotifier`), the raw-forkd path
+(`internal/daemon/server.go` `notifyForked` inspects the `NotifyForked` response
+and reaps a fork that reports `ReseededRNG:false`), and sandbox-server real-mode
+(`cmd/sandbox-server/main.go` `reseedFork`). The "always strict" claim holds on
+all three; see row 1. The KVM husk activate-correctness phase proves it by activating
 two VMs from one bench snapshot and asserting distinct `/dev/urandom`, each wall
 clock within 2s of the runner, and a delivered env var plus secret readable in
 each guest with the secret value absent from the host-side logs. See
@@ -128,11 +129,13 @@ host-entropy-over-vsock hook is our equivalent.
 backed by host entropy is NOT implemented; the current path injects entropy
 only at fork time via NotifyForked, not continuously. Tracked as a follow-up.
 
-**Fail-closed scope (review finding).** The reseed is fail-closed ONLY on the
-husk path. On the raw-forkd path forkd discards the `NotifyForked` response and
-never inspects `ReseededRNG`, and sandbox-server real-mode does no reseed at all,
-so an un-reseeded fork is served on those paths (duplicate CRNG output). See
-row 1.
+**Fail-closed scope.** The reseed is fail-closed on EVERY engine. The husk path
+(`internal/husk` `productionNotifier`), the raw-forkd path
+(`internal/daemon/server.go` `notifyForked` inspects the `NotifyForked` response
+returned by `internal/daemon/sandbox_api.go` and reaps a fork whose guest
+reports `ReseededRNG:false`), and sandbox-server real-mode
+(`cmd/sandbox-server/main.go` `reseedFork`) all refuse to serve an un-reseeded
+fork rather than emitting duplicate CRNG output. See row 1.
 
 **Write-fallback over-reports (review finding).** When `RNDADDENTROPY` fails,
 `reseedCRNG` falls back to writing the bytes to `/dev/urandom`

--- a/internal/daemon/delivery_test.go
+++ b/internal/daemon/delivery_test.go
@@ -103,13 +103,28 @@ func TestForkMockEngineSkipsDelivery(t *testing.T) {
 
 // startFakeVsockAgent listens on sockPath, speaks the Firecracker vsock UDS
 // preamble, then the JSON agent protocol, recording configure and
-// notify_forked payloads. If notifyErr is true, the agent errors every
-// notify_forked request so callers can exercise the fail-closed path.
+// notify_forked payloads. On notify_forked it replies OK with a
+// NotifyForkedResponse reporting ReseededRNG:true, the success the daemon's
+// fail-closed gate requires.
 func startFakeVsockAgent(t *testing.T, sockPath string) *recordedConfig {
 	return startFakeVsockAgentErr(t, sockPath, false)
 }
 
+// startFakeVsockAgentNoReseed replies to notify_forked with OK:true but
+// ReseededRNG:false, the real un-reseeded-fork failure mode: the transport
+// succeeds, yet the guest signals it did not reseed its CRNG. The daemon must
+// FAIL CLOSED on this and never mark the sandbox Ready.
+func startFakeVsockAgentNoReseed(t *testing.T, sockPath string) *recordedConfig {
+	return startFakeVsockAgentReseed(t, sockPath, false, false)
+}
+
 func startFakeVsockAgentErr(t *testing.T, sockPath string, notifyErr bool) *recordedConfig {
+	// notifyErr replies with a transport-level OK:false; otherwise the guest
+	// reports a successful reseed (ReseededRNG:true).
+	return startFakeVsockAgentReseed(t, sockPath, notifyErr, true)
+}
+
+func startFakeVsockAgentReseed(t *testing.T, sockPath string, notifyErr, reseeded bool) *recordedConfig {
 	t.Helper()
 	rec := &recordedConfig{}
 	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
@@ -158,6 +173,17 @@ func startFakeVsockAgentErr(t *testing.T, sockPath string, notifyErr bool) *reco
 							}
 							continue
 						}
+						// Transport OK; the guest reports whether it actually
+						// reseeded its CRNG. reseeded=false is the silent
+						// un-reseeded fork the daemon must fail closed on.
+						resp, _ := json.Marshal(vsock.Response{
+							OK:           true,
+							NotifyForked: &vsock.NotifyForkedResponse{ReseededRNG: reseeded},
+						})
+						if _, err := c.Write(append(resp, '\n')); err != nil {
+							return
+						}
+						continue
 					}
 					resp, _ := json.Marshal(vsock.Response{OK: true})
 					if _, err := c.Write(append(resp, '\n')); err != nil {
@@ -346,6 +372,52 @@ func TestForkFailsWhenNotifyForkedErrors(t *testing.T) {
 	}
 	if got := engine.GetCapacity().ActiveSandboxes; got != 0 {
 		t.Fatalf("active = %d, want 0", got)
+	}
+}
+
+// TestForkFailsWhenGuestDoesNotReseed is the regression guard for the real
+// un-reseeded-fork failure mode (security review blocker 2): the transport
+// SUCCEEDS (OK:true) but the guest reports ReseededRNG:false. A fork whose
+// guest did not reseed its CRNG shares RNG state with its siblings (duplicate
+// TLS keys / tokens / nonces), so the daemon must FAIL CLOSED: the fork must
+// error and be reaped, never marked Ready. Distinct from
+// TestForkFailsWhenNotifyForkedErrors, which only covers a transport OK:false.
+func TestForkFailsWhenGuestDoesNotReseed(t *testing.T) {
+	dir := shortVsockDir(t)
+	engine := kvmEngineWithTemplate(t, dir)
+	startFakeVsockAgentNoReseed(t, filepath.Join(dir, "sandboxes", "sb-noreseed", "vsock.sock"))
+
+	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))
+	_, err := srv.Fork(context.Background(), "py", "sb-noreseed", nil, nil, nil, nil, "test-token")
+	if err == nil {
+		t.Fatal("fork must fail when the guest reports ReseededRNG:false")
+	}
+	if len(engine.terminated) != 1 || engine.terminated[0] != "sb-noreseed" {
+		t.Fatalf("sandbox not reaped after un-reseeded fork: %v", engine.terminated)
+	}
+	if got := engine.GetCapacity().ActiveSandboxes; got != 0 {
+		t.Fatalf("active = %d, want 0", got)
+	}
+}
+
+// TestForkRunningFailsWhenGuestDoesNotReseed is the live-fork (ForkRunning)
+// counterpart: a live fork whose guest reports ReseededRNG:false shares its
+// parent's CRNG state and must be reaped, not served.
+func TestForkRunningFailsWhenGuestDoesNotReseed(t *testing.T) {
+	dir := shortVsockDir(t)
+	engine := kvmEngineWithTemplate(t, dir)
+	if _, err := engine.Fork("py", "sb-src", fork.ForkOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	startFakeVsockAgentNoReseed(t, filepath.Join(dir, "sandboxes", "sb-live-noreseed", "vsock.sock"))
+
+	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))
+	_, err := srv.ForkRunning(context.Background(), "sb-src", "sb-live-noreseed", false, "t")
+	if err == nil {
+		t.Fatal("live fork must fail when the guest reports ReseededRNG:false")
+	}
+	if len(engine.terminated) != 1 || engine.terminated[0] != "sb-live-noreseed" {
+		t.Fatalf("live fork not reaped after un-reseeded fork: %v", engine.terminated)
 	}
 }
 

--- a/internal/daemon/sandbox_api.go
+++ b/internal/daemon/sandbox_api.go
@@ -329,13 +329,17 @@ func (api *SandboxAPI) Configure(sandboxID string, env, secrets map[string]strin
 // volume mount table (device, mount path, read-only) the guest mounts after the
 // host rebound the drives. Entropy is sensitive seed material and is never
 // logged; the network addresses, device nodes, and paths are safe to log.
-func (api *SandboxAPI) NotifyForked(sandboxID string, generation uint64, entropy []byte, guestNet *vsock.NotifyForkedNetwork, volumes []vsock.VolumeMountEntry) error {
+//
+// It RETURNS the guest's NotifyForkedResponse so the caller can enforce the
+// fork-correctness gate (ReseededRNG): a transport success alone does not mean
+// the guest reseeded its CRNG. The response carries booleans and counts only,
+// never entropy bytes.
+func (api *SandboxAPI) NotifyForked(sandboxID string, generation uint64, entropy []byte, guestNet *vsock.NotifyForkedNetwork, volumes []vsock.VolumeMountEntry) (*vsock.NotifyForkedResponse, error) {
 	agent, err := api.getAgent(sandboxID)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = agent.NotifyForkedWithConfig(generation, entropy, guestNet, volumes)
-	return err
+	return agent.NotifyForkedWithConfig(generation, entropy, guestNet, volumes)
 }
 
 func (api *SandboxAPI) getAgent(sandboxID string) (*vsock.Client, error) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -303,14 +303,25 @@ func (s *Server) deliverConfig(sandboxID, vsockPath string, env, secrets map[str
 // crypto/rand entropy) to a connected guest. The agent must already be
 // registered. Entropy is never logged. Errors are returned so the caller can
 // reap the sandbox: a guest that did not reseed shares RNG state.
+//
+// It FAILS CLOSED on the reseed: a transport success alone is not enough. If
+// the guest's response is nil or reports ReseededRNG:false, the guest still
+// shares its siblings' CRNG state (duplicate TLS keys / tokens / nonces), which
+// is incorrect (not merely degraded), so this returns an error and the caller
+// reaps the sandbox rather than marking it Ready. This mirrors the husk path's
+// productionNotifier check. Only the boolean is inspected; no entropy is logged.
 func (s *Server) notifyForked(sandboxID string, guestNet *vsock.NotifyForkedNetwork, volumes []vsock.VolumeMountEntry) error {
 	entropy := make([]byte, 32)
 	if _, err := rand.Read(entropy); err != nil {
 		return fmt.Errorf("generate fork entropy: %w", err)
 	}
 	gen := s.forkGeneration.Add(1)
-	if err := s.sandboxAPI.NotifyForked(sandboxID, gen, entropy, guestNet, volumes); err != nil {
+	resp, err := s.sandboxAPI.NotifyForked(sandboxID, gen, entropy, guestNet, volumes)
+	if err != nil {
 		return fmt.Errorf("notify guest of fork: %w", err)
+	}
+	if resp == nil || !resp.ReseededRNG {
+		return fmt.Errorf("guest did not reseed its RNG after restore; refusing to serve a fork that shares CRNG state")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Blocker 2 of the security remediation: make fork-correctness RNG-reseed FAIL CLOSED on every engine.

A VM restored from a snapshot/fork shares the snapshot's kernel CRNG state with every sibling fork. Two forks that do not reseed emit duplicate TLS keys, tokens, and nonces. The guest signals a successful reseed via the `NotifyForked` response field `ReseededRNG`. The husk path already failed closed on it, but two paths did not:

- `internal/daemon/sandbox_api.go` `NotifyForked` discarded the guest response.
- `internal/daemon/server.go` `notifyForked` treated transport `OK:true` as success and marked the sandbox Ready even when `ReseededRNG` was false, so a silently un-reseeded fork served duplicate CRNG output.
- `cmd/sandbox-server/main.go` `handleFork` ran no reseed handshake at all in real mode.

## Changes

- `sandbox_api.go` `NotifyForked` now RETURNS the guest `NotifyForkedResponse` instead of discarding it.
- `server.go` `notifyForked` fails closed: a nil response or `ReseededRNG:false` returns an error so the fork (both restore via `Fork`/`deliverConfig` and live `ForkRunning`) is reaped and never marked Ready, mirroring the husk `productionNotifier`.
- sandbox-server `handleFork` now runs the reseed handshake (`reseedFork`) on a real-mode fork and fails closed on `!ReseededRNG`, dropping the half-wired sandbox. A real-mode fork whose guest agent is unreachable also now fails closed instead of logging and continuing.

## Tests

- `internal/daemon/delivery_test.go`: new `TestForkFailsWhenGuestDoesNotReseed` and `TestForkRunningFailsWhenGuestDoesNotReseed` feed `Response{OK:true, ReseededRNG:false}` and assert the fork fails and the sandbox is reaped. The existing transport `OK:false` test is kept. The fake agent now returns a real `NotifyForkedResponse{ReseededRNG:true}` on the happy path.
- `cmd/sandbox-server/main_test.go`: `TestRealModeForkFailsClosedWhenGuestDoesNotReseed` and `TestRealModeForkReseedsAndSucceeds` exercise the real-mode handshake.
- All new fail-closed tests fail pre-fix and pass post-fix.

## Docs

`docs/fork-correctness.md` row 1 and the strictness claim now record fail-closed enforcement on ALL engines (husk, raw-forkd, sandbox-server). The husk-only asymmetry note is removed.

## Security notes

No entropy or secret values are logged or placed in error messages; only the reseed boolean is inspected. The husk path is unchanged (it was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)