### PR TITLE
fix(controller): elide no-op SandboxPool status writes (#163)

### DIFF
--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -192,8 +192,14 @@ The following remain OPEN and are tracked in epic #12:
   pool self-heals a lost node's dormant slots, but a raw-forkd claim on a dead
   node fails (NodeLost) with no automatic replacement (acceptable for ephemeral
   sandboxes; the caller re-claims).
-- status-update rate-limiting and batching: status writes are not yet
-  rate-limited or batched.
+- status-update rate-limiting and batching: PARTIAL. The SandboxPool reconcile
+  now elides a no-op status write: it writes (and stamps LastSnapshotTime) only
+  when a field an operator or the autoscaler reads actually changed
+  (`writePoolStatusIfChanged` / `poolStatusUnchanged`,
+  `internal/controller/sandboxpool_controller.go`), so the steady-state 30s
+  requeue no longer churns etcd or re-triggers the pool's own watch. The
+  SandboxClaim and SandboxFork reconcilers, and true rate-limiting/batching of
+  genuine transitions, are not yet done.
 - chaos CI suite: kill -9 of components under load is not yet exercised in CI;
   the in-cluster self-hosted runner (issue #16) plus the cluster-e2e workflow are
   the substrate a chaos suite would build on.

--- a/internal/controller/pool_status_elision_test.go
+++ b/internal/controller/pool_status_elision_test.go
@@ -1,0 +1,128 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1alpha1 "github.com/paperclipinc/mitos/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestPoolStatusUnchanged proves the change-detection that gates a status write
+// (issue #163): a status differing only in the LastSnapshotTime heartbeat is
+// "unchanged", while a change to any field an operator or the autoscaler reads is
+// detected.
+func TestPoolStatusUnchanged(t *testing.T) {
+	t1 := metav1.Now()
+	base := v1alpha1.SandboxPoolStatus{
+		ReadySnapshots:   2,
+		TotalSnapshots:   2,
+		DesiredWarm:      2,
+		TemplateDigest:   "sha256:abc",
+		NodeDistribution: map[string]int32{"n1": 1, "n2": 1},
+		LastSnapshotTime: &t1,
+		Conditions: []metav1.Condition{{
+			Type: "Ready", Status: metav1.ConditionTrue, Reason: "HuskPodsReady",
+			Message: "2/2 warm husk pods", LastTransitionTime: t1,
+		}},
+	}
+
+	// Only the heartbeat differs: unchanged.
+	t2 := metav1.NewTime(t1.Add(time.Minute))
+	bumped := base.DeepCopy()
+	bumped.LastSnapshotTime = &t2
+	if !poolStatusUnchanged(&base, bumped) {
+		t.Fatal("statuses differing only in LastSnapshotTime must be reported unchanged")
+	}
+
+	// Each meaningful field change must be detected.
+	mutations := map[string]func(*v1alpha1.SandboxPoolStatus){
+		"ReadySnapshots":   func(s *v1alpha1.SandboxPoolStatus) { s.ReadySnapshots = 1 },
+		"TemplateDigest":   func(s *v1alpha1.SandboxPoolStatus) { s.TemplateDigest = "sha256:def" },
+		"NodeDistribution": func(s *v1alpha1.SandboxPoolStatus) { s.NodeDistribution = map[string]int32{"n1": 2} },
+		"ConditionMessage": func(s *v1alpha1.SandboxPoolStatus) { s.Conditions[0].Message = "1/2 warm husk pods" },
+		"ConditionStatus":  func(s *v1alpha1.SandboxPoolStatus) { s.Conditions[0].Status = metav1.ConditionFalse },
+		"DesiredWarm":      func(s *v1alpha1.SandboxPoolStatus) { s.DesiredWarm = 3 },
+		"ScaleDownTime":    func(s *v1alpha1.SandboxPoolStatus) { s.LastScaleDownTime = &t2 },
+	}
+	for name, mut := range mutations {
+		changed := base.DeepCopy()
+		mut(changed)
+		if poolStatusUnchanged(&base, changed) {
+			t.Fatalf("%s change must be detected as a status difference", name)
+		}
+	}
+}
+
+// TestWritePoolStatusIfChangedElidesNoOp proves the wiring (issue #163): a no-op
+// reconcile does NOT write status (the object's resourceVersion is stable and the
+// LastSnapshotTime heartbeat is not stamped), while a real change writes and
+// stamps the heartbeat.
+func TestWritePoolStatusIfChangedElidesNoOp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	pool := &v1alpha1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Status:     v1alpha1.SandboxPoolStatus{ReadySnapshots: 1, TotalSnapshots: 1},
+	}
+	c := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.SandboxPool{}).
+		WithObjects(pool).
+		Build()
+	r := &SandboxPoolReconciler{Client: c}
+	ctx := context.Background()
+
+	var live v1alpha1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pool), &live); err != nil {
+		t.Fatal(err)
+	}
+	rv0 := live.ResourceVersion
+
+	// No-op: status identical to the stored object, so no write.
+	before := live.Status.DeepCopy()
+	if err := r.writePoolStatusIfChanged(ctx, &live, before, metav1.Now()); err != nil {
+		t.Fatalf("writePoolStatusIfChanged (no-op): %v", err)
+	}
+	var afterNoop v1alpha1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pool), &afterNoop); err != nil {
+		t.Fatal(err)
+	}
+	if afterNoop.ResourceVersion != rv0 {
+		t.Fatalf("no-op reconcile wrote status: resourceVersion %s -> %s", rv0, afterNoop.ResourceVersion)
+	}
+	if afterNoop.Status.LastSnapshotTime != nil {
+		t.Fatal("no-op reconcile must not stamp LastSnapshotTime")
+	}
+
+	// Real change: ReadySnapshots moves, so the status must be written and the
+	// heartbeat stamped.
+	before2 := live.Status.DeepCopy()
+	live.Status.ReadySnapshots = 5
+	if err := r.writePoolStatusIfChanged(ctx, &live, before2, metav1.Now()); err != nil {
+		t.Fatalf("writePoolStatusIfChanged (change): %v", err)
+	}
+	var afterChange v1alpha1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pool), &afterChange); err != nil {
+		t.Fatal(err)
+	}
+	if afterChange.ResourceVersion == rv0 {
+		t.Fatal("a real status change did not write (resourceVersion unchanged)")
+	}
+	if afterChange.Status.ReadySnapshots != 5 {
+		t.Fatalf("ReadySnapshots = %d, want 5", afterChange.Status.ReadySnapshots)
+	}
+	if afterChange.Status.LastSnapshotTime == nil {
+		t.Fatal("a real change must stamp LastSnapshotTime")
+	}
+}

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/paperclipinc/mitos/internal/kms"
 	forkdpb "github.com/paperclipinc/mitos/proto/forkd"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -279,6 +280,10 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		readySnapshots := r.readySnapshotCount(templateID)
 		setPoolReadySnapshots(pool.Name, readySnapshots)
+		// Snapshot the stored status before mutating so a no-op reconcile can skip
+		// the status write (issue #163). Captured AFTER the metric setter (which
+		// does not touch status) and BEFORE any pool.Status mutation.
+		before := pool.Status.DeepCopy()
 		pool.Status.ReadySnapshots = readySnapshots
 		pool.Status.TotalSnapshots = readySnapshots
 		pool.Status.NodeDistribution = r.nodeDistribution(templateID)
@@ -289,7 +294,6 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			}
 		}
 		now := metav1.Now()
-		pool.Status.LastSnapshotTime = &now
 		if res.scaledDn {
 			pool.Status.LastScaleDownTime = &now
 		}
@@ -300,7 +304,7 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			Reason:             "HuskPodsReady",
 			Message:            fmt.Sprintf("%d/%d warm husk pods (%d in use), %d snapshot node(s)", warm, desiredWarm, res.inUse, readySnapshots),
 		})
-		if err := r.Status().Update(ctx, &pool); err != nil {
+		if err := r.writePoolStatusIfChanged(ctx, &pool, before, now); err != nil {
 			return ctrl.Result{}, err
 		}
 		// Bounded periodic requeue so the warm pool re-converges to Replicas even
@@ -329,6 +333,8 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Update status
 	setPoolReadySnapshots(pool.Name, readySnapshots)
+	// Snapshot before mutating so a no-op reconcile skips the status write (#163).
+	before := pool.Status.DeepCopy()
 	pool.Status.ReadySnapshots = readySnapshots
 	pool.Status.TotalSnapshots = readySnapshots
 	pool.Status.NodeDistribution = r.nodeDistribution(templateID)
@@ -337,7 +343,6 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	now := metav1.Now()
-	pool.Status.LastSnapshotTime = &now
 	setCondition(&pool.Status.Conditions, metav1.Condition{
 		Type:               "Ready",
 		Status:             conditionStatus(readySnapshots >= desired),
@@ -346,7 +351,7 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		Message:            fmt.Sprintf("%d/%d snapshots ready", readySnapshots, desired),
 	})
 
-	if err := r.Status().Update(ctx, &pool); err != nil {
+	if err := r.writePoolStatusIfChanged(ctx, &pool, before, now); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -358,6 +363,39 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // node count.
 func (r *SandboxPoolReconciler) readySnapshotCount(templateID string) int32 {
 	return int32(len(r.NodeRegistry.NodesWithTemplate(templateID)))
+}
+
+// poolStatusUnchanged reports whether two pool statuses are equal for the purpose
+// of skipping a redundant status write. LastSnapshotTime is excluded: it is a
+// reconcile heartbeat that would otherwise change every pass and defeat the
+// comparison. Every field an operator or the autoscaler reads (counts, digest,
+// node distribution, desiredWarm, conditions, scale-down time) IS compared, and
+// setCondition carries an unchanged condition's LastTransitionTime forward, so a
+// steady-state reconcile compares equal. apiequality.Semantic compares metav1.Time
+// by value (handling the monotonic-clock and location pitfalls of DeepEqual).
+func poolStatusUnchanged(a, b *v1alpha1.SandboxPoolStatus) bool {
+	x, y := a.DeepCopy(), b.DeepCopy()
+	x.LastSnapshotTime, y.LastSnapshotTime = nil, nil
+	return apiequality.Semantic.DeepEqual(x, y)
+}
+
+// writePoolStatusIfChanged writes the pool status only when it differs from the
+// before snapshot (ignoring the LastSnapshotTime heartbeat), stamping
+// LastSnapshotTime to now on a real change. This elides the redundant status
+// write the periodic 30s requeue would otherwise issue every pass even when
+// nothing changed: the dominant source of pool status-write churn against etcd
+// (issue #163, failure/GC status-update rate-limiting). On a no-op it leaves the
+// stored object untouched (no write, no heartbeat bump), so the object's own
+// watch is not re-triggered.
+func (r *SandboxPoolReconciler) writePoolStatusIfChanged(ctx context.Context, pool *v1alpha1.SandboxPool, before *v1alpha1.SandboxPoolStatus, now metav1.Time) error {
+	if poolStatusUnchanged(before, &pool.Status) {
+		// Keep the in-memory heartbeat consistent with what is stored (we did not
+		// write), then skip the API call.
+		pool.Status.LastSnapshotTime = before.LastSnapshotTime
+		return nil
+	}
+	pool.Status.LastSnapshotTime = &now
+	return r.Status().Update(ctx, pool)
 }
 
 // snapshotNodeNames returns the hostnames of the healthy nodes that hold the


### PR DESCRIPTION
Part of #163 (failure/GC, gate G2): the "status-update rate-limiting and batching" open item in docs/failure-gc.md. Found while auditing the M1 issues against the code.

## The churn
The pool reconcile requeues every 30s and wrote its status on **every** pass: it unconditionally bumped `LastSnapshotTime = now` and called `Status().Update`, even when nothing an operator or the autoscaler reads had changed. Across N pools that is N status writes per 30s of pure churn: load on etcd (relevant to the "slow etcd" failure mode) and a needless re-trigger of each pool's own watch. `setCondition` already carries an unchanged condition's `LastTransitionTime` forward for exactly this reason, but the caller ignored its signal and the heartbeat changed every pass regardless.

## Fix
Snapshot the stored status before mutating, then write only when it differs **ignoring** the `LastSnapshotTime` heartbeat (`poolStatusUnchanged` via `apiequality.Semantic.DeepEqual`, which compares `metav1.Time` by value and sidesteps the monotonic-clock/location DeepEqual pitfalls). On a real change the heartbeat is stamped and the write proceeds; on a no-op nothing is written. `LastSnapshotTime` now means "time the status last changed" rather than "time of last reconcile", which better matches its name. The reconcile still runs every 30s, so warm-pool self-heal is unaffected; only the redundant write is skipped. Applied to both the husk and raw-forkd branches.

## Tests (TDD)
- `TestPoolStatusUnchanged`: a heartbeat-only delta is "unchanged"; each meaningful field delta (counts, digest, node distribution, condition status/message, desiredWarm, scale-down time) is detected.
- `TestWritePoolStatusIfChangedElidesNoOp`: fake-client wiring proof: a no-op leaves `resourceVersion` stable and does not stamp the heartbeat; a real change writes and stamps it.

The existing pool envtests remain the regression net for the writes-when-changed direction (they assert status fields land). `docs/failure-gc.md` updated to PARTIAL.

## Scope / remaining
This covers the SandboxPool reconcile, the clear fixed-heartbeat churn source. The SandboxClaim and SandboxFork reconcilers, and true rate-limiting/batching of genuine transitions, are noted as remaining in docs/failure-gc.md and left for follow-up.

## Verification
`go build ./...`, full `internal/controller` envtest suite, gofmt, and both `golangci-lint` runs (darwin + `GOOS=linux`) green locally.

## Security review note (named reviewer per CLAUDE.md)
Touches `internal/controller` (security-sensitive). Behavior-preserving: identical status content is written when anything changes; only redundant identical writes are skipped. No new trust surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)