### PR TITLE
fix(controller): constrain template snapshot build to a pool's placement nodes (#172)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -917,12 +917,24 @@ else. Pools, claims, and forks are namespace-scoped objects, but:
 - Snapshots on a node are a flat directory shared by all tenants; no
   per-namespace separation, no enforcement that a claim only forks snapshots
   its namespace published. **open**
-- VMs of different namespaces share nodes, host kernel, and forkd. **open**
-- `dedicatedNodes: true` pool option (hard tenant separation via node
-  pools/taints) is planned, not implemented. **open**
+- VMs of different namespaces share nodes, host kernel, and forkd BY DEFAULT. **open**
+- A pool MAY opt into node separation via `.spec.placement` (`PoolPlacement`: a
+  `nodeSelector` ANDed onto the husk pods plus `tolerations` for tainted dedicated
+  nodes). The controller pins the pool's husk pods to the matching nodes AND
+  constrains the template snapshot build/distribution to that same node set
+  (`placementFilter` / `createSnapshotsOnNodes`,
+  `internal/controller/sandboxpool_controller.go`, issue #172), so a placed pool's
+  VMs and their snapshot never land on a node outside its dedicated set. This is
+  SCHEDULING-enforced separation (Kubernetes `nodeSelector` / taints), NOT a
+  hardware or hypervisor isolation guarantee: it depends on the operator labeling
+  and tainting the dedicated nodes and not co-scheduling other tenants there.
+  Node-side taint enforcement and per-tenant node-pool provisioning remain the
+  operator's responsibility. **partial**
 
-Until the above are closed, treat the whole cluster as one trust domain. This
-posture is recorded as a residual decision in docs/adr/0004-node-flat-snapshot-trust-domain.md.
+Until the above are closed, treat the whole cluster as one trust domain unless an
+operator has provisioned dedicated, tainted node pools and placed each tenant's
+pools onto them. This posture is recorded as a residual decision in
+docs/adr/0004-node-flat-snapshot-trust-domain.md.
 
 ## 8. What we explicitly do NOT claim
 

--- a/internal/controller/distribution_test.go
+++ b/internal/controller/distribution_test.go
@@ -128,7 +128,7 @@ func TestDistributeBuildsOnceAndPulls(t *testing.T) {
 	engineA := startDistForkdNode(t, registry, "node-a", "10.0.0.1:9091", "10.0.0.1:9092", "T")
 	engineB := startDistForkdNode(t, registry, "node-b", "10.0.0.2:9091", "10.0.0.2:9092")
 
-	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, nil, "", 1)
+	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, nil, "", 1, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotsOnNodes: %v", err)
 	}
@@ -166,6 +166,67 @@ func TestDistributeBuildsOnceAndPulls(t *testing.T) {
 	}
 }
 
+// TestDistributeRespectsPlacementNodeFilter is the dedicatedNodes (#172) build
+// constraint: a placed pool's husk pods are pinned to its placement nodes, so
+// the template snapshot MUST be built only on those nodes. A snapshot on a node
+// outside the placement set can never back a placement-pinned pod, so the build
+// loop must skip non-placement nodes even when they are healthy and would
+// otherwise satisfy the deficit. node-a is OUTSIDE the filter and node-b is
+// INSIDE it; with a deficit of 2 the build must still land only on node-b.
+func TestDistributeRespectsPlacementNodeFilter(t *testing.T) {
+	registry := NewNodeRegistry()
+	r := &SandboxPoolReconciler{NodeRegistry: registry, PeerToken: "peer-secret"}
+
+	engineA := startDistForkdNode(t, registry, "node-a", "10.0.0.1:9091", "10.0.0.1:9092")
+	engineB := startDistForkdNode(t, registry, "node-b", "10.0.0.2:9091", "10.0.0.2:9092")
+
+	// Deficit 2, but only node-b is in the placement set.
+	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, nil, "", 2, map[string]bool{"node-b": true})
+	if err != nil {
+		t.Fatalf("createSnapshotsOnNodes: %v", err)
+	}
+	if added != 1 {
+		t.Fatalf("added = %d, want 1 (only the placement node is eligible)", added)
+	}
+	// node-a is outside the placement set: it must NOT have built T.
+	if got := engineA.GetCapacity().TemplateIDs; len(got) != 0 {
+		t.Fatalf("node-a (outside placement) built %v, want nothing", got)
+	}
+	// node-b is the dedicated node: it must hold T.
+	heldB := false
+	for _, tid := range engineB.GetCapacity().TemplateIDs {
+		if tid == "T" {
+			heldB = true
+		}
+	}
+	if !heldB {
+		t.Fatalf("node-b (placement node) did not build T; templates=%v", engineB.GetCapacity().TemplateIDs)
+	}
+}
+
+// TestReadySnapshotCountOnExcludesNonPlacementNodes proves the readiness count
+// is placement-aware (#172): a snapshot held on a node OUTSIDE the placement set
+// must not count toward a placed pool's ready snapshots, otherwise the
+// readySnapshots>=desired gate would report the deficit met while no dedicated
+// node holds the snapshot, and the placement-pinned husk pods would never get an
+// eligible holder. A nil filter (unplaced pool) counts every healthy holder.
+func TestReadySnapshotCountOnExcludesNonPlacementNodes(t *testing.T) {
+	registry := NewNodeRegistry()
+	r := &SandboxPoolReconciler{NodeRegistry: registry}
+
+	// node-a holds T but is outside the placement set; node-b is inside it but
+	// holds nothing.
+	startDistForkdNode(t, registry, "node-a", "10.0.0.1:9091", "10.0.0.1:9092", "T")
+	startDistForkdNode(t, registry, "node-b", "10.0.0.2:9091", "10.0.0.2:9092")
+
+	if got := r.readySnapshotCountOn("T", map[string]bool{"node-b": true}); got != 0 {
+		t.Fatalf("placement-aware count = %d, want 0 (the only holder is outside placement)", got)
+	}
+	if got := r.readySnapshotCountOn("T", nil); got != 1 {
+		t.Fatalf("unfiltered count = %d, want 1", got)
+	}
+}
+
 // TestDistributeNoHolderBuildsThenPulls proves that when NO node holds T, one
 // node builds it (CreateTemplate) and the remaining deficit nodes pull from the
 // freshly built holder in the same pass.
@@ -181,7 +242,7 @@ func TestDistributeNoHolderBuildsThenPulls(t *testing.T) {
 		"node-c": startDistForkdNode(t, registry, "node-c", "10.0.0.3:9091", "10.0.0.3:9092"),
 	}
 
-	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, nil, "", 3)
+	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, nil, "", 3, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotsOnNodes: %v", err)
 	}
@@ -229,7 +290,7 @@ func TestDistributeEncryptedBuildsEverywhere(t *testing.T) {
 	engineB := startFakeForkdNodeTLSDist(t, registry, "node-b", "10.0.0.2:9091", "10.0.0.2:9092", serverTLS, clientTLS)
 	_ = engineA
 
-	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, []byte("0123456789abcdef0123456789abcdef"), "local:test", 1)
+	added, err := r.createSnapshotsOnNodes(context.Background(), "T", "img", nil, nil, []byte("0123456789abcdef0123456789abcdef"), "local:test", 1, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotsOnNodes: %v", err)
 	}

--- a/internal/controller/forkd_client_test.go
+++ b/internal/controller/forkd_client_test.go
@@ -219,7 +219,7 @@ func TestPoolSnapshotAccounting(t *testing.T) {
 	templateVols := []v1alpha1.SandboxVolume{
 		{Name: "data", Size: "64Mi", MountPath: "/data", ForkPolicy: v1alpha1.ForkPolicyFresh},
 	}
-	created, err := r.createSnapshotsOnNodes(context.Background(), "py-tmpl", "python:3.12-slim", initCommands, templateVols, nil, "", 5)
+	created, err := r.createSnapshotsOnNodes(context.Background(), "py-tmpl", "python:3.12-slim", initCommands, templateVols, nil, "", 5, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotsOnNodes: %v", err)
 	}

--- a/internal/controller/husk_pool_build_test.go
+++ b/internal/controller/husk_pool_build_test.go
@@ -127,3 +127,87 @@ func TestHuskPoolBuildsSnapshotAndPlacesPods(t *testing.T) {
 		t.Fatalf("nodeAffinity values = %v, want [kvm-node-A] (the snapshot holder)", expr.Values)
 	}
 }
+
+// TestHuskPoolBuildRespectsDedicatedNodes is the dedicatedNodes (#172) build
+// constraint end to end: a pool with Placement.NodeSelector must build its
+// template snapshot ONLY on nodes matching that selector. It registers two fake
+// forkd nodes, one matching the placement label and one not, and creates the
+// matching corev1.Node objects so the controller's nodesMatchingSelector resolves
+// the placement set against real labels. The build must land on the dedicated
+// node and skip the shared node; otherwise the snapshot would sit on a node the
+// placement-pinned husk pods can never schedule onto, and the pool would never
+// converge.
+func TestHuskPoolBuildRespectsDedicatedNodes(t *testing.T) {
+	c := k8sClient
+	const dedicated, shared = "ded-node-172", "shared-node-172"
+	const tenantLabel = "mitos.run/tenant"
+
+	// Real k8s Node objects so nodesMatchingSelector (a label List) sees them. The
+	// dedicated node carries the placement label; the shared node does not.
+	dedNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: dedicated, Labels: map[string]string{tenantLabel: "acme"}}}
+	sharedNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: shared}}
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ded172-tmpl", Namespace: "default"},
+		Spec:       v1alpha1.SandboxTemplateSpec{Image: "python:3.12-slim"},
+	}
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "ded172-pool", Namespace: "default"},
+		Spec: v1alpha1.SandboxPoolSpec{
+			TemplateRef: v1alpha1.LocalObjectReference{Name: "ded172-tmpl"},
+			Replicas:    1,
+			Placement:   &v1alpha1.PoolPlacement{NodeSelector: map[string]string{tenantLabel: "acme"}},
+		},
+	}
+	for _, obj := range []client.Object{dedNode, sharedNode, template, pool} {
+		if err := c.Create(ctx, obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		_ = c.Delete(ctx, pool)
+		_ = c.Delete(ctx, template)
+		_ = c.Delete(ctx, dedNode)
+		_ = c.Delete(ctx, sharedNode)
+	})
+
+	// Two fake forkd nodes named to match the k8s Nodes; neither holds the template.
+	reg := controller.NewNodeRegistry()
+	stopD, engineD, _, err := controller.StartFakeForkdNodeRecording(reg, dedicated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(stopD)
+	stopS, engineS, _, err := controller.StartFakeForkdNodeRecording(reg, shared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(stopS)
+
+	r := &controller.SandboxPoolReconciler{
+		Client:          c,
+		NodeRegistry:    reg,
+		EnableHuskPods:  true,
+		HuskStubImage:   "mitos-husk-stub:test",
+		KVMResourceName: "mitos.run/kvm",
+	}
+
+	var live v1alpha1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pool), &live); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.EnsureTemplateBuiltForTest(ctx, &live, template); err != nil {
+		t.Fatalf("ensureTemplateBuilt: %v", err)
+	}
+
+	// The dedicated node built the snapshot; the shared node did not.
+	if got := engineD.GetCapacity().TemplateIDs; len(got) != 1 || got[0] != "ded172-tmpl" {
+		t.Fatalf("dedicated node templates = %v, want [ded172-tmpl]", got)
+	}
+	if got := engineS.GetCapacity().TemplateIDs; len(got) != 0 {
+		t.Fatalf("shared node (outside placement) built %v, want nothing", got)
+	}
+	holders := reg.NodesWithTemplate("ded172-tmpl")
+	if len(holders) != 1 || holders[0].Name != dedicated {
+		t.Fatalf("snapshot holders = %v, want [%s]", holders, dedicated)
+	}
+}

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -190,6 +190,15 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	templateID := pool.Spec.TemplateRef.Name
 	desired := pool.Spec.Replicas
 
+	// dedicatedNodes (#172): resolve the pool's placement node set once so every
+	// snapshot readiness count and the template build below are scoped to the
+	// dedicated nodes. nil for an unplaced pool (no placement => any node).
+	nodeFilter, err := r.placementFilter(ctx, &pool)
+	if err != nil {
+		logger.Error(err, "resolve placement nodes for pool")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	// Husk pod warm-pool path (issue #18, the pod-native default). When enabled,
 	// the pool does TWO INDEPENDENT things: it maintains a warm pool of
 	// pre-scheduled DORMANT husk pods, AND it builds the template snapshot on the
@@ -264,7 +273,7 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// node that cannot snapshot (the documented nested-VMM boundary on kind)
 		// the build never completes, yet the warm pool above is still maintained
 		// and self-heals.
-		buildErr := r.ensureTemplateBuilt(ctx, &pool, &template)
+		buildErr := r.ensureTemplateBuilt(ctx, &pool, &template, nodeFilter)
 		if buildErr != nil {
 			logger.Error(buildErr, "failed to build template snapshot for husk pool (warm pool still maintained)")
 		}
@@ -277,7 +286,7 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			logger.Error(err, "failed to ensure husk PDB")
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
-		readySnapshots := r.readySnapshotCount(templateID)
+		readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
 		setPoolReadySnapshots(pool.Name, readySnapshots)
 		pool.Status.ReadySnapshots = readySnapshots
 		pool.Status.TotalSnapshots = readySnapshots
@@ -318,14 +327,14 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Raw-forkd path (the --enable-raw-forkd fallback): build the snapshot on the
 	// target nodes and let each claim fork on a holder. No husk pods.
-	if r.readySnapshotCount(templateID) < desired {
-		logger.Info("snapshot deficit", "ready", r.readySnapshotCount(templateID), "desired", desired)
-		if err := r.ensureTemplateBuilt(ctx, &pool, &template); err != nil {
+	if rawReady := r.readySnapshotCountOn(templateID, nodeFilter); rawReady < desired {
+		logger.Info("snapshot deficit", "ready", rawReady, "desired", desired)
+		if err := r.ensureTemplateBuilt(ctx, &pool, &template, nodeFilter); err != nil {
 			logger.Error(err, "failed to create snapshots")
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 	}
-	readySnapshots := r.readySnapshotCount(templateID)
+	readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
 
 	// Update status
 	setPoolReadySnapshots(pool.Name, readySnapshots)
@@ -357,7 +366,42 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // snapshot. One snapshot per node per template, so replicas are capped by
 // node count.
 func (r *SandboxPoolReconciler) readySnapshotCount(templateID string) int32 {
-	return int32(len(r.NodeRegistry.NodesWithTemplate(templateID)))
+	return r.readySnapshotCountOn(templateID, nil)
+}
+
+// readySnapshotCountOn counts healthy nodes holding templateID, restricted to
+// nodeFilter when non-nil (dedicatedNodes, #172). A snapshot on a node outside a
+// placed pool's placement set cannot back its placement-pinned husk pods, so it
+// must not count toward readiness; otherwise the readySnapshots>=desired gate
+// would report the deficit met while no dedicated node holds the snapshot. A nil
+// filter counts every healthy holder (unplaced pool).
+func (r *SandboxPoolReconciler) readySnapshotCountOn(templateID string, nodeFilter map[string]bool) int32 {
+	nodes := r.NodeRegistry.NodesWithTemplate(templateID)
+	if nodeFilter == nil {
+		return int32(len(nodes))
+	}
+	var n int32
+	for _, node := range nodes {
+		if nodeFilter[node.Name] {
+			n++
+		}
+	}
+	return n
+}
+
+// placementFilter resolves a pool's dedicatedNodes placement (#172) to the set
+// of node names its snapshots may live on. It returns nil when the pool declares
+// no placement (every node is eligible), so callers treat nil as "unconstrained".
+func (r *SandboxPoolReconciler) placementFilter(ctx context.Context, pool *v1alpha1.SandboxPool) (map[string]bool, error) {
+	sel := huskPlacementNodeSelector(pool)
+	if len(sel) == 0 {
+		return nil, nil
+	}
+	matching, err := r.nodesMatchingSelector(ctx, sel)
+	if err != nil {
+		return nil, fmt.Errorf("list placement nodes for pool %s: %w", pool.Name, err)
+	}
+	return matching, nil
 }
 
 // snapshotNodeNames returns the hostnames of the healthy nodes that hold the
@@ -399,9 +443,12 @@ func (r *SandboxPoolReconciler) huskTemplateDigest(templateID string) string {
 // node, so the snapshot must exist there first. A no-op when the deficit is
 // already met. The encrypted-template key handling matches the raw path: the
 // per-template key Secret is owned here and delivered over mTLS, never logged.
-func (r *SandboxPoolReconciler) ensureTemplateBuilt(ctx context.Context, pool *v1alpha1.SandboxPool, template *v1alpha1.SandboxTemplate) error {
+func (r *SandboxPoolReconciler) ensureTemplateBuilt(ctx context.Context, pool *v1alpha1.SandboxPool, template *v1alpha1.SandboxTemplate, nodeFilter map[string]bool) error {
 	templateID := pool.Spec.TemplateRef.Name
-	readySnapshots := r.readySnapshotCount(templateID)
+	// dedicatedNodes (#172): nodeFilter restricts the snapshot to a placed pool's
+	// placement nodes for BOTH the deficit count and the build targets, so a
+	// snapshot is never built off the dedicated set. nil => unconstrained.
+	readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
 	if readySnapshots >= pool.Spec.Replicas {
 		return nil
 	}
@@ -418,7 +465,7 @@ func (r *SandboxPoolReconciler) ensureTemplateBuilt(ctx context.Context, pool *v
 			return fmt.Errorf("ensure encryption key for template %s: %w", templateID, keyErr)
 		}
 	}
-	if _, err := r.createSnapshotsOnNodes(ctx, templateID, template.Spec.Image, template.Spec.Init, template.Spec.Volumes, wrappedDEK, kekID, deficit); err != nil {
+	if _, err := r.createSnapshotsOnNodes(ctx, templateID, template.Spec.Image, template.Spec.Init, template.Spec.Volumes, wrappedDEK, kekID, deficit, nodeFilter); err != nil {
 		return fmt.Errorf("build template snapshot %s: %w", templateID, err)
 	}
 	return nil
@@ -442,7 +489,15 @@ func (r *SandboxPoolReconciler) ensureTemplateBuilt(ctx context.Context, pool *v
 // The pull token is the shared peer credential the controller is configured
 // with; it is delivered to the deficit node over its mTLS gRPC and is never
 // logged.
-func (r *SandboxPoolReconciler) createSnapshotsOnNodes(ctx context.Context, templateID, image string, initCommands []string, templateVolumes []v1alpha1.SandboxVolume, wrappedDEK []byte, kekID string, deficit int32) (int32, error) {
+//
+// nodeFilter constrains which nodes may build or pull (dedicatedNodes, #172):
+// when non-nil only nodes whose name is in the set are eligible, so a placed
+// pool's snapshot lands ONLY on its dedicated nodes (a snapshot built elsewhere
+// could never back a placement-pinned husk pod). A nil filter places on any
+// healthy node, preserving the unplaced behavior. The pull SOURCE is not
+// constrained: the digest is content-addressed, so pulling from any holder into
+// a dedicated node is safe.
+func (r *SandboxPoolReconciler) createSnapshotsOnNodes(ctx context.Context, templateID, image string, initCommands []string, templateVolumes []v1alpha1.SandboxVolume, wrappedDEK []byte, kekID string, deficit int32, nodeFilter map[string]bool) (int32, error) {
 	var added int32
 	var errs []error
 
@@ -454,6 +509,11 @@ func (r *SandboxPoolReconciler) createSnapshotsOnNodes(ctx context.Context, temp
 	for _, node := range r.NodeRegistry.ListNodes() {
 		if added >= deficit {
 			break
+		}
+		// dedicatedNodes (#172): skip a node outside the pool's placement set so
+		// the snapshot is only built where the placement-pinned husk pods can run.
+		if nodeFilter != nil && !nodeFilter[node.Name] {
+			continue
 		}
 		if !node.isHealthy() || node.hasSnapshot(templateID) {
 			continue

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -244,7 +244,11 @@ func (r *SandboxPoolReconciler) ReconcileHuskPodsForTest(ctx context.Context, po
 // be envtested without driving the full Reconcile (which would race the
 // manager's pool reconciler on the pool status subresource).
 func (r *SandboxPoolReconciler) EnsureTemplateBuiltForTest(ctx context.Context, pool *v1alpha1.SandboxPool, template *v1alpha1.SandboxTemplate) error {
-	return r.ensureTemplateBuilt(ctx, pool, template)
+	nodeFilter, err := r.placementFilter(ctx, pool)
+	if err != nil {
+		return err
+	}
+	return r.ensureTemplateBuilt(ctx, pool, template, nodeFilter)
 }
 
 // EncKeyRecorder records, per RPC, the length of any EncryptionKey the fake


### PR DESCRIPTION
Closes part of #172 (dedicatedNodes, gate G3). Found while auditing the M1 issues against the code: the dedicatedNodes placement feature was wired into husk-pod nodeAffinity and snapshot-holder filtering, but the template snapshot BUILD path ignored placement entirely.

## The gap
A pool with `.spec.placement.nodeSelector` pins its husk pods to the matching nodes. But `createSnapshotsOnNodes` iterated every healthy node, and `readySnapshotCount` counted snapshots on any node. So a placed pool could:
- build (or already hold) its template snapshot on a NON-dedicated node,
- see `readySnapshots >= desired` and treat the deficit as met,
- never build on a dedicated node,

leaving the placement-pinned husk pods with no eligible snapshot-holder and the pool stuck below Replicas (Pending pods forever). This is the load-bearing half of dedicatedNodes for hard tenant node separation.

## Fix
Resolve the placement node set once per reconcile (`placementFilter`) and thread it through both halves of the snapshot path:
- `readySnapshotCountOn(templateID, filter)`: counts only snapshots on placement nodes, so the deficit gate is placement-aware.
- `createSnapshotsOnNodes(..., nodeFilter)`: skips nodes outside the set when building or pulling.

The pull SOURCE stays unconstrained: the snapshot is content-addressed, so pulling from any holder into a dedicated node is safe. A nil filter (unplaced pool) preserves the prior any-node behavior exactly.

## Tests (TDD)
- `TestDistributeRespectsPlacementNodeFilter`: with deficit 2 and only one placement node, the build lands only on that node.
- `TestReadySnapshotCountOnExcludesNonPlacementNodes`: a holder outside the placement set does not count.
- `TestHuskPoolBuildRespectsDedicatedNodes`: end to end with real labeled `Node` objects, proving `placementFilter -> nodesMatchingSelector -> createSnapshotsOnNodes` constrains the build to the dedicated node and skips the shared one.

## Threat model
Section 7 (multi-tenancy) updated: `dedicatedNodes` was marked "planned, not implemented"; it is now SCHEDULING-enforced separation via `.spec.placement` (pods + snapshot build), explicitly NOT a hardware/hypervisor guarantee, with node-side taint enforcement and per-tenant node-pool provisioning remaining operator responsibility. Marked **partial**.

## Verification
`go build ./...`, full `internal/controller` envtest suite, gofmt, and both `golangci-lint` runs (darwin + `GOOS=linux`) are green locally.

## Security review requested (named reviewer per CLAUDE.md)
This is a tenant-isolation path (#172 is security-labeled). No new trust surface: it only NARROWS where a placed pool's snapshot may be built (removes nodes, never adds). Please review the placement-filter resolution and the count/build threading.

## Remaining for #172 (not in this PR)
Multi-node kind e2e (mock engine, two labeled kind nodes) as the scheduling proof in CI. Tracked under #172; this PR closes the controller-side build-constraint gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)