### PR TITLE
bench: first reproducible fork-to-first-exec numbers on bare metal (#15)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -165,6 +165,7 @@ reproducible source in `bench/`.
 | --- | --- | --- | --- |
 | warm-claim activate latency | P50 ~27 ms (N=11: min 21.45, P50 26.53, P95 46.66, max 46.66 ms) | husk-stub-reported snapshot load + fork-correctness handshake + guest-ready, parsed from the claim's Ready condition message ("activated ... in X ms") | `bench/husk-activate-latency.sh`, results in `bench/results/2026-06-13-bare-metal-husk.md` |
 | snapshot restore (`/snapshot/load`) | ~6-16 ms | the Firecracker engine restore step alone | `bench/results/2026-06-13-bare-metal-husk.md` (forkd / husk-stub logs) |
+| fork-to-first-exec | P50 ~104 ms (N=20: min 97.5, P50 103.9, P90 107.3, P99 109.4 ms) | `cmd/bench` fork-exec: fork from snapshot, restore, first exec result; ~16 ms is `/snapshot/load`, the rest is lazy page-fault-in + guest agent (the tail #167 targets). Co-located with a busy forkd (a dedicated idle node per #16 would tighten it). | `bench/fork-exec-job.yaml`, results in `bench/results/2026-06-19-bare-metal-fork-exec.md` |
 | marginal memory per forked sandbox | ~3 MiB | per-VM unique (private-dirty) cost via CoW page sharing; the shared snapshot page set is counted once across cgroup v2 memcgs (per-VM dirty ~5 MiB, not overstated) | husk-probe CI proof; `docs/metering.md` for the accounting rules |
 
 ### Honest scope of the activate number

--- a/bench/fork-exec-job.yaml
+++ b/bench/fork-exec-job.yaml
@@ -1,0 +1,58 @@
+# Formal fork-to-first-exec benchmark Job (#15). Runs cmd/bench against a built
+# template on a real KVM node and prints the fork_to_first_exec percentile table
+# to the pod log.
+#
+# Build the image (cmd/bench on top of the forkd image, which carries Firecracker
+# + ip/nft):
+#   GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bench ./cmd/bench/
+#   cat > Dockerfile <<EOF
+#   FROM ghcr.io/paperclipinc/mitos-forkd:<tag>
+#   COPY bench /usr/local/bin/bench
+#   ENTRYPOINT ["/usr/local/bin/bench"]
+#   EOF
+#   docker buildx build --platform linux/amd64 -t <registry>/mitos-bench:<tag> --push .
+#
+# Then set BENCH_IMAGE, TEMPLATE, and (optionally) a node, and apply into a
+# privileged namespace on a cluster where forkd has already built the template.
+# Read the result: kubectl logs -n <ns> job/mitos-bench
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mitos-bench
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      # Pin to a KVM node that holds the template snapshot. For a clean number use
+      # a dedicated/idle reference node (issue #16); co-locating with a busy forkd
+      # adds contention noise.
+      nodeSelector:
+        mitos.run/kvm: "true"
+      containers:
+        - name: bench
+          image: REPLACE_WITH_BENCH_IMAGE
+          args:
+            - "-mode"
+            - "fork-exec"
+            - "-template"
+            - "REPLACE_WITH_TEMPLATE_ID"
+            - "-data-dir"
+            - "/var/lib/mitos"
+            - "-kernel"
+            - "/var/lib/mitos/vmlinux"
+            - "-iterations"
+            - "20"
+            - "-warmup"
+            - "3"
+            - "-summary"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/mitos }
+            - { name: kvm, mountPath: /dev/kvm }
+      volumes:
+        - name: data
+          hostPath: { path: /var/lib/mitos }
+        - name: kvm
+          hostPath: { path: /dev/kvm, type: CharDevice }

--- a/bench/results/2026-06-19-bare-metal-fork-exec.md
+++ b/bench/results/2026-06-19-bare-metal-fork-exec.md
@@ -1,0 +1,43 @@
+# Bare-metal fork-to-first-exec: first formal cmd/bench run (#15)
+
+Hardware: Hetzner dedicated (Intel Core i7-6700, 4c/8t, 64 GiB, NVMe), KVM enabled.
+OS/cluster: Talos Linux v1.13.4, 2-node, Kubernetes v1.36.1, Flannel CNI.
+Engine: Firecracker v1.15.0; `cmd/bench` in-process engine (zero jailer config,
+the same construction as forkd). Mode `fork-exec`.
+Template: `e2e-tmpl` (python:3.12-slim), snapshot mem 512 MiB; guest kernel
+vmlinux 4.14.174 (the chart's default staged kernel).
+Run: `cmd/bench -mode fork-exec -template e2e-tmpl -data-dir /var/lib/mitos
+-kernel /var/lib/mitos/vmlinux -iterations 20 -warmup 3` as a privileged Job on a
+KVM node (see `bench/fork-exec-job.yaml`).
+
+## Measured (real, reproducible on this node)
+
+`fork_to_first_exec` (wall time from fork start to the first exec result, N=20,
+3 warmup iterations discarded; percentiles by `internal/benchstat`, nearest-rank):
+
+| count | min | p50 | p90 | p99 | max | mean |
+| --- | --- | --- | --- | --- | --- | --- |
+| 20 | 97.54 ms | 103.88 ms | 107.28 ms | 109.37 ms | 109.37 ms | 103.65 ms |
+
+Component (from the Firecracker logs during the run):
+- `/snapshot/load` (engine restore): ~16 ms.
+- The remainder is lazy page-fault-in of the restored guest memory plus the guest
+  agent servicing the first exec (the "0.8 ms restore + lazy faults" tail
+  documented in BENCHMARKS.md, here measured end to end).
+
+## Caveats (honest scope)
+
+- The bench ran CO-LOCATED with the live forkd DaemonSet on the same node, so the
+  numbers carry some contention noise (a dedicated, idle reference node per #16
+  would tighten them). They are a real floor, not a tuned best case.
+- Single template (python:3.12-slim), single node, 2015-era CPU. The
+  page-fault-prefetch + hugepage work (#167) targets the lazy-fault tail that
+  dominates this ~104 ms (vs the ~16 ms restore).
+- `fork-exec` includes terminating the sandbox after the first exec; the clock
+  stops at the first exec result (see BENCHMARKS.md methodology).
+
+## Reproduce
+
+Build `bench/fork-exec-job.yaml`'s image (`FROM mitos-forkd + cmd/bench`, see the
+manifest header) and apply it on a cluster with a built template; read the Job
+log for the percentile table.


### PR DESCRIPTION
First formal cmd/bench fork-exec run on the 2-node Talos KVM cluster: fork_to_first_exec N=20 **P50 103.9ms / P99 109.4ms / mean 103.65ms**. Adds the reproducible Job manifest + results record + a BENCHMARKS row (no number without a bench/ source). Caveat: co-located with a busy forkd; a dedicated reference node (#16) would tighten it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)