### PR TITLE
feat(controller): rotate the per-namespace husk server leaf before expiry

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -904,8 +904,10 @@ arbitrary code at sandbox privilege.
      OwnerReferencesPermissionEnforcement plugin, so it is the durable control on
      clusters where control (1) is weaker. End-to-end verified by the husk KVM
      e2e (the controller-pins-vs-husk-serves handshake).
-  RESIDUAL: per-namespace husk cert ROTATION (reissue before NotAfter) is not yet
-  automated; tracked with the multi-tenant work in section 7.
+  ROTATION: EnsureHuskTLS now reissues the per-namespace leaf when it is within
+  HuskCertRenewBefore (30 days) of NotAfter, so a long-lived pool rotates its
+  husk serving cert ahead of expiry across reconciles rather than serving an
+  aging leaf until the control channel breaks.
 
 ## 7. Multi-tenancy statement
 

--- a/internal/controller/husk_tls.go
+++ b/internal/controller/husk_tls.go
@@ -3,11 +3,22 @@ package controller
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"time"
 
 	"github.com/paperclipinc/mitos/internal/pki"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// HuskCertRenewBefore is how long before a per-namespace husk leaf's NotAfter
+// EnsureHuskTLS reissues it. pki leaves are valid for 2 years, so a 30-day
+// window rotates well ahead of expiry across reconciles. A package var so tests
+// can widen it to force the renewal path deterministically.
+var HuskCertRenewBefore = 30 * 24 * time.Hour
 
 // HuskTLSSecretName is the per-pool-namespace husk control-channel server cert
 // (SAN husk.<namespace>.mitos), keys tls.crt/tls.key. Each pool namespace gets
@@ -33,10 +44,49 @@ func EnsureHuskTLS(ctx context.Context, c client.Client, controllerNamespace, po
 	if err != nil {
 		return fmt.Errorf("load CA to issue husk leaf for %s: %w", poolNamespace, err)
 	}
-	if _, err := ensureLeaf(ctx, c, poolNamespace, HuskTLSSecretName, pki.HuskServerName(poolNamespace), ca); err != nil {
+	leaf, err := ensureLeaf(ctx, c, poolNamespace, HuskTLSSecretName, pki.HuskServerName(poolNamespace), ca)
+	if err != nil {
 		return fmt.Errorf("ensure husk tls for %s: %w", poolNamespace, err)
 	}
+	// Rotate ahead of expiry: ensureLeaf only heals an unusable leaf (wrong keys,
+	// tampered, wrong CA), not a valid-but-aging one. Without this a long-lived
+	// pool would keep serving a leaf until it expired and the control channel
+	// broke. Reissue when the current leaf is within HuskCertRenewBefore of
+	// NotAfter; a parse failure is treated as needs-renew (fail toward a fresh,
+	// verifiable leaf).
+	if huskLeafNeedsRenew(leaf.CertPEM, time.Now()) {
+		fresh, err := ca.Issue(pki.HuskServerName(poolNamespace))
+		if err != nil {
+			return fmt.Errorf("reissue husk leaf for %s: %w", poolNamespace, err)
+		}
+		var sec corev1.Secret
+		if err := c.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: HuskTLSSecretName}, &sec); err != nil {
+			return fmt.Errorf("read husk tls secret %s for rotation: %w", poolNamespace, err)
+		}
+		if sec.Data == nil {
+			sec.Data = map[string][]byte{}
+		}
+		sec.Data["tls.crt"] = fresh.CertPEM
+		sec.Data["tls.key"] = fresh.KeyPEM
+		if err := c.Update(ctx, &sec); err != nil {
+			return fmt.Errorf("rotate husk tls secret %s: %w", poolNamespace, err)
+		}
+	}
 	return nil
+}
+
+// huskLeafNeedsRenew reports whether the PEM leaf is unparseable or within
+// HuskCertRenewBefore of its NotAfter as of now.
+func huskLeafNeedsRenew(certPEM []byte, now time.Time) bool {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return true
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return true
+	}
+	return now.Add(HuskCertRenewBefore).After(cert.NotAfter)
 }
 
 // HuskDialTLSConfig builds the controller client mTLS config for dialing a husk

--- a/internal/controller/husk_tls_test.go
+++ b/internal/controller/husk_tls_test.go
@@ -1,12 +1,47 @@
 package controller_test
 
 import (
+	"bytes"
 	"crypto/x509"
 	"testing"
+	"time"
 
 	"github.com/paperclipinc/mitos/internal/controller"
 	"github.com/paperclipinc/mitos/internal/pki"
 )
+
+// TestEnsureHuskTLSRotatesNearExpiryLeaf proves the per-namespace husk leaf is
+// reissued before it expires: with the renew-before window set wide enough that
+// a freshly issued leaf already counts as near expiry, a second EnsureHuskTLS
+// replaces the cert rather than leaving the soon-to-expire one in place.
+func TestEnsureHuskTLSRotatesNearExpiryLeaf(t *testing.T) {
+	c := newCoreClient(t)
+	ctrlNs := newPKINamespace(t, c)
+	if _, err := controller.EnsurePKI(ctx, c, ctrlNs); err != nil {
+		t.Fatal(err)
+	}
+	poolNs := newPKINamespace(t, c)
+	if err := controller.EnsureHuskTLS(ctx, c, ctrlNs, poolNs); err != nil {
+		t.Fatal(err)
+	}
+	first := getSecret(t, c, poolNs, controller.HuskTLSSecretName).Data["tls.crt"]
+
+	// Force the renewal path: a fresh ~2y leaf is "near expiry" under a 100y window.
+	orig := controller.HuskCertRenewBefore
+	controller.HuskCertRenewBefore = 100 * 365 * 24 * time.Hour
+	defer func() { controller.HuskCertRenewBefore = orig }()
+
+	if err := controller.EnsureHuskTLS(ctx, c, ctrlNs, poolNs); err != nil {
+		t.Fatal(err)
+	}
+	second := getSecret(t, c, poolNs, controller.HuskTLSSecretName).Data["tls.crt"]
+	if bytes.Equal(first, second) {
+		t.Fatal("expected the near-expiry husk leaf to be rotated, but the cert is unchanged")
+	}
+	// The rotated leaf must still chain to the CA with the per-namespace SAN.
+	ca := getSecret(t, c, ctrlNs, controller.CASecretName)
+	verifyLeaf(t, second, ca.Data["ca.crt"], pki.HuskServerName(poolNs), x509.ExtKeyUsageServerAuth)
+}
 
 // TestEnsureHuskTLSWritesPerNamespaceLeaf proves the controller issues a
 // husk.<ns>.mitos server leaf signed by the control-plane CA and writes it to a


### PR DESCRIPTION
## Summary
Closes the rotation residual from the per-namespace husk identity work (audit Finding 1 follow-up; path-to-1.0 G3). `EnsureHuskTLS` issued/healed the per-namespace `mitos-husk-tls` leaf but never rotated a valid-but-aging one, so a long-lived pool would serve its `husk.<ns>.mitos` leaf until expiry broke the mTLS control channel. It now reissues when the leaf is within `HuskCertRenewBefore` (30d) of `NotAfter`.

## Test Plan
- [x] `TestEnsureHuskTLSRotatesNearExpiryLeaf` (envtest): widens the renew window so a fresh ~2y leaf is near-expiry, asserts rotation + that the rotated leaf chains to the CA with the per-namespace SAN
- [x] `TestEnsureHuskTLSIsIdempotent` still passes (no rotation under the default window)
- [x] Full controller envtest suite green; gofmt + golangci-lint clean (darwin + linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)