### PR TITLE
fix(ci): sdk-conformance mock server needs a distinct data-dir (#22)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,10 @@ jobs:
         # cleanup step can stop it.
         run: |
           set -euo pipefail
-          /tmp/sandbox-server --mock --addr :8080 &
+          # The binary lives at /tmp/sandbox-server, so the server's default
+          # --data-dir (also /tmp/sandbox-server) would collide with the binary
+          # file (mkdir: not a directory). Point it at a distinct data dir.
+          /tmp/sandbox-server --mock --addr :8080 --data-dir "${RUNNER_TEMP:-/tmp}/sandbox-server-data" &
           echo "SANDBOX_SERVER_PID=$!" >> "$GITHUB_ENV"
           for i in $(seq 1 30); do
             if curl -fsS http://localhost:8080/v1/health >/dev/null 2>&1; then


### PR DESCRIPTION
The sdk-conformance job built the binary to /tmp/sandbox-server and ran it with the default --data-dir of the same path, so os.MkdirAll failed (mkdir /tmp/sandbox-server: not a directory) and the server never became healthy, failing the job on every PR (it reached main because the job isn't required and #256 merged UNSTABLE). Pass a distinct --data-dir. Verified locally: mock server reports /v1/health ok. Refs #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)