### PR TITLE
fix(billing): webhook 500 on internal error, 401 only on bad signature (#212)

### DIFF
--- a/internal/saas/billing/webhook.go
+++ b/internal/saas/billing/webhook.go
@@ -3,12 +3,19 @@ package billing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"mitos.run/mitos/internal/apierr"
 )
+
+// ErrWebhookSignature marks a webhook failure caused by signature verification
+// (or a malformed/unattributable body), as opposed to an internal failure while
+// applying a verified event. ServeHTTP maps this to 401 and everything else to
+// 500, so a transient backend fault is never masked as a client auth failure.
+var ErrWebhookSignature = errors.New("billing: webhook signature verification failed")
 
 // WebhookEventType is the subset of Stripe webhook event types this slice acts
 // on. Stripe sends many more; the handler ignores the rest. The strings match
@@ -77,9 +84,10 @@ func NewWebhookHandler(svc *Service, verifier SignatureVerifier) *WebhookHandler
 func (h *WebhookHandler) Handle(ctx context.Context, payload []byte, signatureHeader string) (BillingStatus, error) {
 	ev, err := h.verifier.Verify(payload, signatureHeader)
 	if err != nil {
-		// The signature did not verify (or the body did not parse). Return the
-		// error WITHOUT echoing the payload or the header, so no secret leaks.
-		return "", fmt.Errorf("webhook verify: %w", err)
+		// The signature did not verify (or the body did not parse). Tag it with
+		// ErrWebhookSignature so ServeHTTP returns 401, and do NOT echo the payload
+		// or the header into the error, so no secret leaks.
+		return "", fmt.Errorf("webhook verify: %w: %w", ErrWebhookSignature, err)
 	}
 	dev, ok := dunningEventFor(ev.Type)
 	if !ok {
@@ -123,9 +131,17 @@ func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sig := r.Header.Get("Stripe-Signature")
 	if _, err := h.Handle(r.Context(), payload, sig); err != nil {
 		// Do NOT include err's detail in the public cause: it could reference the
-		// payload. A fixed, non-secret remediation string only.
-		apierr.Encode(w, apierr.Get(apierr.CodeUnauthorized).
-			WithCause("the webhook signature did not verify"))
+		// payload. A fixed, non-secret remediation string only. Distinguish a
+		// signature/verify failure (401, the caller's problem, non-retryable) from
+		// an internal failure applying a verified event (500, our problem; the
+		// truthful code lets Stripe retry and does not mask the fault as auth).
+		if errors.Is(err, ErrWebhookSignature) {
+			apierr.Encode(w, apierr.Get(apierr.CodeUnauthorized).
+				WithCause("the webhook signature did not verify"))
+			return
+		}
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the webhook could not be processed; it will be retried"))
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/internal/saas/billing/webhook_test.go
+++ b/internal/saas/billing/webhook_test.go
@@ -1,10 +1,59 @@
 package billing
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// failingStatusStore makes the post-verify processing path fail, modelling a
+// transient backend outage while the webhook signature itself is valid.
+type failingStatusStore struct{}
+
+func (failingStatusStore) Status(context.Context, string) (BillingStatus, error) {
+	return "", errors.New("status backend down")
+}
+func (failingStatusStore) SetStatus(context.Context, string, BillingStatus) error { return nil }
+
+// TestWebhookInternalErrorReturns500NotUnauthorized proves a post-verify failure
+// (the signature verified, but applying the event hit a backend error) returns
+// 500, not 401. 401 would both mask an internal failure as a signature problem
+// (misrouting on-call to rotate the webhook secret) and mislabel a retryable
+// server fault as a client auth failure.
+func TestWebhookInternalErrorReturns500NotUnauthorized(t *testing.T) {
+	svc := NewService(Config{Stripe: NewFakeStripe(), Status: failingStatusStore{}, Now: fixedNow})
+	h := NewWebhookHandler(svc, FakeVerifier{})
+
+	body, _ := json.Marshal(WebhookEvent{OrgID: "org1", Type: EventTypePaymentFailed})
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("internal processing error must return 500, got %d", rec.Code)
+	}
+}
+
+// TestWebhookSignatureFailureReturns401 locks in that a genuine verify failure
+// still maps to 401 after the internal-vs-signature split.
+func TestWebhookSignatureFailureReturns401(t *testing.T) {
+	svc := NewService(Config{Stripe: NewFakeStripe(), Now: fixedNow})
+	h := NewWebhookHandler(svc, FakeVerifier{})
+
+	// FakeVerifier rejects a body with no org as a verify failure.
+	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(`{"type":"invoice.payment_failed"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("signature/verify failure must return 401, got %d", rec.Code)
+	}
+}
 
 // TestWebhookPaymentFailedThenSucceededUpdatesStatus asserts the webhook handler
 // runs the dunning machine over fake-verified events: a payment_failed moves the


### PR DESCRIPTION
The Stripe webhook handler mapped ALL errors to 401 'signature did not verify', including post-verify internal failures (status store, suspend-on-dunning). That masks a transient backend fault as a client auth problem and uses a client error code for a retryable server fault. Now tags verify failures with a sentinel and returns 401 only for those; internal failures return 500 (truthful, retryable, not masked). The public cause still never echoes the payload/header. Tests added. Refs #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)