### PR TITLE
fix(controller): reflect backing-pod readiness in a Ready husk claim (#177)

### DIFF
--- a/internal/controller/husk_readiness_test.go
+++ b/internal/controller/husk_readiness_test.go
@@ -1,0 +1,75 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/paperclipinc/mitos/api/v1alpha1"
+)
+
+func rdyClaim() *v1alpha1.SandboxClaim {
+	return &v1alpha1.SandboxClaim{Status: v1alpha1.SandboxClaimStatus{
+		Phase: v1alpha1.SandboxReady, Node: "n1", Endpoint: "10.0.0.1:9091", SandboxID: "pod-1",
+		Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue, Reason: "HuskActivated", LastTransitionTime: metav1.Now()}},
+	}}
+}
+func rdyPod(ready bool) *corev1.Pod {
+	st := corev1.ConditionFalse
+	if ready {
+		st = corev1.ConditionTrue
+	}
+	return &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: st}}}}
+}
+func rdyCond(c *v1alpha1.SandboxClaim) (metav1.ConditionStatus, string) {
+	for _, x := range c.Status.Conditions {
+		if x.Type == "Ready" {
+			return x.Status, x.Reason
+		}
+	}
+	return "", ""
+}
+
+// TestReflectHuskBackingReadiness is the #177 readiness-accuracy unit: a Ready
+// claim must reflect its backing pod going NotReady (node outage) in its Ready
+// condition, and recover when the pod is Ready again, without churning otherwise.
+func TestReflectHuskBackingReadiness(t *testing.T) {
+	now := time.Now()
+
+	// Ready pod: no change to a Ready=True condition.
+	c := rdyClaim()
+	if reflectHuskBackingReadiness(c, rdyPod(true), now) {
+		t.Error("ready backing pod should not change the Ready condition")
+	}
+	if s, _ := rdyCond(c); s != metav1.ConditionTrue {
+		t.Errorf("Ready=%s, want True", s)
+	}
+
+	// NotReady pod: flip Ready -> False with BackingPodNotReady.
+	c = rdyClaim()
+	if !reflectHuskBackingReadiness(c, rdyPod(false), now) {
+		t.Fatal("NotReady backing pod should flip Ready to False")
+	}
+	if s, r := rdyCond(c); s != metav1.ConditionFalse || r != "BackingPodNotReady" {
+		t.Errorf("got Ready=%s reason=%s, want False/BackingPodNotReady", s, r)
+	}
+	// Stable: a second NotReady pass does not churn.
+	if reflectHuskBackingReadiness(c, rdyPod(false), now) {
+		t.Error("already-reflected NotReady should not change again")
+	}
+	// Recovery: pod Ready again flips back to True.
+	if !reflectHuskBackingReadiness(c, rdyPod(true), now) {
+		t.Fatal("recovered backing pod should flip Ready back to True")
+	}
+	if s, _ := rdyCond(c); s != metav1.ConditionTrue {
+		t.Errorf("Ready=%s after recovery, want True", s)
+	}
+
+	// nil pod (lost-but-not-yet-repended edge): treated as NotReady.
+	c = rdyClaim()
+	if !reflectHuskBackingReadiness(c, nil, now) {
+		t.Error("nil backing pod should flip Ready to False")
+	}
+}

--- a/internal/controller/huskdrain.go
+++ b/internal/controller/huskdrain.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -209,4 +210,47 @@ func huskPodToClaim(_ context.Context, obj client.Object) []ctrl.Request {
 		return nil
 	}
 	return []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: obj.GetNamespace(), Name: claimName}}}
+}
+
+// reflectHuskBackingReadiness flips a Ready husk claim's Ready condition to match
+// its backing pod's readiness. A pod whose node is rebooting or unreachable is
+// NotReady (but not yet lost), so the sandbox endpoint is unreachable and the
+// claim must NOT keep reporting Ready (#177). It flips back to True when the pod
+// recovers. Actual loss/eviction (re-pend) is owned by checkHuskPodLost; this
+// only reflects transient unreachability in the condition. Returns whether it
+// changed the condition (so the caller writes status only when needed).
+func reflectHuskBackingReadiness(claim *v1alpha1.SandboxClaim, pod *corev1.Pod, now time.Time) bool {
+	ready := pod != nil && huskPodReady(pod)
+	var cur *metav1.Condition
+	for i := range claim.Status.Conditions {
+		if claim.Status.Conditions[i].Type == "Ready" {
+			cur = &claim.Status.Conditions[i]
+			break
+		}
+	}
+	if !ready {
+		// Already reflected as a backing-pod outage: leave it (avoid churn).
+		if cur != nil && cur.Status == metav1.ConditionFalse && cur.Reason == "BackingPodNotReady" {
+			return false
+		}
+		return setCondition(&claim.Status.Conditions, metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(now),
+			Reason:             "BackingPodNotReady",
+			Message:            fmt.Sprintf("backing husk pod %s on node %s is not Ready; the sandbox is temporarily unreachable (node outage or pod restart)", claim.Status.SandboxID, claim.Status.Node),
+		})
+	}
+	// Healthy again: only act if we previously flipped it to NotReady, so a poll
+	// never clobbers the original activation condition.
+	if cur != nil && cur.Status == metav1.ConditionFalse && cur.Reason == "BackingPodNotReady" {
+		return setCondition(&claim.Status.Conditions, metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(now),
+			Reason:             "HuskActivated",
+			Message:            "backing husk pod recovered to Ready",
+		})
+	}
+	return false
 }

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -50,6 +50,12 @@ const pendingSinceAnnotation = "mitos.run/capacity-pending-since"
 // once a node frees up or a new node joins.
 const capacityPendingRequeue = 5 * time.Second
 
+// huskHealthRequeue is how often a Ready husk claim re-checks its backing pod's
+// readiness so its Ready condition reflects a node/pod outage (the endpoint is
+// unreachable) instead of falsely staying Ready (#177). A pod watch would detect
+// it sooner; this bounded poll is the contained fix.
+const huskHealthRequeue = 15 * time.Second
+
 // huskActivator is the seam the claim reconciler dials a husk stub through. The
 // production value is ActivateHuskPod (huskclient.go); tests inject a fake to
 // record requests without a real mTLS server.
@@ -345,6 +351,16 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				}
 				return r.rependOnHuskPodLost(ctx, &claim, &pool, lostPod)
 			}
+			// The pod is not lost, but it may be NotReady (its node is rebooting or
+			// unreachable): the sandbox endpoint is then unreachable, so the claim
+			// must not keep reporting Ready. Reflect the backing pod's readiness in
+			// the Ready condition (flips back to True when the pod recovers). Actual
+			// loss/eviction is still handled by checkHuskPodLost above (#177).
+			if reflectHuskBackingReadiness(&claim, lostPod, r.now()) {
+				if err := r.Status().Update(ctx, &claim); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
 		}
 		// A Ready claim bound to a workspace hydrates its head into the sandbox
 		// exactly once (idempotent via the hydrated annotation). A transient
@@ -354,7 +370,14 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			logger.Error(err, "hydrate workspace into sandbox; will retry", "claim", claim.Name)
 			return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
 		}
-		return r.reconcileLifetime(ctx, &claim)
+		res, err := r.reconcileLifetime(ctx, &claim)
+		// Re-check backing-pod health periodically even when the claim has no
+		// lifetime/idle timeout (reconcileLifetime returns no requeue then), so a
+		// node/pod outage is reflected within huskHealthRequeue (#177).
+		if r.EnableHuskPods && err == nil && res.RequeueAfter == 0 {
+			res.RequeueAfter = huskHealthRequeue
+		}
+		return res, err
 	}
 
 	// Terminal phases: don't retry.


### PR DESCRIPTION
Second half of #177 (the cross-node failover half merged in #180). A Ready husk claim kept reporting Ready while its backing node was NotReady (rebooting/unreachable), advertising an unreachable endpoint.

`checkHuskPodLost` only re-pends on a GONE/terminating pod, and `reconcileLifetime` does not requeue a Ready claim with no lifetime/idle timeout — so a node-outage window went unreflected. `reflectHuskBackingReadiness` flips the Ready condition to False (`BackingPodNotReady`) when the backing pod is NotReady and back to True on recovery, without churning the activation condition. The existing `Watches(&Pod)` mapping makes detection prompt; `huskHealthRequeue` is the safety-net poll. Re-pend on actual loss stays owned by `checkHuskPodLost`.

Test `TestReflectHuskBackingReadiness` covers flip-on-NotReady, no-churn, recover-to-Ready, nil-pod. Full husk/claim suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)