### PR TITLE
fix(dnsproxy): refuse to pin non-public resolved addresses (DNS-rebind defense)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -439,7 +439,13 @@ husk-network KVM cluster e2e (see the status note below). The datapath is:
   into the per-tap nftables allow set, forwarding to a comma-separated upstream
   resolver list tried in failover order. The recommended value is the public pair
   `1.1.1.1:53,8.8.8.8:53`, deliberately NOT cluster DNS, so an untrusted sandbox
-  cannot resolve internal service names.
+  cannot resolve internal service names. The proxy also REFUSES to pin a resolved
+  address in any non-publicly-routable range (RFC1918, IPv6 ULA, loopback,
+  link-local, multicast, unspecified, RFC6598 CGNAT) and strips it from the
+  answer, so an allowlisted name whose authoritative DNS an attacker influences
+  cannot be rebound at internal cluster services or node-local targets
+  (DNS-rebinding-to-internal defense in depth, complementing the unconditional
+  IMDS block).
 - **The per-template allowlist is threaded husk-side.** `huskNotifyNetwork`
   delivers the fixed in-pod /30 plus the in-pod resolver, and `huskEgressConfig`
   carries the template egress policy + allowlist in the activate request

--- a/internal/dnsproxy/proxy.go
+++ b/internal/dnsproxy/proxy.go
@@ -143,6 +143,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
+	kept := make([]dns.RR, 0, len(resp.Answer))
 	for _, ans := range resp.Answer {
 		// Pin each A and AAAA answer. The pinner routes a v4 address into the v4
 		// set and a v6 address into the v6 set so the element type matches.
@@ -153,6 +154,20 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		case *dns.AAAA:
 			addr = rr.AAAA
 		default:
+			// Preserve non-address records (e.g. CNAME) in the response chain.
+			kept = append(kept, ans)
+			continue
+		}
+		// Refuse to pin a non-publicly-routable address: an allowlisted name whose
+		// authoritative DNS an attacker influences could otherwise be steered at
+		// internal cluster services, node-local, or other private targets (DNS
+		// rebinding to internal). Strip it from the response too so the guest
+		// neither learns nor (since it is not pinned, the default-deny chain drops
+		// it) can reach it. The nft metadata block covers IMDS; this is the
+		// resolver-side complement for the broader private ranges.
+		if isBlockedPinAddr(addr) {
+			s.logger.Warn("refusing to pin non-public resolved address (possible DNS rebinding to internal)",
+				"guest", clientIP.String(), "name", q.Name, "addr", addr.String())
 			continue
 		}
 		ttl := time.Duration(ans.Header().Ttl) * time.Second
@@ -165,11 +180,37 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 					"guest", clientIP.String(), "name", q.Name, "port", port, "err", perr)
 			}
 		}
+		kept = append(kept, ans)
 	}
+	resp.Answer = kept
 
 	if werr := w.WriteMsg(resp); werr != nil {
 		s.logger.Debug("dns write failed", "guest", clientIP.String(), "err", werr)
 	}
+}
+
+// cgnatNet is the RFC6598 shared address space (100.64.0.0/10), used by some
+// Kubernetes and cloud networks and not covered by net.IP.IsPrivate.
+var cgnatNet = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
+// isBlockedPinAddr reports whether a resolved address must NOT be pinned into a
+// guest's egress allow set (and must be stripped from the answer). It blocks
+// every non-globally-routable range: RFC1918 and IPv6 ULA (net.IP.IsPrivate),
+// loopback, link-local uni/multicast, multicast, the unspecified address, and
+// RFC6598 CGNAT. This stops an allowlisted name whose DNS an attacker controls
+// from being rebound at internal cluster services, node-local addresses, or
+// other private targets. Globally-routable addresses (the legitimate egress
+// targets) are unaffected.
+func isBlockedPinAddr(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() || ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() ||
+		ip.IsPrivate() {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil && cgnatNet.Contains(v4) {
+		return true
+	}
+	return false
 }
 
 func (s *Server) refuse(w dns.ResponseWriter, r *dns.Msg) {

--- a/internal/dnsproxy/proxy_test.go
+++ b/internal/dnsproxy/proxy_test.go
@@ -401,3 +401,91 @@ func TestServeDNSUpstreamFailureServfailNoPin(t *testing.T) {
 		t.Errorf("expected no pins on upstream failure, got %d", got)
 	}
 }
+
+func TestIsBlockedPinAddr(t *testing.T) {
+	blocked := []string{
+		"10.0.0.5", "172.16.0.1", "192.168.1.1", // RFC1918 (covers most cluster pod/service CIDRs)
+		"100.64.0.1",         // RFC6598 CGNAT
+		"127.0.0.1",          // loopback
+		"169.254.169.254",    // link-local (cloud metadata)
+		"0.0.0.0",            // unspecified
+		"224.0.0.1",          // multicast
+		"::1",                // v6 loopback
+		"fc00::1", "fd00::1", // v6 ULA
+		"fe80::1", // v6 link-local
+	}
+	for _, s := range blocked {
+		if !isBlockedPinAddr(net.ParseIP(s)) {
+			t.Errorf("isBlockedPinAddr(%s) = false, want true (non-public range)", s)
+		}
+	}
+	allowed := []string{"198.51.100.2", "93.184.216.34", "8.8.8.8", "2001:db8::7", "2606:4700:4700::1111"}
+	for _, s := range allowed {
+		if isBlockedPinAddr(net.ParseIP(s)) {
+			t.Errorf("isBlockedPinAddr(%s) = true, want false (public)", s)
+		}
+	}
+}
+
+// startPrivateUpstream answers internal.test A with a PRIVATE 10.0.0.5 (and a
+// public 198.51.100.9 for split.test, alongside a private one) to test pin
+// filtering.
+func startPrivateUpstream(t *testing.T) (string, func()) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		q := r.Question[0]
+		switch {
+		case q.Qtype == dns.TypeA && canonicalName(q.Name) == "internal.test":
+			rr, _ := dns.NewRR("internal.test. " + itoa(upstreamTTL) + " IN A 10.0.0.5")
+			m.Answer = append(m.Answer, rr)
+		case q.Qtype == dns.TypeA && canonicalName(q.Name) == "split.test":
+			pub, _ := dns.NewRR("split.test. " + itoa(upstreamTTL) + " IN A 198.51.100.9")
+			priv, _ := dns.NewRR("split.test. " + itoa(upstreamTTL) + " IN A 10.0.0.6")
+			m.Answer = append(m.Answer, pub, priv)
+		default:
+			m.SetRcode(r, dns.RcodeNameError)
+		}
+		_ = w.WriteMsg(m)
+	})
+	srv := &dns.Server{PacketConn: pc, Handler: handler}
+	go func() { _ = srv.ActivateAndServe() }()
+	return pc.LocalAddr().String(), func() { _ = srv.Shutdown() }
+}
+
+// TestServeDNSDoesNotPinPrivateAddresses proves an allowlisted name that
+// resolves to a private/internal address is NOT pinned (so the guest cannot
+// reach it) and the private answer is stripped from the response, blocking
+// DNS-rebinding to internal cluster targets.
+func TestServeDNSDoesNotPinPrivateAddresses(t *testing.T) {
+	upstream, stop := startPrivateUpstream(t)
+	defer stop()
+
+	reg := NewRegistry()
+	guest := net.ParseIP("10.200.0.2")
+	reg.Register(guest, map[string][]int{"internal.test": {443}, "split.test": {443}})
+	pinner := NewFakePinner()
+	s := newProxy(t, reg, pinner, upstream)
+
+	rw := &fakeRW{remote: &net.UDPAddr{IP: guest, Port: 5300}}
+	s.ServeDNS(rw, queryFor("internal.test", dns.TypeA))
+	if len(pinner.Pins()) != 0 {
+		t.Errorf("private address was pinned: %+v", pinner.Pins())
+	}
+	if out := rw.written(); out != nil && len(out.Answer) != 0 {
+		t.Errorf("private answer not stripped from response: %+v", out.Answer)
+	}
+
+	// split.test: only the public answer should be pinned and returned.
+	rw2 := &fakeRW{remote: &net.UDPAddr{IP: guest, Port: 5301}}
+	s.ServeDNS(rw2, queryFor("split.test", dns.TypeA))
+	pins := pinner.Pins()
+	if len(pins) != 1 || !pins[0].IP.Equal(net.ParseIP("198.51.100.9")) {
+		t.Errorf("split.test pins = %+v, want only the public 198.51.100.9", pins)
+	}
+}


### PR DESCRIPTION
## Summary
Hardening surfaced by the security review of the husk-network branch (#153). The controlled DNS resolver pinned **every** A/AAAA the upstream returned into the guest's nft egress allow set with no range check. An allowlisted name whose authoritative DNS an attacker influences could be rebound at an internal cluster service, a node-local address, or any private target: DNS-rebinding-to-internal, bypassing the egress allowlist. The unconditional IMDS block covered `169.254.0.0/16` but not the broader private ranges.

## Fix
The resolver now refuses to pin any address in a non-publicly-routable range (RFC1918, IPv6 ULA, loopback, link-local uni/multicast, multicast, unspecified, RFC6598 CGNAT) and strips it from the answer. The guest neither learns the internal IP nor can reach it (not pinned -> default-deny chain drops it). Globally-routable egress targets are unaffected.

Applies to both the husk in-pod proxy and the raw-forkd resolver (shared `internal/dnsproxy`).

## Tests
- `TestIsBlockedPinAddr`: table of private/special ranges blocked, public ranges allowed.
- `TestServeDNSDoesNotPinPrivateAddresses`: an allowlisted name resolving to `10.0.0.5` is not pinned and stripped from the answer; a split-answer name pins/returns only the public address.
- Existing public-IP pin tests unchanged (no regression).

Threat model updated (defense-in-depth note on the resolver pin filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)