### PR TITLE
feat(controller): fork-budget attenuation, depth-aggregate + never-widen (#25)

### DIFF
--- a/api/v1alpha2/budget.go
+++ b/api/v1alpha2/budget.go
@@ -1,0 +1,184 @@
+package v1alpha2
+
+// Never-widen budget primitives for capability attenuation (issue #25). These
+// mirror the internal/captoken Budget semantics (Remaining, Intersect) on the
+// CRD-facing SandboxBudget type, where a nil pointer on any of the five
+// dimensions means UNLIMITED (unset). The load-bearing property is that
+// attenuation can never widen: a child's effective budget, derived as
+// parentRemaining.Intersect(childRequest), is element-wise no greater than the
+// parent's remaining budget on every dimension.
+//
+// Pointer/unlimited semantics, applied uniformly to all five dimensions:
+//
+//   - nil = unlimited. In Intersect, unlimited INTERSECT x = x (nil yields the
+//     other operand; both nil stays nil). In Remaining, an unlimited dimension
+//     stays unlimited regardless of spend (spend cannot make an unlimited
+//     dimension finite).
+//   - a set (non-nil) dimension is a finite ceiling. Intersect takes the
+//     element-wise minimum of two set dimensions; Remaining subtracts the
+//     recorded spend from a set dimension, floored at zero.
+//
+// Spend coverage: SandboxBudgetSpend records only Forks and CpuSeconds today, so
+// Remaining only subtracts from MaxForks and MaxCpuSeconds; the three dimensions
+// with no recorded spend (MaxCheckpoints, MaxLifetimeExtension, MaxEgressBytes)
+// pass through unchanged. When those dimensions gain spend accounting, this is
+// the single place that extends. The result of either method is always a fresh
+// SandboxBudget (deep-copied pointers) so callers never alias the inputs.
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Remaining returns the budget left after subtracting spend, floored at zero on
+// every set dimension. An unlimited (nil) dimension stays unlimited. A nil
+// receiver (unlimited budget) returns nil. The result is the upper bound on what
+// this sandbox may delegate to a self-initiated fork-child.
+func (b *SandboxBudget) Remaining(spend SandboxBudgetSpend) *SandboxBudget {
+	if b == nil {
+		return nil
+	}
+	return &SandboxBudget{
+		MaxForks:             subFloor32(b.MaxForks, spend.Forks),
+		MaxCheckpoints:       copyInt32(b.MaxCheckpoints),
+		MaxCpuSeconds:        subFloor64(b.MaxCpuSeconds, spend.CpuSeconds),
+		MaxLifetimeExtension: copyDuration(b.MaxLifetimeExtension),
+		MaxEgressBytes:       copyQuantity(b.MaxEgressBytes),
+	}
+}
+
+// Intersect returns the element-wise minimum of two budgets with nil = unlimited
+// on every dimension (unlimited INTERSECT x = x). The result is element-wise no
+// greater than either operand on any set dimension, which is the never-widen
+// guarantee: a child request can never widen the parent's remaining budget. A
+// nil receiver returns a copy of other; a nil other returns a copy of the
+// receiver; both nil returns nil.
+func (b *SandboxBudget) Intersect(other *SandboxBudget) *SandboxBudget {
+	if b == nil {
+		return other.DeepCopy()
+	}
+	if other == nil {
+		return b.DeepCopy()
+	}
+	return &SandboxBudget{
+		MaxForks:             minInt32(b.MaxForks, other.MaxForks),
+		MaxCheckpoints:       minInt32(b.MaxCheckpoints, other.MaxCheckpoints),
+		MaxCpuSeconds:        minInt64(b.MaxCpuSeconds, other.MaxCpuSeconds),
+		MaxLifetimeExtension: minDuration(b.MaxLifetimeExtension, other.MaxLifetimeExtension),
+		MaxEgressBytes:       minQuantity(b.MaxEgressBytes, other.MaxEgressBytes),
+	}
+}
+
+// subFloor32 subtracts spend from a set ceiling, floored at zero. A nil ceiling
+// (unlimited) is returned unchanged: spend cannot make an unlimited dimension
+// finite.
+func subFloor32(ceiling *int32, spend int32) *int32 {
+	if ceiling == nil {
+		return nil
+	}
+	v := *ceiling - spend
+	if v < 0 {
+		v = 0
+	}
+	return &v
+}
+
+func subFloor64(ceiling *int64, spend int64) *int64 {
+	if ceiling == nil {
+		return nil
+	}
+	v := *ceiling - spend
+	if v < 0 {
+		v = 0
+	}
+	return &v
+}
+
+// minInt32 returns the element-wise minimum with nil = unlimited: nil yields the
+// other operand, both nil yields nil.
+func minInt32(a, b *int32) *int32 {
+	if a == nil {
+		return copyInt32(b)
+	}
+	if b == nil {
+		return copyInt32(a)
+	}
+	v := *a
+	if *b < v {
+		v = *b
+	}
+	return &v
+}
+
+func minInt64(a, b *int64) *int64 {
+	if a == nil {
+		return copyInt64(b)
+	}
+	if b == nil {
+		return copyInt64(a)
+	}
+	v := *a
+	if *b < v {
+		v = *b
+	}
+	return &v
+}
+
+func minDuration(a, b *metav1.Duration) *metav1.Duration {
+	if a == nil {
+		return copyDuration(b)
+	}
+	if b == nil {
+		return copyDuration(a)
+	}
+	v := *a
+	if b.Duration < v.Duration {
+		v = *b
+	}
+	return &v
+}
+
+func minQuantity(a, b *resource.Quantity) *resource.Quantity {
+	if a == nil {
+		return copyQuantity(b)
+	}
+	if b == nil {
+		return copyQuantity(a)
+	}
+	if b.Cmp(*a) < 0 {
+		return copyQuantity(b)
+	}
+	return copyQuantity(a)
+}
+
+func copyInt32(p *int32) *int32 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func copyInt64(p *int64) *int64 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func copyDuration(p *metav1.Duration) *metav1.Duration {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func copyQuantity(p *resource.Quantity) *resource.Quantity {
+	if p == nil {
+		return nil
+	}
+	v := p.DeepCopy()
+	return &v
+}

--- a/api/v1alpha2/budget_test.go
+++ b/api/v1alpha2/budget_test.go
@@ -1,0 +1,245 @@
+package v1alpha2
+
+// Unit tests for the never-widen budget primitives (issue #25): SandboxBudget
+// Remaining and Intersect. These are the load-bearing capability-attenuation
+// arithmetic; the *pointer = unlimited* semantics and the subtract-with-floor on
+// spend are tested hard here because they are the security guarantee that a
+// child's effective budget can never widen beyond its parent's remaining.
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func i32(v int32) *int32 { return &v }
+func i64(v int64) *int64 { return &v }
+func dur(d metav1.Duration) *metav1.Duration {
+	return &d
+}
+func qty(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+// eqInt32Ptr compares two *int32 treating nil as unlimited (a distinct value
+// from any set value).
+func eqInt32Ptr(a, b *int32) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func eqInt64Ptr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func eqDurPtr(a, b *metav1.Duration) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Duration == b.Duration
+}
+
+func eqQtyPtr(a, b *resource.Quantity) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Cmp(*b) == 0
+}
+
+func eqBudget(t *testing.T, got, want *SandboxBudget) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("budget nil mismatch: got %v want %v", got, want)
+		}
+		return
+	}
+	if !eqInt32Ptr(got.MaxForks, want.MaxForks) {
+		t.Errorf("MaxForks: got %v want %v", deref32(got.MaxForks), deref32(want.MaxForks))
+	}
+	if !eqInt32Ptr(got.MaxCheckpoints, want.MaxCheckpoints) {
+		t.Errorf("MaxCheckpoints: got %v want %v", deref32(got.MaxCheckpoints), deref32(want.MaxCheckpoints))
+	}
+	if !eqInt64Ptr(got.MaxCpuSeconds, want.MaxCpuSeconds) {
+		t.Errorf("MaxCpuSeconds: got %v want %v", deref64(got.MaxCpuSeconds), deref64(want.MaxCpuSeconds))
+	}
+	if !eqDurPtr(got.MaxLifetimeExtension, want.MaxLifetimeExtension) {
+		t.Errorf("MaxLifetimeExtension: got %v want %v", got.MaxLifetimeExtension, want.MaxLifetimeExtension)
+	}
+	if !eqQtyPtr(got.MaxEgressBytes, want.MaxEgressBytes) {
+		t.Errorf("MaxEgressBytes: got %v want %v", got.MaxEgressBytes, want.MaxEgressBytes)
+	}
+}
+
+func deref32(p *int32) any {
+	if p == nil {
+		return "nil"
+	}
+	return *p
+}
+func deref64(p *int64) any {
+	if p == nil {
+		return "nil"
+	}
+	return *p
+}
+
+// TestSandboxBudgetRemaining covers the subtract-with-floor on the two spend-
+// tracked dimensions (forks, cpuSeconds), the floor at zero, the pass-through of
+// the three dimensions with no recorded spend, and the unlimited (nil) handling.
+func TestSandboxBudgetRemaining(t *testing.T) {
+	t.Run("nil receiver stays nil", func(t *testing.T) {
+		var b *SandboxBudget
+		if got := b.Remaining(SandboxBudgetSpend{Forks: 3}); got != nil {
+			t.Fatalf("nil budget Remaining = %v, want nil (unlimited)", got)
+		}
+	})
+
+	t.Run("set dimensions subtract with floor", func(t *testing.T) {
+		b := &SandboxBudget{MaxForks: i32(5), MaxCpuSeconds: i64(100)}
+		got := b.Remaining(SandboxBudgetSpend{Forks: 2, CpuSeconds: 30})
+		eqBudget(t, got, &SandboxBudget{MaxForks: i32(3), MaxCpuSeconds: i64(70)})
+	})
+
+	t.Run("floors at zero, never negative", func(t *testing.T) {
+		b := &SandboxBudget{MaxForks: i32(2), MaxCpuSeconds: i64(10)}
+		got := b.Remaining(SandboxBudgetSpend{Forks: 5, CpuSeconds: 1000})
+		eqBudget(t, got, &SandboxBudget{MaxForks: i32(0), MaxCpuSeconds: i64(0)})
+	})
+
+	t.Run("unlimited (nil) dimension is not touched by spend", func(t *testing.T) {
+		// MaxForks unset = unlimited: spend cannot make an unlimited dimension
+		// finite. MaxCpuSeconds set is reduced.
+		b := &SandboxBudget{MaxCpuSeconds: i64(50)}
+		got := b.Remaining(SandboxBudgetSpend{Forks: 9, CpuSeconds: 20})
+		eqBudget(t, got, &SandboxBudget{MaxForks: nil, MaxCpuSeconds: i64(30)})
+	})
+
+	t.Run("non-spend-tracked dimensions pass through unchanged", func(t *testing.T) {
+		b := &SandboxBudget{
+			MaxForks:             i32(4),
+			MaxCheckpoints:       i32(7),
+			MaxLifetimeExtension: dur(metav1.Duration{Duration: 60}),
+			MaxEgressBytes:       qty("1Gi"),
+		}
+		got := b.Remaining(SandboxBudgetSpend{Forks: 1})
+		eqBudget(t, got, &SandboxBudget{
+			MaxForks:             i32(3),
+			MaxCheckpoints:       i32(7),
+			MaxLifetimeExtension: dur(metav1.Duration{Duration: 60}),
+			MaxEgressBytes:       qty("1Gi"),
+		})
+	})
+}
+
+// TestSandboxBudgetIntersect covers per-field min with nil = unlimited so that
+// unlimited INTERSECT x = x on every one of the five dimensions, and a wider
+// request is clamped down to the narrower operand.
+func TestSandboxBudgetIntersect(t *testing.T) {
+	t.Run("nil receiver returns other", func(t *testing.T) {
+		var b *SandboxBudget
+		other := &SandboxBudget{MaxForks: i32(2)}
+		eqBudget(t, b.Intersect(other), &SandboxBudget{MaxForks: i32(2)})
+	})
+
+	t.Run("nil other returns receiver", func(t *testing.T) {
+		b := &SandboxBudget{MaxForks: i32(2)}
+		eqBudget(t, b.Intersect(nil), &SandboxBudget{MaxForks: i32(2)})
+	})
+
+	t.Run("both nil stays nil (unlimited)", func(t *testing.T) {
+		var b *SandboxBudget
+		if got := b.Intersect(nil); got != nil {
+			t.Fatalf("nil INTERSECT nil = %v, want nil", got)
+		}
+	})
+
+	t.Run("per-field min picks the narrower", func(t *testing.T) {
+		a := &SandboxBudget{MaxForks: i32(5), MaxCpuSeconds: i64(10)}
+		c := &SandboxBudget{MaxForks: i32(3), MaxCpuSeconds: i64(99)}
+		eqBudget(t, a.Intersect(c), &SandboxBudget{MaxForks: i32(3), MaxCpuSeconds: i64(10)})
+	})
+
+	t.Run("unlimited INTERSECT finite = finite on each dimension", func(t *testing.T) {
+		// a has every dimension unlimited (nil); c sets each. The result must equal
+		// c: unlimited INTERSECT x = x.
+		a := &SandboxBudget{}
+		c := &SandboxBudget{
+			MaxForks:             i32(1),
+			MaxCheckpoints:       i32(2),
+			MaxCpuSeconds:        i64(3),
+			MaxLifetimeExtension: dur(metav1.Duration{Duration: 4}),
+			MaxEgressBytes:       qty("5"),
+		}
+		eqBudget(t, a.Intersect(c), c)
+	})
+
+	t.Run("a wider child request is clamped to the parent remaining", func(t *testing.T) {
+		// Parent remaining maxForks=1; child requests a WIDER 9. The intersection
+		// must be the narrower 1: the child can never widen.
+		parentRemaining := &SandboxBudget{MaxForks: i32(1)}
+		childRequest := &SandboxBudget{MaxForks: i32(9)}
+		eqBudget(t, parentRemaining.Intersect(childRequest), &SandboxBudget{MaxForks: i32(1)})
+	})
+
+	t.Run("duration and quantity dimensions take the min", func(t *testing.T) {
+		a := &SandboxBudget{
+			MaxLifetimeExtension: dur(metav1.Duration{Duration: 100}),
+			MaxEgressBytes:       qty("2Gi"),
+		}
+		c := &SandboxBudget{
+			MaxLifetimeExtension: dur(metav1.Duration{Duration: 30}),
+			MaxEgressBytes:       qty("1Gi"),
+		}
+		eqBudget(t, a.Intersect(c), &SandboxBudget{
+			MaxLifetimeExtension: dur(metav1.Duration{Duration: 30}),
+			MaxEgressBytes:       qty("1Gi"),
+		})
+	})
+}
+
+// TestSandboxBudgetNeverWiden is the cross-cutting invariant: for ANY parent
+// remaining budget and ANY child request, the child's effective budget
+// (parentRemaining INTERSECT childRequest) is never greater than the parent
+// remaining on any of the five dimensions, even when the request is wider.
+func TestSandboxBudgetNeverWiden(t *testing.T) {
+	parentRemaining := &SandboxBudget{
+		MaxForks:             i32(1),
+		MaxCheckpoints:       i32(0),
+		MaxCpuSeconds:        i64(5),
+		MaxLifetimeExtension: dur(metav1.Duration{Duration: 10}),
+		MaxEgressBytes:       qty("100"),
+	}
+	// Child requests a strictly wider budget on every dimension.
+	childRequest := &SandboxBudget{
+		MaxForks:             i32(100),
+		MaxCheckpoints:       i32(100),
+		MaxCpuSeconds:        i64(100),
+		MaxLifetimeExtension: dur(metav1.Duration{Duration: 1000}),
+		MaxEgressBytes:       qty("1Ti"),
+	}
+	eff := parentRemaining.Intersect(childRequest)
+
+	if eff.MaxForks == nil || *eff.MaxForks > *parentRemaining.MaxForks {
+		t.Errorf("MaxForks widened: %v > %v", deref32(eff.MaxForks), *parentRemaining.MaxForks)
+	}
+	if eff.MaxCheckpoints == nil || *eff.MaxCheckpoints > *parentRemaining.MaxCheckpoints {
+		t.Errorf("MaxCheckpoints widened: %v > %v", deref32(eff.MaxCheckpoints), *parentRemaining.MaxCheckpoints)
+	}
+	if eff.MaxCpuSeconds == nil || *eff.MaxCpuSeconds > *parentRemaining.MaxCpuSeconds {
+		t.Errorf("MaxCpuSeconds widened: %v > %v", deref64(eff.MaxCpuSeconds), *parentRemaining.MaxCpuSeconds)
+	}
+	if eff.MaxLifetimeExtension == nil || eff.MaxLifetimeExtension.Duration > parentRemaining.MaxLifetimeExtension.Duration {
+		t.Errorf("MaxLifetimeExtension widened")
+	}
+	if eff.MaxEgressBytes == nil || eff.MaxEgressBytes.Cmp(*parentRemaining.MaxEgressBytes) > 0 {
+		t.Errorf("MaxEgressBytes widened")
+	}
+}

--- a/api/v1alpha2/sandbox_types.go
+++ b/api/v1alpha2/sandbox_types.go
@@ -311,6 +311,19 @@ type SandboxStatus struct {
 	// +optional
 	BudgetSpend *SandboxBudgetSpend `json:"budgetSpend,omitempty"`
 
+	// EffectiveBudget is the controller-computed, attenuated capability budget
+	// this sandbox actually holds: the per-field minimum (intersection) of its own
+	// resolved budget and its parent's effective-remaining budget when it is a
+	// self-initiated fork (source.fromSandbox), or its resolved spec/pool budget
+	// otherwise. It is depth-aggregate: because each level intersects with its
+	// parent's remaining, a descendant can never hold a budget wider than the root
+	// has left, so the whole fork subtree is bounded by the root (issue #25, the
+	// never-widen attenuation invariant). A nil dimension means unlimited. This is
+	// STATUS only; the controller never mutates the user-owned spec.budget. NEW v2
+	// field.
+	// +optional
+	EffectiveBudget *SandboxBudget `json:"effectiveBudget,omitempty"`
+
 	// ReadyReplicas is the ready child count for a replicas > 1 Sandbox. Maps
 	// from SandboxForkStatus.readyForks.
 	// +optional

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -562,6 +562,11 @@ func (in *SandboxStatus) DeepCopyInto(out *SandboxStatus) {
 		*out = new(SandboxBudgetSpend)
 		**out = **in
 	}
+	if in.EffectiveBudget != nil {
+		in, out := &in.EffectiveBudget, &out.EffectiveBudget
+		*out = new(SandboxBudget)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Children != nil {
 		in, out := &in.Children, &out.Children
 		*out = make([]SandboxChild, len(*in))

--- a/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
+++ b/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
@@ -641,6 +641,50 @@ spec:
                   - type
                   type: object
                 type: array
+              effectiveBudget:
+                description: |-
+                  EffectiveBudget is the controller-computed, attenuated capability budget
+                  this sandbox actually holds: the per-field minimum (intersection) of its own
+                  resolved budget and its parent's effective-remaining budget when it is a
+                  self-initiated fork (source.fromSandbox), or its resolved spec/pool budget
+                  otherwise. It is depth-aggregate: because each level intersects with its
+                  parent's remaining, a descendant can never hold a budget wider than the root
+                  has left, so the whole fork subtree is bounded by the root (issue #25, the
+                  never-widen attenuation invariant). A nil dimension means unlimited. This is
+                  STATUS only; the controller never mutates the user-owned spec.budget. NEW v2
+                  field.
+                properties:
+                  maxCheckpoints:
+                    description: MaxCheckpoints bounds the self-initiated checkpoints
+                      the sandbox may take.
+                    format: int32
+                    type: integer
+                  maxCpuSeconds:
+                    description: MaxCpuSeconds bounds the cumulative CPU seconds the
+                      sandbox may consume.
+                    format: int64
+                    type: integer
+                  maxEgressBytes:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxEgressBytes bounds the cumulative egress bytes the sandbox may send. It
+                      is a Kubernetes quantity (for example "1Gi").
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxForks:
+                    description: |-
+                      MaxForks bounds the self-initiated forks (depth-aggregate) the sandbox may
+                      create at runtime.
+                    format: int32
+                    type: integer
+                  maxLifetimeExtension:
+                    description: |-
+                      MaxLifetimeExtension bounds the total lifetime extension the sandbox may
+                      request at runtime.
+                    type: string
+                type: object
               endpoint:
                 description: Endpoint is the sandbox API address (host:port). Unchanged
                   from v1alpha1.

--- a/deploy/crds/mitos.run_sandboxes.yaml
+++ b/deploy/crds/mitos.run_sandboxes.yaml
@@ -641,6 +641,50 @@ spec:
                   - type
                   type: object
                 type: array
+              effectiveBudget:
+                description: |-
+                  EffectiveBudget is the controller-computed, attenuated capability budget
+                  this sandbox actually holds: the per-field minimum (intersection) of its own
+                  resolved budget and its parent's effective-remaining budget when it is a
+                  self-initiated fork (source.fromSandbox), or its resolved spec/pool budget
+                  otherwise. It is depth-aggregate: because each level intersects with its
+                  parent's remaining, a descendant can never hold a budget wider than the root
+                  has left, so the whole fork subtree is bounded by the root (issue #25, the
+                  never-widen attenuation invariant). A nil dimension means unlimited. This is
+                  STATUS only; the controller never mutates the user-owned spec.budget. NEW v2
+                  field.
+                properties:
+                  maxCheckpoints:
+                    description: MaxCheckpoints bounds the self-initiated checkpoints
+                      the sandbox may take.
+                    format: int32
+                    type: integer
+                  maxCpuSeconds:
+                    description: MaxCpuSeconds bounds the cumulative CPU seconds the
+                      sandbox may consume.
+                    format: int64
+                    type: integer
+                  maxEgressBytes:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxEgressBytes bounds the cumulative egress bytes the sandbox may send. It
+                      is a Kubernetes quantity (for example "1Gi").
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxForks:
+                    description: |-
+                      MaxForks bounds the self-initiated forks (depth-aggregate) the sandbox may
+                      create at runtime.
+                    format: int32
+                    type: integer
+                  maxLifetimeExtension:
+                    description: |-
+                      MaxLifetimeExtension bounds the total lifetime extension the sandbox may
+                      request at runtime.
+                    type: string
+                type: object
               endpoint:
                 description: Endpoint is the sandbox API address (host:port). Unchanged
                   from v1alpha1.

--- a/internal/controller/sandbox_v2_budget_attenuation_envtest_test.go
+++ b/internal/controller/sandbox_v2_budget_attenuation_envtest_test.go
@@ -1,0 +1,201 @@
+package controller_test
+
+// Depth-aggregate budget attenuation envtest for the v1alpha2 Sandbox kind
+// (issue #25, the deferred core). The earlier sandbox_v2_budget_envtest_test.go
+// proves DIRECT fork-children are bounded by the immediate parent's budget. This
+// file proves the bound is TRANSITIVE: a fork-of-a-fork (grandchild) cannot
+// bypass the ROOT budget, because each level records a STATUS effectiveBudget
+// that is the intersection of its own request and the parent's
+// effective-remaining, and the next level enforces against THAT.
+//
+// The gate runs before fork materialization, so no working forkd node is needed:
+// an admitted child just needs to NOT be rejected at the gate, and an
+// over-budget grandchild must reach a Failed/Ready=False BudgetExhausted
+// condition.
+
+import (
+	"testing"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1alpha1 "mitos.run/mitos/api/v1alpha1"
+	v1alpha2 "mitos.run/mitos/api/v1alpha2"
+)
+
+// getSandbox fetches a Sandbox by name in the default namespace, or fails.
+func getSandbox(t *testing.T, name string) *v1alpha2.Sandbox {
+	t.Helper()
+	var sb v1alpha2.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &sb); err != nil {
+		t.Fatalf("get sandbox %q: %v", name, err)
+	}
+	return &sb
+}
+
+// waitForEffectiveMaxForks polls until the named Sandbox's
+// status.effectiveBudget.maxForks is set and returns it (or fails on timeout).
+func waitForEffectiveMaxForks(t *testing.T, name string) int32 {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		var sb v1alpha2.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &sb); err == nil {
+			if eb := sb.Status.EffectiveBudget; eb != nil && eb.MaxForks != nil {
+				return *eb.MaxForks
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("sandbox %q never got status.effectiveBudget.maxForks", name)
+	return -1
+}
+
+// waitForReadyReason polls until the named Sandbox's Ready condition reason
+// equals want (or fails on timeout), returning the last observed reason.
+func waitForReadyReason(t *testing.T, name, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		last = sandboxReadyConditionReason(t, name)
+		if last == want {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return last
+}
+
+// TestSandboxForkBudgetIsDepthAggregate proves a fork-of-a-fork cannot exceed
+// the ROOT budget. Root R has maxForks=2. R forks C (admitted, R.spend.forks
+// becomes 1). C's effective maxForks must be <= R's remaining (1). C then forks a
+// grandchild GC0 (admitted against C's effective 1, C.spend becomes 1) and GC1
+// (rejected BudgetExhausted, because C's effective budget is exhausted). So the
+// subtree rooted at R holds at most R.maxForks descendants: the depth-aggregate
+// bound holds and the grandchild cannot bypass the root.
+func TestSandboxForkBudgetIsDepthAggregate(t *testing.T) {
+	maxForks := int32(2)
+
+	// Root R: a poolRef sandbox carrying the budget.
+	root := &v1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "agg-root", Namespace: "default"},
+		Spec: v1alpha2.SandboxSpec{
+			Source:   v1alpha2.SandboxSource{PoolRef: &v1alpha1.LocalObjectReference{Name: "agg-pool"}},
+			Replicas: 1,
+			Budget:   &v1alpha2.SandboxBudget{MaxForks: &maxForks},
+		},
+	}
+	if err := k8sClient.Create(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, root) })
+
+	// C: a fork of R. Admitted (R has room for 2).
+	child := &v1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "agg-child", Namespace: "default"},
+		Spec: v1alpha2.SandboxSpec{
+			Source:   v1alpha2.SandboxSource{FromSandbox: &v1alpha2.FromSandboxSource{Name: "agg-root"}},
+			Replicas: 1,
+		},
+	}
+	if err := k8sClient.Create(ctx, child); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, child) })
+
+	// C must be admitted (not BudgetExhausted) and gain an effective budget that
+	// is no wider than R's remaining. R started at 2 and spent 1 on C, so R's
+	// remaining is 1; C's effective maxForks must be <= 1.
+	if r := waitForReadyReason(t, "agg-child", "ForksPending"); r == "BudgetExhausted" {
+		t.Fatalf("agg-child was BudgetExhausted but should be admitted; reason=%q", r)
+	}
+	cEff := waitForEffectiveMaxForks(t, "agg-child")
+	if cEff > 1 {
+		t.Fatalf("agg-child effective maxForks = %d, must be <= R remaining (1): a fork-child must never hold a budget wider than the parent has left", cEff)
+	}
+
+	// Two grandchildren GC0, GC1: forks of C, created sequentially so their
+	// creationTimestamps order GC0 < GC1.
+	gcNames := []string{"agg-grandchild-0", "agg-grandchild-1"}
+	for _, n := range gcNames {
+		gc := &v1alpha2.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"},
+			Spec: v1alpha2.SandboxSpec{
+				Source:   v1alpha2.SandboxSource{FromSandbox: &v1alpha2.FromSandboxSource{Name: "agg-child"}},
+				Replicas: 1,
+			},
+		}
+		if err := k8sClient.Create(ctx, gc); err != nil {
+			t.Fatal(err)
+		}
+		g := gc
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, g) })
+		time.Sleep(1100 * time.Millisecond)
+	}
+
+	// GC1 (the second grandchild) is over C's effective budget (C effective
+	// maxForks is 1, GC0 took it) and must be rejected BudgetExhausted. This is
+	// the load-bearing claim: the grandchild is bounded by the ROOT through C's
+	// attenuated effective budget, so it cannot bypass R.maxForks.
+	if r := waitForReadyReason(t, "agg-grandchild-1", "BudgetExhausted"); r != "BudgetExhausted" {
+		t.Fatalf("agg-grandchild-1 Ready reason = %q, want BudgetExhausted (a fork-of-a-fork must not bypass the root budget)", r)
+	}
+	gc1 := getSandbox(t, "agg-grandchild-1")
+	if gc1.Status.Phase != v1alpha1.SandboxFailed {
+		t.Fatalf("agg-grandchild-1 phase = %q, want Failed", gc1.Status.Phase)
+	}
+	if c := apimeta.FindStatusCondition(gc1.Status.Conditions, "Ready"); c == nil || c.Status != metav1.ConditionFalse {
+		t.Fatalf("agg-grandchild-1 Ready condition = %+v, want Status False", c)
+	}
+
+	// GC0 must NOT be BudgetExhausted (it took C's one remaining fork).
+	if r := sandboxReadyConditionReason(t, "agg-grandchild-0"); r == "BudgetExhausted" {
+		t.Fatalf("agg-grandchild-0 was BudgetExhausted but should have been admitted")
+	}
+}
+
+// TestSandboxEffectiveBudgetNeverWidens proves a child's status.effectiveBudget
+// is never wider than the parent's effective-remaining on any dimension, even
+// when the child's spec requests a WIDER budget than the parent has left. Root R
+// has maxForks=2; child C requests maxForks=100. After R spends 1 on C, R's
+// remaining is 1, so C's effective maxForks must be clamped to 1, never 100.
+func TestSandboxEffectiveBudgetNeverWidens(t *testing.T) {
+	rootMax := int32(2)
+	childRequest := int32(100)
+
+	root := &v1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "widen-root", Namespace: "default"},
+		Spec: v1alpha2.SandboxSpec{
+			Source:   v1alpha2.SandboxSource{PoolRef: &v1alpha1.LocalObjectReference{Name: "widen-pool"}},
+			Replicas: 1,
+			Budget:   &v1alpha2.SandboxBudget{MaxForks: &rootMax},
+		},
+	}
+	if err := k8sClient.Create(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, root) })
+
+	child := &v1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "widen-child", Namespace: "default"},
+		Spec: v1alpha2.SandboxSpec{
+			Source:   v1alpha2.SandboxSource{FromSandbox: &v1alpha2.FromSandboxSource{Name: "widen-root"}},
+			Replicas: 1,
+			// The child asks for a far wider budget than the root will have left.
+			Budget: &v1alpha2.SandboxBudget{MaxForks: &childRequest},
+		},
+	}
+	if err := k8sClient.Create(ctx, child); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, child) })
+
+	cEff := waitForEffectiveMaxForks(t, "widen-child")
+	// R remaining after spending 1 on C is 1; the child's wider request (100) must
+	// be clamped down to at most 1.
+	if cEff > 1 {
+		t.Fatalf("widen-child effective maxForks = %d, must be clamped to R remaining (<=1): a wider child request must never widen the parent budget", cEff)
+	}
+}

--- a/internal/controller/sandbox_v2_controller.go
+++ b/internal/controller/sandbox_v2_controller.go
@@ -7,6 +7,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	v1alpha1 "mitos.run/mitos/api/v1alpha1"
@@ -109,6 +110,11 @@ func (r *SandboxReconciler) reconcilePoolRef(ctx context.Context, sb *v1alpha2.S
 		startupLatencyMs: claim.Status.ForkTimeMicros / 1000,
 		startedAt:        claim.Status.StartedAt,
 		finishedAt:       claim.Status.FinishedAt,
+		// A non-fork (poolRef) sandbox is a budget ROOT: its effective budget is
+		// its own resolved spec budget (no parent to attenuate against). Recording
+		// it in status lets a self-initiated fork of this sandbox attenuate against
+		// a single source of truth (issue #25).
+		effectiveBudget: sb.Spec.Budget.DeepCopy(),
 	}
 	switch claim.Status.Phase {
 	case v1alpha1.SandboxReady:
@@ -129,14 +135,17 @@ func (r *SandboxReconciler) reconcileFromSandbox(ctx context.Context, sb *v1alph
 	// room. An over-budget fork is rejected terminally with a typed
 	// BudgetExhausted condition BEFORE the fork is ever materialized, so no engine
 	// work is spent on a fork the creator's budget forbids.
-	admitted, reason, message, err := r.enforceForkBudget(ctx, sb)
+	decision, err := r.enforceForkBudget(ctx, sb)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if !admitted {
+	if !decision.admitted {
 		return ctrl.Result{}, r.mirror(ctx, sb, v1alpha1.SandboxFailed, sandboxMirror{
-			reason:  reason,
-			message: message,
+			reason:  decision.reason,
+			message: decision.message,
+			// Even a rejected fork records its (attenuated, possibly zero-room)
+			// effective budget so its status is honest about what it would hold.
+			effectiveBudget: decision.childEffective,
 		})
 	}
 
@@ -162,6 +171,10 @@ func (r *SandboxReconciler) reconcileFromSandbox(ctx context.Context, sb *v1alph
 		children:          children,
 		forkSnapshotTaken: fork.Status.ForkSnapshotTaken,
 		checkpointTime:    fork.Status.CheckpointTime,
+		// The child's attenuated effective budget, recorded so the NEXT level
+		// (a fork-of-this-fork) attenuates against it; this is what makes the
+		// budget bound depth-aggregate (issue #25).
+		effectiveBudget: decision.childEffective,
 	}
 
 	// A rejected fork (for example a secret-inheritance denial) is terminal: the
@@ -192,44 +205,82 @@ func effectiveReplicas(sb *v1alpha2.Sandbox) int32 {
 	return sb.Spec.Replicas
 }
 
+// forkBudgetDecision is the outcome of the capability-budget gate for one
+// self-initiated fork. childEffective is the attenuated effective budget the
+// fork-child would hold (recorded in its status so the next level attenuates
+// against it); it is set even on a rejection so the status stays honest.
+type forkBudgetDecision struct {
+	admitted       bool
+	reason         string
+	message        string
+	childEffective *v1alpha2.SandboxBudget
+}
+
 // enforceForkBudget enforces the source Sandbox P's capability budget for a
-// self-initiated fork (sb.Spec.Source.FromSandbox = P), issue #25. It admits
-// forks up to P.spec.budget.maxForks (depth-aggregate by replicas) and rejects
-// the ones beyond, ranking P's fork-children deterministically by
-// (creationTimestamp, name) so the decision is the same regardless of reconcile
-// order. It best-effort records P.status.budgetSpend.forks (the admitted count,
-// capped at the limit).
+// self-initiated fork (sb.Spec.Source.FromSandbox = P), issue #25. The bound is
+// depth-aggregate: it enforces against P's EFFECTIVE-REMAINING budget, not P's
+// raw spec budget. P's effective budget is P.status.effectiveBudget (which the
+// controller already attenuated against P's own parent when P is itself a fork),
+// falling back to P.spec.budget for a root; the remaining is that minus
+// P.status.budgetSpend. Because every level was intersected with its parent's
+// remaining, a grandchild is transitively bounded by the root: a fork-of-a-fork
+// cannot widen past what the root has left.
 //
-// It returns admitted=true (and proceeds the normal flow) when P does not exist,
-// when P has no budget, or when P.budget.maxForks is unset (unlimited): there is
-// no Sandbox-scoped fork budget to enforce in those cases.
-func (r *SandboxReconciler) enforceForkBudget(ctx context.Context, sb *v1alpha2.Sandbox) (bool, string, string, error) {
+// It admits forks up to the parent's REMAINING maxForks (by replicas) and
+// rejects the ones beyond, ranking P's fork-children deterministically by
+// (creationTimestamp, name) so the decision is independent of reconcile order.
+// It best-effort records P.status.budgetSpend.forks (the admitted count, capped
+// at the limit). The child's effective budget is the per-field minimum of the
+// child's own resolved budget and P's effective-remaining (never-widen), set in
+// the returned decision for the caller to mirror into the child's status.
+//
+// It admits (with the child effective budget = the child's own resolved budget
+// intersected with whatever the parent offers) when P does not exist, when P has
+// no budget, or when P's effective maxForks is unset (unlimited): there is no
+// Sandbox-scoped fork limit to enforce in those cases.
+func (r *SandboxReconciler) enforceForkBudget(ctx context.Context, sb *v1alpha2.Sandbox) (forkBudgetDecision, error) {
 	src := sb.Spec.Source.FromSandbox
 	if src == nil {
-		return true, "", "", nil
+		return forkBudgetDecision{admitted: true}, nil
 	}
 
 	var parent v1alpha2.Sandbox
 	if err := r.Get(ctx, client.ObjectKey{Name: src.Name, Namespace: sb.Namespace}, &parent); err != nil {
 		if apierrors.IsNotFound(err) {
 			// No source Sandbox to enforce a budget against; let the normal flow
-			// proceed (the fork reconciler surfaces a missing-source condition).
-			return true, "", "", nil
+			// proceed (the fork reconciler surfaces a missing-source condition). The
+			// child holds at most its own requested budget.
+			return forkBudgetDecision{admitted: true, childEffective: sb.Spec.Budget.DeepCopy()}, nil
 		}
-		return false, "", "", fmt.Errorf("get source sandbox %s/%s for budget: %w", sb.Namespace, src.Name, err)
+		return forkBudgetDecision{}, fmt.Errorf("get source sandbox %s/%s for budget: %w", sb.Namespace, src.Name, err)
 	}
 
-	if parent.Spec.Budget == nil || parent.Spec.Budget.MaxForks == nil {
-		// Unlimited fork budget; admit.
-		return true, "", "", nil
+	// P's effective budget: P's status.effectiveBudget (already attenuated against
+	// P's own parent, so this is the depth-aggregate quantity), falling back to
+	// P.spec.budget for a root. This GROSS effective budget is the total fork
+	// subtree P may ever spawn; the admission limit is its maxForks dimension and
+	// the walk below recomputes the deterministic running spend against it (the
+	// limit is the gross ceiling, NOT ceiling-minus-spend, or a recorded spend
+	// would wrongly shrink the ceiling on every reconcile).
+	parentEffective := parent.Status.EffectiveBudget
+	if parentEffective == nil {
+		parentEffective = parent.Spec.Budget
 	}
-	limit := *parent.Spec.Budget.MaxForks
+
+	if parentEffective == nil || parentEffective.MaxForks == nil {
+		// Unlimited fork budget on the forks dimension; admit. The child still
+		// attenuates its OTHER dimensions against the parent's effective budget so
+		// the next level is bounded (unlimited INTERSECT x = x).
+		childEffective := parentEffective.Intersect(sb.Spec.Budget)
+		return forkBudgetDecision{admitted: true, childEffective: childEffective}, nil
+	}
+	limit := *parentEffective.MaxForks
 
 	// All fork-children of P in the namespace (including sb), ranked
 	// deterministically by (creationTimestamp, name).
 	var siblings v1alpha2.SandboxList
 	if err := r.List(ctx, &siblings, client.InNamespace(sb.Namespace)); err != nil {
-		return false, "", "", fmt.Errorf("list fork-children of %s/%s for budget: %w", sb.Namespace, parent.Name, err)
+		return forkBudgetDecision{}, fmt.Errorf("list fork-children of %s/%s for budget: %w", sb.Namespace, parent.Name, err)
 	}
 	children := make([]v1alpha2.Sandbox, 0, len(siblings.Items))
 	for i := range siblings.Items {
@@ -273,18 +324,28 @@ func (r *SandboxReconciler) enforceForkBudget(ctx context.Context, sb *v1alpha2.
 	// Best-effort record P.status.budgetSpend.forks (idempotent). A conflict is
 	// not fatal: the next reconcile of any child re-derives and re-records it.
 	if err := r.recordParentForkSpend(ctx, &parent, totalAdmitted); err != nil && !apierrors.IsConflict(err) {
-		return false, "", "", err
+		return forkBudgetDecision{}, err
 	}
+
+	// The child's effective budget for delegating FURTHER down: P's effective
+	// budget minus the forks now admitted under P (totalAdmitted, which already
+	// counts this child), intersected with the child's own requested budget. This
+	// is what makes the bound depth-aggregate without double-counting: the slots P
+	// spent on its direct children are not available again to a grandchild, so a
+	// fork-of-a-fork can never widen past what the root has left. unlimited
+	// INTERSECT x = x and a wider child request is clamped down (never-widen).
+	parentRemaining := parentEffective.Remaining(v1alpha2.SandboxBudgetSpend{Forks: totalAdmitted})
+	childEffective := parentRemaining.Intersect(sb.Spec.Budget)
 
 	if sbOverBudget {
 		base := apierr.Get(apierr.CodeBudgetExhausted)
 		message := fmt.Sprintf(
-			"%s The forks budget dimension is exhausted: the limit is %d and 0 remain (%d forks of %q were already admitted ahead of this one). %s",
-			base.Message, limit, sbPriorForks, parent.Name, base.Remediation,
+			"%s The forks budget dimension is exhausted: %q's effective fork budget is %d and 0 remain (%d forks were already admitted ahead of this one). The bound is depth-aggregate, so the whole fork subtree is limited by the root. %s",
+			base.Message, parent.Name, limit, sbPriorForks, base.Remediation,
 		)
-		return false, "BudgetExhausted", message, nil
+		return forkBudgetDecision{admitted: false, reason: "BudgetExhausted", message: message, childEffective: childEffective}, nil
 	}
-	return true, "", "", nil
+	return forkBudgetDecision{admitted: true, childEffective: childEffective}, nil
 }
 
 // recordParentForkSpend writes parent.status.budgetSpend.forks = forks
@@ -383,6 +444,7 @@ type sandboxMirror struct {
 	children          []v1alpha2.SandboxChild
 	forkSnapshotTaken bool
 	checkpointTime    *metav1.Time
+	effectiveBudget   *v1alpha2.SandboxBudget
 }
 
 // mirror writes one sandboxMirror onto the Sandbox status subresource,
@@ -410,6 +472,11 @@ func (r *SandboxReconciler) mirror(ctx context.Context, sb *v1alpha2.Sandbox, ph
 	sb.Status.ForkSnapshotTaken = m.forkSnapshotTaken
 	if m.checkpointTime != nil {
 		sb.Status.CheckpointTime = m.checkpointTime
+	}
+	// EffectiveBudget is the controller-computed attenuated budget; record it
+	// (STATUS only, never the user-owned spec) when one was derived this reconcile.
+	if m.effectiveBudget != nil {
+		sb.Status.EffectiveBudget = m.effectiveBudget
 	}
 
 	apimeta.SetStatusCondition(&sb.Status.Conditions, metav1.Condition{
@@ -440,6 +507,9 @@ func equalSandboxStatus(a, b *v1alpha2.SandboxStatus) bool {
 		a.ForkSnapshotTaken != b.ForkSnapshotTaken || len(a.Children) != len(b.Children) {
 		return false
 	}
+	if !equalBudget(a.EffectiveBudget, b.EffectiveBudget) {
+		return false
+	}
 	for i := range a.Children {
 		if a.Children[i] != b.Children[i] {
 			return false
@@ -455,6 +525,47 @@ func equalSandboxStatus(a, b *v1alpha2.SandboxStatus) bool {
 		return false
 	}
 	return true
+}
+
+// equalBudget reports whether two capability budgets are field-equal, treating a
+// nil pointer as unlimited on every dimension, so a no-op status write is elided.
+func equalBudget(a, b *v1alpha2.SandboxBudget) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return eqInt32Ptr(a.MaxForks, b.MaxForks) &&
+		eqInt32Ptr(a.MaxCheckpoints, b.MaxCheckpoints) &&
+		eqInt64Ptr(a.MaxCpuSeconds, b.MaxCpuSeconds) &&
+		eqDurationPtr(a.MaxLifetimeExtension, b.MaxLifetimeExtension) &&
+		eqQuantityPtr(a.MaxEgressBytes, b.MaxEgressBytes)
+}
+
+func eqInt32Ptr(a, b *int32) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func eqInt64Ptr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func eqDurationPtr(a, b *metav1.Duration) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Duration == b.Duration
+}
+
+func eqQuantityPtr(a, b *resource.Quantity) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Cmp(*b) == 0
 }
 
 // mapPhase maps a v1 claim phase onto a v2 Sandbox phase per the migration table


### PR DESCRIPTION
Implements the deferred core of #25: a fork-childs effective budget (status.effectiveBudget) is the per-field intersection of its resolved budget with the parents effective-remaining, so the fork tree is depth-aggregate-bounded and no descendant budget is ever wider than its parent had left. Adds never-widen primitives (Remaining/Intersect on *SandboxBudget, nil=unlimited) mirroring captoken; enforceForkBudget now enforces against the parents effective budget (transitive). TDD: depth-aggregate (grandchild rejected so subtree cannot exceed root) + never-widen (wider request clamped) + the existing exhaustion test still passes; manifests regenerated. Spec never mutated (status only). Security-sensitive (capability enforcement). Residual noted: re-derivation keeps the aggregate bounded but a transient grandchild can outlive a sibling-induced shrink (strict pre-reservation is a follow-up). Refs #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)