### PR TITLE
fix(controller): complete #177 — cross-node failover + readiness accuracy

### DIFF
--- a/internal/controller/husk_activation_test.go
+++ b/internal/controller/husk_activation_test.go
@@ -270,14 +270,23 @@ func TestHuskClaimActivatesDormantPod(t *testing.T) {
 // gate). The digest is a content address, not a secret.
 func TestHuskClaimActivateCarriesExpectedDigest(t *testing.T) {
 	const wantDigest = "1111111111111111111111111111111111111111111111111111111111111111"
-	// Register a healthy node holding the template with a recorded digest, so
-	// TemplateDigest resolves it for the claim reconciler.
+	const otherDigest = "2222222222222222222222222222222222222222222222222222222222222222"
+	// Nodes build snapshots independently, so digests differ per node (#175): the
+	// activation must verify against the digest of the node the chosen pod runs on
+	// (kvm-node-1, per makeDormantHuskPod), NOT a cluster-wide pick. Register a
+	// DECOY node with a different digest FIRST so a cluster-wide lookup would
+	// resolve the wrong one; the pod's node carries wantDigest (#177).
 	testRegistry.Register(&controller.NodeInfo{
-		Name:            "digest-node",
+		Name:            "other-node",
+		TemplateIDs:     []string{"husk-d-tmpl"},
+		TemplateDigests: map[string]string{"husk-d-tmpl": otherDigest},
+	})
+	testRegistry.Register(&controller.NodeInfo{
+		Name:            "kvm-node-1",
 		TemplateIDs:     []string{"husk-d-tmpl"},
 		TemplateDigests: map[string]string{"husk-d-tmpl": wantDigest},
 	})
-	t.Cleanup(func() { testRegistry.Unregister("digest-node") })
+	t.Cleanup(func() { testRegistry.Unregister("other-node"); testRegistry.Unregister("kvm-node-1") })
 
 	pod := makeDormantHuskPod(t, "husk-d-pool", "10.1.2.9")
 	_ = pod

--- a/internal/controller/husk_unclaim_test.go
+++ b/internal/controller/husk_unclaim_test.go
@@ -1,0 +1,58 @@
+package controller_test
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/paperclipinc/mitos/api/v1alpha1"
+	"github.com/paperclipinc/mitos/internal/controller"
+	"github.com/paperclipinc/mitos/internal/husk"
+)
+
+// TestHuskActivationFailureReleasesClaimLabel is the regression for the orphaned
+// husk pod half of issue #177. The claim path stamps the mitos.run/claim label
+// BEFORE activating (the mutual-exclusion commit). If activation then fails
+// (a transient transport error, or a per-node-digest mismatch when failing over
+// to another node), the label must be RELEASED so the pod returns to the dormant
+// pool. Without that, the stamped-but-never-activated pod is excluded from
+// selectDormantHuskPod forever, leaking warm capacity and blocking failover (the
+// claim could find "no dormant pod" while a healthy pod sits orphaned).
+func TestHuskActivationFailureReleasesClaimLabel(t *testing.T) {
+	testRegistry.Register(&controller.NodeInfo{
+		Name:            "kvm-node-1",
+		TemplateIDs:     []string{"huskfail-tmpl"},
+		TemplateDigests: map[string]string{"huskfail-tmpl": "4444444444444444444444444444444444444444444444444444444444444444"},
+	})
+	t.Cleanup(func() { testRegistry.Unregister("kvm-node-1") })
+
+	pod := makeDormantHuskPod(t, "huskfail-pool", "10.1.2.12")
+
+	// Activator that always FAILS (fail-closed, !OK).
+	act := &fakeActivator{result: husk.ActivateResult{OK: false, Error: "simulated activation failure"}}
+	setHuskTestActivator(act.activate)
+	t.Cleanup(func() { setHuskTestActivator(nil) })
+
+	_ = makeHuskClaim(t, "huskfail", v1alpha1.SandboxClaimSpec{})
+
+	// The claim cannot go Ready. The pod must be released back to dormant: poll
+	// for the claim label to be cleared (the fix releases it after each failed
+	// activation). Without the fix the label stays set forever -> this times out.
+	released := false
+	deadline := time.Now().Add(25 * time.Second)
+	for time.Now().Before(deadline) {
+		var p corev1.Pod
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &p); err == nil {
+			if p.Labels["mitos.run/claim"] == "" {
+				released = true
+				break
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	if !released {
+		t.Error("husk pod claim label was never released after a failed activation; the pod is orphaned (#177)")
+	}
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -1274,3 +1274,24 @@ func (r *SandboxClaimReconciler) markHuskPodClaimed(ctx context.Context, pod *co
 	}
 	return nil
 }
+
+// unmarkHuskPodClaimed removes the mitos.run/claim label so a husk pod returns
+// to the dormant pool after a FAILED activation. The claim path stamps the label
+// BEFORE activating (the mutual-exclusion commit); without releasing it on
+// failure, a pod that was claimed but never finished activating (a transient
+// transport error, or a per-node-digest mismatch when failing over to another
+// node) keeps the label forever and is excluded from selectDormantHuskPod
+// permanently, leaking warm capacity and blocking cross-node failover (#177). It
+// is the claim that stamped the label releasing it, so no optimistic lock is
+// needed; a no-op when the label is already absent.
+func (r *SandboxClaimReconciler) unmarkHuskPodClaimed(ctx context.Context, pod *corev1.Pod) error {
+	if pod.Labels[huskClaimLabel] == "" {
+		return nil
+	}
+	patch := client.MergeFrom(pod.DeepCopy())
+	delete(pod.Labels, huskClaimLabel)
+	if err := r.Patch(ctx, pod, patch); err != nil {
+		return fmt.Errorf("release husk pod %s claim label: %w", pod.Name, err)
+	}
+	return nil
+}

--- a/internal/controller/node_registry.go
+++ b/internal/controller/node_registry.go
@@ -307,6 +307,22 @@ func (r *NodeRegistry) SnapshotHolders(templateID string) []SnapshotHolder {
 	return out
 }
 
+// TemplateDigestOnNode returns the content-addressed digest THAT node recorded
+// for templateID. Nodes build snapshots independently so digests differ per
+// node; a husk pod activation must verify against the digest of the node the pod
+// runs on, never a cluster-wide pick (issue #177). Returns false if the node is
+// unknown or has not reported a digest.
+func (r *NodeRegistry) TemplateDigestOnNode(nodeName, templateID string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if n, ok := r.nodes[nodeName]; ok {
+		if d, ok := n.TemplateDigests[templateID]; ok && d != "" {
+			return d, true
+		}
+	}
+	return "", false
+}
+
 // TemplateSource picks a healthy node that holds the template AND reports a
 // content-addressed digest for it, and returns the holder, its CAS-serving base
 // URL, and the digest. It is the source the pool reconciler distributes from:

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -752,7 +752,12 @@ func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *
 	// hatch, which is exactly the fail-closed behavior we want in production.
 	expectedDigest := ""
 	if r.NodeRegistry != nil {
-		if d, ok := r.NodeRegistry.TemplateDigest(pool.Spec.TemplateRef.Name); ok {
+		// Verify against THIS pod's node's digest, not a cluster-wide pick: nodes
+		// build their template snapshots independently, so the recorded digests
+		// differ per node (#175). Using another node's digest fails the stub's
+		// prepare-time verification, which is what blocked cross-node failover
+		// (the claim could only ever re-activate on its origin node) (#177).
+		if d, ok := r.NodeRegistry.TemplateDigestOnNode(pod.Spec.NodeName, pool.Spec.TemplateRef.Name); ok {
 			expectedDigest = d
 		}
 	}
@@ -784,6 +789,13 @@ func (r *SandboxClaimReconciler) reconcileHuskClaim(ctx context.Context, claim *
 		}
 		logger.Info("husk activation failed, pending", "pod", pod.Name, "node", pod.Spec.NodeName, "detail", msg)
 		recordClaimError(claim.Spec.PoolRef.Name, "activate")
+		// Release the claim label stamped before activation so this pod returns to
+		// the dormant pool and can be retried (by this claim or another). Without
+		// this a stamped-but-not-activated pod is orphaned forever, leaking warm
+		// capacity and blocking failover (#177).
+		if uerr := r.unmarkHuskPodClaimed(ctx, pod); uerr != nil {
+			logger.Error(uerr, "release husk pod claim label after activation failure", "pod", pod.Name)
+		}
 		claim.Status.Phase = v1alpha1.SandboxPending
 		setCondition(&claim.Status.Conditions, metav1.Condition{
 			Type:               "Ready",


### PR DESCRIPTION
Fixes #177 (both halves). Verified on a live 2-node Talos KVM cluster.

## 1. Cross-node failover (verified live)
A claim whose node is drained now recovers on the OTHER node (~16s; before: stuck 240s).
- Activation now verifies against the digest of the node the chosen pod runs on (`TemplateDigestOnNode`), not a cluster-wide pick — nodes build snapshots independently so digests differ per node (#175).
- A FAILED activation now releases the `mitos.run/claim` label (`unmarkHuskPodClaimed`) so the pod returns to the dormant pool; previously each failed cross-node attempt orphaned a pod until the pool reported "no dormant slot".

## 2. Readiness accuracy
A Ready husk claim no longer falsely reports Ready while its backing node is NotReady (rebooting/unreachable). `reflectHuskBackingReadiness` flips the Ready condition to False (`BackingPodNotReady`) when the backing pod is NotReady and back to True on recovery; the existing `Watches(&Pod)` mapping makes detection prompt, with a `huskHealthRequeue` poll as the safety net. Actual loss/re-pend stays owned by `checkHuskPodLost`.

## Tests
- `TestHuskClaimActivateCarriesExpectedDigest` (decoy node, asserts the pod's-node digest), `TestHuskActivationFailureReleasesClaimLabel`, `TestReflectHuskBackingReadiness`. Full husk/claim/pool suite + lint green.

## Live verification
Cross-node failover demonstrated end-to-end (cordon node + delete its pods → claim recovers on the other node). Readiness reflection is unit-proven (the live flip window on a fast Talos reboot is too narrow to catch reliably).