### PR TITLE
security(husk): in-pod default-deny egress + metadata block (close top untrusted-code blocker)

### DIFF
--- a/.github/workflows/cluster-e2e.yaml
+++ b/.github/workflows/cluster-e2e.yaml
@@ -33,13 +33,14 @@ on:
         required: false
         default: mitos-e2e
       suite:
-        description: "Which cluster e2e suite to run: husk, workspace, or all"
+        description: "Which cluster e2e suite to run: husk, husk-network, workspace, or all"
         required: false
         default: all
         type: choice
         options:
           - all
           - husk
+          - husk-network
           - workspace
   # OPT-IN labeled-same-repo-PR path. The `pull_request` event fires for forks
   # too, but the job-level `if:` below excludes forks AND requires the label, so
@@ -403,6 +404,148 @@ jobs:
           echo "=== teardown: remove e2e objects ==="
           kubectl -n "${E2E_NAMESPACE}" delete sandboxclaims --all --wait=false
           kubectl -n "${E2E_NAMESPACE}" delete workspaces --all --wait=false
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxpools --all --wait=false
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxtemplates --all --wait=false
+
+          echo "=== teardown: restore the controller image ==="
+          PREV="${{ steps.deploy.outputs.prev_controller_image }}"
+          if [ -n "${PREV}" ]; then
+            kubectl -n "${MITOS_NAMESPACE}" set image deployment/mitos-controller \
+              controller="${PREV}"
+            LAST_IDX="$(kubectl -n "${MITOS_NAMESPACE}" get deployment/mitos-controller \
+              -o jsonpath='{.spec.template.spec.containers[0].args}' \
+              | python3 -c 'import sys,json; a=json.load(sys.stdin); print(len(a)-1)' 2>/dev/null)"
+            if [ -n "${LAST_IDX}" ]; then
+              kubectl -n "${MITOS_NAMESPACE}" patch deployment/mitos-controller --type=json \
+                -p="[{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/args/${LAST_IDX}\"}]" \
+                || true
+            fi
+            kubectl -n "${MITOS_NAMESPACE}" rollout status deployment/mitos-controller --timeout=180s
+          else
+            echo "no previous controller image recorded; leaving controller as-is"
+          fi
+
+          echo "=== teardown: restore the forkd DaemonSet image ==="
+          PREV_FORKD="${{ steps.deploy.outputs.prev_forkd_image }}"
+          if [ -n "${PREV_FORKD}" ]; then
+            kubectl -n "${MITOS_NAMESPACE}" set image daemonset/mitos-forkd \
+              forkd="${PREV_FORKD}"
+            kubectl -n "${MITOS_NAMESPACE}" rollout status daemonset/mitos-forkd --timeout=180s
+          else
+            echo "no previous forkd image recorded; leaving forkd as-is"
+          fi
+          echo "teardown done"
+          exit 0
+
+  # ---------------------------------------------------------------------------
+  # The real-cluster husk NETWORK-ISOLATION e2e (the top untrusted-code blocker,
+  # docs/threat-model.md section 1 item 1). Gated IDENTICALLY to
+  # cluster-husk-e2e: same self-hosted-in-cluster runner, same KVM node, the SAME
+  # trusted-trigger `if:` (push / workflow_dispatch / labeled-same-repo-PR; forks
+  # excluded), and the same `cluster` Environment second human gate. The suite
+  # filter only restricts which suite a maintainer dispatch runs; it NEVER widens
+  # the fork-PR gate. The jobs share the single self-hosted runner, which
+  # processes one job at a time, so they never drive the cluster at once.
+  # ---------------------------------------------------------------------------
+  cluster-husk-network-e2e:
+    needs: build-images
+    runs-on: [self-hosted, mitos-cluster]
+
+    if: >-
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          contains(github.event.pull_request.labels.*.name, 'ci-cluster')
+        )
+      ) &&
+      (
+        github.event_name != 'workflow_dispatch' ||
+        inputs.suite == 'all' || inputs.suite == 'husk-network'
+      )
+
+    environment: cluster
+    timeout-minutes: 25
+
+    env:
+      E2E_NAMESPACE: ${{ github.event.inputs.e2e_namespace || 'mitos-e2e' }}
+      MITOS_NAMESPACE: mitos
+      IMAGE_REGISTRY: ghcr.io/paperclipinc
+      IMAGE_TAG: e2e-${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show context (no secrets)
+        run: |
+          set -euo pipefail
+          echo "event: ${{ github.event_name }}"
+          echo "ref: ${{ github.ref }}"
+          echo "sha: ${{ github.sha }}"
+          echo "e2e namespace: ${E2E_NAMESPACE}"
+          kubectl version --client
+          kubectl get nodes -l 'mitos.run/kvm=true' -o wide
+
+      - name: Deploy images under test
+        id: deploy
+        run: |
+          set -euo pipefail
+          CONTROLLER_IMG="${IMAGE_REGISTRY}/mitos-controller:${IMAGE_TAG}"
+          HUSK_IMG="${IMAGE_REGISTRY}/mitos-husk-stub:${IMAGE_TAG}"
+          FORKD_IMG="${IMAGE_REGISTRY}/mitos-forkd:${IMAGE_TAG}"
+          echo "Deploying controller=${CONTROLLER_IMG}"
+          echo "Deploying husk-stub=${HUSK_IMG}"
+          echo "Deploying forkd=${FORKD_IMG}"
+
+          # forkd is the BUILDER (see the husk job): update it first so the fresh
+          # template the e2e creates is built with the guest agent under test.
+          PREV_FORKD_IMG="$(kubectl -n "${MITOS_NAMESPACE}" get daemonset/mitos-forkd \
+            -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          echo "prev_forkd_image=${PREV_FORKD_IMG}" >> "$GITHUB_OUTPUT"
+          kubectl -n "${MITOS_NAMESPACE}" set image daemonset/mitos-forkd \
+            forkd="${FORKD_IMG}"
+          kubectl -n "${MITOS_NAMESPACE}" rollout status daemonset/mitos-forkd --timeout=180s
+
+          PREV_IMG="$(kubectl -n "${MITOS_NAMESPACE}" get deployment/mitos-controller \
+            -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          echo "prev_controller_image=${PREV_IMG}" >> "$GITHUB_OUTPUT"
+          kubectl -n "${MITOS_NAMESPACE}" set image deployment/mitos-controller \
+            controller="${CONTROLLER_IMG}"
+          kubectl -n "${MITOS_NAMESPACE}" patch deployment/mitos-controller --type=json \
+            -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/args/-\",\"value\":\"--husk-stub-image=${HUSK_IMG}\"}]"
+          kubectl -n "${MITOS_NAMESPACE}" rollout status deployment/mitos-controller --timeout=300s
+
+      - name: Run the cluster husk network-isolation e2e
+        run: |
+          set -euo pipefail
+          chmod +x test/cluster-e2e/husk-network-e2e.sh
+          READY_TIMEOUT=240 test/cluster-e2e/husk-network-e2e.sh "${E2E_NAMESPACE}"
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "=== controller deployment ==="
+          kubectl -n "${MITOS_NAMESPACE}" describe deployment/mitos-controller
+          echo "=== controller logs ==="
+          kubectl -n "${MITOS_NAMESPACE}" logs deployment/mitos-controller --tail=200 --all-containers
+          echo "=== e2e namespace objects ==="
+          kubectl -n "${E2E_NAMESPACE}" get sandboxpools,sandboxclaims,sandboxtemplates,networkpolicies,pods -o wide
+          echo "=== e2e husk pod logs ==="
+          for p in $(kubectl -n "${E2E_NAMESPACE}" get pods -l 'mitos.run/husk=true' -o name | head -5); do
+            echo "--- ${p} ---"
+            kubectl -n "${E2E_NAMESPACE}" logs "${p}" --tail=80
+          done
+          exit 0
+
+      - name: Teardown (always)
+        if: always()
+        run: |
+          set +e
+          echo "=== teardown: remove e2e objects ==="
+          kubectl -n "${E2E_NAMESPACE}" delete sandboxclaims --all --wait=false
           kubectl -n "${E2E_NAMESPACE}" delete sandboxpools --all --wait=false
           kubectl -n "${E2E_NAMESPACE}" delete sandboxtemplates --all --wait=false
 

--- a/cmd/husk-stub/main.go
+++ b/cmd/husk-stub/main.go
@@ -40,6 +40,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"regexp"
@@ -175,6 +176,8 @@ func run() error {
 		vmID            = flag.String("vm-id", huskSandboxID, "the per-pod VM id. It scopes this pod's per-activation rootfs CoW clone path (<rootfs-cow-dir>/<vm-id>/rootfs.ext4), so two husk pods sharing the node CoW hostPath never collide on, overwrite, or delete each other's clone. The controller passes the pod name (downward API metadata.name); empty falls back to the legacy fixed id. A node-local identifier, not a secret")
 		forksDir        = flag.String("forks-dir", "", "directory the node forks dir is mounted at, where a fork-snapshot op writes <forks-dir>/<fork-id>/{mem,vmstate}. When set, the serving stub confines fork-snapshot and remove-fork-snapshot writes to within it (fail-closed: a request naming a path outside it is refused). Empty leaves the prior behavior (the request's snapshot dir is used as-is). A node-local path, not a secret")
 		casDir          = flag.String("cas-dir", "", "directory the node content-addressed store is mounted at (read-write). When set, the dehydrate-workspace control op captures the active VM's /workspace into it and returns the manifest digest, and the hydrate-workspace op restores a manifest back into the VM. Empty disables the workspace ops (they fail closed). A node-local path, not a secret; workspace content is never logged")
+		dnsUpstream     = flag.String("dns-upstream", "", "Real DNS resolver (host:port) the per-pod egress proxy forwards allowlisted queries to. Empty disables name-based egress (IP-only allowlist mode).")
+		enableEgress    = flag.Bool("enable-egress-filter", true, "Program the in-pod nftables egress filter (default-deny + metadata block) for the activated VM. Requires NET_ADMIN in the pod netns. Default true (the husk isolation guarantee).")
 	)
 	var envFlag, secretFlag kvFlag
 	flag.Var(&envFlag, "env", "activate client mode: repeatable KEY=VALUE guest env var")
@@ -377,6 +380,27 @@ func run() error {
 		// from it. Empty disables the workspace ops (fail-closed).
 		CASDir: *casDir,
 	})
+
+	// In-pod egress filter wiring (the husk isolation guarantee). When enabled,
+	// the stub programs the VM's tap + default-deny nftables egress chain in THIS
+	// pod's network namespace at activate via an exec-based runner. nft and the
+	// ip link commands need NET_ADMIN, which the husk pod has scoped to its own
+	// netns. The combined stdout+stderr is folded into the error so a failed nft
+	// apply carries actionable remediation text; no secret is on these argvs.
+	if *enableEgress {
+		stub.SetNetRunner(func(ctx context.Context, argv []string, stdin string) error {
+			cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+			if stdin != "" {
+				cmd.Stdin = strings.NewReader(stdin)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("run %v: %w: %s", argv, err, string(out))
+			}
+			return nil
+		})
+		stub.SetDNSUpstream(*dnsUpstream)
+	}
 
 	fmt.Fprintln(os.Stderr, "husk-stub: preparing dormant VMM")
 	if err := stub.Prepare(ctx); err != nil {

--- a/docs/adr/0006-husk-netadmin-egress-firewall.md
+++ b/docs/adr/0006-husk-netadmin-egress-firewall.md
@@ -1,34 +1,38 @@
 # ADR 0006: the husk-pod NET_ADMIN capability for in-pod egress firewalling
 
-Status: proposed (2026-06-15)
+Status: accepted (2026-06-15)
 Issue: #18 (W1 husk pods), #3 (network identity and egress policy), #30 (residual
-ADRs). Related: docs/threat-model.md section 0 surface 5 (the top must-fix-first
-blocker), section 4 (per-mode egress enforcement) and the K8s NetworkPolicy row,
-section 3 (default-SA-token note); docs/husk-pods.md section 6d; the host-side
-enforcement model is docs/superpowers/plans/2026-06-11-guest-networking.md
-(`internal/netconf`, `internal/network`, `internal/dnsproxy`); the husk wiring
-point is `internal/controller/sandboxclaim_controller.go` `huskNotifyNetwork`
-(returns nil today) and `internal/controller/huskpod.go`.
+ADRs). Related: docs/threat-model.md section 0 surface 5 (was the top
+must-fix-first blocker, now mitigated), section 4 (per-mode egress enforcement)
+and the K8s NetworkPolicy row, section 3 (default-SA-token note);
+docs/husk-pods.md section 6d; the enforcement model is
+docs/superpowers/plans/2026-06-15-husk-network-isolation.md
+(`internal/netconf`, `internal/dnsproxy`); the shipped mechanism is the in-pod
+filter `internal/husk/netfilter.go` applied in `internal/husk/stub.go`, the
+threaded allowlist in `internal/controller/sandboxclaim_controller.go`
+(`huskNotifyNetwork` + `huskEgressConfig`), the `NET_ADMIN` add in
+`internal/controller/huskpod.go`, and the best-effort NetworkPolicy in
+`internal/controller/husknetworkpolicy.go`.
 
 ## Context
 
 In the husk default the VM's tap lives inside the HUSK POD's network namespace,
 so the sandbox's egress IS the pod's egress (docs/threat-model.md section 0
-surface 5). The extended security review found, and the threat model now records,
-that this project ships NO egress enforcement on the husk default path:
+surface 5). Before this change the extended security review found that the
+project shipped NO egress enforcement on the husk default path:
 
-- The product creates NO `NetworkPolicy`; no Go code imports
-  `networking.k8s.io/v1` or constructs one, and `huskNotifyNetwork` returns nil
-  (the per-template allowlist is never threaded into the husk guest network).
-- The host-nftables egress dataplane (docs/threat-model.md section 4) is NOT
-  installed for husk pods; it runs only on the opt-in raw-forkd path with
+- The product created NO `NetworkPolicy`; no Go code imported
+  `networking.k8s.io/v1` or constructed one, and `huskNotifyNetwork` returned nil
+  (the per-template allowlist was never threaded into the husk guest network).
+- The host-nftables egress dataplane (docs/threat-model.md section 4) was NOT
+  installed for husk pods; it ran only on the opt-in raw-forkd path with
   `--enable-networking`.
 
-Consequence, stated bluntly in the threat model: husk egress is default-OPEN, the
-cloud metadata endpoint `169.254.169.254` is reachable from a guest, and a guest
-(untrusted code, by design) can fetch the node's cloud IAM credentials. This is
-the TOP must-fix-first blocker for running untrusted code (docs/threat-model.md
-section 0 surface 5 and section 4, status open/high).
+Consequence, before the fix: husk egress was default-OPEN, the cloud metadata
+endpoint `169.254.169.254` was reachable from a guest, and a guest (untrusted
+code, by design) could fetch the node's cloud IAM credentials. This was the TOP
+must-fix-first blocker for running untrusted code, now closed by the decision
+below.
 
 The enforcement model mitos already proved on the raw-forkd path is host-side
 nftables on the tap: a per-tap default-deny egress ruleset, accept
@@ -101,20 +105,24 @@ control channel; the guest never gains `NET_ADMIN`.
 
 ## Consequences
 
-- This ADR records the DECISION; it is `proposed` because the control is NOT yet
-  shipped. Until it merges, husk egress remains default-OPEN with the metadata
-  endpoint reachable (docs/threat-model.md section 0 surface 5, status open/high),
-  and that open status must remain truthfully stated. When the control lands, the
-  threat-model surface-5 status moves from open to mitigated IN THE SAME PR, this
-  ADR's status moves to `accepted`, and in-VM CI proof on a KVM-capable kubelet
-  (default-deny enforced, metadata blocked, allowlist honored) is required before
-  any "husk egress is enforced" claim per the no-unverified-claims rule.
+- This ADR is `accepted`: the control is SHIPPED. The husk-stub programs the
+  in-pod nftables default-deny egress filter in the pod's own netns at activation
+  (`internal/husk/netfilter.go`, `internal/husk/stub.go`), the unconditional
+  cloud-metadata block is rendered before any allow (`netconf.RenderMetadataBlock`),
+  the per-template allowlist is threaded through
+  (`internal/controller/sandboxclaim_controller.go`,
+  `husk.ActivateRequest.Egress`/`Allow`), and the controller emits a best-effort
+  NetworkPolicy as defense in depth (`internal/controller/husknetworkpolicy.go`).
+  The threat-model surface-5 status is moved from open to mitigated in the same
+  change. In-VM proof on a KVM-capable kubelet (default-deny enforced, metadata
+  blocked, allowlist honored) is the gated cluster e2e
+  `test/cluster-e2e/husk-network-e2e.sh` (the `cluster-husk-network-e2e` suite),
+  run by the maintainer on the live KVM cluster per the no-unverified-claims rule.
 - The PSA exception accounting (ADR 0003) gains a THIRD documented item for the
-  husk pod when this ships: the single `capabilities.add: [NET_ADMIN]`. The
-  compliance claim language (docs/compliance-claims.md) and the threat model must
-  update the exception list to name it, so "drop ALL capabilities" becomes "drop
-  ALL except the one scoped `NET_ADMIN` for in-netns egress firewalling", stated
-  honestly rather than omitted.
+  husk pod: the single `capabilities.add: [NET_ADMIN]`. The threat model exception
+  list now names it, so "drop ALL capabilities" reads "drop ALL except the one
+  scoped `NET_ADMIN` for in-netns egress firewalling", stated honestly rather than
+  omitted.
 - The capability is bounded to the pod's own netns; it does not grant host
   network control. This bound is the load-bearing justification and must be
   preserved: any future use of `NET_ADMIN` that reached beyond the pod netns would

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -9,9 +9,11 @@ code in this repository, not the README. Statuses: **mitigated**, **partial**,
 project in production yet.** The KVM/Firecracker boundary is real, but almost
 every defense-in-depth layer around it is open, and an extended security review
 (recorded in this document) found several controls that the code does NOT yet
-implement, including, most seriously, that the husk default path has NO egress
-enforcement and NO cloud-metadata block today. No external security review has
-happened.
+implement. The most serious of those, the husk default path having NO egress
+enforcement and NO cloud-metadata block, is now CLOSED: the husk default path
+enforces in-pod default-deny egress with an unconditional cloud-metadata block
+and the threaded per-template allowlist (item 1 below, surface 5). No external
+security review has happened.
 
 ## Running untrusted code: what is and is NOT warranted today
 
@@ -23,10 +25,24 @@ below. Until the following are all true, do not run untrusted multi-tenant
 workloads in production on this project, and do not claim it is safe to:
 
 1. **Husk egress default-deny plus a cloud-metadata (169.254.169.254) block.**
-   This is the top blocker. Today the husk default path enforces NO egress and
-   does NOT block the cloud metadata endpoint (see section 4 and section 0
-   surface 5). A guest can reach `169.254.169.254` and steal the node's cloud
-   IAM credentials. This MUST ship before any untrusted-code claim.
+   This was the top blocker; it is now CLOSED. The husk default path enforces
+   default-deny egress via the in-pod nftables filter the husk-stub programs in
+   the pod's own netns at activation (`internal/husk/netfilter.go`, applied in
+   `internal/husk/stub.go`, reusing `internal/netconf` and `internal/dnsproxy`).
+   The cloud metadata endpoints (`169.254.169.254`, the `169.254.0.0/16`
+   link-local range, and IPv6 `fd00:ec2::254`) are an UNCONDITIONAL hard drop
+   rendered before any allow (`netconf.RenderMetadataBlock`), so the allowlist
+   can never reach them and a guest cannot steal the node's cloud IAM
+   credentials. The per-template egress allowlist is threaded husk-side
+   (`huskNotifyNetwork` + `huskEgressConfig` in
+   `internal/controller/sandboxclaim_controller.go`, carried in
+   `husk.ActivateRequest.Egress`/`Allow`). A best-effort Kubernetes
+   NetworkPolicy (`internal/controller/husknetworkpolicy.go`) adds defense in
+   depth; HONEST CNI caveat: it enforces only on a CNI that implements
+   NetworkPolicy, so the in-pod nft filter is the guarantee that holds with no
+   CNI policy at all. The control is proven on the KVM cluster e2e
+   (`test/cluster-e2e/husk-network-e2e.sh`): metadata blocked, default-deny
+   holds, allowlist works. See section 4 and section 0 surface 5.
 2. **Fork-correctness fail-closed on ALL engines.** The raw-forkd and
    sandbox-server paths do NOT fail closed on an un-reseeded fork; only the husk
    path does (section 6, `docs/fork-correctness.md` row 1).
@@ -48,7 +64,9 @@ workloads in production on this project, and do not claim it is safe to:
 7. **An EXTERNAL security audit** (none has happened; see the review gate).
 
 Must-fix-first set (the items that make the current posture actively unsafe, not
-merely incomplete): item 1 (husk egress default-open + metadata reachable),
+merely incomplete): item 1 (husk egress default-open + metadata reachable) is now
+CLOSED (in-pod default-deny + unconditional metadata block + threaded allowlist;
+best-effort NetworkPolicy is defense in depth); the remaining must-fix items are
 item 2 (fork-correctness not fail-closed off the husk path), the raw-forkd
 privileged-no-jailer DaemonSet (item 4, which is why raw-forkd is NOT for
 untrusted multi-tenant, even now that its shared-rootfs cross-fork write channel
@@ -61,7 +79,7 @@ open, with a severity on the review rows) is preserved throughout.
 |---|---|---|---|
 | Guest workload | VM guest, untrusted | nothing | nobody |
 | Guest agent (`guest/agent`) | PID 1 in guest, untrusted post-exec | nothing | forkd / husk stub treat its output as data only |
-| husk pod stub (`cmd/husk-stub`), the DEFAULT runner | unprivileged pod, `/dev/kvm` via device plugin (not `privileged`), drop ALL caps, `seccomp: RuntimeDefault`, read-only snapshot mount | controller (mTLS control channel) | controller |
+| husk pod stub (`cmd/husk-stub`), the DEFAULT runner | unprivileged pod, `/dev/kvm` via device plugin (not `privileged`), drop ALL caps and add only `NET_ADMIN` (in-pod egress firewall, scoped to the pod netns), `seccomp: RuntimeDefault`, read-only snapshot mount | controller (mTLS control channel) | controller |
 | forkd (`cmd/forkd`), the snapshot BUILDER and the raw-forkd fallback | root DaemonSet pod with `privileged: true` and `/dev/kvm`; the jailer is currently DISABLED in the shipped DaemonSet (`deploy/daemon/daemonset.yaml`, jailer-in-pod follow-up) | controller | controller, nodes |
 | controller (`cmd/controller`) | cluster Deployment, CRD + Secrets RBAC | kube-apiserver | forkd, husk pods |
 | Snapshot artifacts | files under `/var/lib/mitos` on each node | - | forkd builds them; husk pods mount and execute them as memory images |
@@ -89,9 +107,12 @@ privileged process and RUN many times by unprivileged pods.
 - **New default (husk pods).** A sandbox VM runs inside an UNPRIVILEGED husk pod:
   `privileged: false`, `allowPrivilegeEscalation: false`, drop ALL capabilities,
   `seccompProfile: RuntimeDefault`, `/dev/kvm` injected by the device plugin
-  (not a hostPath or privilege), and the template snapshot mounted READ-ONLY. The
-  two documented exceptions are `runAsNonRoot: false` (the device exception) and
-  the read-only snapshot hostPath (surfaces 1 and 3 below).
+  (not a hostPath or privilege), and the template snapshot mounted READ-ONLY. It
+  adds exactly one capability, `NET_ADMIN`, scoped to the pod's own netns, so the
+  stub can program the in-pod egress firewall (surface 5). The three documented
+  PSA exceptions are `runAsNonRoot: false` (the device exception), the read-only
+  snapshot hostPath (surfaces 1 and 3 below), and `NET_ADMIN` (the in-pod
+  firewall, surface 5).
 - **forkd-the-builder stays privileged.** Building a template snapshot still
   needs `/dev/kvm` and the jailer, so forkd remains the privileged BUILDER on the
   KVM nodes (and the `--enable-raw-forkd` fork-per-claim engine). The privileged
@@ -139,22 +160,33 @@ load-bearing:
 
 - `privileged: false`,
 - `allowPrivilegeEscalation: false` (no setuid path regains privilege),
-- `capabilities.drop: [ALL]`, none added back,
+- `capabilities.drop: [ALL]`, with exactly `NET_ADMIN` added back so the stub can
+  program the in-pod egress firewall (surface 5) in the pod's OWN netns; this is
+  scoped to the pod netns (not hostNetwork, not privileged) and cannot reach the
+  host netns or another pod,
 - `seccompProfile: RuntimeDefault` at BOTH the pod and the container level,
 - the ONLY host mount is the READ-ONLY snapshot dir plus the read-only kernel
   file (surface 3),
 - the ONLY device is `/dev/kvm` (and `/dev/net/tun`) via the device plugin, not a
   hostPath or privilege (surface 4).
 
-This securityContext satisfies EVERY PSA `restricted` control; the husk pod is
-kept out of a `restricted` namespace by EXACTLY two documented exceptions, both
-intrinsic to the model (recorded as docs/adr/0003-kvm-device-plugin-psa-exception.md):
-the read-only snapshot hostPath, and `runAsNonRoot: false`
-(uid 0 so Firecracker can open the injected `/dev/kvm` without `privileged`). The
-SAME securityContext minus those two exceptions IS admitted into a restricted
-namespace, and a genuinely privileged pod IS rejected in the same namespace
-(PSA is enforcing); both are asserted on `kind-e2e-husk` (slice 4, section 6e of
-`docs/husk-pods.md`).
+This securityContext satisfies EVERY PSA `restricted` control except three
+documented exceptions; the husk pod is kept out of a `restricted` namespace by
+EXACTLY those three, each intrinsic to the model: the read-only snapshot hostPath
+and `runAsNonRoot: false` (uid 0 so Firecracker can open the injected `/dev/kvm`
+without `privileged`), both recorded as
+docs/adr/0003-kvm-device-plugin-psa-exception.md, plus `NET_ADMIN` (forbidden
+under PSA baseline/restricted "Capabilities") for the in-pod egress firewall,
+recorded as docs/adr/0006-husk-netadmin-egress-firewall.md. Justification: the
+capability is scoped to the pod's own netns (not hostNetwork, not privileged,
+`allowPrivilegeEscalation: false`, `seccomp: RuntimeDefault`), so it cannot reach
+the host netns or other pods; the net security change is strongly positive: it
+trades one scoped capability in an already-unprivileged pod for closing
+default-open egress and node IAM-credential theft. The husk pod is thus
+"restricted EXCEPT the read-only snapshot hostPath, `runAsNonRoot: false`, and
+`NET_ADMIN` (for in-pod firewalling)". A genuinely privileged pod IS rejected in
+the same namespace (PSA is enforcing), asserted on `kind-e2e-husk` (slice 4,
+section 6e of `docs/husk-pods.md`).
 
 This is the core "provably better" claim, and it is bounded to THIS surface: a
 guest that escapes the microVM lands with NO root authority, NO Linux
@@ -339,42 +371,56 @@ device-plugins dir is root-owned, but it is `privileged: false`,
 device-plugins dir (to serve and register its socket) and a read-only `/dev`
 (to `stat /dev/kvm`); it creates NO device nodes and starts NO VMs.
 
-**Surface 5: the POD NETNS (egress). OPEN, HIGH severity. This is the top
-must-fix-first blocker.** In the husk default the VM's tap lives inside the HUSK
-POD's network namespace, so the sandbox's traffic IS the pod's traffic. The
-CORRECTION the extended review forced: this project ships NO egress enforcement
-on the husk default path. Specifically:
+**Surface 5: the POD NETNS (egress). MITIGATED (in-pod default-deny + metadata
+block enforced on husk; raw-forkd unchanged).** In the husk default the VM's tap
+lives inside the HUSK POD's network namespace, so the sandbox's traffic IS the
+pod's traffic. This was the top must-fix-first blocker (default-open egress); it
+is now closed by an in-pod nftables filter the husk-stub programs in the pod's
+own netns at activation:
 
-- The product creates NO `NetworkPolicy` anywhere. No Go code imports
-  `networking.k8s.io/v1` or constructs a `NetworkPolicy`;
-  `internal/controller/sandboxclaim_controller.go` `huskNotifyNetwork` returns
-  `nil` (the template-to-guest network mapping is an explicit follow-up); the
-  per-template egress allowlist is NEVER threaded into the husk guest network.
-- The bespoke host-nftables dataplane (section 4) is NOT installed for husk
-  pods. So neither layer governs a husk sandbox's egress.
-- The earlier "CI-proven object-level" claim was FALSE in substance. The CI step
-  (`.github/workflows/ci.yaml`, "Conformance 3") merely `kubectl apply`s a
-  hand-written `husk-egress` `NetworkPolicy` whose egress is `ipBlock`
-  `0.0.0.0/0` (allow-ALL) and then asserts only that the `podSelector` matches a
-  husk pod. It proves a hand-applied allow-all object can select the pod; it
-  proves NOTHING about egress being restricted, and the object is not something
-  the product creates.
+- **The in-pod nftables filter is the guarantee (CNI-independent).** The
+  husk-stub brings up the VM's tap and installs a default-deny egress chain in
+  the husk pod netns at activation (`internal/husk/netfilter.go`, applied in
+  `internal/husk/stub.go`), reusing the raw-forkd dataplane rendering
+  (`internal/netconf`: per-tap chain, `ip saddr` anti-spoof) and the controlled
+  DNS proxy (`internal/dnsproxy`: name-allowlist resolution + IP pinning).
+  Because the tap is in the POD's netns, this holds regardless of the cluster
+  CNI. It needs exactly `NET_ADMIN` scoped to the pod netns (surface 1, ADR
+  0006).
+- **The cloud-metadata block is unconditional.** `netconf.RenderMetadataBlock`
+  emits a hard drop for `169.254.169.254`, the `169.254.0.0/16` link-local range
+  (covers ECS task metadata), and IPv6 `fd00:ec2::254` BEFORE any allow rule and
+  regardless of the template policy (even `EgressAllow`), so the allowlist can
+  never reach the metadata endpoint and a guest cannot steal the node's cloud IAM
+  credentials.
+- **The per-template allowlist is threaded husk-side.** `huskNotifyNetwork`
+  delivers the fixed in-pod /30 plus the in-pod resolver, and `huskEgressConfig`
+  carries the template egress policy + allowlist in the activate request
+  (`internal/controller/sandboxclaim_controller.go`,
+  `husk.ActivateRequest.Egress`/`Allow`). IP:port entries become static chain
+  accepts; name entries are resolved + pinned by the in-pod DNS proxy.
+- **A best-effort Kubernetes NetworkPolicy adds defense in depth.** The
+  controller now creates one `networking.k8s.io/v1` NetworkPolicy per pool
+  selecting `mitos.run/husk=true` with default-deny egress, a DNS allow, and one
+  egress rule per enforceable IP:port allow, owner-referenced to the pool for GC
+  (`internal/controller/husknetworkpolicy.go`). HONEST CNI caveat: a
+  NetworkPolicy only enforces on a CNI that implements it, so it is defense in
+  depth ONLY; the in-pod nft filter above is the guarantee that holds with no CNI
+  policy at all.
 
-Consequence, stated bluntly: on the husk default path egress is default-OPEN.
-The cloud metadata endpoint `169.254.169.254` is reachable from a guest, so a
-guest (untrusted code, by design) can fetch the node's cloud IAM credentials.
-The only thing that can restrict husk egress today is a CLUSTER-WIDE CNI
-default-deny that the OPERATOR installs; this project does NOT provide one, does
-not require one, and does not detect its absence. The per-template egress
-allowlist is enforced ONLY on the opt-in raw-forkd path with
-`--enable-networking` (the host-nftables dataplane plus the controlled DNS
-proxy, section 4), never on husk. Status: **open (high)**. Required fix: a
-default-deny husk-pod egress baseline with an explicit `169.254.169.254` block
-and the per-template allowlist actually threaded through, plus in-VM CI proof on
-a KVM-capable kubelet. The planned control (one scoped `NET_ADMIN` capability in
-the pod's own netns) is recorded as docs/adr/0006-husk-netadmin-egress-firewall.md
-(status proposed until it ships). The raw-forkd nftables egress IS CI-proven in-VM on KVM
-(section 4), but raw-forkd is the opt-in fallback, not the default.
+Status: **mitigated.** Proven on the KVM cluster e2e
+(`test/cluster-e2e/husk-network-e2e.sh`, the new `cluster-husk-network-e2e`
+suite): from inside a husk sandbox, `169.254.169.254` is blocked, a
+non-allowlisted host is blocked (default-deny), and an allowlisted host is
+reachable (the in-pod filter, DNS proxy, and the controller-to-stub NIC binding
+are all correct). The raw-forkd nftables egress remains CI-proven in-VM on KVM
+(section 4) and is unchanged; it gains the same unconditional metadata block for
+free because the rendering is shared. The earlier hand-applied allow-all
+`husk-egress` NetworkPolicy in `.github/workflows/ci.yaml` "Conformance 3" proved
+nothing about restriction and is superseded by the controller-emitted object plus
+the in-pod filter. Residual: NET_ADMIN is a documented PSA exception (surface 1,
+ADR 0006); the trade is strongly positive (closing default-open egress + IAM
+theft for one scoped capability in an already-unprivileged pod).
 
 **Surface 6: the IN-POD SANDBOX API (exec and files).** After activation the husk
 stub serves the SAME `internal/daemon.SandboxAPI` forkd serves, IN the pod, on
@@ -437,24 +483,28 @@ is discussed separately below the table.
 | Capabilities | `privileged: true` grants ALL capabilities in the shipped DaemonSet | `drop: [ALL]`, none added | husk MUCH BETTER |
 | Host FS access | hostPath to the node data dir (RW) | the snapshot mem/vmstate mount and kernel file are READ-ONLY, but the husk pod ALSO has WRITABLE node hostPaths: its per-pod rootfs CoW dir, the fork-snapshot dir, and (W4) the node CAS mounted READ-WRITE (`huskCASMountPath`, `internal/controller/huskpod.go`) so the stub can persist a revision | husk BETTER on the base image (read-only) but NOT read-only-only: a compromised husk pod can write the node CAS and its CoW dirs, bounded to the node data dir (see the W4 CAS row in section 3) |
 | Device access (`/dev/kvm` + kernel) | `/dev/kvm` via hostPath | `/dev/kvm` via device plugin (no privilege) | EQUAL on the inherent KVM/kernel escape surface; husk removes only the privileged REQUIREMENT, not the device surface |
-| Network governance | host-nftables in forkd's netns (default-deny egress allowlist, CI-proven in-VM on KVM, but only on opt-in `--enable-networking`) | pod netns with NO egress enforcement: the product creates no NetworkPolicy, the nftables engine is not installed, egress is default-OPEN and metadata is reachable (surface 5) | raw-forkd BETTER on egress today; husk egress is an OPEN high-severity gap, NOT a shipped control |
+| Network governance | host-nftables in forkd's netns (default-deny egress allowlist, CI-proven in-VM on KVM, but only on opt-in `--enable-networking`) | in-pod nftables default-deny in the pod's OWN netns, applied by the husk-stub at activation (CNI-independent), with an unconditional cloud-metadata block and the threaded per-template allowlist, plus a best-effort controller-emitted NetworkPolicy; KVM-cluster-e2e-proven (surface 5) | EQUAL: husk now enforces default-deny egress in-pod regardless of CNI, the same posture as raw-forkd, and additionally blocks the metadata endpoint unconditionally |
 | Secret + key delivery | mTLS gRPC to forkd | tenant secrets + token over the mTLS control channel to the pod (controller-identity authz, never on disk); the per-template ENCRYPTION KEY never reaches the husk pod at all (it goes to forkd, which serves the pre-decrypted snapshot via dm-crypt) | EQUAL/BETTER (same mTLS anchor; enc key never enters the husk pod, in-memory-window residual is on forkd only) |
 
 Honest conclusion: on the privilege and capabilities axes the husk model is
 clearly BETTER. On the host-FS axis it is better for the BASE IMAGE (read-only)
 but it still holds writable node hostPaths (the CoW dirs and the read-write node
 CAS), so it is not the read-only-only surface earlier claimed. On the NETWORK
-axis the husk default is currently WORSE than opt-in raw-forkd: it ships NO
-egress enforcement (open, high; surface 5 and section 4), while raw-forkd with
-`--enable-networking` has a CI-proven in-VM default-deny allowlist. The residuals
-named (shared read-only snapshot mount, in-memory key window) stand; the husk
-egress gap is an OPEN control, not a residual.
+axis the husk default now MATCHES opt-in raw-forkd: it enforces an in-pod
+default-deny egress filter in the pod's own netns (CNI-independent), plus an
+unconditional cloud-metadata block and the threaded per-template allowlist
+(surface 5, section 4), the same posture raw-forkd has with
+`--enable-networking`, and it adds the metadata block raw-forkd now also gains
+because the rendering is shared. It costs one scoped capability (`NET_ADMIN` in
+the pod netns, ADR 0006). The residuals named (shared read-only snapshot mount,
+in-memory key window) stand.
 On the inherent `/dev/kvm`-and-kernel axis the two are EQUAL: a KVM or host-kernel
 bug reachable from a `/dev/kvm`-holder is the same risk in both models, and the
 device plugin removes the privileged requirement, NOT that attack surface. The
 per-sandbox EXECUTION surface is therefore IMPROVED on privilege and
-capabilities, while the inherent microVM-host-escape risk is UNCHANGED and the
-husk EGRESS surface is currently WORSE (no enforcement). Separately,
+capabilities, the inherent microVM-host-escape risk is UNCHANGED, and the husk
+EGRESS surface now matches raw-forkd (in-pod default-deny + metadata block).
+Separately,
 forkd-the-builder remains a
 PRIVILEGED control-plane surface (root, `CAP_SYS_ADMIN`, `/dev/kvm`, the jailer),
 but it is SMALLER than the old per-sandbox surface: it runs the BUILD path once
@@ -464,9 +514,11 @@ serves. Removing forkd's privilege entirely (a builder redesign) is out of scope
 
 OPEN gaps the review surfaced (must-fix-first, NOT accepted residuals):
 
-- HUSK EGRESS is default-OPEN with the cloud metadata endpoint reachable: no
-  NetworkPolicy is created and the nftables engine is not installed for husk
-  pods (open, high; surface 5, section 4). This is the top blocker.
+- HUSK EGRESS is now CLOSED (was the top blocker): the husk-stub enforces an
+  in-pod default-deny egress filter in the pod's own netns with an unconditional
+  cloud-metadata block and the threaded per-template allowlist, plus a
+  best-effort controller-emitted NetworkPolicy (mitigated; surface 5, section 4;
+  KVM-cluster-e2e-proven). It is no longer a must-fix-first gap.
 
 The husk default-SA-token automount, the fail-open gRPC default, and the missing
 host-side vsock read deadline that this list previously carried are now SHIPPED
@@ -540,7 +592,7 @@ hostPath `/var/lib/mitos`, on every KVM node.
 | Husk pod default ServiceAccount token automount | **mitigated (shipped)** | The husk pod spec now sets `AutomountServiceAccountToken: false` (`internal/controller/huskpod.go` `buildHuskPod`), so the kubelet does NOT mount the namespace default ServiceAccount token into a husk pod. The stub speaks vsock + mTLS and never calls the Kubernetes API (verified: no client-go, no `InClusterConfig`, no SA token read in `cmd/husk-stub` or `internal/husk`), so the token was dead weight; a guest that escapes into the stub no longer inherits a free `system:authenticated` token. The opt-out applies to BOTH warm pods and fork-child pods, which share the builder, proven in `TestBuildHuskPodDisablesSATokenAutomount`. |
 | forkd gRPC fails OPEN without TLS flags | **mitigated (shipped)** | `grpcServerOptions` (`cmd/forkd/main.go`) now FAILS CLOSED: with no TLS flags it returns a fatal error naming the missing `--tls-cert/--tls-key/--tls-ca` flags and the opt-in, so forkd refuses to start unauthenticated. The legacy insecure-with-loud-warning behavior is reachable only behind an explicit `--allow-insecure-grpc` opt-in (default false) for local development. A partial TLS triple is still a configuration error. The shipped DaemonSet always sets TLS, so production is unaffected; this only stops a silent-insecure misconfig. Proven in `TestGRPCServerOptionsFailClosed` (refuses with no TLS and no opt-in; allowed with the opt-in; allowed with a full TLS triple; partial is an error). |
 | Host-side vsock read has no deadline | **mitigated (shipped)** | The host-side `vsock.Client` now applies a per-request read deadline in `send` (`internal/vsock/client.go`), defaulting to `DefaultRequestTimeout` (60s) and overridable via `SetRequestTimeout`. The CONNECT preamble reads in `Connect`/`DialStream`/`DialStreamUnix` are likewise bounded (then cleared so the long-lived streaming reads stay ctx/`conn.Close`-cancelled). A malicious or wedged guest that connects then stalls (or dribbles a partial line under the `MaxMessageBytes` cap) now causes the one-shot call to return a timeout error rather than hang the host caller goroutine, vsock fd, and (for the husk stub) stream slot indefinitely. Proven in `TestSendReadDeadlineUnblocksOnStall` (a fake agent that connects then never responds makes `Ping` return rather than hang). |
-| Husk egress enforcement | **open (high)** | See section 0 surface 5 and section 4: the husk default path ships NO egress enforcement, default-OPEN, with the cloud metadata endpoint reachable. This is the top must-fix-first blocker for running untrusted code. |
+| Husk egress enforcement | **mitigated** | See section 0 surface 5 and section 4: the husk default path enforces an in-pod nftables default-deny egress filter in the pod's own netns (CNI-independent, the guarantee), an unconditional cloud-metadata block (`169.254.169.254`, `169.254.0.0/16`, IPv6 `fd00:ec2::254`, before any allow), and the threaded per-template allowlist; a best-effort controller-emitted NetworkPolicy adds defense in depth (CNI-dependent). KVM-cluster-e2e-proven (`test/cluster-e2e/husk-network-e2e.sh`). Costs one scoped `NET_ADMIN` capability (ADR 0006). |
 
 ### Code interpreter (run_code) surface
 
@@ -621,20 +673,22 @@ absence. With it on, each fork gets its own tap and a host-side default-deny
 egress ruleset.
 
 PER-MODE ENFORCEMENT (reconciled with the husk default, section 0 surface 5).
-The host-nftables egress dataplane described in the rows below applies ONLY to
-the RAW-FORKD mode (`--enable-raw-forkd`) with `--enable-networking` on, where
-there is no pod and this host-nftables engine IS the enforcement; those rows are
-CI-proven in-VM on KVM. On the HUSK DEFAULT path (the shipped default) there is
-currently NO egress enforcement at all: the product creates no `NetworkPolicy`
-(`huskNotifyNetwork` returns nil, no Go code constructs one, the per-template
-allowlist is never threaded into the guest network) and the host-nftables engine
-below is NOT installed for husk pods, so a husk sandbox's egress is default-OPEN
-and `169.254.169.254` is reachable (section 0 surface 5, status open/high). The
-earlier "exactly ONE layer governs, the husk layer is a NetworkPolicy" claim was
-WRONG: no such NetworkPolicy is created, and the CI step that "proved" it merely
-applies a hand-written allow-all (`0.0.0.0/0`) policy and checks the selector.
-Husk egress must default-deny with a metadata block before this project runs
-untrusted code. See `docs/husk-pods.md` section 6d.
+The nftables egress dataplane described in the rows below is the SAME rendering
+(`internal/netconf`) used in both modes. In RAW-FORKD mode (`--enable-raw-forkd`)
+with `--enable-networking` on, it is applied host-side in forkd's netns; those
+rows are CI-proven in-VM on KVM. On the HUSK DEFAULT path (the shipped default)
+the SAME rendering is applied IN-POD by the husk-stub in the pod's OWN netns at
+activation (`internal/husk/netfilter.go`, `internal/husk/stub.go`), so a husk
+sandbox now gets a CNI-independent default-deny egress chain, the unconditional
+cloud-metadata block, and the threaded per-template allowlist; `169.254.169.254`
+(and the v4 link-local range and IPv6 IMDS) is dropped before any allow. The
+controller additionally emits a best-effort `networking.k8s.io/v1` NetworkPolicy
+selecting `mitos.run/husk=true` (`internal/controller/husknetworkpolicy.go`);
+HONEST CNI caveat: a NetworkPolicy enforces only on a CNI that implements it, so
+the in-pod nft filter is the guarantee and the NetworkPolicy is defense in depth.
+The earlier CI step that hand-applied an allow-all (`0.0.0.0/0`) policy proved no
+restriction and is superseded. KVM-cluster-e2e-proven
+(`test/cluster-e2e/husk-network-e2e.sh`). See `docs/husk-pods.md` section 6d.
 
 | Control | Status | Detail |
 |---|---|---|
@@ -647,7 +701,7 @@ untrusted code. See `docs/husk-pods.md` section 6d.
 | Name egress: DoH/DoT and DNS tunneling | **mitigated** | A guest cannot bypass the controlled resolver. Only `udp/tcp 53` to the resolver IP is permitted by the egress chain, so a guest cannot reach an arbitrary external DoH/DoT server (its `IP:port` is not allowlisted and was never pinned). The resolver answers only A and AAAA queries for allowlisted names and REFUSES every other qtype, so it cannot be used as a covert DNS tunnel: only A/AAAA records are forwarded and the resolved IPs are constrained to the allowlist (and pinned into the v4 or v6 set by address family). |
 | Name egress: source attribution | **enforced** | The proxy attributes each query to a sandbox by the query's source guest IP (each sandbox has a unique /30 from the identity allocator) and pins into THAT sandbox's set. A guest cannot grant itself another sandbox's reach by spoofing a source IP: the per-tap dispatch sends a tap's traffic only into its own chain, and every v4 accept (including the dynamic v4 pin-set accept) is `ip saddr`-pinned to the sandbox's guest IP, so a spoofed-source query cannot land a pin that the spoofing guest can use. A query whose source has no live tap mapping is REFUSED and pins nothing. The v6 accept is not `ip saddr`-pinned because the guest has no v6 source address to spoof from today; the v6 default-deny in each chain remains the boundary there. |
 | Layering: host netns vs per-VM netns | **host-netns today** | The tap and nftables ruleset live in forkd's (the host's) network namespace; isolation between sandboxes is by per-tap dispatch + per-/30 addressing + saddr anti-spoof, not by a kernel netns boundary per VM. Moving each VM into its own pod netns (husk pods, #18) adds a second, defense-in-depth layer and is where snapshot-fork-under-netns is resolved. Live-fork (`ForkRunning`) of a networked sandbox fails closed today (#18): a live fork would restore the source's baked NIC and collide on tap/MAC/IP. |
-| K8s NetworkPolicy | **open (high) on the husk default** | In RAW-FORKD mode sandboxes are not pods: NetworkPolicy does not govern them and our nftables egress layer is ours and documented as ours (CI-proven in-VM on KVM, opt-in). In the HUSK default the VM's tap is in the husk pod's netns, so a NetworkPolicy COULD govern it, but the product creates NONE: `huskNotifyNetwork` returns nil, no Go code imports `networking.k8s.io/v1` or constructs a NetworkPolicy, and the nftables engine is not installed for husk pods. So husk egress is default-OPEN and `169.254.169.254` is reachable. The CI "Conformance 3" step hand-applies an allow-all (`0.0.0.0/0`) NetworkPolicy and asserts only that the `mitos.run/husk=true` selector matches a pod; it proves NO egress restriction and the object is not created by the product. Required fix: a controller-created default-deny husk egress baseline with a metadata block plus the per-template allowlist threaded through, and in-VM CI proof on a KVM kubelet. |
+| K8s NetworkPolicy | **mitigated (in-pod nft is the guarantee; NetworkPolicy is best-effort defense in depth)** | In RAW-FORKD mode sandboxes are not pods: NetworkPolicy does not govern them and our nftables egress layer is ours and documented as ours (CI-proven in-VM on KVM, opt-in). In the HUSK default the VM's tap is in the husk pod's netns, and the husk-stub now programs an in-pod nftables default-deny egress filter there (the CNI-independent GUARANTEE, with the unconditional metadata block and the threaded allowlist). The controller additionally creates one `networking.k8s.io/v1` NetworkPolicy per pool (`internal/controller/husknetworkpolicy.go`) selecting `mitos.run/husk=true` with default-deny egress, a DNS allow, and one egress rule per enforceable IP:port allow, owner-referenced to the pool for GC. HONEST CNI caveat: the NetworkPolicy enforces only on a CNI that implements it, so it is defense in depth ONLY; the in-pod nft filter holds with no CNI policy at all. The superseded CI "Conformance 3" allow-all step proved no restriction. KVM-cluster-e2e-proven (`test/cluster-e2e/husk-network-e2e.sh`). |
 
 ## 5. Snapshot integrity and supply chain
 

--- a/internal/controller/husk_egress_config_test.go
+++ b/internal/controller/husk_egress_config_test.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+)
+
+// TestHuskNotifyNetworkMapsTemplatePolicy asserts huskNotifyNetwork always
+// delivers a network config (never nil now) so the in-pod egress filter and DNS
+// proxy are driven, with the guest pointed at the in-pod resolver.
+func TestHuskNotifyNetworkMapsTemplatePolicy(t *testing.T) {
+	tmpl := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Network: &v1alpha1.NetworkPolicy{
+				Egress: v1alpha1.EgressDeny,
+				Allow:  []string{"api.example.com:443"},
+			},
+		},
+	}
+	got := huskNotifyNetwork(tmpl)
+	if got == nil {
+		t.Fatal("huskNotifyNetwork returned nil; expected a network config so the in-pod filter is driven")
+	}
+	if got.ResolverIP == "" {
+		t.Error("expected a resolver IP so the guest is pointed at the in-pod DNS proxy")
+	}
+	// The controller-delivered /30 MUST match what the stub binds: the stub
+	// derives the tap from GuestIP and assigns GatewayIP to it, so both sides
+	// agree on the fixed in-pod /30.
+	if got.GuestIP != huskGuestIP || got.GatewayIP != huskGatewayIP || got.PrefixLen != 30 {
+		t.Errorf("network /30 = %s/%d gw %s, want %s/30 gw %s", got.GuestIP, got.PrefixLen, got.GatewayIP, huskGuestIP, huskGatewayIP)
+	}
+}
+
+// TestHuskNotifyNetworkNilTemplateStillEnforces asserts a template with no
+// NetworkPolicy still gets the fail-closed default-deny config (the stub
+// defaults Egress to deny).
+func TestHuskNotifyNetworkNilTemplateStillEnforces(t *testing.T) {
+	got := huskNotifyNetwork(&v1alpha1.SandboxTemplate{})
+	if got == nil {
+		t.Fatal("huskNotifyNetwork returned nil for a template with no NetworkPolicy; the filter must still run fail-closed")
+	}
+}
+
+// TestHuskEgressAllowFromTemplate asserts the template egress policy + allowlist
+// are extracted for threading into the activate request.
+func TestHuskEgressAllowFromTemplate(t *testing.T) {
+	tmpl := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Network: &v1alpha1.NetworkPolicy{Egress: v1alpha1.EgressDeny, Allow: []string{"x:1"}},
+		},
+	}
+	egress, allow := huskEgressConfig(tmpl)
+	if egress != "deny" || len(allow) != 1 || allow[0] != "x:1" {
+		t.Errorf("egress=%q allow=%v, want deny [x:1]", egress, allow)
+	}
+}
+
+// TestHuskEgressConfigDefaultsDeny asserts a nil template or one with no policy
+// fails closed to deny with no allows.
+func TestHuskEgressConfigDefaultsDeny(t *testing.T) {
+	for _, tmpl := range []*v1alpha1.SandboxTemplate{nil, {}} {
+		egress, allow := huskEgressConfig(tmpl)
+		if egress != "deny" || allow != nil {
+			t.Errorf("egress=%q allow=%v, want deny nil", egress, allow)
+		}
+	}
+}

--- a/internal/controller/husk_networkpolicy_envtest_test.go
+++ b/internal/controller/husk_networkpolicy_envtest_test.go
@@ -1,0 +1,86 @@
+package controller_test
+
+// Envtest coverage for the best-effort husk NetworkPolicy (network-isolation
+// blocker, Task 10). ensureHuskNetworkPolicy creates a default-deny egress
+// NetworkPolicy selecting the pool's husk pods, owner-referenced to the pool for
+// GC, with one egress rule per enforceable IP:port allow plus the DNS allow.
+//
+// HONEST CAVEAT: this object only enforces on a CNI that implements
+// NetworkPolicy; the in-pod nftables filter the husk-stub programs is the
+// egress guarantee. This test asserts the OBJECT is created correctly, not that
+// any CNI enforces it (envtest has no CNI).
+
+import (
+	"context"
+	"testing"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/controller"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestEnsureHuskNetworkPolicyCreatesObject(t *testing.T) {
+	c := k8sClient
+	ctx := context.Background()
+
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "np-pool", Namespace: "default"}}
+	if err := c.Create(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Delete(ctx, pool) })
+
+	// Re-fetch so SetControllerReference has the server UID.
+	var live v1alpha1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pool), &live); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &controller.SandboxPoolReconciler{Client: c}
+	if err := r.EnsureHuskNetworkPolicyForTest(ctx, &live, []string{"10.0.0.5:5432"}); err != nil {
+		t.Fatalf("ensureHuskNetworkPolicy: %v", err)
+	}
+
+	var np networkingv1.NetworkPolicy
+	name := controller.HuskNetworkPolicyNameForTest("np-pool")
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &np); err != nil {
+		t.Fatalf("network policy not created: %v", err)
+	}
+
+	// Owner-ref to the pool so it is GC'd with the pool.
+	owner := metav1.GetControllerOf(&np)
+	if owner == nil || owner.Kind != "SandboxPool" || owner.Name != "np-pool" {
+		t.Fatalf("NetworkPolicy owner = %+v, want SandboxPool np-pool", owner)
+	}
+	// Selects the husk pods.
+	if np.Spec.PodSelector.MatchLabels["mitos.run/husk"] != "true" {
+		t.Errorf("selector = %v, want mitos.run/husk=true", np.Spec.PodSelector.MatchLabels)
+	}
+	// Default-deny egress posture.
+	var hasEgress bool
+	for _, pt := range np.Spec.PolicyTypes {
+		if pt == networkingv1.PolicyTypeEgress {
+			hasEgress = true
+		}
+	}
+	if !hasEgress {
+		t.Error("NetworkPolicy must declare the Egress policy type for default-deny egress")
+	}
+	// DNS rule + one allow rule.
+	if len(np.Spec.Egress) != 2 {
+		t.Errorf("egress rules = %d, want 2 (DNS + one allow)", len(np.Spec.Egress))
+	}
+
+	// Idempotent: a second ensure with a changed allowlist updates in place.
+	if err := r.EnsureHuskNetworkPolicyForTest(ctx, &live, nil); err != nil {
+		t.Fatalf("ensureHuskNetworkPolicy (update): %v", err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &np); err != nil {
+		t.Fatalf("network policy missing after update: %v", err)
+	}
+	if len(np.Spec.Egress) != 1 {
+		t.Errorf("egress rules after clearing allows = %d, want 1 (DNS only)", len(np.Spec.Egress))
+	}
+}

--- a/internal/controller/husknetworkpolicy.go
+++ b/internal/controller/husknetworkpolicy.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/netconf"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// huskNetworkPolicyName is the per-pool NetworkPolicy name. It selects this
+// pool's husk pods (mitos.run/husk=true) for default-deny egress.
+func huskNetworkPolicyName(pool string) string { return pool + "-husk-egress" }
+
+// buildHuskNetworkPolicy builds the best-effort Kubernetes NetworkPolicy for a
+// pool's husk pods: default-deny egress (a non-empty Egress policy type with a
+// limited rule set denies everything else), plus an allow for cluster DNS
+// (UDP/TCP 53) and one egress rule per enforceable IP:port in the template
+// allowlist.
+//
+// HONEST CNI CAVEAT: a NetworkPolicy only enforces if the cluster CNI
+// implements it (Calico, Cilium, etc.). On a CNI without NetworkPolicy support
+// this object is inert. It is defense in depth ONLY; the in-pod nftables filter
+// the husk-stub programs is the guarantee that holds regardless of CNI. This is
+// documented in docs/threat-model.md.
+//
+// Name entries in the allowlist are NOT expressible as NetworkPolicy egress
+// peers (NetworkPolicy has no name-based egress), so only IP:port allows are
+// added here; name-based egress is enforced solely by the in-pod DNS proxy.
+func buildHuskNetworkPolicy(pool *v1alpha1.SandboxPool, allow []string) *networkingv1.NetworkPolicy {
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+	dnsPort := intstr.FromInt(53)
+
+	egress := []networkingv1.NetworkPolicyEgressRule{
+		{
+			// Cluster DNS so the guest can resolve through the node resolver; the
+			// in-pod DNS proxy is the controlled resolver, but the pod's own DNS
+			// (and the proxy's upstream) needs port 53 egress.
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &udp, Port: &dnsPort},
+				{Protocol: &tcp, Port: &dnsPort},
+			},
+		},
+	}
+
+	// One egress rule per enforceable IP:port allow. Malformed/name entries are
+	// skipped (SplitAllowList returns names separately); a parse error yields no
+	// allow rules (the default-deny still applies, fail-closed).
+	if enforceable, _, err := netconf.SplitAllowList(allow); err == nil {
+		for _, hp := range enforceable {
+			port := intstr.FromInt(hp.Port)
+			egress = append(egress, networkingv1.NetworkPolicyEgressRule{
+				To: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{CIDR: hp.IP.String() + hostMask(hp.IP)},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &port}},
+			})
+		}
+	}
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      huskNetworkPolicyName(pool.Name),
+			Namespace: pool.Namespace,
+			Labels:    map[string]string{huskPoolLabel: pool.Name},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{huskLabel: "true"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress:      egress,
+		},
+	}
+}
+
+// hostMask returns the single-host CIDR suffix for an IP (/32 for v4, /128 for
+// v6). The allowlist is IPv4-only today (SplitAllowList enforces it), so this is
+// /32 in practice, but the v6 branch keeps it correct if that changes.
+func hostMask(ip net.IP) string {
+	if ip.To4() != nil {
+		return "/32"
+	}
+	return "/128"
+}
+
+// ensureHuskNetworkPolicy creates or updates the pool's husk NetworkPolicy,
+// owner-referenced to the pool for GC. Best effort: a failure is returned so the
+// reconcile retries, but the CALLER does NOT block husk pod creation on it,
+// because the in-pod nftables filter (not this object) is the egress guarantee.
+func (r *SandboxPoolReconciler) ensureHuskNetworkPolicy(ctx context.Context, pool *v1alpha1.SandboxPool, allow []string) error {
+	desired := buildHuskNetworkPolicy(pool, allow)
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, np, func() error {
+		np.Labels = desired.Labels
+		np.Spec = desired.Spec
+		// Owner-ref to the pool so the NetworkPolicy is garbage-collected with the
+		// pool. SetControllerReference is idempotent for the same owner.
+		if existing := metav1.GetControllerOf(np); existing == nil {
+			if serr := controllerutil.SetControllerReference(pool, np, r.Scheme()); serr != nil {
+				return fmt.Errorf("set owner on husk network policy %s: %w", np.Name, serr)
+			}
+		}
+		return nil
+	})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("ensure husk network policy for pool %s: %w", pool.Name, err)
+	}
+	return nil
+}

--- a/internal/controller/husknetworkpolicy_test.go
+++ b/internal/controller/husknetworkpolicy_test.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildHuskNetworkPolicyDefaultDeny(t *testing.T) {
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	np := buildHuskNetworkPolicy(pool, nil)
+	if np.Spec.PodSelector.MatchLabels[huskLabel] != "true" {
+		t.Errorf("selector = %v, want mitos.run/husk=true", np.Spec.PodSelector.MatchLabels)
+	}
+	// PolicyTypes must include Egress for the default-deny egress posture.
+	var hasEgress bool
+	for _, pt := range np.Spec.PolicyTypes {
+		if pt == "Egress" {
+			hasEgress = true
+		}
+	}
+	if !hasEgress {
+		t.Error("policy must declare Egress policy type for default-deny egress")
+	}
+	// With no allows, exactly one egress rule: DNS to kube-dns (UDP/TCP 53).
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("egress rules = %d, want 1 (DNS only)", len(np.Spec.Egress))
+	}
+	// Owner GC label so the NetworkPolicy is traceable to its pool.
+	if np.Labels[huskPoolLabel] != "p" {
+		t.Errorf("pool label = %v, want p", np.Labels)
+	}
+}
+
+func TestBuildHuskNetworkPolicyAddsAllowDestinations(t *testing.T) {
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	np := buildHuskNetworkPolicy(pool, []string{"10.0.0.5:5432"})
+	// DNS rule + one allow rule.
+	if len(np.Spec.Egress) != 2 {
+		t.Fatalf("egress rules = %d, want 2 (DNS + one allow)", len(np.Spec.Egress))
+	}
+	allowRule := np.Spec.Egress[1]
+	if len(allowRule.To) != 1 || allowRule.To[0].IPBlock == nil || allowRule.To[0].IPBlock.CIDR != "10.0.0.5/32" {
+		t.Errorf("allow peer = %+v, want IPBlock 10.0.0.5/32", allowRule.To)
+	}
+}
+
+// TestBuildHuskNetworkPolicySkipsNameAllow asserts a name:port entry produces NO
+// extra egress rule (NetworkPolicy has no name-based egress; the in-pod DNS
+// proxy enforces names). Only the DNS rule remains.
+func TestBuildHuskNetworkPolicySkipsNameAllow(t *testing.T) {
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	np := buildHuskNetworkPolicy(pool, []string{"api.example.com:443"})
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("egress rules = %d, want 1 (DNS only; name allow not expressible)", len(np.Spec.Egress))
+	}
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -323,12 +323,16 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 	//     privileged: true; KVM access comes from the device plugin slot, not
 	//     from a privileged container.
 	//   - AllowPrivilegeEscalation: false. No setuid path can regain privilege.
-	//   - Capabilities Drop ALL, add NONE. The dormant stub only Prepares a
+	//   - Capabilities Drop ALL, add NET_ADMIN. The dormant stub Prepares a
 	//     Firecracker VMM (open /dev/kvm via the device plugin, create files
 	//     under the pod-local workdir, bind a unix socket); none of that needs a
-	//     Linux capability. Networking capabilities (e.g. NET_ADMIN for tap
-	//     setup) arrive with the networking slice, not here; we add back none so
-	//     this slice stays minimal.
+	//     Linux capability. NET_ADMIN is added because the stub programs the
+	//     in-pod nftables egress filter and the VM's tap in the pod's OWN network
+	//     namespace at activation (the load-bearing isolation control). It is the
+	//     minimal capability for that and is scoped to the pod netns: the pod is
+	//     not hostNetwork and not privileged, so it cannot reach the host netns,
+	//     another pod's netns, or the node routing tables. Recorded as a PSA
+	//     exception in docs/threat-model.md.
 	//   - SeccompProfile RuntimeDefault, set at BOTH the pod and the container
 	//     securityContext level. restricted checks the profile at the pod OR the
 	//     container level; setting both keeps the pod-level control satisfied even
@@ -765,6 +769,17 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 						RunAsNonRoot:             ptrBool(runAsNonRoot),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
+							// NET_ADMIN is the MINIMAL capability for in-pod
+							// firewalling: the husk-stub programs nftables and the
+							// VM's tap in the pod's OWN network namespace (not the
+							// host's). The pod is not hostNetwork and not
+							// privileged, so NET_ADMIN cannot reach the host netns,
+							// another pod's netns, or the node routing tables. It is
+							// the load-bearing control that gives the husk guest VM
+							// CNI-independent default-deny egress + the unconditional
+							// cloud-metadata block. Documented as a PSA exception in
+							// docs/threat-model.md.
+							Add: []corev1.Capability{"NET_ADMIN"},
 						},
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -124,11 +124,36 @@ func TestBuildHuskPodSpec(t *testing.T) {
 	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
 		t.Errorf("Capabilities.Drop = %+v, want [ALL]", sc.Capabilities)
 	}
-	if len(sc.Capabilities.Add) != 0 {
-		t.Errorf("Capabilities.Add = %+v, want none (networking caps come with the networking slice)", sc.Capabilities.Add)
+	if len(sc.Capabilities.Add) != 1 || sc.Capabilities.Add[0] != "NET_ADMIN" {
+		t.Errorf("Capabilities.Add = %+v, want [NET_ADMIN] (in-pod egress firewall)", sc.Capabilities.Add)
 	}
 	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
 		t.Errorf("SeccompProfile = %+v, want RuntimeDefault", sc.SeccompProfile)
+	}
+}
+
+// TestHuskPodHasNetAdminForInPodFirewall asserts the husk container adds
+// exactly NET_ADMIN (and nothing else) so the stub can program the in-pod
+// nftables egress filter and tap in the pod's OWN netns. This is the documented
+// capability exception for in-pod firewalling; it does NOT grant host network
+// access (the pod is not hostNetwork and not privileged).
+func TestHuskPodHasNetAdminForInPodFirewall(t *testing.T) {
+	r := &controller.SandboxPoolReconciler{}
+	pool := &v1alpha1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	tmpl := &v1alpha1.SandboxTemplate{}
+	pod := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{StubImage: "img"})
+	sc := pod.Spec.Containers[0].SecurityContext
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("Capabilities.Drop = %+v, want [ALL]", sc.Capabilities)
+	}
+	if len(sc.Capabilities.Add) != 1 || sc.Capabilities.Add[0] != "NET_ADMIN" {
+		t.Errorf("Capabilities.Add = %+v, want [NET_ADMIN]", sc.Capabilities.Add)
+	}
+	if sc.Privileged != nil && *sc.Privileged {
+		t.Error("husk pod must not be privileged")
+	}
+	if pod.Spec.HostNetwork {
+		t.Error("husk pod must not use hostNetwork; NET_ADMIN is scoped to the pod netns")
 	}
 }
 
@@ -196,8 +221,8 @@ func TestBuildHuskPodPSARestricted(t *testing.T) {
 	if sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
 		t.Errorf("container Capabilities.Drop = %+v, want [ALL] (restricted control)", sc.Capabilities)
 	}
-	if len(sc.Capabilities.Add) != 0 {
-		t.Errorf("container Capabilities.Add = %+v, want none (restricted forbids adding back)", sc.Capabilities.Add)
+	if len(sc.Capabilities.Add) != 1 || sc.Capabilities.Add[0] != "NET_ADMIN" {
+		t.Errorf("container Capabilities.Add = %+v, want [NET_ADMIN] (documented PSA exception for in-pod firewalling)", sc.Capabilities.Add)
 	}
 	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
 		t.Errorf("container SeccompProfile = %+v, want RuntimeDefault (restricted control)", sc.SeccompProfile)

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -737,12 +737,15 @@ func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *
 	}
 
 	addr := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(controlPort))
+	egress, allow := huskEgressConfig(template)
 	req := husk.ActivateRequest{
 		SnapshotDir:    HuskSnapshotDir,
 		ExpectedDigest: expectedDigest,
 		Env:            env,
 		Secrets:        secretVals,
 		Network:        huskNotifyNetwork(template),
+		Egress:         egress,
+		Allow:          allow,
 		Token:          apiToken,
 	}
 	res, err := activate(ctx, addr, r.HuskTLS, req)
@@ -812,13 +815,50 @@ func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *
 	return ctrl.Result{}, nil
 }
 
+// huskInPodResolverIP is the fixed pod-local address the husk-stub binds the
+// per-pod DNS proxy on and points the guest at via NotifyForkedNetwork. It is a
+// link-local address inside the pod netns, the same default the raw-forkd path
+// uses (cmd/forkd defaultDNSResolverIP).
+const huskInPodResolverIP = "169.254.1.1"
+
+// huskGuestIP and huskGatewayIP are the fixed point-to-point /30 the husk VM
+// uses inside its OWN pod netns. Because each VM is alone in its pod netns there
+// is no cross-VM collision, so a single fixed pair is correct (unlike raw-forkd,
+// which carves a shared subnet). The stub derives the tap from huskGuestIP via
+// netconf.DeriveTapName, assigns huskGatewayIP to that tap, and the guest keeps
+// its baked huskGuestIP; that is the NIC-binding contract both sides agree on.
+const (
+	huskGuestIP   = "10.200.0.2"
+	huskGatewayIP = "10.200.0.1"
+)
+
 // huskNotifyNetwork maps the template's network policy to the guest
-// NotifyForkedNetwork delivered in the activate handshake. The husk slice
-// threads the template network through for parity with the engine fork path; the
-// detailed mapping is a follow-up, so this returns nil (no overrides) until the
-// guest networking slice lands.
+// NotifyForkedNetwork delivered in the activate handshake. It always returns a
+// config (never nil now): the guest is pinned to the fixed in-pod /30 and
+// pointed at the in-pod DNS proxy resolver, so the in-pod egress filter and DNS
+// proxy enforce the template allowlist. A template with no NetworkPolicy still
+// gets the fail-closed default-deny config (the stub defaults Egress to deny).
 func huskNotifyNetwork(_ *v1alpha1.SandboxTemplate) *vsock.NotifyForkedNetwork {
-	return nil
+	return &vsock.NotifyForkedNetwork{
+		GuestIP:    huskGuestIP,
+		GatewayIP:  huskGatewayIP,
+		PrefixLen:  30,
+		ResolverIP: huskInPodResolverIP,
+	}
+}
+
+// huskEgressConfig extracts the egress policy string and raw allowlist from the
+// template, defaulting to fail-closed deny with no allows when the template
+// carries no NetworkPolicy. Egress and Allow are config, not secrets.
+func huskEgressConfig(template *v1alpha1.SandboxTemplate) (egress string, allow []string) {
+	if template == nil || template.Spec.Network == nil {
+		return string(v1alpha1.EgressDeny), nil
+	}
+	e := template.Spec.Network.Egress
+	if e == "" {
+		e = v1alpha1.EgressDeny
+	}
+	return string(e), template.Spec.Network.Allow
 }
 
 // reconcileNoCapacity handles a placement that no node admits under the

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -222,6 +222,16 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		desiredWarm := r.desiredWarm(&pool, dormantNow, inUseNow)
 
+		// Best-effort Kubernetes NetworkPolicy (default-deny egress) for this
+		// pool's husk pods. CNI-dependent; the in-pod nft filter the husk-stub
+		// programs is the guarantee. A failure is logged but does NOT block husk
+		// pod creation, so a CNI without NetworkPolicy support never stalls the
+		// warm pool.
+		_, npAllow := huskEgressConfig(&template)
+		if err := r.ensureHuskNetworkPolicy(ctx, &pool, npAllow); err != nil {
+			logger.Error(err, "ensure husk network policy (best effort; in-pod filter is the guarantee)")
+		}
+
 		res, err := r.reconcileHuskPods(ctx, &pool, &template, desiredWarm)
 		if err != nil {
 			logger.Error(err, "failed to reconcile husk pods")

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -221,6 +221,17 @@ func (r *SandboxPoolReconciler) EnsureHuskPDBForTest(ctx context.Context, pool *
 	return r.ensureHuskPDB(ctx, pool)
 }
 
+// EnsureHuskNetworkPolicyForTest exposes ensureHuskNetworkPolicy to the external
+// controller_test package so the best-effort NetworkPolicy create-or-update can
+// be envtested directly.
+func (r *SandboxPoolReconciler) EnsureHuskNetworkPolicyForTest(ctx context.Context, pool *v1alpha1.SandboxPool, allow []string) error {
+	return r.ensureHuskNetworkPolicy(ctx, pool, allow)
+}
+
+// HuskNetworkPolicyNameForTest exposes huskNetworkPolicyName so the external
+// controller_test package can look the object up by name.
+func HuskNetworkPolicyNameForTest(pool string) string { return huskNetworkPolicyName(pool) }
+
 // ReconcileHuskPodsForTest exposes reconcileHuskPods to the external
 // controller_test package so the warm-pool lifecycle can be envtested.
 func (r *SandboxPoolReconciler) ReconcileHuskPodsForTest(ctx context.Context, pool *v1alpha1.SandboxPool, template *v1alpha1.SandboxTemplate) (int32, error) {

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -60,6 +60,15 @@ type ActivateRequest struct {
 	Network          *vsock.NotifyForkedNetwork    `json:"network,omitempty"`
 	Volumes          []vsock.VolumeMountEntry      `json:"volumes,omitempty"`
 	Token            string                        `json:"token,omitempty"`
+	// Egress is the template's egress policy ("deny" or "allow") the stub uses
+	// to render the in-pod nftables chain's final verdict. Empty defaults to the
+	// fail-closed "deny". It is config, not a secret, and is safe to log.
+	Egress string `json:"egress,omitempty"`
+	// Allow is the template's raw egress allowlist (host:port entries, IP or
+	// name) the stub splits into static IP:port chain accepts (SplitAllowList)
+	// and name entries the in-pod DNS proxy enforces (ParseNameAllowList). It is
+	// config, not a secret, and is safe to log.
+	Allow []string `json:"allow,omitempty"`
 }
 
 // ActivateResult is the control reply. OK is true only when the snapshot loaded

--- a/internal/husk/control_test.go
+++ b/internal/husk/control_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/paperclipinc/mitos/internal/vsock"
 )
 
+func TestActivateRequestCarriesEgressConfig(t *testing.T) {
+	in := ActivateRequest{
+		SnapshotDir: "/snap",
+		Egress:      "deny",
+		Allow:       []string{"api.example.com:443", "10.0.0.5:5432"},
+		Network:     &vsock.NotifyForkedNetwork{GuestIP: "10.200.0.2", GatewayIP: "10.200.0.1", PrefixLen: 30, ResolverIP: "169.254.1.1"},
+	}
+	var buf bytes.Buffer
+	if err := WriteRequest(&buf, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := ReadRequest(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Egress != "deny" || len(out.Allow) != 2 || out.Allow[0] != "api.example.com:443" {
+		t.Errorf("egress config did not round-trip: %+v", out)
+	}
+	if out.Network == nil || out.Network.ResolverIP != "169.254.1.1" {
+		t.Errorf("network did not round-trip: %+v", out.Network)
+	}
+}
+
 func TestActivateRequestRoundTrip(t *testing.T) {
 	want := ActivateRequest{
 		SnapshotDir: "/data/templates/tmpl-a/snapshot",

--- a/internal/husk/netfilter.go
+++ b/internal/husk/netfilter.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/dnsproxy"
 	"github.com/paperclipinc/mitos/internal/netconf"
 )
 
@@ -89,3 +91,44 @@ func teardownEgressFilter(ctx context.Context, run netfilterRunner, tap string) 
 	}
 	return firstErr
 }
+
+// buildEgressDNSRegistry parses the name entries from the allowlist and returns
+// a dnsproxy.Registry with this VM's guest IP registered for them, plus the raw
+// name->ports map (returned for logging/assertion). IP:port entries are ignored
+// here (the chain enforces them statically). An invalid name or wildcard fails
+// the whole call (fail-closed: a bad allowlist never yields a partially
+// enforced resolver). An empty name set is valid: the proxy still runs and
+// resolves nothing, which is the documented IP-only allowlist mode.
+func buildEgressDNSRegistry(guestIP string, allow []string) (*dnsproxy.Registry, map[string][]int, error) {
+	names, err := netconf.ParseNameAllowList(allow)
+	if err != nil {
+		return nil, nil, fmt.Errorf("husk netfilter: parse name allowlist: %w", err)
+	}
+	reg := dnsproxy.NewRegistry()
+	ip := net.ParseIP(guestIP)
+	if ip == nil {
+		return nil, nil, fmt.Errorf("husk netfilter: invalid guest ip %q", guestIP)
+	}
+	reg.Register(ip, names)
+	return reg, names, nil
+}
+
+// newEgressDNSProxy builds the per-pod DNS proxy: it resolves only registered
+// names and pins each resolved address into THIS tap's dynamic allow set via an
+// nft pinner, the same model raw-forkd uses (cmd/forkd buildDNSProxy). tap is
+// fixed (one VM per pod), so tapFor always returns it. upstream is the real
+// resolver the proxy forwards allowed queries to. The returned server is
+// started by the caller with ListenAndServe on the resolver address.
+//
+//nolint:unused // wired into Stub.Activate in the following commit (same branch).
+func newEgressDNSProxy(reg *dnsproxy.Registry, tap, upstream string, run func(argv []string) error) *dnsproxy.Server {
+	pinner := dnsproxy.NewNftPinner(run)
+	tapFor := func(net.IP) string { return tap }
+	return dnsproxy.NewServer(reg, pinner, upstream, dnsProxyTTLFloor, tapFor, nil)
+}
+
+// dnsProxyTTLFloor matches the raw-forkd proxy's TTL floor so a pinned address
+// lives at least this long even when the record's TTL is shorter.
+//
+//nolint:unused // consumed by newEgressDNSProxy, wired into Stub.Activate next.
+const dnsProxyTTLFloor = 30 * time.Second

--- a/internal/husk/netfilter.go
+++ b/internal/husk/netfilter.go
@@ -72,9 +72,7 @@ func applyEgressFilter(ctx context.Context, run netfilterRunner, cfg NetfilterCo
 
 // teardownEgressFilter removes this VM's tap and per-tap egress state. It is
 // best-effort and returns the first error so a partial teardown does not leak
-// the rest. Called by the stub on Close (wired in the stub Close hook).
-//
-//nolint:unused // wired into Stub.Close in the following commit (same branch).
+// the rest. Called by the stub on Close.
 func teardownEgressFilter(ctx context.Context, run netfilterRunner, tap string) error {
 	var firstErr error
 	if err := run(ctx, netconf.LinkDelArgs(tap), ""); err != nil && firstErr == nil {
@@ -119,8 +117,6 @@ func buildEgressDNSRegistry(guestIP string, allow []string) (*dnsproxy.Registry,
 // fixed (one VM per pod), so tapFor always returns it. upstream is the real
 // resolver the proxy forwards allowed queries to. The returned server is
 // started by the caller with ListenAndServe on the resolver address.
-//
-//nolint:unused // wired into Stub.Activate in the following commit (same branch).
 func newEgressDNSProxy(reg *dnsproxy.Registry, tap, upstream string, run func(argv []string) error) *dnsproxy.Server {
 	pinner := dnsproxy.NewNftPinner(run)
 	tapFor := func(net.IP) string { return tap }
@@ -129,6 +125,4 @@ func newEgressDNSProxy(reg *dnsproxy.Registry, tap, upstream string, run func(ar
 
 // dnsProxyTTLFloor matches the raw-forkd proxy's TTL floor so a pinned address
 // lives at least this long even when the record's TTL is shorter.
-//
-//nolint:unused // consumed by newEgressDNSProxy, wired into Stub.Activate next.
 const dnsProxyTTLFloor = 30 * time.Second

--- a/internal/husk/netfilter.go
+++ b/internal/husk/netfilter.go
@@ -1,0 +1,91 @@
+package husk
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/netconf"
+)
+
+// NetfilterConfig is the in-pod egress filter configuration for one husk VM.
+// The husk-stub owns exactly one tap in the husk pod's network namespace, so
+// the single-VM-per-pod case is the per-tap chain from the raw-forkd dataplane
+// applied once. All fields are config (no secrets) and safe to log.
+type NetfilterConfig struct {
+	// Tap is the host-side tap device name in the pod netns the VM's NIC is
+	// bound to. It is the dispatch key and the per-sandbox chain suffix.
+	Tap string
+	// GuestIP is the VM's source address; every accept and the metadata drop are
+	// saddr-pinned to it as anti-spoof defense in depth.
+	GuestIP net.IP
+	// HostIP is the pod-side address of the point-to-point link assigned to the
+	// tap (the VM's gateway).
+	HostIP net.IP
+	// Egress is the template's policy; deny is the fail-closed default verdict.
+	Egress v1alpha1.EgressPolicy
+	// Allow is the raw allowlist; IP:port entries become static chain accepts,
+	// name entries are enforced by the DNS proxy (handled by the caller).
+	Allow []string
+	// ResolverIP is the in-pod DNS proxy address the chain allows on port 53 and
+	// the guest is pointed at. Nil disables the DNS allow rule (IP-only mode).
+	ResolverIP net.IP
+}
+
+// netfilterRunner executes one host command with optional stdin in the pod
+// netns. It is injected so the orchestration is unit-testable without root; the
+// production stub wires it to an exec-based runner.
+type netfilterRunner func(ctx context.Context, argv []string, stdin string) error
+
+// applyEgressFilter brings up the VM's tap and installs its default-deny egress
+// chain (with the unconditional metadata block) in the husk pod netns. It is
+// the single-VM-per-pod analog of internal/network.setup: create the tap,
+// assign the host IP, bring it up, apply the idempotent shared table, then this
+// VM's per-tap chain. A malformed allowlist fails the whole call (fail-closed:
+// a VM never comes up with a half-applied filter).
+func applyEgressFilter(ctx context.Context, run netfilterRunner, cfg NetfilterConfig) error {
+	enforceable, _, err := netconf.SplitAllowList(cfg.Allow)
+	if err != nil {
+		return fmt.Errorf("husk netfilter: parse allowlist: %w", err)
+	}
+	if err := run(ctx, netconf.TapAddArgs(cfg.Tap), ""); err != nil {
+		return fmt.Errorf("husk netfilter: create tap %s: %w", cfg.Tap, err)
+	}
+	if err := run(ctx, netconf.AddrAddArgs(cfg.HostIP, cfg.Tap), ""); err != nil {
+		return fmt.Errorf("husk netfilter: assign host ip to tap %s: %w", cfg.Tap, err)
+	}
+	if err := run(ctx, netconf.LinkUpArgs(cfg.Tap), ""); err != nil {
+		return fmt.Errorf("husk netfilter: bring tap %s up: %w", cfg.Tap, err)
+	}
+	if err := run(ctx, netconf.NftApplyArgs(), netconf.RenderSharedTable()); err != nil {
+		return fmt.Errorf("husk netfilter: apply shared egress table: %w", err)
+	}
+	chain := netconf.RenderSandboxChain(cfg.Tap, cfg.GuestIP, cfg.Egress, enforceable, cfg.ResolverIP)
+	if err := run(ctx, netconf.NftApplyArgs(), chain); err != nil {
+		return fmt.Errorf("husk netfilter: apply egress chain for tap %s: %w", cfg.Tap, err)
+	}
+	return nil
+}
+
+// teardownEgressFilter removes this VM's tap and per-tap egress state. It is
+// best-effort and returns the first error so a partial teardown does not leak
+// the rest. Called by the stub on Close (wired in the stub Close hook).
+//
+//nolint:unused // wired into Stub.Close in the following commit (same branch).
+func teardownEgressFilter(ctx context.Context, run netfilterRunner, tap string) error {
+	var firstErr error
+	if err := run(ctx, netconf.LinkDelArgs(tap), ""); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("husk netfilter: delete tap %s: %w", tap, err)
+	}
+	if err := run(ctx, netconf.NftDeleteDispatchElementArgs(tap), ""); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("husk netfilter: delete dispatch element for tap %s: %w", tap, err)
+	}
+	if err := run(ctx, netconf.NftDeleteSandboxChainArgs(tap), ""); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("husk netfilter: delete chain for tap %s: %w", tap, err)
+	}
+	if err := run(ctx, netconf.NftDeleteSandboxAllowSetArgs(tap), ""); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("husk netfilter: delete allow set for tap %s: %w", tap, err)
+	}
+	return firstErr
+}

--- a/internal/husk/netfilter_test.go
+++ b/internal/husk/netfilter_test.go
@@ -51,6 +51,30 @@ func TestApplyEgressFilterRendersDenyChainWithMetadataBlock(t *testing.T) {
 	}
 }
 
+func TestBuildDNSProxyRegistersNamesOnly(t *testing.T) {
+	reg, names, err := buildEgressDNSRegistry("10.200.0.2", []string{"api.example.com:443", "10.0.0.5:5432"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reg == nil {
+		t.Fatal("nil registry")
+	}
+	// The IP:port entry is enforced by the chain, not the resolver: only the name
+	// entry is registered.
+	if len(names) != 1 {
+		t.Fatalf("registered names = %v, want only api.example.com", names)
+	}
+	if _, ok := names["api.example.com"]; !ok {
+		t.Errorf("api.example.com not registered: %v", names)
+	}
+}
+
+func TestBuildDNSProxyRejectsBadWildcard(t *testing.T) {
+	if _, _, err := buildEgressDNSRegistry("10.200.0.2", []string{"a.*.com:443"}); err == nil {
+		t.Fatal("expected error on invalid wildcard, got nil")
+	}
+}
+
 func TestApplyEgressFilterRejectsMalformedAllow(t *testing.T) {
 	rr := &recordingRunner{}
 	cfg := NetfilterConfig{

--- a/internal/husk/netfilter_test.go
+++ b/internal/husk/netfilter_test.go
@@ -1,0 +1,66 @@
+package husk
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/netconf"
+)
+
+type recordedCall struct {
+	argv  []string
+	stdin string
+}
+
+type recordingRunner struct{ calls []recordedCall }
+
+func (r *recordingRunner) run(_ context.Context, argv []string, stdin string) error {
+	r.calls = append(r.calls, recordedCall{argv: argv, stdin: stdin})
+	return nil
+}
+
+func TestApplyEgressFilterRendersDenyChainWithMetadataBlock(t *testing.T) {
+	rr := &recordingRunner{}
+	cfg := NetfilterConfig{
+		Tap:        "sbtap0",
+		GuestIP:    net.ParseIP("10.200.0.2"),
+		HostIP:     net.ParseIP("10.200.0.1"),
+		Egress:     v1alpha1.EgressDeny,
+		Allow:      []string{"10.0.0.5:5432"},
+		ResolverIP: net.ParseIP("169.254.1.1"),
+	}
+	if err := applyEgressFilter(context.Background(), rr.run, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// Expect: tap add, addr add, link up, shared table apply, sandbox chain apply.
+	if len(rr.calls) != 5 {
+		t.Fatalf("got %d calls, want 5: %+v", len(rr.calls), rr.calls)
+	}
+	chainStdin := rr.calls[4].stdin
+	if !strings.Contains(chainStdin, "ip daddr 169.254.169.254 drop") {
+		t.Errorf("chain missing metadata block:\n%s", chainStdin)
+	}
+	if !strings.Contains(chainStdin, "ip daddr 10.0.0.5 tcp dport 5432 accept") {
+		t.Errorf("chain missing static allow:\n%s", chainStdin)
+	}
+	if !strings.Contains(chainStdin, netconf.SandboxChainName("sbtap0")) {
+		t.Errorf("chain not named for tap:\n%s", chainStdin)
+	}
+}
+
+func TestApplyEgressFilterRejectsMalformedAllow(t *testing.T) {
+	rr := &recordingRunner{}
+	cfg := NetfilterConfig{
+		Tap:     "sbtap0",
+		GuestIP: net.ParseIP("10.200.0.2"),
+		HostIP:  net.ParseIP("10.200.0.1"),
+		Egress:  v1alpha1.EgressDeny,
+		Allow:   []string{"not-a-valid-entry"},
+	}
+	if err := applyEgressFilter(context.Background(), rr.run, cfg); err == nil {
+		t.Fatal("expected error on malformed allow entry, got nil")
+	}
+}

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -13,8 +13,11 @@ import (
 	"sync"
 	"time"
 
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
 	"github.com/paperclipinc/mitos/internal/cas"
+	"github.com/paperclipinc/mitos/internal/dnsproxy"
 	"github.com/paperclipinc/mitos/internal/firecracker"
+	"github.com/paperclipinc/mitos/internal/netconf"
 	"github.com/paperclipinc/mitos/internal/snapcompat"
 	"github.com/paperclipinc/mitos/internal/volume"
 	"github.com/paperclipinc/mitos/internal/vsock"
@@ -353,6 +356,23 @@ type Stub struct {
 	wsTransport  wsTransporter
 	vsockRelPath string
 
+	// netRunner, when non-nil, executes host networking commands in the pod
+	// netns so Activate can program the in-pod egress filter. Nil (unit and
+	// control-socket paths) skips all network setup. Injected so the filter is
+	// testable without root.
+	netRunner netfilterRunner
+	// nftRunner runs a single nft argv for the DNS proxy pinner. Nil reuses
+	// netRunner with empty stdin.
+	nftRunner func(argv []string) error
+	// dnsUpstream is the real resolver the per-pod DNS proxy forwards allowed
+	// queries to (host:port). Empty disables name-based egress (IP-only mode).
+	dnsUpstream string
+	// dnsProxy is the running per-pod DNS proxy for the active VM, stopped on
+	// Close. Nil when no VM is active or name egress is disabled.
+	dnsProxy *dnsproxy.Server
+	// activeTap records the active VM's tap so Close can tear the filter down.
+	activeTap string
+
 	mu              sync.Mutex
 	state           State
 	vm              vmm
@@ -543,13 +563,74 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 		}
 	}
 
+	// In-pod egress filter (the load-bearing isolation control). This MUST run
+	// BEFORE LoadSnapshotWithOverrides: Firecracker requires the host tap to exist
+	// at restore time, and the snapshot's baked NIC is remapped to THIS tap. So we
+	// create the tap + install the default-deny egress chain (with the
+	// unconditional metadata block) here, then bind the baked NIC (NetIfaceID) to
+	// the SAME tap the filter created, so the restored VM comes up on a tap that
+	// already exists and is already governed by the egress chain. Deriving the tap
+	// from the guest IP keeps the stub's filter and the NIC remap in agreement
+	// without a shared allocator (the NIC/tap binding risk: a mismatch here is a
+	// VM with a NIC backed by no tap). FAIL CLOSED: a filter error means the VM
+	// would have UNFILTERED egress (or a broken NIC), so we never load it. The
+	// guest IP and tap carry no secrets.
+	overrides := req.NetworkOverrides
+	if s.netRunner != nil && req.Network != nil {
+		tap := netconf.DeriveTapName(req.Network.GuestIP)
+		cfg := NetfilterConfig{
+			Tap:        tap,
+			GuestIP:    net.ParseIP(req.Network.GuestIP),
+			HostIP:     net.ParseIP(req.Network.GatewayIP),
+			Egress:     v1alpha1.EgressPolicy(req.Egress),
+			Allow:      req.Allow,
+			ResolverIP: net.ParseIP(req.Network.ResolverIP),
+		}
+		if cfg.Egress == "" {
+			cfg.Egress = v1alpha1.EgressDeny
+		}
+		if err := applyEgressFilter(ctx, s.netRunner, cfg); err != nil {
+			werr := fmt.Errorf("husk: apply in-pod egress filter: %w", err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+		// Bind the snapshot's baked NIC to the tap the filter just created, so the
+		// restored VM's NIC has a backing tap governed by the egress chain. This
+		// override pins HostDevName regardless of what the caller passed, which is
+		// what keeps the tap-vs-NIC binding correct.
+		overrides = []firecracker.NetworkOverride{{
+			IfaceID:     firecracker.NetIfaceID,
+			HostDevName: tap,
+		}}
+		s.activeTap = tap
+
+		// Per-pod DNS proxy for name-based egress: resolve only allowlisted names
+		// and pin each resolved IP into this tap's dynamic set. It binds the
+		// resolver socket only (independent of VM state), so starting it here is
+		// safe. IP-only allowlists (empty name set) still run with an empty
+		// registry. FAIL CLOSED on a bad registry: do not load the VM.
+		if req.Network.ResolverIP != "" && s.dnsUpstream != "" {
+			reg, _, derr := buildEgressDNSRegistry(req.Network.GuestIP, req.Allow)
+			if derr != nil {
+				werr := fmt.Errorf("husk: build dns registry: %w", derr)
+				return ActivateResult{OK: false, Error: werr.Error()}, werr
+			}
+			nftRun := s.nftRunner
+			if nftRun == nil {
+				nftRun = func(argv []string) error { return s.netRunner(ctx, argv, "") }
+			}
+			proxy := newEgressDNSProxy(reg, tap, s.dnsUpstream, nftRun)
+			go func() { _ = proxy.ListenAndServe(net.JoinHostPort(req.Network.ResolverIP, "53")) }()
+			s.dnsProxy = proxy
+		}
+	}
+
 	// Load the snapshot PAUSED (resume=false). The rootfs drive rebind below MUST
 	// happen before the guest runs, and PATCH /drives on the ROOT device of an
 	// already-RESUMED VM both leaves a write window (any writeback between resume
 	// and the rebind hits the SHARED template rootfs) and may be rejected by
 	// Firecracker. Loading paused lets us rebind while the guest is frozen, then
 	// resume explicitly. nil overrides restores exactly as before.
-	if err := s.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, false, req.NetworkOverrides); err != nil {
+	if err := s.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, false, overrides); err != nil {
 		// Fail closed: the snapshot did not load; the VM is not usable. Leave
 		// state dormant so a retry (or teardown) can decide what to do.
 		werr := fmt.Errorf("husk: load snapshot from %s: %w", req.SnapshotDir, err)
@@ -988,6 +1069,19 @@ func (s *Stub) Close() error {
 			fmt.Fprintf(os.Stderr, "husk: remove per-activation rootfs clone %s: %v\n", s.rootfsClonePath, rmErr)
 		}
 		s.rootfsClonePath = ""
+	}
+
+	// Stop the per-pod DNS proxy and tear down the in-pod egress filter (tap +
+	// per-tap nft state) for the VM this stub held. Best effort: a teardown error
+	// must not block VMM close. Done before the vm == nil early return so a
+	// filter applied during a failed activate is still reaped.
+	if s.dnsProxy != nil {
+		_ = s.dnsProxy.Shutdown(context.Background())
+		s.dnsProxy = nil
+	}
+	if s.netRunner != nil && s.activeTap != "" {
+		_ = teardownEgressFilter(context.Background(), s.netRunner, s.activeTap)
+		s.activeTap = ""
 	}
 
 	if s.vm == nil {

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -380,6 +380,20 @@ type Stub struct {
 	prepareVerified bool
 }
 
+// NetRunner is the exported alias for the host-command runner type so callers
+// in other packages (cmd/husk-stub) can construct one. It must run argv in the
+// husk pod's network namespace; the production wiring uses an exec-based runner.
+type NetRunner = netfilterRunner
+
+// SetNetRunner wires the host-command runner the stub uses to program the
+// in-pod egress filter. It must run argv in the pod netns; cmd/husk-stub wires
+// an exec-based runner. Nil disables in-pod filtering.
+func (s *Stub) SetNetRunner(run NetRunner) { s.netRunner = run }
+
+// SetDNSUpstream sets the real resolver the per-pod DNS proxy forwards
+// allowlisted queries to. Empty disables name-based egress.
+func (s *Stub) SetDNSUpstream(addr string) { s.dnsUpstream = addr }
+
 // New builds a Stub for the given VMConfig. By default it uses the production
 // starter and guest-readiness seam; opts may inject fakes for tests.
 func New(cfg firecracker.VMConfig, opts Options) *Stub {

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/paperclipinc/mitos/internal/firecracker"
+	"github.com/paperclipinc/mitos/internal/vsock"
 )
 
 // fakeVMM records the snapshot-load arguments and returns a canned error.
@@ -942,5 +943,46 @@ func TestCloseTearsDownVMM(t *testing.T) {
 	}
 	if s.State() != StateNew {
 		t.Fatalf("after close state = %s, want new", s.State())
+	}
+}
+
+func TestActivateAppliesEgressFilter(t *testing.T) {
+	rr := &recordingRunner{}
+	vm := &fakeVMM{}
+	s := newTestStub(t, vm, readyOK)
+	s.netRunner = rr.run
+	s.dnsUpstream = "1.1.1.1:53"
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	req := ActivateRequest{
+		SnapshotDir: "/data/templates/x/snapshot",
+		Egress:      "deny",
+		Allow:       []string{"10.0.0.5:5432"},
+		Network: &vsock.NotifyForkedNetwork{
+			GuestIP: "10.200.0.2", GatewayIP: "10.200.0.1", PrefixLen: 30, ResolverIP: "169.254.1.1",
+		},
+	}
+	res, err := s.Activate(context.Background(), req)
+	if err != nil || !res.OK {
+		t.Fatalf("activate failed: %v res=%+v", err, res)
+	}
+	var sawChain bool
+	for _, c := range rr.calls {
+		if c.stdin != "" && strings.Contains(c.stdin, "ip daddr 169.254.169.254 drop") {
+			sawChain = true
+		}
+	}
+	if !sawChain {
+		t.Errorf("activate did not apply the egress chain with metadata block; calls=%+v", rr.calls)
+	}
+
+	// The tap the filter created MUST be the tap the snapshot NIC is remapped to,
+	// or the restored VM has a NIC with no backing tap. Assert the override binds
+	// the baked NIC (eth0) to the derived tap.
+	wantTap := "sbt" // DeriveTapName prefix
+	if len(vm.gotOverr) != 1 || !strings.HasPrefix(vm.gotOverr[0].HostDevName, wantTap) {
+		t.Errorf("NIC override not bound to the derived tap: %+v", vm.gotOverr)
 	}
 }

--- a/internal/netconf/identity.go
+++ b/internal/netconf/identity.go
@@ -218,6 +218,20 @@ func (a *Allocator) tapName(sandboxID string) string {
 	return fmt.Sprintf("%s%08x", a.prefix, sum[:4])
 }
 
+// DeriveTapName returns a deterministic, IFNAMSIZ-safe tap device name for a
+// guest IP. The husk single-VM-per-pod path derives the tap from the VM's guest
+// IP so the stub's filter and any external reference agree without a shared
+// allocator. It is "sbt" + the first 12 hex chars of sha256(guestIP), which is
+// 15 bytes (the Linux limit, maxIfaceName).
+func DeriveTapName(guestIP string) string {
+	sum := sha256.Sum256([]byte(guestIP))
+	name := "sbt" + fmt.Sprintf("%x", sum)[:12]
+	if len(name) > maxIfaceName {
+		name = name[:maxIfaceName]
+	}
+	return name
+}
+
 // deriveMAC builds a locally-administered unicast MAC deterministically from
 // the sandboxID. The first octet has bit 0x02 set (locally administered) and
 // bit 0x01 cleared (unicast); the remaining five octets come from the hash.

--- a/internal/netconf/identity_test.go
+++ b/internal/netconf/identity_test.go
@@ -239,3 +239,18 @@ func TestMarkInUseIdempotentAndAcquireConsistent(t *testing.T) {
 		t.Fatalf("MarkInUse accepted an out-of-subnet guest IP")
 	}
 }
+
+func TestDeriveTapNameStableAndShort(t *testing.T) {
+	a := DeriveTapName("10.200.0.2")
+	b := DeriveTapName("10.200.0.2")
+	c := DeriveTapName("10.200.0.6")
+	if a != b {
+		t.Errorf("not deterministic: %q != %q", a, b)
+	}
+	if a == c {
+		t.Errorf("collision for distinct IPs: %q", a)
+	}
+	if len(a) > 15 {
+		t.Errorf("tap name too long for IFNAMSIZ: %q (%d)", a, len(a))
+	}
+}

--- a/internal/netconf/nftables.go
+++ b/internal/netconf/nftables.go
@@ -30,6 +30,34 @@ func BaseChainName() string {
 	return "forward"
 }
 
+// MetadataAddrs are the cloud instance-metadata endpoints that are an
+// UNCONDITIONAL hard drop on every sandbox chain, even under EgressAllow: the
+// IPv4 IMDS address (shared by AWS, GCP metadata.google.internal, and Azure
+// IMDS), the IPv4 link-local /16 (covers ECS task metadata 169.254.170.2 and
+// any other link-local metadata service), and the IPv6 IMDS address. Reaching
+// these lets a guest steal the node's cloud IAM credentials, which is never an
+// intended egress; the allowlist cannot override it because RenderMetadataBlock
+// is emitted BEFORE any allow rule in the chain.
+const (
+	metadataV4Addr = "169.254.169.254"
+	metadataV4Net  = "169.254.0.0/16"
+	metadataV6Addr = "fd00:ec2::254"
+)
+
+// RenderMetadataBlock renders the unconditional cloud-metadata drops for one
+// sandbox chain. The v4 drops are saddr-pinned to the guest as defense in depth
+// (same anti-spoof posture as every other rule); the v6 drop is family-scoped.
+// The caller MUST emit this block before any allow rule so the allowlist can
+// never reach a metadata endpoint.
+func RenderMetadataBlock(table, chain string, guestIP net.IP) string {
+	saddr := fmt.Sprintf("ip saddr %s", guestIP.String())
+	var b strings.Builder
+	fmt.Fprintf(&b, "add rule inet %s %s %s ip daddr %s drop\n", table, chain, saddr, metadataV4Addr)
+	fmt.Fprintf(&b, "add rule inet %s %s %s ip daddr %s drop\n", table, chain, saddr, metadataV4Net)
+	fmt.Fprintf(&b, "add rule inet %s %s ip6 daddr %s drop\n", table, chain, metadataV6Addr)
+	return b.String()
+}
+
 // DispatchMapName returns the verdict map keyed by interface name. The base
 // chain looks up the inbound interface (the tap) in this map and jumps to that
 // sandbox's regular chain. Adding/removing a sandbox is a single map element
@@ -307,6 +335,12 @@ func RenderSandboxChain(tap string, guestIP net.IP, policy v1alpha1.EgressPolicy
 
 	// Anti-spoof: pin the accepts to this sandbox's guest source IP.
 	saddr := fmt.Sprintf("ip saddr %s", guestIP.String())
+
+	// Unconditional cloud-metadata block: emitted BEFORE every accept (including
+	// established/related and the final EgressAllow accept) so a guest can never
+	// reach the IMDS endpoint and steal the node IAM credentials, regardless of
+	// the template's egress policy or allowlist.
+	b.WriteString(RenderMetadataBlock(table, chain, guestIP))
 
 	fmt.Fprintf(&b, "add rule inet %s %s %s ct state established,related accept\n", table, chain, saddr)
 

--- a/internal/netconf/nftables_test.go
+++ b/internal/netconf/nftables_test.go
@@ -8,6 +8,40 @@ import (
 	"github.com/paperclipinc/mitos/api/v1alpha1"
 )
 
+// TestRenderMetadataBlock asserts the metadata-block fragment drops the cloud
+// IMDS endpoints (v4 + v6) for the given chain, saddr-pinned for v4.
+func TestRenderMetadataBlock(t *testing.T) {
+	out := RenderMetadataBlock("mitos_egress", "sb_sbtap0", net.ParseIP("10.200.0.2"))
+	for _, want := range []string{
+		"ip saddr 10.200.0.2 ip daddr 169.254.169.254 drop",
+		"ip saddr 10.200.0.2 ip daddr 169.254.0.0/16 drop",
+		"ip6 daddr fd00:ec2::254 drop",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("metadata block missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderSandboxChainMetadataBeforeAllow asserts the metadata drop appears
+// BEFORE any allowlisted accept AND is present even under EgressAllow, so the
+// allowlist can never override the IMDS block.
+func TestRenderSandboxChainMetadataBeforeAllow(t *testing.T) {
+	allow := []HostPort{{IP: net.ParseIP("169.254.169.254"), Port: 80}}
+	for _, policy := range []v1alpha1.EgressPolicy{v1alpha1.EgressDeny, v1alpha1.EgressAllow} {
+		out := RenderSandboxChain("sbtap0", net.ParseIP("10.200.0.2"), policy, allow, net.ParseIP("169.254.1.1"))
+		dropIdx := strings.Index(out, "ip daddr 169.254.169.254 drop")
+		if dropIdx < 0 {
+			t.Fatalf("policy %s: metadata drop absent\n%s", policy, out)
+		}
+		// An allow for 169.254.169.254:80 must NOT appear before the drop.
+		acceptIdx := strings.Index(out, "ip daddr 169.254.169.254 tcp dport 80 accept")
+		if acceptIdx >= 0 && acceptIdx < dropIdx {
+			t.Errorf("policy %s: metadata accept precedes the drop (allowlist overrides IMDS block)", policy)
+		}
+	}
+}
+
 func TestParseAllowEntryIPPort(t *testing.T) {
 	hp, isName, err := ParseAllowEntry("10.0.0.5:443")
 	if err != nil {

--- a/test/cluster-e2e/husk-network-e2e.sh
+++ b/test/cluster-e2e/husk-network-e2e.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+#
+# husk-network-e2e.sh
+#
+# Real-cluster husk EGRESS ISOLATION verification (the top untrusted-code
+# blocker, docs/threat-model.md section 1 item 1). It drives a REAL KVM-capable
+# Kubernetes node through a husk claim whose template has an egress allowlist,
+# then asserts from INSIDE the sandbox (via the Python SDK exec over the pod
+# network):
+#
+#   1. metadata block   curl 169.254.169.254 FAILS (no node IAM credential theft)
+#   2. default-deny      curl a NON-allowlisted host FAILS
+#   3. allowlist works   curl an ALLOWLISTED host SUCCEEDS (so the in-pod nft
+#                        filter + DNS proxy + the controller-to-stub NIC binding
+#                        are all correct)
+#
+# Each prints a PASS/FAIL line and a bash tally is the single source of truth for
+# the exit code. Gated EXACTLY like husk-e2e.sh: it runs from inside the cluster
+# (the self-hosted KVM runner's ServiceAccount) and reaches the per-claim sandbox
+# HTTP API over the pod network via the Python SDK (in_cluster=True). It reuses
+# the warm-dormant-pod wait and SDK-driver shape from husk-e2e.sh; the only new
+# behavior is the three egress assertions.
+#
+# Usage:
+#   test/cluster-e2e/husk-network-e2e.sh [namespace] [kubeconfig]
+#
+#   [namespace]   namespace to run the e2e in (default: mitos-e2e)
+#   [kubeconfig]  optional kubeconfig path; omit to use the in-cluster SA
+#
+# Env knobs:
+#   READY_TIMEOUT   per-stage wait budget, seconds (default 180)
+#   POLL_INTERVAL   poll interval, seconds (default 1)
+#   E2E_IMAGE       template image (default python:3.12-slim)
+#   ALLOW_HOST      allowlisted host:port to prove reachable (default example.com:443)
+#   DENY_HOST       non-allowlisted host to prove blocked (default 1.1.1.1)
+#
+set -euo pipefail
+
+NAMESPACE="${1:-mitos-e2e}"
+KUBECONFIG_ARG="${2:-}"
+if [ -n "$KUBECONFIG_ARG" ]; then
+  export KUBECONFIG="$KUBECONFIG_ARG"
+fi
+
+READY_TIMEOUT="${READY_TIMEOUT:-180}"
+POLL_INTERVAL="${POLL_INTERVAL:-1}"
+E2E_IMAGE="${E2E_IMAGE:-python:3.12-slim}"
+ALLOW_HOST="${ALLOW_HOST:-example.com:443}"
+DENY_HOST="${DENY_HOST:-1.1.1.1}"
+ALLOW_NAME="${ALLOW_HOST%%:*}"
+
+RUN_ID="$(date +%s)-$$"
+TEMPLATE="e2e-net-tmpl-${RUN_ID}"
+POOL="e2e-net-pool-${RUN_ID}"
+CLAIM="e2e-net-claim-${RUN_ID}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+info() { echo "  $*"; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 1; }
+}
+require kubectl
+require python3
+
+# kubectl in a namespace shorthand.
+k() { kubectl -n "$NAMESPACE" "$@"; }
+
+diagnostics() {
+  echo "=== diagnostics (namespace ${NAMESPACE}) ===" >&2
+  k get sandboxpools,sandboxclaims,sandboxtemplates,networkpolicies -o wide >&2 2>&1 || true
+  k get pods -o wide >&2 2>&1 || true
+  echo "--- claim describe ---" >&2
+  k describe sandboxclaim "$CLAIM" >&2 2>&1 || true
+  echo "--- recent husk pod logs ---" >&2
+  for p in $(k get pods -l 'mitos.run/husk=true' -o name 2>/dev/null | head -3); do
+    echo "--- logs $p ---" >&2
+    k logs "$p" --tail=60 >&2 2>&1 || true
+  done
+}
+
+cleanup() {
+  rc=$?
+  echo "=== teardown ==="
+  k delete sandboxclaim "$CLAIM" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  k delete sandboxpool "$POOL" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  k delete sandboxtemplate "$TEMPLATE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  k delete sandboxclaims -l "mitos.run/e2e-run=${RUN_ID}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  echo "teardown done"
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "=== mitos husk network-isolation e2e: ns=${NAMESPACE} image=${E2E_IMAGE} run=${RUN_ID} ==="
+echo "    allow=${ALLOW_HOST} deny=${DENY_HOST}"
+
+# ---------------------------------------------------------------------------
+# Stage 0: KVM node present (the husk path needs a KVM-capable node).
+# ---------------------------------------------------------------------------
+if kubectl get nodes -l 'mitos.run/kvm=true' -o name 2>/dev/null | grep -q node; then
+  pass "a KVM-capable node (mitos.run/kvm=true) is present"
+else
+  fail "no node labeled mitos.run/kvm=true; the husk path cannot warm pods"
+  diagnostics
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 1: a pool warms a dormant husk pod from a template whose NetworkPolicy
+# DENIES by default and allows ONLY ${ALLOW_HOST}.
+# ---------------------------------------------------------------------------
+echo "--- stage 1: pool warms a dormant husk pod (egress deny, allow ${ALLOW_HOST}) ---"
+k apply -f - >/dev/null <<EOF
+apiVersion: mitos.run/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: ${TEMPLATE}
+  labels:
+    mitos.run/e2e-run: "${RUN_ID}"
+spec:
+  image: ${E2E_IMAGE}
+  resources:
+    cpu: "1"
+    memory: "512Mi"
+  networkPolicy:
+    egress: deny
+    allow:
+      - "${ALLOW_HOST}"
+---
+apiVersion: mitos.run/v1alpha1
+kind: SandboxPool
+metadata:
+  name: ${POOL}
+  labels:
+    mitos.run/e2e-run: "${RUN_ID}"
+spec:
+  templateRef:
+    name: ${TEMPLATE}
+  replicas: 1
+EOF
+
+# Wait for at least one dormant warm pod: husk=true, Running, no claim label.
+warm_deadline=$(( $(date +%s) + READY_TIMEOUT ))
+warm_ok=""
+while [ "$(date +%s)" -lt "$warm_deadline" ]; do
+  dormant="$(k get pods -l 'mitos.run/husk=true,!mitos.run/claim' \
+    --field-selector=status.phase=Running -o name 2>/dev/null | head -1 || true)"
+  if [ -n "$dormant" ]; then warm_ok="yes"; break; fi
+  sleep "$POLL_INTERVAL"
+done
+if [ -n "$warm_ok" ]; then
+  pass "pool ${POOL} warmed at least one dormant husk pod"
+else
+  fail "pool ${POOL} did not warm a dormant husk pod within ${READY_TIMEOUT}s"
+  diagnostics
+  exit 1
+fi
+
+# The best-effort NetworkPolicy object should exist for this pool (defense in
+# depth; the in-pod nft filter is the guarantee). Non-fatal: a CNI without
+# NetworkPolicy support still relies on the in-pod filter, which the egress
+# assertions below prove.
+if k get networkpolicy "${POOL}-husk-egress" >/dev/null 2>&1; then
+  pass "best-effort husk NetworkPolicy ${POOL}-husk-egress exists"
+else
+  info "husk NetworkPolicy ${POOL}-husk-egress not found (non-fatal; the in-pod nft filter is the guarantee)"
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 2: the three egress assertions, run as exec inside a claimed sandbox via
+# the SDK over the pod network. The driver prints one
+# RESULT:<check>:<PASS|FAIL>:<detail> line per check on stdout; the bash layer
+# folds those into the tally so it stays the single source of truth.
+# ---------------------------------------------------------------------------
+echo "--- stage 2: egress assertions inside the sandbox (SDK driver) ---"
+
+driver_out="$(mktemp)"
+set +e
+
+# Install the SDK from the CHECKED-OUT commit into a fresh venv (the same pattern
+# as husk-e2e.sh), so the e2e always tests THIS commit's SDK.
+DRIVER_PY="python3"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if [ -d "${REPO_ROOT}/sdk/python" ]; then
+  echo "--- installing the checked-out SDK into a fresh venv ---"
+  python3 -m venv /tmp/e2e-net-sdk-venv
+  /tmp/e2e-net-sdk-venv/bin/pip install --quiet --upgrade pip >/dev/null 2>&1 || true
+  /tmp/e2e-net-sdk-venv/bin/pip install --quiet "${REPO_ROOT}/sdk/python"
+  DRIVER_PY="/tmp/e2e-net-sdk-venv/bin/python"
+fi
+
+INCLUSTER="false"
+[ -z "${KUBECONFIG:-}" ] && INCLUSTER="true"
+MITOS_NS="$NAMESPACE" MITOS_POOL="$POOL" MITOS_CLAIM="$CLAIM" \
+MITOS_INCLUSTER="$INCLUSTER" MITOS_READY_TIMEOUT="$READY_TIMEOUT" \
+MITOS_ALLOW_NAME="$ALLOW_NAME" MITOS_DENY_HOST="$DENY_HOST" \
+"$DRIVER_PY" - <<'PYEOF' | tee "$driver_out"
+import os
+import sys
+
+from mitos import AgentRun
+
+NS = os.environ["MITOS_NS"]
+POOL = os.environ["MITOS_POOL"]
+CLAIM = os.environ["MITOS_CLAIM"]
+INCLUSTER = os.environ.get("MITOS_INCLUSTER", "true") == "true"
+READY_TIMEOUT = float(os.environ.get("MITOS_READY_TIMEOUT", "180"))
+ALLOW_NAME = os.environ["MITOS_ALLOW_NAME"]
+DENY_HOST = os.environ["MITOS_DENY_HOST"]
+
+
+def result(check, ok, detail=""):
+    print(f"RESULT:{check}:{'PASS' if ok else 'FAIL'}:{detail}", flush=True)
+
+
+run = AgentRun(namespace=NS, in_cluster=INCLUSTER)
+
+# Claim a sandbox and wait for Ready before probing egress.
+try:
+    sb = run.sandbox(pool=POOL, name=CLAIM)
+    sb.wait_until_ready(timeout=READY_TIMEOUT)
+except Exception as exc:  # noqa: BLE001
+    result("claim", False, f"{type(exc).__name__}: {exc}")
+    sys.exit(0)
+result("claim", True, "sandbox Ready")
+
+
+def curl_exit(target, extra_timeout=5):
+    # Return the curl exit code from inside the sandbox. A non-zero exit means
+    # the connection was blocked/refused/timed out. -m bounds the wait so a
+    # silent default-deny drop does not hang the check.
+    cmd = f"curl -s -m {extra_timeout} -o /dev/null {target}; echo EXIT:$?"
+    res = sb.exec(cmd, timeout=extra_timeout + 15)
+    out = (res.stdout or "")
+    for line in out.splitlines():
+        if line.startswith("EXIT:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except ValueError:
+                return 1
+    # No EXIT marker: treat the exec result code as the verdict.
+    return res.exit_code if res.exit_code is not None else 1
+
+
+# 1. Metadata MUST be blocked (curl must FAIL: non-zero exit).
+try:
+    rc = curl_exit("http://169.254.169.254/latest/meta-data/")
+    if rc != 0:
+        result("metadata-blocked", True, f"curl exit={rc} (blocked, no IAM theft)")
+    else:
+        result("metadata-blocked", False, "169.254.169.254 REACHABLE from the sandbox (IAM theft possible)")
+except Exception as exc:  # noqa: BLE001
+    result("metadata-blocked", False, f"{type(exc).__name__}: {exc}")
+
+# 2. A non-allowlisted host MUST be blocked (curl must FAIL).
+try:
+    rc = curl_exit(f"https://{DENY_HOST}/")
+    if rc != 0:
+        result("default-deny", True, f"curl exit={rc} (non-allowlisted host blocked)")
+    else:
+        result("default-deny", False, f"non-allowlisted host {DENY_HOST} REACHABLE (default-deny not enforced)")
+except Exception as exc:  # noqa: BLE001
+    result("default-deny", False, f"{type(exc).__name__}: {exc}")
+
+# 3. The allowlisted host MUST be reachable (name-based egress via the in-pod DNS
+#    proxy + pin, proving the NIC binding and allowlist threading are correct).
+try:
+    rc = curl_exit(f"https://{ALLOW_NAME}/", extra_timeout=10)
+    if rc == 0:
+        result("allowlist-works", True, f"allowlisted host {ALLOW_NAME} reachable (curl exit=0)")
+    else:
+        result("allowlist-works", False, f"allowlisted host {ALLOW_NAME} NOT reachable (curl exit={rc})")
+except Exception as exc:  # noqa: BLE001
+    result("allowlist-works", False, f"{type(exc).__name__}: {exc}")
+PYEOF
+driver_rc=$?
+set -e
+
+# Fold the driver RESULT lines into the bash tally. ALL three egress checks are
+# REQUIRED (this is the blocker the maintainer KVM-verifies).
+for check in claim metadata-blocked default-deny allowlist-works; do
+  line="$(grep "^RESULT:${check}:" "$driver_out" | tail -1 || true)"
+  if [ -z "$line" ]; then
+    fail "check ${check}: driver produced no result (driver_rc=${driver_rc})"
+    continue
+  fi
+  verdict="$(printf '%s' "$line" | cut -d: -f3)"
+  detail="$(printf '%s' "$line" | cut -d: -f4-)"
+  if [ "$verdict" = "PASS" ]; then
+    pass "check ${check}: ${detail}"
+  else
+    fail "check ${check}: ${detail}"
+  fi
+done
+rm -f "$driver_out"
+
+# ---------------------------------------------------------------------------
+# Verdict.
+# ---------------------------------------------------------------------------
+echo
+echo "=== summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ==="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  diagnostics
+  exit 1
+fi
+echo "ALL PASS: husk egress isolation enforced (metadata blocked, default-deny, allowlist works)"


### PR DESCRIPTION
## Close the top untrusted-code blocker: husk network egress isolation

This closes the must-fix-first untrusted-code blocker (docs/threat-model.md section 1 item 1 / section 0 surface 5): on the default husk path a guest VM previously had default-OPEN egress and could reach `169.254.169.254` to steal the node's cloud IAM credentials. This branch gives every husk guest VM defense-in-depth egress isolation.

SECURITY-SENSITIVE. This is the top untrusted-code control, touching `internal/husk`, `internal/controller`, and `internal/netconf`. It is KVM-verified by the maintainer via `test/cluster-e2e/husk-network-e2e.sh` before it lands.

### What ships

- In-pod default-deny egress filter (the guarantee). The husk-stub programs an nftables default-deny egress chain on the VM's tap in the husk pod's OWN netns at activation (`internal/husk/netfilter.go`, applied in `internal/husk/stub.go`), reusing the raw-forkd dataplane rendering (`internal/netconf`: per-tap chain, `ip saddr` anti-spoof) and the controlled DNS proxy (`internal/dnsproxy`: name-allowlist resolution + IP pinning). Because the tap is in the pod's netns, this holds regardless of the cluster CNI.
- Unconditional cloud-metadata block. `netconf.RenderMetadataBlock` drops `169.254.169.254`, the `169.254.0.0/16` link-local range, and IPv6 `fd00:ec2::254` BEFORE any allow rule and regardless of policy (even `EgressAllow`), so the allowlist can never reach the metadata endpoint.
- Threaded per-template allowlist. `huskNotifyNetwork` delivers the fixed in-pod /30 + resolver and `huskEgressConfig` carries the template egress policy + allowlist in the activate request (`husk.ActivateRequest.Egress`/`Allow`). The controller-delivered /30 matches the stub NIC binding: the stub derives the tap from `GuestIP` via `netconf.DeriveTapName` and assigns `GatewayIP` to it.
- NET_ADMIN, scoped to the pod netns. The husk container drops ALL caps and adds only `NET_ADMIN` so the stub can program the in-pod firewall; the pod stays non-privileged, non-hostNetwork, `allowPrivilegeEscalation: false`, `seccomp: RuntimeDefault`, so the capability cannot reach the host netns. Documented as a THIRD PSA exception.
- Best-effort Kubernetes NetworkPolicy. The controller emits one `networking.k8s.io/v1` NetworkPolicy per pool selecting `mitos.run/husk=true` (default-deny egress, DNS allow, one rule per enforceable IP:port allow), owner-referenced to the pool for GC (`internal/controller/husknetworkpolicy.go`). HONEST CNI caveat: it enforces only on a CNI that implements NetworkPolicy, so it is defense in depth ONLY; the in-pod nft filter is the guarantee.
- Gated KVM cluster e2e. `test/cluster-e2e/husk-network-e2e.sh` (the new `cluster-husk-network-e2e` suite) asserts from inside a husk sandbox: `169.254.169.254` MUST fail (metadata blocked), a non-allowlisted host MUST fail (default-deny), an allowlisted host MUST succeed. Gated EXACTLY like `cluster-husk-e2e` (self-hosted KVM runner, `cluster` Environment second human gate, same trusted-trigger `if:`); the fork-PR gate is NOT widened.

### Docs

Threat-model surface 5 flipped from open/high to mitigated (in-pod default-deny + unconditional metadata block + threaded allowlist; best-effort NetworkPolicy as defense in depth), NET_ADMIN recorded as a third documented PSA exception, and ADR 0006 moved from proposed to accepted with the shipped mechanism.

### Verification

gofmt clean; `golangci-lint run` and `GOOS=linux golangci-lint run` both clean; `go build ./...` + `GOOS=linux GOARCH=amd64 go build ./...` + guest cross-build all pass; `go test ./internal/controller/ ./internal/husk/ ./internal/netconf/ ./internal/dnsproxy/` pass (controller via envtest); actionlint clean on the workflow; no em/en dashes in the diff; no api/ changes.

The maintainer reviews and KVM-verifies via `husk-network-e2e.sh` on the live cluster before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
