### PR TITLE
fix(usage): reset-aware counter integration, no negative bill on restart (#211)

### DIFF
--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -41,9 +41,13 @@ The split between *rate* units and *counter* units is load-bearing:
   trapezoid-free (left-rectangle: each sample's level holds until the next
   sample). Per-second granularity.
 - **Counter units** (egress bytes, GPU-seconds) are already cumulative on the
-  source. The pipeline takes the delta between the first and last sample that
-  fall in the window, so a missed scrape never loses counter progress and a
-  duplicate scrape never adds it twice.
+  source. The pipeline sums the positive steps between consecutive in-window
+  samples, so a missed scrape never loses counter progress and a duplicate scrape
+  never adds it twice. A DECREASE between consecutive samples means the cumulative
+  counter RESET (a sandbox restart zeroes its nftables egress / GPU counter): the
+  post-reset value is counted as fresh progress from zero, never a negative bill.
+  For a counter that never resets this is exactly last-minus-first; the
+  step-sum is what keeps a restart within the window honest rather than negative.
 
 ## Time integration
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -118,18 +118,22 @@ func Integrate(samples []Sample, cfg Config) []UsageRecord {
 		group = dedupeByTimestamp(group)
 		sort.Slice(group, func(i, j int) bool { return group[i].Timestamp.Before(group[j].Timestamp) })
 
-		// Counter units: per window, hold the first and last cumulative reading that
-		// fall in the window so the window delta is last-in-window minus
-		// first-in-window. A missed scrape never loses counter progress because the
-		// cumulative counter already reflects it.
-		firstCounter := map[time.Time]Sample{}
-		lastCounter := map[time.Time]Sample{}
+		// Counter units: per window, the in-window progress is the SUM of the
+		// positive steps between consecutive in-window samples. A non-decreasing
+		// step is the difference; a DECREASE means the cumulative counter reset
+		// (a sandbox restart zeroes its egress/GPU counter), so the post-reset
+		// value is fresh progress counted from zero, never a negative bill. For a
+		// monotonic counter this telescopes to last-minus-first (unchanged); a
+		// single in-window sample contributes zero. group is already sorted by
+		// timestamp, so each window's slice is in time order.
+		byWindow := map[time.Time][]Sample{}
+		var windows []time.Time
 		for _, s := range group {
 			w := s.Timestamp.Truncate(cfg.Window)
-			if _, ok := firstCounter[w]; !ok {
-				firstCounter[w] = s
+			if _, ok := byWindow[w]; !ok {
+				windows = append(windows, w)
 			}
-			lastCounter[w] = s
+			byWindow[w] = append(byWindow[w], s)
 		}
 
 		// Rate units: integrate level * elapsed between consecutive samples, clipped
@@ -149,12 +153,15 @@ func Integrate(samples []Sample, cfg Config) []UsageRecord {
 			integrateInterval(recs, sandbox, a, a.Timestamp, a.Timestamp.Add(held), cfg.Window)
 		}
 
-		// Apply the counter deltas to the records of each window. Ensure a record
-		// exists for every window that saw a sample, even a single one.
-		for w, last := range lastCounter {
-			first := firstCounter[w]
-			egress := last.EgressBytes - first.EgressBytes
-			gpu := last.GPUSeconds - first.GPUSeconds
+		// Apply the reset-aware counter deltas to each window's record. Ensure a
+		// record exists for every window with non-zero counter progress.
+		for _, w := range windows {
+			win := byWindow[w]
+			var egress, gpu int64
+			for i := 1; i < len(win); i++ {
+				egress += counterStep(win[i-1].EgressBytes, win[i].EgressBytes)
+				gpu += counterStep(win[i-1].GPUSeconds, win[i].GPUSeconds)
+			}
 			k := recKey{sandbox: sandbox, window: w}
 			r := recs[k]
 			if r == nil {
@@ -165,7 +172,7 @@ func Integrate(samples []Sample, cfg Config) []UsageRecord {
 				if egress == 0 && gpu == 0 {
 					continue
 				}
-				r = &UsageRecord{OrgID: last.OrgID, SandboxID: sandbox, Window: w}
+				r = &UsageRecord{OrgID: win[len(win)-1].OrgID, SandboxID: sandbox, Window: w}
 				recs[k] = r
 			}
 			r.EgressBytes += egress
@@ -341,4 +348,15 @@ func SamplesFromReport(
 		CoWSavings: report.UsedNaive - report.UsedCoWAware,
 	}
 	return samples, recon
+}
+
+// counterStep returns the in-window progress of a cumulative counter between two
+// consecutive readings. A non-decreasing step is the plain difference; a decrease
+// means the counter reset (for example a sandbox restart zeroing it), so the new
+// lower value is fresh progress counted from zero rather than a negative bill.
+func counterStep(prev, curr int64) int64 {
+	if curr >= prev {
+		return curr - prev
+	}
+	return curr
 }

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -257,3 +257,54 @@ func approx(a, b float64) bool {
 type staticSource struct{ samples []Sample }
 
 func (s *staticSource) Collect(_ context.Context) ([]Sample, error) { return s.samples, nil }
+
+// TestCounterResetNoNegativeBill proves a cumulative counter that RESETS within
+// a window (a sandbox restart zeroes its egress counter) never produces a
+// negative or under-counted bill: the in-window progress is the sum of the
+// positive steps, and the post-reset value counts as fresh progress from zero.
+// The old last-minus-first delta would bill 50-100 = -50 here.
+func TestCounterResetNoNegativeBill(t *testing.T) {
+	samples := []Sample{
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 0), VCPUs: 1, EgressBytes: 100, GPUSeconds: 10},
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 20), VCPUs: 1, EgressBytes: 350, GPUSeconds: 40},
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 40), VCPUs: 1, EgressBytes: 50, GPUSeconds: 5},
+	}
+	recs := Integrate(samples, DefaultConfig())
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	// progress = (350-100) + (50 after reset) = 300; never negative.
+	if recs[0].EgressBytes != 300 {
+		t.Errorf("EgressBytes = %d, want 300 (reset-aware, never negative)", recs[0].EgressBytes)
+	}
+	if recs[0].GPUSeconds != 35 {
+		t.Errorf("GPUSeconds = %d, want 35 (= (40-10)+5 reset-aware)", recs[0].GPUSeconds)
+	}
+	if recs[0].EgressBytes < 0 || recs[0].GPUSeconds < 0 {
+		t.Errorf("a counter reset must never bill negative: egress=%d gpu=%d", recs[0].EgressBytes, recs[0].GPUSeconds)
+	}
+}
+
+// TestOutOfOrderSamplesFold proves late/out-of-order samples integrate to the
+// same result as in-order delivery (the integrator sorts by timestamp), so a
+// delayed scrape is not lost or mis-bucketed.
+func TestOutOfOrderSamplesFold(t *testing.T) {
+	inOrder := []Sample{
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 0), VCPUs: 1, EgressBytes: 100},
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 20), VCPUs: 1, EgressBytes: 200},
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 40), VCPUs: 1, EgressBytes: 300},
+	}
+	shuffled := []Sample{inOrder[2], inOrder[0], inOrder[1]}
+	a := Integrate(inOrder, DefaultConfig())
+	b := Integrate(shuffled, DefaultConfig())
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("want 1 record each, got %d and %d", len(a), len(b))
+	}
+	if a[0].EgressBytes != b[0].EgressBytes || a[0].VCPUSeconds != b[0].VCPUSeconds {
+		t.Errorf("out-of-order result differs: in-order egress=%d vcpu-s=%g, shuffled egress=%d vcpu-s=%g",
+			a[0].EgressBytes, a[0].VCPUSeconds, b[0].EgressBytes, b[0].VCPUSeconds)
+	}
+	if a[0].EgressBytes != 200 {
+		t.Errorf("EgressBytes = %d, want 200 (300-100, monotonic)", a[0].EgressBytes)
+	}
+}


### PR DESCRIPTION
Fixes a billing-correctness bug in the #211 usage pipeline (`internal/usage`). Cumulative counters (egress, GPU-seconds) were billed last-minus-first per window, assuming monotonic. A sandbox restart zeroes its counter, so a within-window reset produced a NEGATIVE bill (100 -> 350 -> 50 billed -50). Now sums positive steps between consecutive in-window samples, counting a post-reset value as fresh progress from zero; for a never-resetting counter this is identical to before.

Tests added: counter-reset-within-window (reset-aware sum, never negative) and out-of-order-folds. Doc (docs/saas/usage-pipeline.md) updated. The collection loop + org-scoped usage API already exist; this hardens the load-bearing no-double-bill property. Refs #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)