### PR TITLE
fix(controller): status elision compares Ready observedGeneration (#25)

### DIFF
--- a/internal/controller/sandbox_v2_controller.go
+++ b/internal/controller/sandbox_v2_controller.go
@@ -450,7 +450,8 @@ func equalSandboxStatus(a, b *v1alpha2.SandboxStatus) bool {
 	if (ca == nil) != (cb == nil) {
 		return false
 	}
-	if ca != nil && (ca.Status != cb.Status || ca.Reason != cb.Reason || ca.Message != cb.Message) {
+	if ca != nil && (ca.Status != cb.Status || ca.Reason != cb.Reason || ca.Message != cb.Message ||
+		ca.ObservedGeneration != cb.ObservedGeneration) {
 		return false
 	}
 	return true

--- a/internal/controller/sandbox_v2_status_elision_test.go
+++ b/internal/controller/sandbox_v2_status_elision_test.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"mitos.run/mitos/api/v1alpha2"
+)
+
+// TestEqualSandboxStatusDetectsObservedGenerationChange proves the status-write
+// elision does not hide a stale observedGeneration. docs/conditions.md requires
+// the Ready condition's observedGeneration to match the object's generation; if
+// equalSandboxStatus ignores it, a spec change (generation bump) whose phase and
+// message are unchanged elides the write and leaves observedGeneration pointing
+// at the previous generation forever, so tooling that checks
+// observedGeneration == metadata.generation reads the status as never-current.
+func TestEqualSandboxStatusDetectsObservedGenerationChange(t *testing.T) {
+	mk := func(gen int64) *v1alpha2.SandboxStatus {
+		return &v1alpha2.SandboxStatus{
+			Phase: "Ready",
+			Conditions: []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				Message:            "ok",
+				ObservedGeneration: gen,
+			}},
+		}
+	}
+	if equalSandboxStatus(mk(1), mk(2)) {
+		t.Fatal("a different Ready condition observedGeneration must compare unequal so the status write is not elided")
+	}
+	if !equalSandboxStatus(mk(3), mk(3)) {
+		t.Fatal("identical statuses must compare equal (no spurious writes)")
+	}
+}


### PR DESCRIPTION
The Sandbox status-write elision (equalSandboxStatus) compared the Ready condition's status/reason/message but not its observedGeneration, so a spec-generation bump with an otherwise-unchanged condition elided the write and left conditions[Ready].observedGeneration stale at the prior generation. That violates docs/conditions.md (observedGeneration must match the object generation) and makes tooling that checks observedGeneration == metadata.generation read the status as never-current. Now compares observedGeneration. Unit test added. Refs #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)