### PR TITLE
fix(husk): enable forkd networking so the template bakes the eth0 NIC

### DIFF
--- a/deploy/daemon/daemonset.yaml
+++ b/deploy/daemon/daemonset.yaml
@@ -59,6 +59,18 @@ spec:
             # Guest agent injected as /init for OCI image template builds. The
             # binary ships in the forkd image at this path (Dockerfile.forkd).
             - --agent-bin=/usr/local/bin/agent
+            # Networking is REQUIRED on the husk default: forkd is the template
+            # BUILDER, and the husk activation path remaps the snapshot's baked
+            # eth0 NIC to each pod's own tap via network_overrides on
+            # snapshot/load. Firecracker cannot add a NIC on restore, so the
+            # device must be baked at snapshot time; CreateTemplate only bakes it
+            # when networking is enabled (it creates a transient build-time
+            # placeholder tap, boots with eth0, then pauses and snapshots). Without
+            # this, husk activation fails with "Unknown Network Device" and the
+            # in-pod egress filter has no guest NIC to govern. The runtime
+            # per-pod tap + egress nftables are programmed IN the husk pod by the
+            # husk-stub (NET_ADMIN in the pod netns), not by forkd.
+            - --enable-networking
             # JAILER FOLLOW-UP: the per-VM jailer (uid/gid, chroot, cgroup) is
             # disabled here. forkd runs privileged: true (below) on the husk
             # path until jailer-in-pod lands. Re-add --jailer / --chroot-base /


### PR DESCRIPTION
Root cause of the husk-network e2e activation failure: forkd built husk templates without --enable-networking, so no eth0 NIC was baked, and the activation network_override hit 'Unknown Network Device'. Enable it on the forkd DaemonSet (forkd is the template builder; runtime per-pod networking is still in the husk-stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)