### PR TITLE
fix(controller): per-node snapshot digest for husk pods (#175)

### DIFF
--- a/internal/controller/husk_pernode_digest_test.go
+++ b/internal/controller/husk_pernode_digest_test.go
@@ -1,0 +1,127 @@
+package controller_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/controller"
+)
+
+// TestHuskPodsUsePerNodeDigest is the regression for issue #175. Each forkd node
+// builds its template snapshot INDEPENDENTLY, so the recorded content-addressed
+// digests differ per node. The controller must pin each husk pod to one snapshot
+// node and pass THAT node's digest as --expected-digest; handing every pod a
+// single cluster-wide digest makes pods that land on any other node fail
+// prepare-time snapshot verification ("read recorded manifest: no such file").
+func TestHuskPodsUsePerNodeDigest(t *testing.T) {
+	c := k8sClient
+	const (
+		tmpl     = "pernode-tmpl"
+		poolName = "pernode-pool"
+		digestA  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		digestB  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: tmpl, Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName, Namespace: "default"},
+		Spec: v1alpha1.SandboxPoolSpec{
+			TemplateRef: v1alpha1.LocalObjectReference{Name: tmpl},
+			Replicas:    2,
+		},
+	}
+	for _, obj := range []client.Object{template, pool} {
+		if err := c.Create(ctx, obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, p := range listHuskPods(t, c, poolName) {
+			_ = c.Delete(ctx, &p)
+		}
+		_ = c.Delete(ctx, pool)
+		_ = c.Delete(ctx, template)
+	})
+
+	// Two healthy holders of the SAME template with DIFFERENT recorded digests.
+	reg := controller.NewNodeRegistry()
+	reg.Register(&controller.NodeInfo{
+		Name:            "node-a",
+		TemplateIDs:     []string{tmpl},
+		TemplateDigests: map[string]string{tmpl: digestA},
+	})
+	reg.Register(&controller.NodeInfo{
+		Name:            "node-b",
+		TemplateIDs:     []string{tmpl},
+		TemplateDigests: map[string]string{tmpl: digestB},
+	})
+
+	r := &controller.SandboxPoolReconciler{
+		Client:          c,
+		NodeRegistry:    reg,
+		EnableHuskPods:  true,
+		HuskStubImage:   "mitos-husk-stub:test",
+		KVMResourceName: "mitos.run/kvm",
+	}
+	if _, err := r.ReconcileHuskPodsForTest(ctx, pool, template); err != nil {
+		t.Fatalf("reconcileHuskPods: %v", err)
+	}
+
+	pods := listHuskPods(t, c, poolName)
+	if len(pods) != 2 {
+		t.Fatalf("want 2 husk pods, got %d", len(pods))
+	}
+
+	// Each pod must be pinned to exactly one node and carry THAT node's digest.
+	wantDigestForNode := map[string]string{"node-a": digestA, "node-b": digestB}
+	seenNode := map[string]bool{}
+	for _, p := range pods {
+		node := pinnedNode(t, &p)
+		digest := argValue(p.Spec.Containers[0].Args, "--expected-digest")
+		if want := wantDigestForNode[node]; digest != want {
+			t.Errorf("pod %s pinned to %q has --expected-digest %q, want %q (the node-local digest)", p.Name, node, digest, want)
+		}
+		seenNode[node] = true
+	}
+	// Both nodes must be used (the bug pinned both pods to one digest/node).
+	if !seenNode["node-a"] || !seenNode["node-b"] {
+		t.Errorf("husk pods did not spread across both snapshot nodes: %v", seenNode)
+	}
+}
+
+// pinnedNode returns the single hostname a husk pod is pinned to via required
+// node affinity, or "" if it is not pinned to exactly one.
+func pinnedNode(t *testing.T, p *corev1.Pod) string {
+	t.Helper()
+	aff := p.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil || aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("pod %s has no required node affinity (not pinned to a snapshot node)", p.Name)
+	}
+	terms := aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	for _, term := range terms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == "kubernetes.io/hostname" && len(expr.Values) == 1 {
+				return expr.Values[0]
+			}
+		}
+	}
+	t.Fatalf("pod %s not pinned to exactly one hostname: %+v", p.Name, terms)
+	return ""
+}
+
+// argValue returns the value following flag in args, or "" if absent.
+func argValue(args []string, flag string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -1051,18 +1051,47 @@ func (r *SandboxPoolReconciler) reconcileHuskPods(ctx context.Context, pool *v1a
 			DataDir:         r.DataDir,
 			TLSSecretName:   r.HuskTLSSecretName,
 			CASecretName:    r.HuskCASecretName,
-			// The recorded snapshot manifest digest, so the husk pod mounts the
-			// manifest and the stub verifies the snapshot before loading
-			// (fail-closed). Empty (no node has reported it yet) falls back to the
-			// stub's development escape hatch so the warm pool still activates.
-			ExpectedDigest: r.huskTemplateDigest(pool.Spec.TemplateRef.Name),
-			// Pin husk pods to the nodes the pool built the snapshot on, so the
-			// read-only snapshot hostPath resolves. Empty (no registry, or no node
-			// holds it yet) falls back to the kvm nodeSelector alone.
-			SnapshotNodes: r.snapshotNodeNames(pool.Spec.TemplateRef.Name),
+			// ExpectedDigest and SnapshotNodes are assigned PER POD below. Each node
+			// builds its template snapshot independently, so the recorded
+			// content-addressed digests differ per node. A husk pod must be pinned to
+			// exactly ONE snapshot node and verify against THAT node's digest;
+			// handing every pod a single cluster-wide digest makes pods that land on
+			// any other node fail prepare-time snapshot verification (issue #175).
+		}
+		// Snapshot holders with their own per-node digests, balanced across so a
+		// pool spreads its warm pods (and so a lost node's slots refill onto the
+		// survivors, where the digest is correct for that node).
+		var holders []SnapshotHolder
+		if r.NodeRegistry != nil {
+			holders = r.NodeRegistry.SnapshotHolders(pool.Spec.TemplateRef.Name)
+		}
+		assigned := map[string]int{}
+		for i := range owned {
+			if n := owned[i].Spec.NodeName; n != "" {
+				assigned[n]++
+			}
 		}
 		for i := int32(0); i < deficit; i++ {
-			pod := r.buildHuskPod(pool, template, opts)
+			podOpts := opts
+			if len(holders) > 0 {
+				// Pick the least-loaded holder so the deficit spreads evenly.
+				pick := holders[0]
+				for _, h := range holders {
+					if assigned[h.Name] < assigned[pick.Name] {
+						pick = h
+					}
+				}
+				assigned[pick.Name]++
+				podOpts.SnapshotNodes = []string{pick.Name}
+				podOpts.ExpectedDigest = pick.Digest
+			} else {
+				// No registry, or no node has reported holding the snapshot yet: fall
+				// back to the kvm nodeSelector alone and the stub's unverified escape
+				// hatch so a pre-digest pool still warms.
+				podOpts.SnapshotNodes = r.snapshotNodeNames(pool.Spec.TemplateRef.Name)
+				podOpts.ExpectedDigest = r.huskTemplateDigest(pool.Spec.TemplateRef.Name)
+			}
+			pod := r.buildHuskPod(pool, template, podOpts)
 			if err := r.Create(ctx, pod); err != nil {
 				result.dormant = existing
 				return result, fmt.Errorf("create husk pod for pool %s: %w", pool.Name, err)

--- a/internal/controller/node_registry.go
+++ b/internal/controller/node_registry.go
@@ -282,6 +282,31 @@ func (r *NodeRegistry) NodesWithTemplate(templateID string) []*NodeInfo {
 	return out
 }
 
+// SnapshotHolder is a healthy node that holds a template snapshot, paired with
+// the content-addressed digest THAT node recorded for it. Each node builds its
+// template snapshot independently, so these digests differ per node; a husk pod
+// pinned to a node must verify against this node's digest, never another's.
+type SnapshotHolder struct {
+	Name   string
+	Digest string
+}
+
+// SnapshotHolders returns every healthy node holding templateID with its own
+// recorded digest (empty string if the node has not reported one yet). The
+// name/digest pairs are copied out under the lock so callers never read
+// NodeInfo concurrently.
+func (r *NodeRegistry) SnapshotHolders(templateID string) []SnapshotHolder {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []SnapshotHolder
+	for _, n := range r.nodes {
+		if n.isHealthy() && n.hasSnapshot(templateID) {
+			out = append(out, SnapshotHolder{Name: n.Name, Digest: n.TemplateDigests[templateID]})
+		}
+	}
+	return out
+}
+
 // TemplateSource picks a healthy node that holds the template AND reports a
 // content-addressed digest for it, and returns the holder, its CAS-serving base
 // URL, and the digest. It is the source the pool reconciler distributes from:


### PR DESCRIPTION
Fixes #175. Verified on a real 2-node Talos KVM cluster.

Each forkd node builds its template snapshot independently, so recorded content-addressed digests differ per node. `reconcileHuskPods` handed every husk pod a single cluster-wide digest (first healthy holder's) plus affinity to ALL snapshot nodes, so a pod landing on any other node failed prepare-time verification (`read recorded manifest: no such file`) and CrashLoopBackOff'd. Only the build node ran husk pods: no cross-node redundancy, broken refill, while the pool still reported readySnapshots>0 (masking it).

## Change
- `NodeRegistry.SnapshotHolders(templateID)` returns each healthy holder with its OWN digest (lock-safe).
- `reconcileHuskPods` assigns each deficit pod to one holder (balanced), pinning `SnapshotNodes` to that single node and `ExpectedDigest` to that node's digest.

## Verification (live 2-node cluster)
- Before: node1 husk pods CrashLoopBackOff (told to expect node2's digest 330d9c7a; node1 has 0a90da7a).
- After (this image deployed): node1 pods use 0a90da7a, node2 pods use 330d9c7a, BOTH Running, one per node on a fresh pool.
- `TestHuskPodsUsePerNodeDigest` (regression): two holders, different digests -> each pod pinned to its node with that node's --expected-digest. Full husk/pool envtest suite + lint green.

## Follow-up (separate, filed)
Node-loss failover latency + a claim falsely reporting Ready while its node is NotReady (transient reboots are ridden out within the ~2min/5min windows; permanent-death failover unverified).