### PR TITLE
fix(controller): adopt an already-active fork child instead of looping forever (#183)

### DIFF
--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -506,3 +506,52 @@ func TestHuskForkChildPodHasFullHuskShape(t *testing.T) {
 		t.Fatalf("fork child --template-rootfs must be the source pod rootfs; args=%v", stub.Args)
 	}
 }
+
+// TestHuskForkAdoptsAlreadyActiveChild is the #183 regression. Activation is not
+// transactional: a prior Activate can succeed (VM active) while its ack or the
+// controller's post-activate bookkeeping is lost, so the child is never recorded.
+// On the next pass the stub refuses to re-activate a non-dormant VM and returns
+// AlreadyActive (OK=false). Before the fix the controller logged "will retry" and
+// looped forever (ReadyForks stuck below Replicas); the fix ADOPTS an
+// AlreadyActive child (the VM is up with the stable, persisted token) so the fork
+// converges. The fake activator below ALWAYS reports AlreadyActive, so without the
+// adoption this test times out.
+func TestHuskForkAdoptsAlreadyActiveChild(t *testing.T) {
+	srcPod := makeDormantHuskPod(t, "pool-hfaa", "10.0.2.5")
+	makeForkSourceClaim(t, "src-claim-aa", "pool-hfaa", srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: false, AlreadyActive: true, Error: "activate in state active: must be dormant"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	fork := &v1alpha1.SandboxFork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hfaa-1",
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1alpha1.SandboxForkSpec{SourceRef: v1alpha1.LocalObjectReference{Name: "src-claim-aa"}, Replicas: 2},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren("hfaa-1"))
+		for i := range pods.Items {
+			forceHuskPodReady(t, &pods.Items[i])
+		}
+		var got v1alpha1.SandboxFork
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "hfaa-1", Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyForks == 2
+	})
+}

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -453,9 +453,18 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 			continue
 		}
 
-		apiToken, err := mintAPIToken()
+		endpoint := net.JoinHostPort(child.Status.PodIP, strconv.Itoa(sandboxPort))
+		// Persist a STABLE token BEFORE activating (issue #183). Activation is not
+		// transactional: the activate ack can be lost, or the post-activate
+		// bookkeeping below can fail, leaving the VM ACTIVE while the controller
+		// did not record it. If the token were minted fresh per pass and written
+		// only AFTER activate, the next pass would re-activate an already-active VM
+		// (the stub refuses: "must be dormant") with a different token, forever.
+		// Persisting first and reusing the same token means a re-drive activates
+		// with the token the VM already holds, and AlreadyActive lets us adopt it.
+		apiToken, err := ensureForkChildToken(ctx, r.Client, fork, childName+tokenSecretSuffix, endpoint)
 		if err != nil {
-			logger.Error(err, "token minting failed", "child", childName)
+			logger.Error(err, "fork child token secret write failed", "child", childName)
 			continue
 		}
 
@@ -471,23 +480,20 @@ func (r *SandboxForkReconciler) reconcileHuskFork(ctx context.Context, fork *v1a
 				Token:       apiToken,
 			})
 		}
-		if err != nil || !actRes.OK {
+		if err != nil {
+			logger.Info("fork child activation failed, will retry", "child", childName, "detail", err.Error())
+			continue
+		}
+		if !actRes.OK && !actRes.AlreadyActive {
 			// Surface WHY (issue #28 LLM-legible errors): the bare "will retry" hid
-			// the cause of stuck fork children. Log the transport error or the
-			// stub's activation error so an operator can act.
-			detail := actRes.Error
-			if err != nil {
-				detail = err.Error()
-			}
-			logger.Info("fork child activation failed, will retry", "child", childName, "detail", detail)
+			// the cause of stuck fork children.
+			logger.Info("fork child activation failed, will retry", "child", childName, "detail", actRes.Error)
 			continue
 		}
-
-		endpoint := net.JoinHostPort(child.Status.PodIP, strconv.Itoa(sandboxPort))
-		if err := ensureSandboxTokenSecret(ctx, r.Client, fork, childName+tokenSecretSuffix, apiToken, endpoint); err != nil {
-			logger.Error(err, "token secret write failed", "child", childName)
-			continue
-		}
+		// OK, or AlreadyActive: a prior Activate brought this child up but its ack
+		// or bookkeeping was lost (issue #183). Either way the VM is active with the
+		// stable token persisted above, so ADOPT it as ready rather than retrying a
+		// non-dormant VM forever.
 
 		forks = append(forks, v1alpha1.ForkInfo{
 			Name:      childName,

--- a/internal/controller/token_secret.go
+++ b/internal/controller/token_secret.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -15,6 +16,32 @@ import (
 // tokenSecretSuffix is appended to the claim or fork sandbox name to form
 // the name of the Secret carrying the sandbox API bearer token.
 const tokenSecretSuffix = "-sandbox-token"
+
+// ensureForkChildToken returns a STABLE bearer token for a fork child, persisted
+// BEFORE activation so a lost activate-ack (or a later bookkeeping failure) never
+// leaves the VM active with a token the controller forgot (issue #183). If the
+// owned token Secret already exists it REUSES that token, so a re-drive activates
+// with the same token the VM already holds; otherwise it mints one and writes the
+// Secret. The token value is never logged.
+func ensureForkChildToken(ctx context.Context, c client.Client, owner client.Object, name, endpoint string) (string, error) {
+	var existing corev1.Secret
+	err := c.Get(ctx, client.ObjectKey{Namespace: owner.GetNamespace(), Name: name}, &existing)
+	if err == nil {
+		if tok := string(existing.Data["token"]); tok != "" {
+			return tok, nil
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("read token secret %s/%s: %w", owner.GetNamespace(), name, err)
+	}
+	token, err := mintAPIToken()
+	if err != nil {
+		return "", err
+	}
+	if err := ensureSandboxTokenSecret(ctx, c, owner, name, token, endpoint); err != nil {
+		return "", err
+	}
+	return token, nil
+}
 
 // mintAPIToken returns 32 bytes of crypto/rand entropy hex-encoded
 // (64 chars). The value is a bearer credential: never log it and never put

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -81,6 +81,12 @@ type ActivateResult struct {
 	VsockPath string  `json:"vsock_path,omitempty"`
 	LatencyMs float64 `json:"latency_ms"`
 	Error     string  `json:"error,omitempty"`
+	// AlreadyActive is set when Activate was refused because the stub is ALREADY
+	// in the active state (a prior Activate succeeded). It is not OK, but it tells
+	// an idempotent caller that the VM is in fact activated, so a re-drive that
+	// lost its ack (or whose post-activate bookkeeping failed) can ADOPT the VM
+	// instead of retrying forever (issue #183).
+	AlreadyActive bool `json:"already_active,omitempty"`
 }
 
 // WriteRequest writes an ActivateRequest as one line of JSON followed by a

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -593,7 +593,10 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 	defer s.mu.Unlock()
 
 	if s.state != StateDormant {
-		return ActivateResult{OK: false, Error: fmt.Sprintf("activate in state %s: must be dormant", s.state)},
+		// AlreadyActive lets an idempotent caller adopt a VM that a prior Activate
+		// already brought up but whose ack/bookkeeping was lost (issue #183),
+		// instead of retrying a non-dormant VM forever.
+		return ActivateResult{OK: false, AlreadyActive: s.state == StateActive, Error: fmt.Sprintf("activate in state %s: must be dormant", s.state)},
 			fmt.Errorf("husk: activate in state %s: must be dormant", s.state)
 	}
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION
Fixes #183, root-caused live on the bare-metal cluster (the CI run reproduced it; #182's logging captured `activate in state active: must be dormant`).

## Root cause
Fork-child activation is not transactional. A prior Activate can succeed (VM active) while its ack is lost, or the post-activate bookkeeping (token Secret write / status update) fails, so the controller never records the child. Next pass it minted a fresh token and re-activated an already-active VM, which the stub refuses ("must be dormant"), forever. ReadyForks stuck below Replicas.

## Fix
1. **Stable, persisted-first token** (`ensureForkChildToken`): write the token Secret BEFORE activating and reuse it across passes, so a lost ack never orphans the VM with a forgotten token and a re-drive uses the token the VM already holds.
2. **Adopt `AlreadyActive`**: the stub returns a structured `AlreadyActive` flag when refused for being already active; the controller treats that (and OK) as success and records the child ready.

`TestHuskForkAdoptsAlreadyActiveChild` reaches `ReadyForks==2` with the fix, times out without it. Build + suites + lint (darwin+linux) green.

## ⚠️ Security review requested (named reviewer per CLAUDE.md)
Touches token issuance + the husk activate state machine. **No surface change**: token Secret / RBAC / mTLS channel unchanged; `AlreadyActive` originates only from the trusted host-side stub over mTLS; token-before-activate removes (not adds) an orphaned-token window. Threat model unchanged. Please review the token-ordering + the idempotent adoption before merge. **Not auto-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)