### PR TITLE
ci(chaos): grant the CI runner node cordon so cross-node failover runs (#163)

### DIFF
--- a/.github/workflows/cluster-e2e.yaml
+++ b/.github/workflows/cluster-e2e.yaml
@@ -2,7 +2,7 @@ name: Cluster e2e (self-hosted)
 
 # =============================================================================
 # SECURITY: this workflow runs on a SELF-HOSTED runner that lives INSIDE the
-# maintainer's single-node Talos KVM cluster. That runner can drive the cluster
+# maintainer's multi-node Talos KVM cluster. That runner can drive the cluster
 # (it has KVM via the husk pods and a scoped ServiceAccount). The repo
 # paperclipinc/mitos is PUBLIC. Therefore this job MUST NEVER execute code from
 # an untrusted fork pull request: a malicious fork PR could otherwise own the

--- a/deploy/ci-runner/rbac.yaml
+++ b/deploy/ci-runner/rbac.yaml
@@ -224,14 +224,26 @@ subjects:
     name: mitos-ci-runner
     namespace: mitos-ci
 ---
-# Cluster-scoped READ ONLY: the controller places husk pods on nodes labeled
-# mitos.run/kvm=true and the e2e asserts the node is KVM-capable, so the runner
-# needs to read nodes (get/list). Nodes are cluster-scoped, so this is the one
-# unavoidable ClusterRole; it grants READ on nodes ONLY and binds the same SA.
+# Cluster-scoped node access: READ for the KVM-capability assertions (the
+# controller places husk pods on nodes labeled mitos.run/kvm=true and the e2e
+# asserts the node is KVM-capable), plus CORDON (patch/update) so the chaos suite
+# can exercise CROSS-NODE failover on the multi-node KVM CI cluster: stage 5 of
+# test/cluster-e2e/chaos-e2e.sh cordons a claim's node and asserts the claim
+# recovers on another node (issue #163, gate G2). Nodes are cluster-scoped, so
+# this is the one unavoidable ClusterRole.
+#
+# SECURITY: patch/update on nodes lets this SA cordon any node, a cluster-wide
+# capability. It is contained by the cluster-e2e workflow's trigger gate, which
+# is the ONLY thing that drives this runner: push to main (already-reviewed code),
+# or a labeled SAME-REPO PR behind the `cluster` Environment approval. A fork PR
+# can never reach the runner (see .github/workflows/cluster-e2e.yaml), so no
+# untrusted code ever exercises this grant. The suite uncordons every node it
+# cordons. (Renamed from mitos-ci-runner-nodes-read; delete that stale ClusterRole
+# and its binding after applying.)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: mitos-ci-runner-nodes-read
+  name: mitos-ci-runner-nodes
   labels:
     app.kubernetes.io/name: mitos
     app.kubernetes.io/component: ci-runner
@@ -243,18 +255,23 @@ rules:
     verbs:
       - get
       - list
+      # cordon/uncordon for the cross-node chaos stage (#163). kubectl cordon
+      # patches node.spec.unschedulable; update is included so `kubectl auth
+      # can-i update nodes` (the stage's capability probe) reports true.
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: mitos-ci-runner-nodes-read
+  name: mitos-ci-runner-nodes
   labels:
     app.kubernetes.io/name: mitos
     app.kubernetes.io/component: ci-runner
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mitos-ci-runner-nodes-read
+  name: mitos-ci-runner-nodes
 subjects:
   - kind: ServiceAccount
     name: mitos-ci-runner

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -103,10 +103,19 @@ TRUSTED triggers ONLY. There are three independent layers:
      ReplicaSets/Pods/Pod logs (rollout + diagnostics), read Secrets presence.
      It CANNOT create or delete Deployments, write Secrets, or touch the
      controller's own RBAC.
-   - cluster-scoped: `get/list nodes` ONLY (nodes are cluster-scoped and the
-     e2e checks for a KVM-capable node).
+   - cluster-scoped: `get/list nodes` (the e2e checks for a KVM-capable node)
+     plus `patch/update nodes` for CORDON, so the chaos suite can exercise
+     cross-node failover on the multi-node KVM cluster (issue #163: cordon a
+     node, assert the claim recovers elsewhere, uncordon). This is the
+     `mitos-ci-runner-nodes` ClusterRole (renamed from `mitos-ci-runner-nodes-read`).
 
-   There is deliberately NO `ClusterRole` granting writes and NO `cluster-admin`.
+   `patch/update nodes` is a cluster-wide capability (the SA can cordon any
+   node), so it is justified ONLY by the workflow's trigger gate: this runner is
+   driven exclusively by push-to-main (reviewed code) or a labeled same-repo PR
+   behind the `cluster` Environment approval, never by fork code. Apart from node
+   cordon there is NO `ClusterRole` granting writes and NO `cluster-admin`. When
+   upgrading an existing deployment, delete the old `mitos-ci-runner-nodes-read`
+   ClusterRole and ClusterRoleBinding after applying.
 
 4. **Ephemeral runner.** The runner is registered with `--ephemeral`: it runs
    one job, exits, and the Deployment restarts it, re-registering a fresh

--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -200,6 +200,10 @@ The following remain OPEN and are tracked in epic #12:
   requeue no longer churns etcd or re-triggers the pool's own watch. The
   SandboxClaim and SandboxFork reconcilers, and true rate-limiting/batching of
   genuine transitions, are not yet done.
-- chaos CI suite: kill -9 of components under load is not yet exercised in CI;
-  the in-cluster self-hosted runner (issue #16) plus the cluster-e2e workflow are
-  the substrate a chaos suite would build on.
+- chaos CI suite: PARTIAL. test/cluster-e2e/chaos-e2e.sh runs on the multi-node
+  self-hosted KVM cluster via the cluster-e2e workflow and exercises pod-loss
+  recovery, warm-pool self-heal, AND cross-node failover (stage 5: cordon a
+  claim's node, assert the claim recovers on another node, uncordon) now that the
+  runner holds node cordon (mitos-ci-runner-nodes). Still open: kill -9 of the
+  controller/forkd/guest processes under a claim storm (process-crash injection,
+  distinct from pod deletion and node cordon).

--- a/test/cluster-e2e/chaos-e2e.sh
+++ b/test/cluster-e2e/chaos-e2e.sh
@@ -120,7 +120,7 @@ kvm_nodes=$(kubectl get nodes -l 'mitos.run/kvm=true' --no-headers 2>/dev/null |
 if [ "${kvm_nodes:-0}" -lt 2 ]; then
   info "only ${kvm_nodes} KVM node(s); skipping cross-node failover stage"
 elif ! kubectl auth can-i update nodes >/dev/null 2>&1; then
-  info "no node-write permission (least-privilege runner); skipping cross-node failover stage (run as admin to exercise it)"
+  info "no node cordon permission; skipping cross-node failover (the CI runner has it via the mitos-ci-runner-nodes ClusterRole; this branch is for an unprivileged manual run)"
 else
   cn="$(claim_node)"
   info "cordoning ${cn} + deleting its husk pods to force cross-node failover"


### PR DESCRIPTION
Part of #163 (failure/GC, gate G2). Acting on the clarification that the self-hosted cluster-e2e runner already lives in a **multi-node KVM cluster** (the `cluster-e2e.yaml` header said "single-node" — stale, fixed here).

## The gap
`test/cluster-e2e/chaos-e2e.sh` already has stage 5 (cross-node failover: cordon a claim's node, delete its husk pods, assert the claim recovers on a *different* node, uncordon), and `cluster-e2e.yaml` already runs the chaos suite. But stage 5 was **silently skipped**: the runner's ServiceAccount had read-only node access (`get/list`), so `kubectl auth can-i update nodes` was false. So the cluster could run the headline failure/GC proof, but RBAC stopped it.

## Fix
Grant the runner node cordon: add `patch`/`update` on `nodes` to its cluster-scoped node ClusterRole, renamed `mitos-ci-runner-nodes-read` -> `mitos-ci-runner-nodes` (no longer read-only). `kubectl cordon` patches `node.spec.unschedulable`; `update` is included so the stage's capability probe reports true. Updated the stage-5 skip message, the stale single-node comment, `docs/ci-runner.md`, and `docs/failure-gc.md` (chaos item -> PARTIAL: cross-node failover now exercised; process `kill -9` still open).

## Security (named reviewer per CLAUDE.md)
`patch/update nodes` is cluster-wide (the SA can cordon any node). It is contained by the cluster-e2e **trigger gate** — the only thing that drives this runner: push to main (reviewed code) or a labeled same-repo PR behind the `cluster` Environment approval; a fork PR can never reach it. The suite uncordons every node it cordons. This is CI-infra privilege, documented in `docs/ci-runner.md`; it is not a sandbox/forkd surface, so the sandbox threat model is unchanged. **Please review the RBAC widening against the trigger gate before merge.**

## Upgrade note
Delete the old `mitos-ci-runner-nodes-read` ClusterRole + ClusterRoleBinding after applying (kustomize does not prune the renamed objects).

## Verification
`kubectl kustomize deploy/ci-runner` renders the role with `get/list/patch/update`; `actionlint` clean on `cluster-e2e.yaml`. The cross-node run itself executes on the multi-node KVM cluster via `cluster-e2e` (push-to-main or the `ci-cluster` label) — the standard verification path for this self-hosted suite; it cannot run on GitHub-hosted CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)