### PR TITLE
fix(sdk): lazy-load kubernetes so direct mode needs only httpx (#22)

### DIFF
--- a/sdk/python/mitos/_k8s.py
+++ b/sdk/python/mitos/_k8s.py
@@ -1,0 +1,69 @@
+"""Lazy accessor for the optional ``kubernetes`` client (issue #22).
+
+The cluster-mode modules (``client``, ``aio``, ``sandbox``, ``workspace``) need
+the official Kubernetes client, but direct mode (``mitos.direct`` over the
+sandbox-server REST API) and the in-guest SDK (``mitos.guest``) speak only
+httpx and must import with no Kubernetes installed. To keep ``import mitos`` and
+``from mitos.direct import SandboxServer`` light, those modules import the
+``kubernetes`` symbols through :func:`k8s` at the moment a cluster code path
+runs, never at module import time. This mirrors the TypeScript SDK, whose
+``@kubernetes/client-node`` is lazy-loaded so direct mode never pulls it in.
+
+A missing ``kubernetes`` raises a clear, actionable AgentRunError naming the
+install command, rather than a bare ModuleNotFoundError from deep in an import.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mitos.errors import AgentRunError
+
+if TYPE_CHECKING:
+    # Annotation-only imports: TYPE_CHECKING is False at runtime, so these never
+    # force the kubernetes import for callers that only use direct mode.
+    from kubernetes import client as _client_mod
+    from kubernetes import config as _config_mod
+    from kubernetes.client.rest import ApiException as _ApiException
+
+
+class _K8s:
+    """The three kubernetes symbols the cluster modules use, bound lazily."""
+
+    __slots__ = ("client", "config", "ApiException")
+
+    def __init__(self, client, config, ApiException):
+        self.client = client
+        self.config = config
+        self.ApiException = ApiException
+
+
+_cached: "_K8s | None" = None
+
+
+def k8s() -> "_K8s":
+    """Import and return the kubernetes client/config/ApiException, cached.
+
+    Called only from cluster code paths. If the optional ``kubernetes`` package
+    is not installed, raises an AgentRunError that names the fix instead of
+    letting a raw ModuleNotFoundError surface from an unexpected place."""
+    global _cached
+    if _cached is not None:
+        return _cached
+    try:
+        from kubernetes import client as k8s_client
+        from kubernetes import config as k8s_config
+        from kubernetes.client.rest import ApiException
+    except ModuleNotFoundError as exc:
+        raise AgentRunError(
+            "cluster mode requires the kubernetes client, which is not installed",
+            code="kubernetes_not_installed",
+            cause=f"importing the kubernetes package failed: {exc}",
+            remediation=(
+                "Install it with 'pip install kubernetes' or 'pip install mitos[k8s]'. "
+                "Direct mode (mitos.create / mitos.direct) and the in-guest SDK "
+                "(mitos.guest) do not need it."
+            ),
+        ) from exc
+    _cached = _K8s(k8s_client, k8s_config, ApiException)
+    return _cached

--- a/sdk/python/mitos/aio.py
+++ b/sdk/python/mitos/aio.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import uuid
-from typing import Awaitable, Callable, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Union
 
 import httpx
-from kubernetes import client as k8s_client
-from kubernetes import config as k8s_config
-from kubernetes.client.rest import ApiException
 
+from mitos._k8s import k8s
 from mitos.client import API_GROUP, API_VERSION, default_pool_name
 from mitos.direct import _resolve_auth
 from mitos.errors import AgentRunError, ExecutionDeadlineError
@@ -20,6 +18,9 @@ from mitos.sandbox import (
     _validate_timeout,
 )
 from mitos.types import Execution, ExecResult, FileInfo, Network, Result, SandboxPhase
+
+if TYPE_CHECKING:
+    from kubernetes import client as k8s_client
 
 POLL_INTERVAL = 0.05
 
@@ -317,7 +318,7 @@ class AsyncSandbox:
             secret = self._core_api.read_namespaced_secret(
                 name=f"{self.name}-sandbox-token", namespace=self.namespace
             )
-        except ApiException:
+        except k8s().ApiException:
             return
         token_b64 = (secret.data or {}).get("token")
         if token_b64:
@@ -396,12 +397,13 @@ class AsyncAgentRun:
         in_cluster: bool = False,
         allow_default_pool: bool = True,
     ):
+        _k8s = k8s()
         if in_cluster:
-            k8s_config.load_incluster_config()
+            _k8s.config.load_incluster_config()
         else:
-            k8s_config.load_kube_config(config_file=kubeconfig)
-        self._api = k8s_client.CustomObjectsApi()
-        self._core_api = k8s_client.CoreV1Api()
+            _k8s.config.load_kube_config(config_file=kubeconfig)
+        self._api = _k8s.client.CustomObjectsApi()
+        self._core_api = _k8s.client.CoreV1Api()
         self._namespace = namespace
         self._allow_default_pool = allow_default_pool
 
@@ -475,7 +477,7 @@ class AsyncAgentRun:
                 plural="sandboxpools", name=name,
             )
             return name
-        except ApiException as exc:
+        except k8s().ApiException as exc:
             if exc.status != 404:
                 raise
         template = {
@@ -498,7 +500,7 @@ class AsyncAgentRun:
                 group=API_GROUP, version=API_VERSION, namespace=self._namespace,
                 plural=plural, body=body,
             )
-        except ApiException as exc:
+        except k8s().ApiException as exc:
             if exc.status != 409:
                 raise
 

--- a/sdk/python/mitos/client.py
+++ b/sdk/python/mitos/client.py
@@ -4,10 +4,7 @@ import re
 import uuid
 from typing import Optional
 
-from kubernetes import client as k8s_client
-from kubernetes import config as k8s_config
-from kubernetes.client.rest import ApiException
-
+from mitos._k8s import k8s
 from mitos.errors import AgentRunError
 from mitos.sandbox import Sandbox
 from mitos.types import PoolStatus, SandboxPhase
@@ -45,15 +42,16 @@ class AgentRun:
         in_cluster: bool = False,
         allow_default_pool: bool = True,
     ):
+        _k8s = k8s()
         if in_cluster:
-            k8s_config.load_incluster_config()
+            _k8s.config.load_incluster_config()
         else:
-            k8s_config.load_kube_config(config_file=kubeconfig)
+            _k8s.config.load_kube_config(config_file=kubeconfig)
 
-        self._api = k8s_client.CustomObjectsApi()
+        self._api = _k8s.client.CustomObjectsApi()
         # Same loaded config as the CustomObjectsApi; used to read the
         # per-sandbox bearer token Secrets.
-        self._core_api = k8s_client.CoreV1Api()
+        self._core_api = _k8s.client.CoreV1Api()
         self._namespace = namespace
         self._allow_default_pool = allow_default_pool
 
@@ -127,7 +125,7 @@ class AgentRun:
             )
             self._verify_pool_image(existing, name, image)
             return name
-        except ApiException as exc:
+        except k8s().ApiException as exc:
             if exc.status != 404:
                 raise
 
@@ -169,7 +167,7 @@ class AgentRun:
                 plural="sandboxtemplates",
                 name=template_name,
             )
-        except ApiException as exc:
+        except k8s().ApiException as exc:
             # Pool with no resolvable template: cannot prove the image, so fail
             # closed rather than risk the wrong image.
             raise AgentRunError(
@@ -198,7 +196,7 @@ class AgentRun:
                 plural=plural,
                 body=body,
             )
-        except ApiException as exc:
+        except k8s().ApiException as exc:
             if exc.status != 409:  # raced another creator; reuse it
                 raise
 

--- a/sdk/python/mitos/sandbox.py
+++ b/sdk/python/mitos/sandbox.py
@@ -5,12 +5,11 @@ import json
 import threading
 import time
 import uuid
-from typing import Callable, Iterable, Optional
+from typing import TYPE_CHECKING, Callable, Iterable, Optional
 
 import httpx
-from kubernetes import client as k8s_client
-from kubernetes.client.rest import ApiException
 
+from mitos._k8s import k8s
 from mitos._envelope import raise_for_status, raise_for_status_stream
 from mitos.errors import AgentRunError, ExecutionDeadlineError, TimeoutTooLargeError
 from mitos.pty import PtyHandle
@@ -25,6 +24,9 @@ from mitos.types import (
     SandboxInfo,
     SandboxPhase,
 )
+
+if TYPE_CHECKING:
+    from kubernetes import client as k8s_client
 
 
 def _decode_stream_bytes(value) -> str:
@@ -261,7 +263,7 @@ class Sandbox:
         self._api = api
         # Reads the <name>-sandbox-token Secret; defaults to a CoreV1Api on
         # the same loaded kube config the CustomObjectsApi came from.
-        self._core_api = core_api if core_api is not None else k8s_client.CoreV1Api()
+        self._core_api = core_api if core_api is not None else k8s().client.CoreV1Api()
         self._endpoint = _endpoint
         self._phase = _phase
         self._sandbox_id: Optional[str] = None
@@ -336,7 +338,7 @@ class Sandbox:
             secret = self._core_api.read_namespaced_secret(
                 name=f"{self.name}-sandbox-token", namespace=self.namespace
             )
-        except ApiException:
+        except k8s().ApiException:
             return
         data = secret.data or {}
         token_b64 = data.get("token")

--- a/sdk/python/mitos/workspace.py
+++ b/sdk/python/mitos/workspace.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-from kubernetes import client as k8s_client
-from kubernetes.client.rest import ApiException
-
+from mitos._k8s import k8s
 from mitos.errors import AgentRunError
+
+if TYPE_CHECKING:
+    from kubernetes import client as k8s_client
 
 API_GROUP = "mitos.run"
 API_VERSION = "v1alpha1"
@@ -54,7 +56,7 @@ class Workspace:
                 group=API_GROUP, version=API_VERSION, namespace=self.namespace,
                 plural="workspaces", name=self.name,
             )
-        except ApiException as e:
+        except k8s().ApiException as e:
             raise AgentRunError(
                 f"workspace {self.name} not found", code="workspace_not_found",
                 cause=str(e.reason), status=e.status,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,13 +6,21 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
-    "kubernetes>=31.0.0",
     "httpx>=0.27.0",
     "websocket-client>=1.7.0",
 ]
 
 [project.optional-dependencies]
+# Cluster mode (mitos.client.AgentRun, mitos.aio, mitos.sandbox, mitos.workspace)
+# needs the Kubernetes client. Direct mode (mitos.create / mitos.direct over the
+# sandbox-server REST API) and the in-guest SDK (mitos.guest) speak only httpx
+# and never import it, so it is an optional extra: 'pip install mitos' stays
+# light and 'pip install mitos[k8s]' adds cluster support (issue #22).
+k8s = [
+    "kubernetes>=31.0.0",
+]
 dev = [
+    "kubernetes>=31.0.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "websockets>=12.0",


### PR DESCRIPTION
import mitos failed without the kubernetes client installed, because client/aio/sandbox/workspace imported it eagerly, forcing a heavy dep on direct-mode/guest users (the TS SDK lazy-loads it). Adds mitos/_k8s.py lazy accessor (clear kubernetes_not_installed error when absent), uses it in the four cluster modules, and moves kubernetes to the [k8s] optional extra (httpx stays core). Verified: direct import works with only httpx (kubernetes never loaded); 51 tests pass without kubernetes, 214 with mitos[k8s]. Refs #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)