### PR TITLE
fix(controller): fast husk-pod eviction on node loss (~60s, #177)

### DIFF
--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -716,7 +716,18 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1alpha1.SandboxPool, templat
 			// above narrows further to the snapshot-holding nodes when known.
 			NodeSelector: map[string]string{huskKVMNodeLabel: "true"},
 			Affinity:     affinity,
-			Volumes:      volumes,
+			// Evict a husk pod from a NotReady/unreachable node well before the
+			// Kubernetes default 300s, so node-loss FAILOVER (re-pend of an active
+			// claim onto a surviving node via checkHuskPodLost) and warm-pool refill
+			// happen in ~a minute instead of ~5 (#177). A transient reboot is still
+			// ridden out: the node returns within the node-monitor grace + this
+			// window, so the pod is not evicted and the readiness reflection
+			// (reflectHuskBackingReadiness) covers the brief unreachable window.
+			Tolerations: []corev1.Toleration{
+				{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptrInt64(huskNodeLossTolerationSeconds)},
+				{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptrInt64(huskNodeLossTolerationSeconds)},
+			},
+			Volumes: volumes,
 			Containers: []corev1.Container{
 				{
 					Name:  huskContainerName,
@@ -1125,6 +1136,15 @@ func (r *SandboxPoolReconciler) reconcileHuskPods(ctx context.Context, pool *v1a
 }
 
 func ptrBool(b bool) *bool { return &b }
+
+func ptrInt64(i int64) *int64 { return &i }
+
+// huskNodeLossTolerationSeconds is how long a husk pod tolerates its node being
+// NotReady/unreachable before Kubernetes evicts it (vs the 300s default). Chosen
+// longer than a typical node reboot (~40-60s, ridden out without eviction) but
+// far below 5min so a real node loss fails an active claim over and refills the
+// warm pool in ~a minute (#177).
+const huskNodeLossTolerationSeconds int64 = 60
 
 // refillObservedAnnotation marks a husk pod whose create-to-Ready refill latency
 // has already been recorded, so the histogram counts each pod exactly once.

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -1060,3 +1060,33 @@ func TestBuildHuskPodDisablesSATokenAutomount(t *testing.T) {
 		t.Errorf("fork-child husk pod AutomountServiceAccountToken = %v, want false", child.Spec.AutomountServiceAccountToken)
 	}
 }
+
+// TestBuildHuskPodFastNodeLossEviction asserts husk pods carry a short NoExecute
+// toleration (60s) for not-ready/unreachable instead of the Kubernetes default
+// 300s, so a node loss evicts the pod and fails an active claim over (or refills
+// the warm pool) in ~a minute, not ~5 (#177).
+func TestBuildHuskPodFastNodeLossEviction(t *testing.T) {
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "tol-pool", Namespace: "default", UID: "tol-uid"},
+		Spec:       v1alpha1.SandboxPoolSpec{TemplateRef: v1alpha1.LocalObjectReference{Name: "tol-tmpl"}, Replicas: 1},
+	}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tol-tmpl", Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+	r := &controller.SandboxPoolReconciler{Client: k8sClient}
+	pod := r.BuildHuskPodForTest(pool, template, controller.HuskPodOptions{StubImage: "mitos-husk-stub:test", KVMResourceName: "mitos.run/kvm"})
+
+	want := map[string]int64{"node.kubernetes.io/not-ready": 60, "node.kubernetes.io/unreachable": 60}
+	got := map[string]int64{}
+	for _, tol := range pod.Spec.Tolerations {
+		if tol.Effect == corev1.TaintEffectNoExecute && tol.TolerationSeconds != nil {
+			got[tol.Key] = *tol.TolerationSeconds
+		}
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("husk pod NoExecute toleration %s tolerationSeconds = %d, want %d (#177 fast node-loss eviction)", k, got[k], v)
+		}
+	}
+}


### PR DESCRIPTION
Husk pods inherited the default 300s NoExecute toleration, so a dead node's pods evicted only after 5min -> active-claim failover + warm-pool refill lagged node loss by ~5min. Set a 60s NoExecute toleration so a real node loss fails over in ~a minute; a transient reboot is still ridden out (readiness reflection #177 covers the window). Unit test asserts the tolerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)