### PR TITLE
perf(husk): default CPU request 250m for higher sandbox density

### DIFF
--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -220,10 +220,15 @@ const defaultDataDir = "/var/lib/mitos"
 
 // defaultHuskCPU and defaultHuskMemory size a husk pod when the template
 // carries no Resources. They make the sandbox visible to the scheduler as
-// ordinary pod requests (scheduler truth). Documented defaults: 1 cpu, 512Mi,
-// matching the dormant stub's --mem-mib default.
+// ordinary pod requests (scheduler truth). The CPU default is a small RESERVATION
+// (250m), not a cap: the husk container has NO CPU limit, so the microVM bursts
+// freely up to node capacity when the agent runs, while the modest request packs
+// many mostly-idle sandboxes per node (agent sandboxes spend most time waiting on
+// the model, not on CPU). The k8s CPU request is decoupled from the guest vCPU
+// count (firecracker.VMConfig.VcpuCount); a template can raise the request for a
+// CPU-heavy workload, or memory becomes the binding density constraint first.
 var (
-	defaultHuskCPU    = resource.MustParse("1")
+	defaultHuskCPU    = resource.MustParse("250m")
 	defaultHuskMemory = resource.MustParse("512Mi")
 )
 

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -587,8 +587,8 @@ func TestBuildHuskPodDefaultSizing(t *testing.T) {
 	if got := pod.Spec.Containers[0].Resources.Requests[kvm]; got.Cmp(resource.MustParse("1")) != 0 {
 		t.Errorf("default kvm request = %s, want 1", got.String())
 	}
-	if got := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; got.Cmp(resource.MustParse("1")) != 0 {
-		t.Errorf("default cpu request = %s, want 1", got.String())
+	if got := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; got.Cmp(resource.MustParse("250m")) != 0 {
+		t.Errorf("default cpu request = %s, want 250m", got.String())
 	}
 	if got := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse("512Mi")) != 0 {
 		t.Errorf("default memory request = %s, want 512Mi", got.String())

--- a/test/cluster-e2e/husk-e2e.sh
+++ b/test/cluster-e2e/husk-e2e.sh
@@ -127,7 +127,7 @@ metadata:
 spec:
   image: ${E2E_IMAGE}
   resources:
-    cpu: "1"
+    cpu: "250m"
     memory: "512Mi"
 ---
 apiVersion: mitos.run/v1alpha1

--- a/test/cluster-e2e/husk-network-e2e.sh
+++ b/test/cluster-e2e/husk-network-e2e.sh
@@ -124,7 +124,7 @@ metadata:
 spec:
   image: ${E2E_IMAGE}
   resources:
-    cpu: "1"
+    cpu: "250m"
     memory: "512Mi"
   networkPolicy:
     egress: deny

--- a/test/cluster-e2e/workspace-e2e.sh
+++ b/test/cluster-e2e/workspace-e2e.sh
@@ -135,7 +135,7 @@ metadata:
 spec:
   image: ${E2E_IMAGE}
   resources:
-    cpu: "1"
+    cpu: "250m"
     memory: "512Mi"
 ---
 apiVersion: mitos.run/v1alpha1


### PR DESCRIPTION
Husk pods requested a full CPU by default, capping an 8-core node at ~8 sandboxes. The request is a scheduling reservation (no CPU limit, so the VM bursts), decoupled from the guest vCPU count. Lower the default to 250m (4x density; memory becomes the binding constraint) and drop the cluster-e2e templates to match (also fixes the e2e single-node capacity exhaustion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)