### PR TITLE
ci(cluster-e2e): pull base image via mirror.gcr.io (root cause: Docker Hub rate limit)

### DIFF
--- a/test/cluster-e2e/husk-e2e.sh
+++ b/test/cluster-e2e/husk-e2e.sh
@@ -36,7 +36,7 @@
 # Env knobs:
 #   READY_TIMEOUT   per-stage wait budget, seconds (default 180)
 #   POLL_INTERVAL   poll interval, seconds (default 1)
-#   E2E_IMAGE       template image (default python:3.12-slim)
+#   E2E_IMAGE       template image (default mirror.gcr.io/library/python:3.12-slim)
 #
 set -euo pipefail
 
@@ -48,7 +48,7 @@ fi
 
 READY_TIMEOUT="${READY_TIMEOUT:-180}"
 POLL_INTERVAL="${POLL_INTERVAL:-1}"
-E2E_IMAGE="${E2E_IMAGE:-python:3.12-slim}"
+E2E_IMAGE="${E2E_IMAGE:-mirror.gcr.io/library/python:3.12-slim}"
 
 RUN_ID="$(date +%s)-$$"
 TEMPLATE="e2e-tmpl-${RUN_ID}"

--- a/test/cluster-e2e/husk-network-e2e.sh
+++ b/test/cluster-e2e/husk-network-e2e.sh
@@ -30,7 +30,7 @@
 # Env knobs:
 #   READY_TIMEOUT   per-stage wait budget, seconds (default 180)
 #   POLL_INTERVAL   poll interval, seconds (default 1)
-#   E2E_IMAGE       template image (default python:3.12-slim)
+#   E2E_IMAGE       template image (default mirror.gcr.io/library/python:3.12-slim)
 #   ALLOW_HOST      allowlisted host:port to prove reachable (default example.com:443)
 #   DENY_HOST       non-allowlisted host to prove blocked (default 1.1.1.1)
 #
@@ -44,7 +44,7 @@ fi
 
 READY_TIMEOUT="${READY_TIMEOUT:-180}"
 POLL_INTERVAL="${POLL_INTERVAL:-1}"
-E2E_IMAGE="${E2E_IMAGE:-python:3.12-slim}"
+E2E_IMAGE="${E2E_IMAGE:-mirror.gcr.io/library/python:3.12-slim}"
 ALLOW_HOST="${ALLOW_HOST:-example.com:443}"
 DENY_HOST="${DENY_HOST:-1.1.1.1}"
 ALLOW_NAME="${ALLOW_HOST%%:*}"

--- a/test/cluster-e2e/workspace-e2e.sh
+++ b/test/cluster-e2e/workspace-e2e.sh
@@ -40,7 +40,7 @@
 # Env knobs:
 #   READY_TIMEOUT       per-stage wait budget, seconds (default 240)
 #   POLL_INTERVAL       poll interval, seconds (default 1)
-#   E2E_IMAGE           template image (default python:3.12-slim)
+#   E2E_IMAGE           template image (default mirror.gcr.io/library/python:3.12-slim)
 #   WORKSPACE_MEMORY    set to "1" to run stage 7 (the controller must run with
 #                       --workspace-memory-snapshots on a KVM node)
 #
@@ -54,7 +54,7 @@ fi
 
 READY_TIMEOUT="${READY_TIMEOUT:-240}"
 POLL_INTERVAL="${POLL_INTERVAL:-1}"
-E2E_IMAGE="${E2E_IMAGE:-python:3.12-slim}"
+E2E_IMAGE="${E2E_IMAGE:-mirror.gcr.io/library/python:3.12-slim}"
 WORKSPACE_MEMORY="${WORKSPACE_MEMORY:-0}"
 
 RUN_ID="$(date +%s)-$$"


### PR DESCRIPTION
The cluster-e2e suites were failing because template builds pull python:3.12-slim unauthenticated from Docker Hub and the node hit TOOMANYREQUESTS, producing empty template snapshots (husk pods then crash-loop on the missing rootfs). Default the e2e base image to mirror.gcr.io/library/python (no anonymous rate limit, no credential). Confirmed on the live KVM cluster: the same template builds FULL via the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)