### PR TITLE
fix(forkd): sample lifetime memory metrics periodically (#3 fork-correctness Row 5)

### DIFF
--- a/cmd/forkd/main.go
+++ b/cmd/forkd/main.go
@@ -340,6 +340,15 @@ func main() {
 	// scheme stays unchanged so SDK clients are unaffected.
 	go daemon.ServeHTTP(httpAddr, engine, sandboxAPI, casServing)
 
+	// Periodically refresh the metering gauges /metrics serves so they report
+	// LIFETIME memory, not the fork-time footprint (fork-correctness Row 5, issue
+	// #3). Without this the mitos_memory_unique_bytes gauge is never populated.
+	// Bound to a cancelable context cancelled on shutdown below. interval 0 uses
+	// the daemon default.
+	metricsCtx, metricsCancel := context.WithCancel(context.Background())
+	defer metricsCancel()
+	go server.SampleMetrics(metricsCtx, 0)
+
 	// Start the controlled DNS resolver (node-level Runnable) when enabled. It
 	// binds the resolver IP on port 53 (udp + tcp); a listen failure is fatal
 	// because name-based egress would silently not work otherwise.

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -15,7 +15,7 @@ test missing or incomplete. `done` = implemented + test runs in the
 | 2 | Stale wall clock after restore | kvm-clock resync + agent clock step from host wall clock in NotifyForked | go: `TestForkNotifiesAgentWithFreshEntropy` (carries `HostWallClockNanos`); KVM: each fork `WALLCLOCK_NS` within 2s of the runner clock | **partial; CLOCK_MONOTONIC residual documented (no step possible)** (guest wall-clock step done, 500ms tolerance; KVM proof is guest-only. The review finding on CLOCK_MONOTONIC is assessed and DOCUMENTED rather than "fixed": Linux rejects `clock_settime(CLOCK_MONOTONIC)` with EINVAL so a literal step is impossible, and a PAUSED-across-restore VM resumes the monotonic clock continuously so clean-restore monotonic timers do not mis-fire. The narrow residual is mixed wall/monotonic-derived deadlines, handled by the existing SIGUSR2 userspace reset signal. See section 2 for the full assessment; `guest/agent/notifyforked.go` `stepClock` carries the rationale inline.) |
 | 3 | Secrets duplicated into live forks | Per-fork credential reissue; inheritance requires opt-in | `TestLiveForkOfSecretHolderIsRejectedByDefault`, `TestForkDeliversConfigureToAgent`, KVM `test-agent` configure check | **partial** (default-deny gate + vsock delivery implemented; reissue open) |
 | 4 | Duplicate MAC/IP/TCP state in forks | Fresh NIC identity per fork; parent TCP dead in fork | `TestForkNetworkIdentity` | **open** (guests currently have no NIC at all; see note) |
-| 5 | Misleading memory accounting | Report lifetime unique bytes, not just T=0 dirty pages | `TestMemoryAccountingLifetime` | **partial** (smaps_rollup sampling exists at fork time only, `internal/fork/engine.go:readMemoryStats`) |
+| 5 | Misleading memory accounting | Report lifetime unique bytes, not just T=0 dirty pages | `TestUpdateMetricsPopulatesMemoryGauge`, `TestSampleMetricsTicksAndStopsOnContextCancel`; KVM growth assertion pending | **partial** (lifetime re-sampling wired: `Engine.Metering` re-stats `smaps_rollup` each pass and `Server.SampleMetrics` refreshes the gauge periodically; per-sandbox labels + KVM growth assertion open) |
 | 6 | Incompatible snapshot restored (crash/corruption) | Refuse on load: the manifest records the producing environment (format version, Firecracker version, CPU model, kernel, config hash); require exact VMM match, exact CPU-model match, format version in the supported set (kernel informational); `--allow-incompatible-snapshots` dev escape hatch | go: `internal/snapcompat` `TestCheck*`, `internal/fork/compat_test.go`; KVM: record a real manifest, assert compatible passes and a VMM / format-version mismatch is refused | **done** (load-gate enforcement after the digest verify, before any Firecracker launch; CPU templates + live cross-version restore open) |
 | 7 | forkd crash orphans its own VMs (in-memory map lost on restart) | Persist a per-VM journal (`<dataDir>/sandboxes/<id>.json`, atomic write) on create, remove on clean terminate; `NewEngine` reconciles it before serving: re-adopt a still-running pre-crash VM into the live map (PID-recycle-guarded: `/proc/<pid>/exe` must resolve to the recorded firecracker binary, else comm is `firecracker`) so the GC can reconcile it, or reap a dead/recycled VM's leaked artifacts (jailer chroot, rootfs CoW clone, fork network, jailer uid, volume backings) and drop the record. The adopted VM's exact /30 network block is pinned from its recorded guest IP (`netconf.Allocator.MarkInUse`), not re-Acquired, so a later fresh fork cannot be handed the same /30 and Release frees the right block. Fail-open; the startup reap never kills (only adoption enables a later GC-driven kill). That GC-driven kill (`reapAdopted`) RE-RUNS the same PID-recycle guard against the recorded firecracker binary immediately before signalling, so a pid recycled to an unrelated process between adoption and Terminate is never SIGKILLed (its artifacts are still reaped). Journal holds ids/pids/paths/uids/IPs only, never secrets | go: `internal/fork/journal_test.go`, `internal/fork/reconcile_engine_test.go` (live-pid adopt, dead-pid reap, recycled-pid reject, fail-open, adopted-terminate reap, reap-adopted skips kill on recycled pid + kills when still ours, adopted network block pinned) and `internal/netconf/identity_test.go` (`TestMarkInUse*`) with injected pid/verifier seams; `internal/firecracker` `TestJailerState`, `TestUIDAllocatorMarkInUse` | **partial** (journal + reconcile + reap + TOCTOU re-verification + block pinning done and unit-verified on darwin; real-VM reap on KVM, start a sandbox, kill -9 forkd, restart forkd, assert the orphan FC is reaped (dead) or re-adopted + GC-terminated with no leaked process/chroot/uid, is a TARGET pending a kvm-test.yaml crash-reap phase (issue #12); typed claim condition for a GC'd re-adopted orphan open) |
 
@@ -310,15 +310,22 @@ makes pages unique.
 
 Required implementation:
 
-- `mitos_memory_unique_bytes` (per-sandbox label) sampled periodically over
-  the sandbox lifetime, not only at fork time. The current implementation
-  samples `/proc/<pid>/smaps_rollup` once, at fork (`readMemoryStats`).
+- `mitos_memory_unique_bytes` sampled periodically over the sandbox lifetime,
+  not only at fork time. DONE for the aggregate gauge: `Engine.Metering`
+  re-samples each live sandbox's `/proc/<pid>/smaps_rollup` on every pass, and
+  `Server.SampleMetrics` (started by `cmd/forkd`) refreshes the gauge on an
+  interval, so `/metrics` reports lifetime unique bytes rather than the T=0
+  footprint recorded by `readMemoryStats` at fork. Per-sandbox-labeled series
+  remain a follow-up (the gauge is the node aggregate today).
 - Published density numbers must include unique-memory-after-representative-
   workload (e.g., after `pip install numpy && python -c "import numpy"`)
   alongside the T=0 number, produced by `bench/`.
 
-Test: fork, record T=0 unique bytes; run a write-heavy workload; assert the
-exported metric grows accordingly and that `GetCapacity` reflects it.
+Test: `TestUpdateMetricsPopulatesMemoryGauge` and
+`TestSampleMetricsTicksAndStopsOnContextCancel` cover the periodic wiring
+locally. The KVM variant (fork, record T=0 unique bytes, run a write-heavy
+workload, assert the exported metric grows and `GetCapacity` reflects it)
+remains for the fork-correctness KVM phase.
 
 ## 6. Snapshot compatibility on restore
 

--- a/internal/daemon/metrics_sampler_test.go
+++ b/internal/daemon/metrics_sampler_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/paperclipinc/mitos/internal/fork"
+	"github.com/paperclipinc/mitos/internal/metering"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// gaugeValue reads the current value of a prometheus Gauge without pulling in the
+// testutil helper (and its extra test-only dependency).
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("write gauge: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+// meteringSpyEngine embeds a MockEngine (to satisfy the ForkEngine interface) but
+// overrides Metering to return a fixed report and count how many times it was
+// sampled, so a test can prove the periodic sampler actually drives UpdateMetrics.
+type meteringSpyEngine struct {
+	*fork.MockEngine
+	unique int64
+	calls  atomic.Int64
+}
+
+func (e *meteringSpyEngine) Metering() metering.Report {
+	e.calls.Add(1)
+	return metering.Report{TotalUnique: e.unique}
+}
+
+// TestUpdateMetricsPopulatesMemoryGauge proves UpdateMetrics pushes the engine's
+// metering report into the mitos_memory_unique_bytes gauge. Before the periodic
+// sampler was wired this gauge was never populated, so /metrics reported a stale
+// zero (fork-correctness Row 5, issue #3).
+func TestUpdateMetricsPopulatesMemoryGauge(t *testing.T) {
+	const mib = int64(1024 * 1024)
+	eng := &meteringSpyEngine{MockEngine: fork.NewMockEngine(), unique: 7 * mib}
+	srv := NewServer(eng, NewSandboxAPI(t.TempDir()))
+
+	srv.UpdateMetrics()
+
+	if got := gaugeValue(t, memoryUnique); got != float64(7*mib) {
+		t.Fatalf("mitos_memory_unique_bytes = %v, want %d", got, 7*mib)
+	}
+}
+
+// TestSampleMetricsTicksAndStopsOnContextCancel proves the sampler refreshes the
+// gauges periodically (the metering engine is sampled more than once) AND returns
+// promptly when its context is cancelled, so it is a well-behaved background loop
+// (fork-correctness Row 5, issue #3).
+func TestSampleMetricsTicksAndStopsOnContextCancel(t *testing.T) {
+	const mib = int64(1024 * 1024)
+	eng := &meteringSpyEngine{MockEngine: fork.NewMockEngine(), unique: 3 * mib}
+	srv := NewServer(eng, NewSandboxAPI(t.TempDir()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		srv.SampleMetrics(ctx, 2*time.Millisecond)
+		close(done)
+	}()
+
+	// The loop samples once immediately and then on each tick: wait for at least
+	// two samples so we have proven it is periodic, not one-shot.
+	deadline := time.After(2 * time.Second)
+	for eng.calls.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("sampler did not tick at least twice; calls=%d", eng.calls.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	if got := gaugeValue(t, memoryUnique); got != float64(3*mib) {
+		t.Fatalf("mitos_memory_unique_bytes = %v, want %d", got, 3*mib)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SampleMetrics did not return after context cancel")
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -470,6 +470,36 @@ func volumeSpecs(mounts []*forkdpb.VolumeMount) ([]volume.Spec, error) {
 	return specs, nil
 }
 
+// defaultMetricsSampleInterval bounds how often SampleMetrics refreshes the
+// metering gauges. The metering report stats each live sandbox's
+// /proc/<pid>/smaps_rollup and backing files, so it is sampled on an interval
+// rather than on every Prometheus scrape.
+const defaultMetricsSampleInterval = 15 * time.Second
+
+// SampleMetrics periodically refreshes the metering gauges (UpdateMetrics) until
+// ctx is cancelled. The engine re-samples each live sandbox's memory on every
+// metering pass, so the gauges report LIFETIME unique memory, not the T=0
+// fork-time footprint (fork-correctness Row 5, issue #3). Without this loop the
+// gauges UpdateMetrics sets are never populated and /metrics serves a stale zero.
+// It samples once immediately so the first scrape after startup is already
+// populated; interval <= 0 selects defaultMetricsSampleInterval.
+func (s *Server) SampleMetrics(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultMetricsSampleInterval
+	}
+	s.UpdateMetrics()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.UpdateMetrics()
+		}
+	}
+}
+
 // UpdateMetrics refreshes capacity and metering gauges. Memory gauges are
 // CoW-aware: shared is each template's shared set counted once, unique is the
 // per-fork dirty total. The disk gauge reflects CoW-aware metered backing


### PR DESCRIPTION
Part of #3 (fork-engine correctness, gate G1), Row 5 "memory accounting truthfulness". Found while auditing the M1 issues against the code.

## The bug
`Server.UpdateMetrics()` pushes the engine's metering report into the `mitos_memory_unique_bytes` (plus shared / cow-savings / disk) gauges, but **nothing ever called it**. The gauge is registered and exposed on `/metrics`, yet always reads zero in production. So memory accounting was truthful only at fork time (`readMemoryStats` samples `smaps_rollup` once, at fork/adopt), and lifetime growth as a fork dirties pages was invisible to operators.

## Fix
`Server.SampleMetrics(ctx, interval)`: a ticker loop that calls `UpdateMetrics` until its context is cancelled, sampling once immediately so the first scrape after startup is already populated. `cmd/forkd` starts it on a context cancelled at shutdown. `Engine.Metering` already re-samples each live sandbox's `smaps_rollup` on every pass (see `TestMeteringResamplesLiveMemory`), so the gauge now reports LIFETIME unique memory, not the T=0 footprint. Default interval 15s bounds the per-sandbox `/proc` + backing-file stat cost off the fork hot path.

## Tests (TDD)
- `TestUpdateMetricsPopulatesMemoryGauge`: the previously-dead wiring now populates the gauge from the engine's report.
- `TestSampleMetricsTicksAndStopsOnContextCancel`: the loop refreshes periodically (engine sampled more than once) and returns promptly on context cancel.

The gauge value is read via `client_model/go` (already a direct dep) rather than the prometheus `testutil` helper, so **no new dependency** is added (go.mod/go.sum unchanged).

## Docs
`docs/fork-correctness.md` Row 5 updated: lifetime re-sampling is now wired (aggregate gauge). Per-sandbox-labeled series and the KVM growth assertion (fork, dirty pages, assert the metric grows) remain follow-ups for the fork-correctness KVM phase.

## Verification
`go build ./...`, `internal/daemon` suite, gofmt, and both `golangci-lint` runs (darwin + `GOOS=linux`) green locally.

## Security review note (named reviewer per CLAUDE.md)
Touches `internal/daemon` and `cmd/forkd` (security-sensitive paths). No new surface: a read-only metering loop. The metering report already excludes secret values (ids, template names, byte counts only); this PR only schedules its existing computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)