### PR TITLE
feat(fork): re-sample live memory in Metering (lifetime accounting, G1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -514,8 +514,13 @@ below it; a `fork-correctness` CI job gates PRs touching `internal/fork/`,
   `--allow-unverified-snapshots`). Proven by unit tests and the KVM CI
   tamper-detection phase on a real snapshot; residual (verify-once, not
   per-fork) tracked in the threat model. See docs/snapshot-distribution.md.
-- ⬜ Lifetime memory accounting (`mitos_memory_unique_bytes` over time,
-  not just T=0)
+- 🔨 Lifetime memory accounting (`mitos_memory_unique_bytes` over time,
+  not just T=0): `Engine.Metering` now RE-SAMPLES each live sandbox's
+  `/proc/<pid>/smaps_rollup` on every metering scrape (off the GetCapacity hot
+  path), so the metering report reflects current lifetime memory instead of the
+  fork-time figure; unit-proven via an injected stat seam
+  (`TestMeteringResamplesLiveMemory`). Remaining: a KVM assertion that the metric
+  tracks growth after a real workload (pip-install-and-run)
 - ⬜ External security review scheduled before any 1.0 claim
 
 ## 2. Failure and GC semantics

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -43,6 +43,10 @@ type Engine struct {
 	jailer         firecracker.JailerConfig
 	sandboxes      map[string]*Sandbox
 	nextPort       int32
+	// memStat reads a live process's (unique, shared) resident memory. Nil uses
+	// readMemoryStats (/proc/<pid>/smaps_rollup); a seam so Metering's lifetime
+	// re-sample is unit-testable without a real VM.
+	memStat func(pid int) (unique, shared int64)
 
 	// casStore content-addresses every template snapshot for integrity
 	// verification (issue #9) and incremental transfer (Task 4). Rooted at
@@ -1513,10 +1517,20 @@ func (e *Engine) memorySamplesLocked() []metering.Sample {
 type meteringSnapshot struct {
 	id           string
 	template     string
+	pid          int
 	memoryUnique int64
 	memoryShared int64
 	hasVolumes   bool
 	volumes      []volume.Spec
+}
+
+// memStatFn returns the engine's memory-stat reader (the seam tests inject).
+// Production reads /proc/<pid>/smaps_rollup via readMemoryStats.
+func (e *Engine) memStatFn() func(pid int) (unique, shared int64) {
+	if e.memStat != nil {
+		return e.memStat
+	}
+	return readMemoryStats
 }
 
 // Metering returns the full CoW-aware node metering report (per-sandbox and
@@ -1551,6 +1565,7 @@ func (e *Engine) Metering() metering.Report {
 		snaps = append(snaps, meteringSnapshot{
 			id:           s.ID,
 			template:     s.TemplateID,
+			pid:          s.Pid,
 			memoryUnique: s.MemoryUnique,
 			memoryShared: s.MemoryShared,
 			hasVolumes:   s.hasVolumes,
@@ -1559,14 +1574,21 @@ func (e *Engine) Metering() metering.Report {
 	}
 	e.mu.RUnlock()
 
+	// Re-sample each live sandbox's memory now (outside the lock, like the disk
+	// stat below) so the report reflects LIFETIME memory, not the T=0 footprint
+	// recorded at fork time. A dead/recycled pid reads back zero (readMemoryStats
+	// guards pid<=0 and a missing /proc), which is correct for a sandbox going
+	// away. This is off the GetCapacity hot path, so the per-sandbox stat is fine.
+	stat := e.memStatFn()
 	samples := make([]metering.Sample, 0, len(snaps))
 	for _, sn := range snaps {
 		du, ds := e.diskFootprint(sn)
+		mu, ms := stat(sn.pid)
 		samples = append(samples, metering.Sample{
 			ID:           sn.id,
 			Template:     sn.template,
-			MemoryUnique: sn.memoryUnique,
-			MemoryShared: sn.memoryShared,
+			MemoryUnique: mu,
+			MemoryShared: ms,
 			DiskUnique:   du,
 			DiskShared:   ds,
 		})

--- a/internal/fork/metering_test.go
+++ b/internal/fork/metering_test.go
@@ -99,3 +99,27 @@ func TestMeteringDiskFreshIsAllUnique(t *testing.T) {
 		t.Errorf("Fresh DiskCoWSavings = %d, want 0", report.DiskCoWSavings)
 	}
 }
+
+// TestMeteringResamplesLiveMemory proves Metering re-reads each live sandbox's
+// memory (a lifetime sample) rather than returning the stale T=0 value recorded
+// at fork time. The sandbox's stored MemoryUnique is the fork-time figure; the
+// injected memStat reports the (larger) current footprint, and the report must
+// reflect the current value. This is the lifetime-memory-accounting fix (#3 / G1).
+func TestMeteringResamplesLiveMemory(t *testing.T) {
+	const mib = int64(1024 * 1024)
+	e := &Engine{
+		sandboxes: map[string]*Sandbox{
+			"s1": {ID: "s1", TemplateID: "tmpl-A", Pid: 4242, MemoryUnique: 1 * mib, MemoryShared: 20 * mib},
+		},
+		memStat: func(pid int) (int64, int64) {
+			if pid == 4242 {
+				return 9 * mib, 20 * mib // grew since fork
+			}
+			return 0, 0
+		},
+	}
+	report := e.Metering()
+	if report.TotalUnique != 9*mib {
+		t.Errorf("TotalUnique = %d, want %d (the live re-sampled value, not the T=0 fork-time 1MiB)", report.TotalUnique, 9*mib)
+	}
+}


### PR DESCRIPTION
## Summary
Path-to-1.0 G1 (fork-correctness §1, lifetime memory accounting). Each sandbox's `MemoryUnique`/`MemoryShared` was recorded once at fork time and never refreshed, so the metering report and `mitos_memory_unique_bytes` showed the T=0 footprint, not lifetime memory. `Engine.Metering` now re-reads `/proc/<pid>/smaps_rollup` per live sandbox at scrape time (in the existing post-lock loop, alongside the disk stat), staying off the lock-light `GetCapacity` hot path.

Read goes through a `memStat` seam (nil = `readMemoryStats`) so it's unit-testable without a real VM.

## Test Plan
- [x] `TestMeteringResamplesLiveMemory`: stored MemoryUnique is the T=0 value, injected memStat reports a larger current footprint, report reflects the live value
- [x] Existing metering/capacity fork tests still pass; `go build ./...`; gofmt + golangci-lint clean (darwin + linux)
- [ ] KVM gate: a fork-correctness assertion that the metric tracks growth after a pip-install-and-run workload (remaining; flips the §1 row fully)

A dead/recycled pid reads back zero (readMemoryStats guards pid<=0 / missing /proc), correct for a sandbox going away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)