### PR TITLE
fix(security): per-fork rootfs CoW on raw-forkd to stop cross-fork write bleed

### DIFF
--- a/cmd/forkd/main.go
+++ b/cmd/forkd/main.go
@@ -274,6 +274,17 @@ func main() {
 		}
 		engine = real
 
+		// Raw-forkd multi-tenant gate (security blocker 5): the raw-forkd engine
+		// path (this non-husk forkd DaemonSet) runs the daemon privileged and, when
+		// the jailer is disabled, runs Firecracker unjailed. Snapshots are node-flat,
+		// so a node that mixes tenants on raw-forkd exposes them to one another at the
+		// host boundary. Per-fork rootfs CoW now stops the cross-fork rootfs write
+		// bleed, but raw-forkd is still NOT a hardened multi-tenant isolation
+		// boundary. Surface this loudly at startup so an operator enabling it is never
+		// misled into placing untrusted multi-tenant workloads on it; the hardened
+		// multi-tenant path is the husk-pod engine. See docs/threat-model.md.
+		fmt.Fprintln(os.Stderr, "forkd: WARNING raw-forkd (the non-husk engine path) is NOT for untrusted multi-tenant workloads: the daemon runs privileged, snapshots are node-flat, and (without --jailer) Firecracker runs unjailed. Use the husk-pod engine for untrusted multi-tenant isolation. See docs/threat-model.md.")
+
 		// Enable CAS peer distribution only when mTLS AND a peer token are set:
 		// the surface serves digest-addressed bytes over TLS, gated by the shared
 		// token. It is served on its OWN listener (--cas-listen), NOT the sandbox

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -35,7 +35,10 @@ workloads in production on this project, and do not claim it is safe to:
    child path (section 3, W4 row).
 4. **The secondary hardening** below: the default-SA-token automount on husk
    pods, the fail-open gRPC default, the missing host-side vsock read deadline,
-   the raw-forkd shared-rootfs channel, and the raw-forkd privileged DaemonSet.
+   and the raw-forkd privileged DaemonSet. (The raw-forkd shared-rootfs cross-fork
+   write channel is now FIXED via per-fork rootfs CoW, mirroring the husk fix; see
+   the per-row table. The privileged-no-jailer DaemonSet remains, which is why
+   raw-forkd is still NOT for untrusted multi-tenant.)
 5. **The fork-correctness and failure/GC CI suites green** (a precondition
    already stated in CLAUDE.md and ROADMAP).
 6. **A CVE / patch pipeline for the guest kernel and Firecracker** (today CVE
@@ -45,9 +48,9 @@ workloads in production on this project, and do not claim it is safe to:
 Must-fix-first set (the items that make the current posture actively unsafe, not
 merely incomplete): item 1 (husk egress default-open + metadata reachable),
 item 2 (fork-correctness not fail-closed off the husk path), the raw-forkd
-shared-rootfs cross-fork channel and privileged-no-jailer DaemonSet (item 4,
-which is why raw-forkd is NOT for untrusted multi-tenant), and item 3 (node-CAS
-write/integrity/DoS). The per-row honest status discipline (mitigated / partial /
+privileged-no-jailer DaemonSet (item 4, which is why raw-forkd is NOT for
+untrusted multi-tenant, even now that its shared-rootfs cross-fork write channel
+is fixed by per-fork rootfs CoW), and item 3 (node-CAS write/integrity/DoS). The per-row honest status discipline (mitigated / partial /
 open, with a severity on the review rows) is preserved throughout.
 
 ## Components and trust
@@ -504,7 +507,7 @@ The primary boundary is KVM hardware virtualization via Firecracker.
 | Control | Status | Detail |
 |---|---|---|
 | Separate KVM VMs per sandbox | **mitigated** | No two sandboxes share a kernel. |
-| raw-forkd: forks share ONE writable rootfs inode (cross-fork filesystem channel) | **open (critical) on raw-forkd** | On the raw-forkd fork path the template rootfs is hard-linked into each fork's chroot and the rootfs drive is attached with `readOnly=false` (`internal/firecracker/template.go` `AddDrive("rootfs", templateRootfs, false, true)`; `internal/fork/engine.go` fork path), and it is NEVER rebound to a per-fork backing. So all forks of one template on a node share a SINGLE writable rootfs inode: a write by one fork is visible to its siblings, a cross-fork filesystem read/write channel (and a corruption vector). The HUSK path FIXED this: `Stub.Prepare` reflink-clones a PER-POD rootfs and `Stub.Activate` rebinds the baked drive to that clone with `PatchDrive` while the guest is frozen (section 0 surface 3). The raw-forkd path did NOT get the per-fork rebind. Status: open (critical) for raw-forkd; another reason raw-forkd is not for untrusted multi-tenant. Required fix: per-fork rootfs clone + PatchDrive on the raw-forkd path, mirroring the husk fix. |
+| raw-forkd: forks share ONE writable rootfs inode (cross-fork filesystem channel) | **fixed (per-fork rootfs CoW) on raw-forkd** | Previously, on the raw-forkd fork path the template rootfs was hard-linked into each fork's chroot and the rootfs drive was attached with `readOnly=false` (`internal/firecracker/template.go` `AddDrive("rootfs", templateRootfs, false, true)`) and NEVER rebound, so all forks of one template on a node shared a SINGLE writable rootfs inode: a write by one fork was visible to its siblings (and across tenants, since snapshots are node-flat), a cross-fork filesystem read/write channel and a corruption vector. FIXED: `internal/fork/engine.go` now gives each fork its OWN copy-on-write clone of the template rootfs (`prepareForkRootfs` reflink-clones the template rootfs to `<dataDir>/sandboxes/<id>/rootfs.ext4` through the SAME `volume.Backend.ReflinkCopy` owner the husk path uses), loads the snapshot PAUSED (`resume=false`), rebinds the baked `rootfs` drive to that per-fork clone with `PatchDrive` while the guest is frozen, then `Resume`s, exactly mirroring the husk `Stub.Prepare`/`Stub.Activate` fix (section 0 surface 3). The template rootfs is now the READ-ONLY CoW SOURCE; no two forks, and no fork and the source, ever write the same rootfs path. The per-fork clone is hard-linked into the jailer chroot (never the shared template) and reaped with the sandbox dir at Terminate. Proven by `internal/fork/rootfs_cow_test.go` (distinct backing paths, distinct inodes, and a write in one fork's rootfs not visible in a sibling or the template); real-VM cross-fork isolation is KVM-gated (firecracker-test). Residual: raw-forkd is STILL not for untrusted multi-tenant for the OTHER reasons below (privileged DaemonSet, node-flat snapshots, jailer disabled as shipped). |
 | CoW page sharing side channels | **open** | All forks of a snapshot share read-only pages via `mmap(MAP_PRIVATE)` of the same mem file. Flush+Reload-style attacks across forks of the *same tenant's* snapshot are in scope to document; cross-tenant page sharing must be prevented by never sharing snapshot files across trust boundaries. Not yet enforced anywhere. |
 | KSM | **open** | We must mandate KSM off on hosts (we control the reference platform). Not yet documented in any platform guide or checked by forkd at startup. |
 | CPU vulnerability mitigations | **open** | Reference hosts (bare metal) must run current microcode with mitigations on; forkd should refuse or warn on `/sys/devices/system/cpu/vulnerabilities` red flags. Not implemented. |

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -183,6 +183,15 @@ type Engine struct {
 	// (reap). nil falls back to procfsVerifier; reconcile tests inject a fake on
 	// darwin.
 	verifyPID pidVerifier
+
+	// rootfsReflink clones the template rootfs.ext4 to a per-fork copy-on-write
+	// backing so every raw-forkd fork writes its OWN rootfs, never the shared
+	// template inode or a sibling's. It is the SAME reflink-with-full-copy-fallback
+	// owner the husk per-activation rootfs CoW uses (volume.Backend.ReflinkCopy), so
+	// the two paths cannot drift. Set in NewEngine; tests inject a fake. Without it,
+	// two forks of one snapshot hard-linked one writable rootfs inode, a cross-fork
+	// (and cross-tenant) filesystem read/write channel. src and dst carry no secrets.
+	rootfsReflink func(src, dst string) error
 }
 
 // Placeholder network identity used only while building a template snapshot.
@@ -233,6 +242,36 @@ func (e *Engine) volumesEnabled() bool {
 type driveRebind struct {
 	DriveID    string
 	PathOnHost string
+}
+
+// prepareForkRootfs gives a raw-forkd fork its OWN copy-on-write clone of the
+// template rootfs.ext4 instead of hard-linking the shared template rootfs
+// writable into every fork's chroot. It reflink-clones rootfsPath (the template
+// rootfs, the read-only CoW SOURCE) to <dataDir>/sandboxes/<sandboxID>/rootfs.ext4
+// and returns the drive rebind (drive id "rootfs", the root device the template
+// build attaches) the caller applies with PATCH /drives while the restored VM is
+// PAUSED, before resume, so the guest never writes a single block through the
+// shared template rootfs or a sibling fork's. It returns (nil, "", nil) when
+// rootfsPath is empty (a snapshot with no on-disk rootfs, e.g. the mock paths),
+// so those paths are untouched.
+//
+// This is the raw-forkd analog of the husk per-activation rootfs CoW
+// (internal/husk/stub.go): both go through the SAME ReflinkCopy owner and both
+// rebind the "rootfs" drive while paused. The clone is removed with the sandbox
+// dir at Terminate (and on any in-flight fork failure). The source and clone
+// paths carry no secrets.
+func (e *Engine) prepareForkRootfs(snapshotID, sandboxID, rootfsPath string) (*driveRebind, string, error) {
+	if rootfsPath == "" {
+		return nil, "", nil
+	}
+	if e.rootfsReflink == nil {
+		return nil, "", fmt.Errorf("per-fork rootfs CoW for %s: no reflink configured", sandboxID)
+	}
+	clonePath := filepath.Join(e.dataDir, "sandboxes", sandboxID, "rootfs.ext4")
+	if err := e.rootfsReflink(rootfsPath, clonePath); err != nil {
+		return nil, "", fmt.Errorf("clone per-fork rootfs for %s: %w", sandboxID, err)
+	}
+	return &driveRebind{DriveID: "rootfs", PathOnHost: clonePath}, clonePath, nil
 }
 
 // prepareForkVolumes prepares a per-fork backing file for each volume spec per
@@ -713,6 +752,10 @@ func NewEngine(dataDir, firecrackerBin, kernelPath string, jailer firecracker.Ja
 		meminfoReader:        opts.MeminfoReader,
 		journal:              newJournal(dataDir),
 		verifyPID:            procfsVerifier,
+		// Per-fork rootfs CoW: clone the template rootfs to each fork's own backing
+		// through the SAME reflink owner the husk rootfs CoW uses, so a raw-forkd
+		// fork never writes the shared template rootfs inode.
+		rootfsReflink: volume.New(dataDir).ReflinkCopy,
 	}
 	if e.memReserveBytes == 0 {
 		e.memReserveBytes = defaultMemoryReserveBytes
@@ -1040,12 +1083,28 @@ func (e *Engine) fork(snapshotID, sandboxID, rootfsPath string, opts ForkOpts, r
 	// We don't need to mmap it ourselves; just point Firecracker at the
 	// original snapshot file. Each FC process gets its own CoW mapping.
 
-	// In jailer mode the snapshot files and the backing rootfs are
-	// hard-linked into the per-VM chroot before launch; the API paths
-	// below then resolve inside it (mirror layout, see chrootPath).
+	// Per-fork rootfs copy-on-write: clone the template rootfs to THIS fork's own
+	// backing so the fork writes its own clone, never the shared template inode or
+	// a sibling fork's. The template rootfs is the READ-ONLY CoW source. This
+	// closes the cross-fork (and cross-tenant) rootfs read/write channel the prior
+	// hard-link-the-shared-writable-rootfs behavior left open; it is the raw-forkd
+	// analog of the husk per-activation rootfs CoW. The rebind is applied with
+	// PATCH /drives while the restored VM is PAUSED, before resume, below. Returns
+	// (nil, "") when there is no on-disk rootfs (e.g. mock paths), so those paths
+	// are unchanged.
+	rootfsRebind, rootfsClone, err := e.prepareForkRootfs(snapshotID, sandboxID, rootfsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// In jailer mode the snapshot files and the per-fork rootfs CLONE are
+	// hard-linked into the per-VM chroot before launch; the API paths below then
+	// resolve inside it (mirror layout, see chrootPath). We link the fork's OWN
+	// clone, never the shared template rootfs, so the chroot can never reach the
+	// shared writable inode.
 	chrootFiles := []string{memFile, vmStateFile}
-	if rootfsPath != "" {
-		chrootFiles = append(chrootFiles, rootfsPath)
+	if rootfsClone != "" {
+		chrootFiles = append(chrootFiles, rootfsClone)
 	}
 
 	// Start a new Firecracker process
@@ -1097,35 +1156,68 @@ func (e *Engine) fork(snapshotID, sandboxID, rootfsPath string, opts ForkOpts, r
 		return nil, err
 	}
 
-	// Load snapshot: Firecracker mmaps the mem file with MAP_PRIVATE. When
-	// networking is on, network_overrides rebinds the baked NIC to the fork's
-	// own tap (v1.15 supports this; it is the network analog of the relative
-	// vsock uds_path). nil overrides restores exactly as before.
-	if err := fcClient.LoadSnapshotWithOverrides(memFile, vmStateFile, true, overrides); err != nil {
+	// cleanupFork tears down everything this in-flight fork has allocated so far
+	// (the FC process, the per-fork network, and the per-fork volume backings) on
+	// any failure between here and commit. os.RemoveAll(sandboxDir) also removes the
+	// per-fork rootfs clone so it never outlives a failed fork.
+	cleanupFork := func() {
 		_ = fcClient.Kill()
 		if fnet != nil {
 			e.teardownForkNetwork(sandboxID, fnet.identity)
 		}
-		if len(rebinds) > 0 {
+		if len(rebinds) > 0 && e.volBackend != nil {
 			_ = e.volBackend.Cleanup(sandboxID)
 		}
+		_ = os.RemoveAll(sandboxDir)
+	}
+
+	// Load the snapshot PAUSED (resume=false). The rootfs drive rebind below MUST
+	// happen before the guest runs: PATCH /drives on the ROOT device of an
+	// already-RESUMED VM both leaves a write window (any writeback between resume
+	// and the rebind would hit the SHARED template rootfs) and may be rejected by
+	// Firecracker. Loading paused lets us rebind the rootfs (and the volume drives)
+	// while the guest is frozen, then resume explicitly. When networking is on,
+	// network_overrides rebinds the baked NIC to the fork's own tap (v1.15 supports
+	// this; the network analog of the relative vsock uds_path). nil overrides
+	// restores exactly as before. This mirrors the husk activate path's
+	// load-paused, rebind-rootfs, resume order.
+	if err := fcClient.LoadSnapshotWithOverrides(memFile, vmStateFile, false, overrides); err != nil {
+		cleanupFork()
 		return nil, fmt.Errorf("load snapshot: %w", err)
 	}
 
-	// Rebind each baked placeholder volume drive to THIS fork's backing now that
-	// the snapshot is loaded and resumed. The guest mounts the volumes only
-	// after it receives the post-restore vsock mount table (Task 4), so the
-	// PATCH lands before the device is in use. Firecracker supports updating a
-	// drive's path_on_host on a restored+resumed VM (v1.15).
+	// Rebind the baked "rootfs" drive to THIS fork's CoW clone while the VM is still
+	// PAUSED (loaded, not yet resumed), so the guest never writes a single block
+	// through the shared template rootfs. Skipped when no clone was prepared (no
+	// on-disk rootfs, e.g. mock paths). Fail closed: a rebind failure leaves the VM
+	// pointed at the shared template rootfs, the exact corruption hazard this
+	// prevents, so do NOT resume; tear the fork down.
+	if rootfsRebind != nil {
+		if err := fcClient.PatchDrive(rootfsRebind.DriveID, rootfsRebind.PathOnHost); err != nil {
+			cleanupFork()
+			return nil, fmt.Errorf("rebind rootfs drive to per-fork clone for %s: %w", sandboxID, err)
+		}
+	}
+
+	// Rebind each baked placeholder volume drive to THIS fork's backing while the
+	// VM is still PAUSED, before the guest mounts them (the guest mounts only after
+	// it receives the post-restore vsock mount table), so each volume drive points
+	// at the fork's OWN backing before any access. Firecracker supports updating a
+	// drive's path_on_host on a restored, paused VM (v1.15).
 	for _, rb := range rebinds {
 		if err := fcClient.PatchDrive(rb.DriveID, rb.PathOnHost); err != nil {
-			_ = fcClient.Kill()
-			if fnet != nil {
-				e.teardownForkNetwork(sandboxID, fnet.identity)
-			}
-			_ = e.volBackend.Cleanup(sandboxID)
+			cleanupFork()
 			return nil, fmt.Errorf("rebind volume drive %s for %s: %w", rb.DriveID, sandboxID, err)
 		}
+	}
+
+	// Resume the VM only AFTER the rootfs and volume drives are rebound, so the
+	// guest comes up already bound to its own per-fork rootfs clone and volume
+	// backings, never the shared template. Fail closed: a rejected resume means the
+	// VM never runs usably, so tear the fork down.
+	if err := fcClient.Resume(); err != nil {
+		cleanupFork()
+		return nil, fmt.Errorf("resume fork %s after drive rebind: %w", sandboxID, err)
 	}
 
 	elapsed := time.Since(start)

--- a/internal/fork/rootfs_cow_test.go
+++ b/internal/fork/rootfs_cow_test.go
@@ -1,0 +1,182 @@
+package fork
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realCopyReflinker is a reflinker seam that performs an honest byte copy from
+// src to dst (creating the parent dir). It stands in for the production FICLONE
+// clone so the per-fork rootfs CoW helper can be unit-tested with no subprocess
+// and no KVM: a divergent write to one clone must not be visible in the other,
+// which a byte copy models exactly (a real reflink clone diverges per-block on
+// first write with the same observable semantics).
+func realCopyReflinker(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src) //nolint:gosec // test-only paths under t.TempDir()
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst) //nolint:gosec // test-only paths under t.TempDir()
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+// newRootfsEngine builds an Engine with the per-fork rootfs CoW reflinker wired
+// to an honest byte copy, rooted at a temp dir, WITHOUT touching /dev/kvm or
+// Firecracker, so prepareForkRootfs is unit testable.
+func newRootfsEngine(t *testing.T) *Engine {
+	t.Helper()
+	return &Engine{
+		dataDir:       t.TempDir(),
+		rootfsReflink: realCopyReflinker,
+	}
+}
+
+// writeTemplateRootfs writes a fake template rootfs.ext4 with known bytes under
+// the engine data dir and returns its host path, mirroring the layout Fork uses
+// (<dataDir>/templates/<id>/rootfs.ext4).
+func writeTemplateRootfs(t *testing.T, e *Engine, templateID string, content []byte) string {
+	t.Helper()
+	dir := filepath.Join(e.dataDir, "templates", templateID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir template dir: %v", err)
+	}
+	p := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		t.Fatalf("write template rootfs: %v", err)
+	}
+	return p
+}
+
+func TestPrepareForkRootfsNoRootfsPathIsNoOp(t *testing.T) {
+	e := newRootfsEngine(t)
+	rebind, clone, err := e.prepareForkRootfs("tmpl", "sb1", "")
+	if err != nil {
+		t.Fatalf("prepareForkRootfs: %v", err)
+	}
+	if rebind != nil || clone != "" {
+		t.Errorf("expected no rebind for empty rootfs path, got rebind=%v clone=%q", rebind, clone)
+	}
+}
+
+func TestPrepareForkRootfsRebindsRootfsDrive(t *testing.T) {
+	e := newRootfsEngine(t)
+	tmpl := writeTemplateRootfs(t, e, "tmpl", []byte("template-bytes"))
+
+	rebind, clone, err := e.prepareForkRootfs("tmpl", "sb1", tmpl)
+	if err != nil {
+		t.Fatalf("prepareForkRootfs: %v", err)
+	}
+	if rebind == nil {
+		t.Fatal("expected a rootfs drive rebind, got nil")
+	}
+	// The drive id MUST be "rootfs": the template build attaches the root device
+	// under that id, and the rebind must target the same drive.
+	if rebind.DriveID != "rootfs" {
+		t.Errorf("rebind drive id = %q, want \"rootfs\"", rebind.DriveID)
+	}
+	if rebind.PathOnHost != clone {
+		t.Errorf("rebind path %q does not match clone path %q", rebind.PathOnHost, clone)
+	}
+	// The clone must NOT be the shared template rootfs: a rebind that points back
+	// at the template is exactly the shared-writable-inode bug.
+	if clone == tmpl {
+		t.Fatal("clone path equals the shared template rootfs: forks would share one writable inode")
+	}
+	if !strings.Contains(clone, "sb1") {
+		t.Errorf("clone path %q is not sandbox-scoped to sb1", clone)
+	}
+}
+
+func TestTwoForksGetDistinctRootfsBackingPaths(t *testing.T) {
+	e := newRootfsEngine(t)
+	tmpl := writeTemplateRootfs(t, e, "tmpl", []byte("pristine-template"))
+
+	_, cloneA, err := e.prepareForkRootfs("tmpl", "fork-a", tmpl)
+	if err != nil {
+		t.Fatalf("prepare fork-a: %v", err)
+	}
+	_, cloneB, err := e.prepareForkRootfs("tmpl", "fork-b", tmpl)
+	if err != nil {
+		t.Fatalf("prepare fork-b: %v", err)
+	}
+
+	if cloneA == cloneB {
+		t.Fatalf("two forks share one rootfs backing path %q (cross-fork write bleed)", cloneA)
+	}
+	if cloneA == tmpl || cloneB == tmpl {
+		t.Fatalf("a fork's rootfs backing equals the shared template (cloneA=%q cloneB=%q tmpl=%q)", cloneA, cloneB, tmpl)
+	}
+
+	// Distinct inodes: a byte copy (and a real reflink clone after first write)
+	// must not share an inode, so a write to one is invisible to the other.
+	if sameFileInode(t, cloneA, cloneB) {
+		t.Fatal("two forks' rootfs clones share one inode")
+	}
+	if sameFileInode(t, cloneA, tmpl) {
+		t.Fatal("a fork's rootfs clone shares the template inode")
+	}
+}
+
+func TestWriteInOneForkRootfsNotVisibleInSibling(t *testing.T) {
+	e := newRootfsEngine(t)
+	tmpl := writeTemplateRootfs(t, e, "tmpl", []byte("AAAAAAAAAAAA"))
+
+	_, cloneA, err := e.prepareForkRootfs("tmpl", "fork-a", tmpl)
+	if err != nil {
+		t.Fatalf("prepare fork-a: %v", err)
+	}
+	_, cloneB, err := e.prepareForkRootfs("tmpl", "fork-b", tmpl)
+	if err != nil {
+		t.Fatalf("prepare fork-b: %v", err)
+	}
+
+	// Guest A writes to its own rootfs backing.
+	if err := os.WriteFile(cloneA, []byte("SECRET-FROM-A"), 0o644); err != nil {
+		t.Fatalf("write to fork-a rootfs: %v", err)
+	}
+
+	// Guest B must still read the pristine template content, NOT A's write.
+	gotB, err := os.ReadFile(cloneB) //nolint:gosec // test path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read fork-b rootfs: %v", err)
+	}
+	if string(gotB) == "SECRET-FROM-A" {
+		t.Fatal("guest A's rootfs write bled into guest B: cross-fork rootfs write channel")
+	}
+
+	// The template source must also be untouched by A's write.
+	gotTmpl, err := os.ReadFile(tmpl) //nolint:gosec // test path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read template rootfs: %v", err)
+	}
+	if string(gotTmpl) == "SECRET-FROM-A" {
+		t.Fatal("guest A's rootfs write bled into the shared template source")
+	}
+}
+
+func sameFileInode(t *testing.T, a, b string) bool {
+	t.Helper()
+	ai, err := os.Stat(a)
+	if err != nil {
+		t.Fatalf("stat %s: %v", a, err)
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		t.Fatalf("stat %s: %v", b, err)
+	}
+	return os.SameFile(ai, bi)
+}


### PR DESCRIPTION
## Summary

Fixes blocker 5 of the mitos security remediation: the raw-forkd cross-fork rootfs write-bleed, and adds an honest not-for-untrusted-multi-tenant gate on the raw-forkd engine path.

## The bug

In raw-forkd mode, two forks of one snapshot shared a single writable rootfs inode. `internal/fork/engine.go` fork() hard-linked the template `rootfs.ext4` into each per-VM chroot (`os.Link`, same inode) and the baked rootfs drive was attached writable (`AddDrive("rootfs", ..., readOnly=false)`) and NEVER rebound per-fork. So guest A's rootfs writes landed in the same bytes guest B read: a cross-fork (and cross-tenant, since snapshots are node-flat) filesystem read/write channel. The husk path already fixed exactly this; raw-forkd did not.

## The fix (full per-fork rootfs CoW)

Each raw-forkd fork now gets its OWN copy-on-write clone of the template rootfs, mirroring the husk approach:

- `prepareForkRootfs` reflink-clones the template rootfs to `<dataDir>/sandboxes/<id>/rootfs.ext4` through the SAME `volume.Backend.ReflinkCopy` owner the husk per-activation rootfs CoW uses (reflink with full-copy fallback), so the two paths cannot drift.
- fork() loads the snapshot PAUSED (`resume=false`), rebinds the baked `rootfs` drive to the per-fork clone with `PatchDrive` while the guest is frozen, rebinds the volume drives, then `Resume`s.
- The template rootfs is now the READ-ONLY CoW SOURCE; no two forks, and no fork and the source, ever write the same rootfs path.
- The per-fork clone is hard-linked into the jailer chroot (never the shared template) and reaped with the sandbox dir at Terminate and on any in-flight fork failure.

The husk fork path is unchanged.

## Gating

raw-forkd also runs the forkd DaemonSet privileged with no jailer (a separate documented residual). forkd now logs a prominent startup warning that the raw-forkd (non-husk) engine path is NOT for untrusted multi-tenant workloads, and `docs/threat-model.md` documents the same.

## Tests

`internal/fork/rootfs_cow_test.go` proves, with no KVM (using the reflinker seam):
- two forks of one snapshot get DISTINCT rootfs backing paths and DISTINCT inodes;
- the rebind targets the `rootfs` drive at the per-fork clone path;
- a write in one fork's rootfs is NOT visible in a sibling or the template source.

Real-VM cross-fork rootfs isolation is KVM-gated (firecracker-test). All existing internal/fork engine + husk + volume tests stay green.

## threat-model delta

Flips the raw-forkd rootfs write-bleed row from open(critical) to fixed (per-fork CoW); keeps and clarifies the privileged-forkd not-for-untrusted-multi-tenant gating row.

## Verification

- `go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` clean
- `go test ./internal/fork/ ./internal/firecracker/` green
- `golangci-lint run` and `GOOS=linux golangci-lint run` clean on the touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
