### PR TITLE
feat(controller): enforce capability fork budget on self-initiated forks (#25)

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -54,6 +54,7 @@ respective reconcilers in `internal/controller` for the precise emission points.
 | `SecretInheritanceDenied` | SandboxFork | A fork was rejected because the source claim holds secrets and inheritance was not explicitly opted into. |
 | `ExplicitOptIn` | SandboxFork | Secret inheritance was explicitly permitted on the fork. |
 | `Forked` / `ForksCreated` | SandboxFork | The requested forks were created. |
+| `BudgetExhausted` | Sandbox (v1alpha2, source.fromSandbox) | A self-initiated fork was rejected because the source sandbox's capability budget (`spec.budget.maxForks`) is spent; admitted forks are ranked deterministically by creation time, and the ones beyond the limit fail terminally with the LLM-legible `budget_exhausted` remediation (request a larger budget from the creator). Issue #25. |
 | `WorkspaceBusy` | SandboxClaim | Another writer holds the single-writer-per-workspace lock for the claim's target workspace; this claim waits and retries until the first writer releases it. |
 
 ### Operator actions per SandboxClaim reason

--- a/internal/controller/sandbox_v2_budget_envtest_test.go
+++ b/internal/controller/sandbox_v2_budget_envtest_test.go
@@ -1,0 +1,137 @@
+package controller_test
+
+// Budget-enforcement envtest for the v1alpha2 consolidated Sandbox kind (issue
+// #25): when a self-initiated fork (source.fromSandbox = P) is created, the
+// controller enforces P's capability budget. Forks are admitted up to
+// P.spec.budget.maxForks; the ones beyond are rejected with a typed
+// BudgetExhausted condition (the LLM-legible apierr.CodeBudgetExhausted
+// remediation), and P.status.budgetSpend.forks records the admitted count.
+//
+// The gate runs BEFORE fork materialization, so this test needs no working
+// forkd node: the admitted children just need to NOT be rejected at the gate,
+// and the over-budget child must reach a Failed/Ready=False BudgetExhausted
+// condition.
+
+import (
+	"testing"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1alpha1 "mitos.run/mitos/api/v1alpha1"
+	v1alpha2 "mitos.run/mitos/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// sandboxReadyConditionReason returns the Reason of the named Sandbox's Ready
+// condition, or "" when the Sandbox or its condition is absent.
+func sandboxReadyConditionReason(t *testing.T, name string) string {
+	t.Helper()
+	var sb v1alpha2.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &sb); err != nil {
+		return ""
+	}
+	if c := apimeta.FindStatusCondition(sb.Status.Conditions, "Ready"); c != nil {
+		return c.Reason
+	}
+	return ""
+}
+
+// TestSandboxForkBudgetAdmitsUpToMaxAndRejectsBeyond proves the controller-side
+// capability-budget enforcement (issue #25): a parent P with budget.maxForks=2
+// admits the first two fork-children (deterministically ranked by
+// creationTimestamp then name) and rejects the third with a BudgetExhausted
+// condition, recording P.status.budgetSpend.forks == 2.
+func TestSandboxForkBudgetAdmitsUpToMaxAndRejectsBeyond(t *testing.T) {
+	maxForks := int32(2)
+
+	parent := &v1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "budget-parent", Namespace: "default"},
+		Spec: v1alpha2.SandboxSpec{
+			Source:   v1alpha2.SandboxSource{PoolRef: &v1alpha1.LocalObjectReference{Name: "budget-pool"}},
+			Replicas: 1,
+			Budget:   &v1alpha2.SandboxBudget{MaxForks: &maxForks},
+		},
+	}
+	if err := k8sClient.Create(ctx, parent); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, parent) })
+
+	// Three fork-children of the parent, created sequentially so their
+	// creationTimestamps order child-0 < child-1 < child-2 (the name tiebreak
+	// settles any tie at second granularity).
+	names := []string{"budget-child-0", "budget-child-1", "budget-child-2"}
+	for _, n := range names {
+		child := &v1alpha2.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"},
+			Spec: v1alpha2.SandboxSpec{
+				Source:   v1alpha2.SandboxSource{FromSandbox: &v1alpha2.FromSandboxSource{Name: "budget-parent"}},
+				Replicas: 1,
+			},
+		}
+		if err := k8sClient.Create(ctx, child); err != nil {
+			t.Fatal(err)
+		}
+		c := child
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, c) })
+		// Sequential creation with a small gap so the timestamp ordering is stable.
+		time.Sleep(1100 * time.Millisecond)
+	}
+
+	// child-2 (the over-budget one) must reach a BudgetExhausted Ready=False
+	// condition.
+	deadline := time.Now().Add(20 * time.Second)
+	var rejectedReason string
+	for time.Now().Before(deadline) {
+		rejectedReason = sandboxReadyConditionReason(t, "budget-child-2")
+		if rejectedReason == "BudgetExhausted" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if rejectedReason != "BudgetExhausted" {
+		t.Fatalf("budget-child-2 Ready reason = %q, want BudgetExhausted", rejectedReason)
+	}
+
+	var rejected v1alpha2.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "budget-child-2", Namespace: "default"}, &rejected); err != nil {
+		t.Fatal(err)
+	}
+	if rejected.Status.Phase != v1alpha1.SandboxFailed {
+		t.Fatalf("budget-child-2 phase = %q, want Failed", rejected.Status.Phase)
+	}
+	if c := apimeta.FindStatusCondition(rejected.Status.Conditions, "Ready"); c == nil || c.Status != metav1.ConditionFalse {
+		t.Fatalf("budget-child-2 Ready condition = %+v, want Status False", c)
+	}
+
+	// The two admitted children must NOT be BudgetExhausted (they pass the gate).
+	for _, n := range []string{"budget-child-0", "budget-child-1"} {
+		if r := sandboxReadyConditionReason(t, n); r == "BudgetExhausted" {
+			t.Fatalf("%s was BudgetExhausted but should have been admitted", n)
+		}
+	}
+
+	// P.status.budgetSpend.forks records the admitted count, capped at the limit.
+	deadline = time.Now().Add(20 * time.Second)
+	var spend int32 = -1
+	for time.Now().Before(deadline) {
+		var p v1alpha2.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "budget-parent", Namespace: "default"}, &p); err == nil {
+			if p.Status.BudgetSpend != nil {
+				spend = p.Status.BudgetSpend.Forks
+				if spend == maxForks {
+					break
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if spend != maxForks {
+		t.Fatalf("budget-parent status.budgetSpend.forks = %d, want %d", spend, maxForks)
+	}
+}
+
+// ensure client import stays used even if the rest of the file changes shape.
+var _ client.Object = (*v1alpha2.Sandbox)(nil)

--- a/internal/controller/sandbox_v2_controller.go
+++ b/internal/controller/sandbox_v2_controller.go
@@ -3,12 +3,15 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	v1alpha1 "mitos.run/mitos/api/v1alpha1"
 	v1alpha2 "mitos.run/mitos/api/v1alpha2"
+	"mitos.run/mitos/internal/apierr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -121,6 +124,22 @@ func (r *SandboxReconciler) reconcilePoolRef(ctx context.Context, sb *v1alpha2.S
 // reconcileFromSandbox maps source.fromSandbox onto an owned SandboxFork (the
 // fork equivalent) and mirrors readyForks / per-child status back.
 func (r *SandboxReconciler) reconcileFromSandbox(ctx context.Context, sb *v1alpha2.Sandbox) (ctrl.Result, error) {
+	// Capability-budget enforcement (issue #25): a self-initiated fork
+	// (source.fromSandbox = P) is admitted only while P's capability budget has
+	// room. An over-budget fork is rejected terminally with a typed
+	// BudgetExhausted condition BEFORE the fork is ever materialized, so no engine
+	// work is spent on a fork the creator's budget forbids.
+	admitted, reason, message, err := r.enforceForkBudget(ctx, sb)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !admitted {
+		return ctrl.Result{}, r.mirror(ctx, sb, v1alpha1.SandboxFailed, sandboxMirror{
+			reason:  reason,
+			message: message,
+		})
+	}
+
 	fork, err := r.ensureFork(ctx, sb)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -162,6 +181,127 @@ func (r *SandboxReconciler) reconcileFromSandbox(ctx context.Context, sb *v1alph
 	m.reason = "ForksPending"
 	m.message = fmt.Sprintf("%d/%d children ready (forking from %q)", fork.Status.ReadyForks, fork.Spec.Replicas, sb.Spec.Source.FromSandbox.Name)
 	return ctrl.Result{}, r.mirror(ctx, sb, v1alpha1.SandboxRestoring, m)
+}
+
+// effectiveReplicas treats a zero (unset) replicas as one, matching the
+// kubebuilder default so an unset replicas counts as a single fork.
+func effectiveReplicas(sb *v1alpha2.Sandbox) int32 {
+	if sb.Spec.Replicas <= 0 {
+		return 1
+	}
+	return sb.Spec.Replicas
+}
+
+// enforceForkBudget enforces the source Sandbox P's capability budget for a
+// self-initiated fork (sb.Spec.Source.FromSandbox = P), issue #25. It admits
+// forks up to P.spec.budget.maxForks (depth-aggregate by replicas) and rejects
+// the ones beyond, ranking P's fork-children deterministically by
+// (creationTimestamp, name) so the decision is the same regardless of reconcile
+// order. It best-effort records P.status.budgetSpend.forks (the admitted count,
+// capped at the limit).
+//
+// It returns admitted=true (and proceeds the normal flow) when P does not exist,
+// when P has no budget, or when P.budget.maxForks is unset (unlimited): there is
+// no Sandbox-scoped fork budget to enforce in those cases.
+func (r *SandboxReconciler) enforceForkBudget(ctx context.Context, sb *v1alpha2.Sandbox) (bool, string, string, error) {
+	src := sb.Spec.Source.FromSandbox
+	if src == nil {
+		return true, "", "", nil
+	}
+
+	var parent v1alpha2.Sandbox
+	if err := r.Get(ctx, client.ObjectKey{Name: src.Name, Namespace: sb.Namespace}, &parent); err != nil {
+		if apierrors.IsNotFound(err) {
+			// No source Sandbox to enforce a budget against; let the normal flow
+			// proceed (the fork reconciler surfaces a missing-source condition).
+			return true, "", "", nil
+		}
+		return false, "", "", fmt.Errorf("get source sandbox %s/%s for budget: %w", sb.Namespace, src.Name, err)
+	}
+
+	if parent.Spec.Budget == nil || parent.Spec.Budget.MaxForks == nil {
+		// Unlimited fork budget; admit.
+		return true, "", "", nil
+	}
+	limit := *parent.Spec.Budget.MaxForks
+
+	// All fork-children of P in the namespace (including sb), ranked
+	// deterministically by (creationTimestamp, name).
+	var siblings v1alpha2.SandboxList
+	if err := r.List(ctx, &siblings, client.InNamespace(sb.Namespace)); err != nil {
+		return false, "", "", fmt.Errorf("list fork-children of %s/%s for budget: %w", sb.Namespace, parent.Name, err)
+	}
+	children := make([]v1alpha2.Sandbox, 0, len(siblings.Items))
+	for i := range siblings.Items {
+		c := siblings.Items[i]
+		if c.Spec.Source.FromSandbox != nil && c.Spec.Source.FromSandbox.Name == parent.Name {
+			children = append(children, c)
+		}
+	}
+	sort.SliceStable(children, func(i, j int) bool {
+		ti, tj := children[i].CreationTimestamp, children[j].CreationTimestamp
+		if ti.Equal(&tj) {
+			return children[i].Name < children[j].Name
+		}
+		return ti.Before(&tj)
+	})
+
+	// Walk in rank order. priorForks accumulates the replicas of strictly-earlier
+	// children; sb is over budget when its prior allocation already meets the
+	// limit. totalAdmitted is the cumulative replicas admitted (capped at limit),
+	// the value mirrored into P.status.budgetSpend.forks.
+	var totalAdmitted int32
+	var sbPriorForks int32
+	var sbOverBudget bool
+	for i := range children {
+		c := &children[i]
+		prior := totalAdmitted
+		if c.UID == sb.UID {
+			sbPriorForks = prior
+			sbOverBudget = prior >= limit
+		}
+		if prior < limit {
+			room := limit - prior
+			reps := effectiveReplicas(c)
+			if reps > room {
+				reps = room
+			}
+			totalAdmitted += reps
+		}
+	}
+
+	// Best-effort record P.status.budgetSpend.forks (idempotent). A conflict is
+	// not fatal: the next reconcile of any child re-derives and re-records it.
+	if err := r.recordParentForkSpend(ctx, &parent, totalAdmitted); err != nil && !apierrors.IsConflict(err) {
+		return false, "", "", err
+	}
+
+	if sbOverBudget {
+		base := apierr.Get(apierr.CodeBudgetExhausted)
+		message := fmt.Sprintf(
+			"%s The forks budget dimension is exhausted: the limit is %d and 0 remain (%d forks of %q were already admitted ahead of this one). %s",
+			base.Message, limit, sbPriorForks, parent.Name, base.Remediation,
+		)
+		return false, "BudgetExhausted", message, nil
+	}
+	return true, "", "", nil
+}
+
+// recordParentForkSpend writes parent.status.budgetSpend.forks = forks
+// idempotently onto the source Sandbox status subresource. It returns nil when
+// the value already matches so a steady state does not write.
+func (r *SandboxReconciler) recordParentForkSpend(ctx context.Context, parent *v1alpha2.Sandbox, forks int32) error {
+	if parent.Status.BudgetSpend != nil && parent.Status.BudgetSpend.Forks == forks {
+		return nil
+	}
+	if parent.Status.BudgetSpend == nil {
+		parent.Status.BudgetSpend = &v1alpha2.SandboxBudgetSpend{}
+	}
+	parent.Status.BudgetSpend.Forks = forks
+	if err := r.Status().Update(ctx, parent); err != nil {
+		return fmt.Errorf("record budgetSpend.forks on sandbox %s/%s: %w", parent.Namespace, parent.Name, err)
+	}
+	return nil
 }
 
 // ensureClaim get-or-creates the SandboxClaim owned by a poolRef Sandbox,


### PR DESCRIPTION
## Summary

Controller-side capability **fork-budget enforcement** for the v1alpha2 `Sandbox` (issue #25). When a `Sandbox` is a self-initiated fork (`source.fromSandbox = P`), the reconciler enforces P's budget before materializing the fork:

- Ranks P's fork-children deterministically by `(creationTimestamp, name)`.
- Admits replicas up to `P.spec.budget.maxForks`; rejects the ones beyond **terminally** with a typed `BudgetExhausted` condition carrying the LLM-legible `apierr` `budget_exhausted` remediation (names the orchestrator escalation path).
- Records `P.status.budgetSpend.forks` (admitted count, capped) idempotently.
- The gate runs **before** any fork materialization, so no engine work is spent on an over-budget fork.

Builds on already-landed pieces: the macaroon token core (`internal/captoken`, never-widen invariant + tests) and `apierr.CodeBudgetExhausted`. `secretInheritance: reissue` is already the wired default.

## Test
`internal/controller/sandbox_v2_budget_envtest_test.go`: parent with `maxForks=2` admits the first two fork-children, rejects the third with `BudgetExhausted`, and records `budgetSpend.forks == 2`. Verified locally (envtest passes).

## Verification
Builds darwin + `GOOS=linux`; gofmt clean; controller envtest passes.

Refs #25. Remaining for #25 (rides the Connect runtime surface #24): in-guest self-service `Fork`/`Checkpoint`/`ExtendLifetime` RPCs, per-token attenuation at issuance, and the CPU/egress/checkpoint budget dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
