### PR TITLE
feat(forkd): LLM-legible guest-kernel-missing error; close out #174

### DIFF
--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -145,6 +145,12 @@ type Engine struct {
 	agentBinPath string
 	busyboxPath  string
 
+	// kernelStaged checks that the guest kernel is present before a template build
+	// boots from it (issue #174). NewEngine sets it to ensureGuestKernelStaged;
+	// tests that construct an Engine directly with a fake builder (no real boot)
+	// leave it nil, which skips the check. Production always sets it.
+	kernelStaged func(kernelPath string) error
+
 	// hugePages is the guest-memory page granularity baked into every template
 	// snapshot this engine builds (issue #167). "" is the Firecracker default
 	// (4 KiB base pages); "2M" backs guest memory with 2 MiB hugetlbfs pages so
@@ -825,6 +831,7 @@ func NewEngine(dataDir, firecrackerBin, kernelPath string, jailer firecracker.Ja
 		agentBinPath:         opts.AgentBinPath,
 		busyboxPath:          opts.BusyboxPath,
 		hugePages:            opts.HugePages,
+		kernelStaged:         ensureGuestKernelStaged,
 		enableVolumes:        opts.EnableVolumes,
 		volBackend:           volBackend,
 		enableEncryption:     opts.EnableEncryption,
@@ -1977,8 +1984,11 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 	// Fail fast with an actionable error if the guest kernel the build boots from
 	// is not staged yet (issue #174 box 5): the kernel-provisioner DaemonSet may
 	// still be coming up, and an opaque Firecracker boot failure would hide that.
-	if err := ensureGuestKernelStaged(e.kernelPath); err != nil {
-		return fmt.Errorf("create template %s: %w", id, err)
+	// Skipped when the seam is unset (tests with a fake builder that never boots).
+	if e.kernelStaged != nil {
+		if err := e.kernelStaged(e.kernelPath); err != nil {
+			return fmt.Errorf("create template %s: %w", id, err)
+		}
 	}
 
 	cfg := firecracker.DefaultVMConfig()

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -1974,6 +1974,13 @@ func logBuildPlan(image string, initCommands []string, cache templatebuild.Cache
 }
 
 func (e *Engine) CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec) (retErr error) {
+	// Fail fast with an actionable error if the guest kernel the build boots from
+	// is not staged yet (issue #174 box 5): the kernel-provisioner DaemonSet may
+	// still be coming up, and an opaque Firecracker boot failure would hide that.
+	if err := ensureGuestKernelStaged(e.kernelPath); err != nil {
+		return fmt.Errorf("create template %s: %w", id, err)
+	}
+
 	cfg := firecracker.DefaultVMConfig()
 	// Bake the configured guest-memory page granularity into this template's
 	// snapshot (issue #167). "" leaves the Firecracker default (4 KiB); "2M"

--- a/internal/fork/kernelcheck.go
+++ b/internal/fork/kernelcheck.go
@@ -1,0 +1,24 @@
+package fork
+
+import (
+	"fmt"
+	"os"
+)
+
+// ensureGuestKernelStaged checks that the guest kernel the template build boots
+// from is present, returning an actionable, LLM-legible error if not (issue #174
+// box 5, extending the issue #28 error rule to the deploy layer). The kernel is
+// staged on each KVM node by the kernel-provisioner DaemonSet, which may still be
+// running when forkd starts; rather than letting CreateTemplate surface an opaque
+// Firecracker boot failure, fail fast and name the path and the likely cause so
+// an operator (or an agent reading the log) knows exactly what to check.
+func ensureGuestKernelStaged(kernelPath string) error {
+	info, err := os.Stat(kernelPath)
+	if err != nil {
+		return fmt.Errorf("guest kernel missing at %s: %w; the kernel-provisioner DaemonSet stages it on each KVM node, is it healthy? (kubectl -n <install-ns> get pods -l app=kernel-provisioner; run `mitos doctor` for a full preflight)", kernelPath, err)
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		return fmt.Errorf("guest kernel at %s is not a usable image (empty or not a regular file); the kernel-provisioner stages it, is it healthy? run `mitos doctor` for a full preflight", kernelPath)
+	}
+	return nil
+}

--- a/internal/fork/kernelcheck_test.go
+++ b/internal/fork/kernelcheck_test.go
@@ -1,0 +1,38 @@
+package fork
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureGuestKernelStagedMissing proves the build path fails fast with an
+// actionable, LLM-legible error (issue #174 box 5, extending #28 to the deploy
+// layer) when the guest kernel is not staged, instead of surfacing an opaque
+// Firecracker boot failure. The error must name the missing path and point at the
+// kernel-provisioner so an operator (or an agent reading the log) knows the fix.
+func TestEnsureGuestKernelStagedMissing(t *testing.T) {
+	err := ensureGuestKernelStaged(filepath.Join(t.TempDir(), "vmlinux"))
+	if err == nil {
+		t.Fatal("expected an error for a missing guest kernel")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "vmlinux") {
+		t.Errorf("error should name the missing kernel path, got: %v", err)
+	}
+	if !strings.Contains(msg, "kernel-provisioner") {
+		t.Errorf("error should point at the kernel-provisioner, got: %v", err)
+	}
+}
+
+// TestEnsureGuestKernelStagedPresent proves a staged kernel passes.
+func TestEnsureGuestKernelStagedPresent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "vmlinux")
+	if err := os.WriteFile(p, []byte("kernel"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureGuestKernelStaged(p); err != nil {
+		t.Errorf("a staged kernel should pass, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last open box of #174 (boxes 1-4 already shipped in `docs/platforms/prerequisites.md` + `host-prerequisites.md` + `internal/agentcli` doctor, including the userfaultfd check from #231).

Box 5 (extend the #28 LLM-legible-error rule to the deploy layer): `CreateTemplate` now fails fast with an actionable error when the guest kernel it boots from is missing or unusable, naming the path and pointing at the kernel-provisioner DaemonSet and `mitos doctor`, instead of an opaque Firecracker boot failure.

- `ensureGuestKernelStaged` (pure, unit-tested on any host).
- Wired at the top of `CreateTemplate`.

## Verification
- Builds darwin + GOOS=linux; new unit tests pass; gofmt clean.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
