### PR TITLE
fix(chart): fresh helm install comes up out of the box (#173)

### DIFF
--- a/deploy/charts/mitos/README.md
+++ b/deploy/charts/mitos/README.md
@@ -24,17 +24,30 @@ kubectl label node <node-name> mitos.run/kvm=true
 
 ## Install
 
+forkd, the husk pods, and the device plugin are privileged and the install
+namespace MUST carry `pod-security.kubernetes.io/enforce: privileged`. Helm
+cannot both create its release namespace AND apply those labels (it needs the
+namespace to exist before it can store the release), and `--create-namespace`
+makes an UNLABELED namespace that PSA `restricted` then rejects. So create the
+labeled namespace first, then install with `namespace.create=false`:
+
 ```
-helm install mitos deploy/charts/mitos -n mitos --create-namespace
+kubectl create namespace mitos
+kubectl label namespace mitos \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged
+helm install mitos deploy/charts/mitos -n mitos --set namespace.create=false
 ```
 
 The `crds/` directory installs the CRDs before the templated resources. Helm does
 not upgrade or delete CRDs on chart upgrade or uninstall; manage CRD schema
 changes out of band.
 
-If you let the chart manage the namespace (the default, `namespace.create=true`),
-you can drop `--create-namespace`; the chart renders the Namespace with the
-required PodSecurity labels.
+`namespace.create=true` renders a Namespace object with the PodSecurity labels
+for the case where the chart is installed into a DIFFERENT namespace than the one
+it creates; do not combine it with `--create-namespace` for the release namespace
+(see above).
 
 ## Uninstall
 

--- a/deploy/charts/mitos/templates/forkd-daemonset.yaml
+++ b/deploy/charts/mitos/templates/forkd-daemonset.yaml
@@ -136,6 +136,10 @@ spec:
         - name: docker-config
           secret:
             secretName: {{ .Values.imagePullSecret.name }}
+            # Optional so forkd starts even when no pull secret exists (public
+            # base images need none). Without this a missing imagePullSecret is a
+            # FailedMount that blocks forkd indefinitely (issue #173).
+            optional: true
             items:
               - key: .dockerconfigjson
                 path: config.json

--- a/deploy/charts/mitos/templates/kernel-daemonset.yaml
+++ b/deploy/charts/mitos/templates/kernel-daemonset.yaml
@@ -33,6 +33,18 @@ spec:
       initContainers:
         - name: stage-kernel
           image: curlimages/curl:8.11.0
+          # Run as root: the curl image defaults to uid 100, but the forkd data
+          # dir (/var/lib/mitos) is root-owned 0755 on a freshly provisioned data
+          # disk, so uid 100 cannot write the kernel and the download fails with
+          # curl (23), CrashLoopBackOff on every fresh node (issue #173). forkd
+          # reads this kernel as root, so staging it as root is correct.
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Fixes #173. Three blockers that each break a default install on a clean cluster, found + verified on a real 2-node Talos KVM cluster:

1. **kernel-stage init as root** - curl image (uid 100) cannot write the root-owned /var/lib/mitos data dir -> curl(23) CrashLoopBackOff on every fresh node.
2. **forkd ghcr-pull volume optional** - it's mounted as a volume, so the default imagePullSecret.create=false was a FailedMount blocking forkd forever; public images need no secret.
3. **README namespace/PSA** - documented the verified create+label-namespace then `--set namespace.create=false` path (helm can't create-and-label its own release namespace; --create-namespace makes an unlabeled one PSA restricted rejects).

helm lint + template (kube 1.31) clean; kernel-stage + namespace paths verified live; ghcr-pull optional render-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)