### PR TITLE
fix(billing): Drawdown replay reports original credit split, not FromCredit:0 (#212)

### DIFF
--- a/internal/saas/billing/service.go
+++ b/internal/saas/billing/service.go
@@ -203,14 +203,47 @@ func (s *Service) Drawdown(ctx context.Context, rec usage.UsageRecord) (Drawdown
 			Note:   "usage drawdown",
 		})
 		if err == ErrDuplicateEntry {
-			// Already settled: idempotent replay, charge nothing again.
-			return DrawdownResult{Cost: cost, FromCredit: 0, Remaining: cost - 0}, nil
+			// Idempotent replay: the credit was already debited on the first call.
+			// Recover the credit portion from the existing ledger entry so the
+			// returned split matches the first call. Returning FromCredit:0
+			// (Remaining:cost) here would tell the caller to re-bill the WHOLE cost
+			// via Stripe even though credit already covered part of it: a double-bill.
+			prior, perr := s.priorDrawdownCredit(ctx, rec)
+			if perr != nil {
+				return DrawdownResult{}, perr
+			}
+			return DrawdownResult{Cost: cost, FromCredit: prior, Remaining: cost - prior}, nil
 		}
 		if err != nil {
 			return DrawdownResult{}, fmt.Errorf("append drawdown: %w", err)
 		}
 	}
 	return DrawdownResult{Cost: cost, FromCredit: fromCredit, Remaining: cost - fromCredit}, nil
+}
+
+// priorDrawdownCredit returns the credit amount debited by the already-recorded
+// drawdown for rec (its ledger entry's debit, as a positive Money), so a
+// replayed Drawdown reports the same FromCredit it did the first time. The entry
+// is found by the same (org, sandbox, window) idempotency key the drawdown wrote.
+func (s *Service) priorDrawdownCredit(ctx context.Context, rec usage.UsageRecord) (Money, error) {
+	entries, err := s.ledger.Entries(ctx, rec.OrgID)
+	if err != nil {
+		return 0, fmt.Errorf("read ledger for prior drawdown: %w", err)
+	}
+	key := usageKey(rec)
+	for _, e := range entries {
+		if e.Kind == KindUsageDrawdown && e.Key == key {
+			// The drawdown stored a negative Amount (-fromCredit); return its
+			// magnitude as the credit portion.
+			if e.Amount < 0 {
+				return -e.Amount, nil
+			}
+			return 0, nil
+		}
+	}
+	// No matching entry: the first call debited nothing (fromCredit was 0), so the
+	// duplicate guard cannot have fired on a drawdown entry; treat as zero credit.
+	return 0, nil
 }
 
 // usageKey is the (org, sandbox, window) ledger idempotency key for a drawdown.

--- a/internal/saas/billing/service_test.go
+++ b/internal/saas/billing/service_test.go
@@ -179,3 +179,45 @@ func TestSoftCapFiresAlertHardCapSuspends(t *testing.T) {
 		t.Errorf("status after hard cap = %q, want suspended", st)
 	}
 }
+
+// TestDrawdownReplayReturnsSameSplit proves a replayed drawdown of the same
+// usage record is idempotent in its RESULT, not just in the ledger. The first
+// call debits the credit portion; a replay must report the SAME FromCredit /
+// Remaining, because returning FromCredit:0 (Remaining:cost) would tell the
+// caller to re-bill the whole cost via Stripe even though credit already
+// covered part of it: a double-bill. The ledger must be debited exactly once.
+func TestDrawdownReplayReturnsSameSplit(t *testing.T) {
+	led := NewMemCreditLedger()
+	// Seed credit larger than the record cost so the first drawdown is fully
+	// covered by credit (FromCredit == cost, Remaining == 0).
+	if err := led.Append(context.Background(), LedgerEntry{OrgID: "org1", Kind: KindTopUp, Amount: Money(100_000_000), Key: "seed", At: fixedNow()}); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(Config{Ledger: led, Now: fixedNow})
+	rec := sampleRecord()
+
+	first, err := svc.Drawdown(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("first drawdown: %v", err)
+	}
+	if first.Cost <= 0 {
+		t.Fatalf("expected a positive cost, got %d", first.Cost)
+	}
+	if first.FromCredit != first.Cost || first.Remaining != 0 {
+		t.Fatalf("first: FromCredit=%d Remaining=%d, want fully credit-covered (FromCredit=Cost=%d, Remaining=0)", first.FromCredit, first.Remaining, first.Cost)
+	}
+
+	balAfterFirst, _ := led.Balance(context.Background(), "org1")
+
+	second, err := svc.Drawdown(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("replay drawdown: %v", err)
+	}
+	if second.FromCredit != first.FromCredit || second.Remaining != first.Remaining || second.Cost != first.Cost {
+		t.Fatalf("replay result %+v != first result %+v (idempotency must report the same split, not FromCredit:0)", second, first)
+	}
+	balAfterSecond, _ := led.Balance(context.Background(), "org1")
+	if balAfterSecond != balAfterFirst {
+		t.Fatalf("replay debited the ledger again: balance %d -> %d", balAfterFirst, balAfterSecond)
+	}
+}


### PR DESCRIPTION
A replayed `Drawdown` of the same usage record returned `{FromCredit:0, Remaining:cost}`, telling the caller to re-bill the whole cost via Stripe even though the first call already debited credit, a double-bill. Now recovers the credit portion from the existing ledger entry (matched by the same (org,sandbox,window) drawdown key) and returns the same split, so the result is idempotent, not just the ledger (which was already debited once). Test added. Refs #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)