### PR TITLE
fix(controller): log the cause of a failed fork-child activation (#28)

### DIFF
--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -472,7 +472,14 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 			})
 		}
 		if err != nil || !actRes.OK {
-			logger.Info("fork child activation failed, will retry", "child", childName)
+			// Surface WHY (issue #28 LLM-legible errors): the bare "will retry" hid
+			// the cause of stuck fork children. Log the transport error or the
+			// stub's activation error so an operator can act.
+			detail := actRes.Error
+			if err != nil {
+				detail = err.Error()
+			}
+			logger.Info("fork child activation failed, will retry", "child", childName, "detail", detail)
 			continue
 		}
 


### PR DESCRIPTION
The fork-child activation failure path logged 'will retry' with no error. Log the transport error / stub activation error (no secrets) so a fork stuck below its replica count is diagnosable. Surfaced when a SandboxFork(replicas=2) reached 1/2 ready on a live cluster with no signal as to why (a re-run reached 2/2, so the underlying stall is transient/flaky — this makes the next occurrence diagnosable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)