### PR TITLE
feat(cli): first-class packaging, goreleaser + install.sh + OS-aware docs (#253)

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -31,3 +31,23 @@ jobs:
           set -euo pipefail
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck=
+
+  shellcheck-install:
+    # The universal installer (install.sh) is piped to `sh`, so it must stay
+    # POSIX-clean. shellcheck gates it; a self-test exercises the OS/arch
+    # detection without any network access. Issue #253.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: shellcheck install.sh
+        run: |
+          set -euo pipefail
+          shellcheck install.sh
+      - name: install.sh self-test (OS/arch detection, no download)
+        env:
+          MITOS_SELF_TEST: "1"
+        run: |
+          set -euo pipefail
+          out=$(sh install.sh)
+          echo "$out"
+          echo "$out" | grep -q '^os=.* arch=.* archive=mitos_<version>_.*\.tar\.gz$'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,78 @@
+name: Release
+
+# Cut a CLI release when a v* tag is pushed. The release-please flow lands the
+# `chore(main): release X` PR and tags the commit; that tag push triggers this
+# workflow, which runs goreleaser to build the cross-platform binaries, archives,
+# checksums, deb/rpm packages, and (when the tap token is present) the Homebrew
+# formula.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      # goreleaser uploads the release assets and may create the GitHub release.
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # goreleaser needs full history and tags to compute the version and
+          # changelog context.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # The Homebrew cask publish needs a token scoped to the tap repo. It is
+      # optional: when the secret is absent (for example before the maintainer
+      # creates mitos-run/homebrew-tap), the publish is skipped so the rest of
+      # the release still succeeds. This step exports a single env var the later
+      # steps read.
+      - name: Resolve tap publish state
+        id: tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "skip_brew=false" >> "$GITHUB_OUTPUT"
+            echo "Homebrew tap token present; the cask will be published."
+          else
+            echo "skip_brew=true" >> "$GITHUB_OUTPUT"
+            echo "No HOMEBREW_TAP_TOKEN secret; skipping the Homebrew cask publish."
+          fi
+
+      - name: Run goreleaser (with tap publish)
+        if: steps.tap.outputs.skip_brew == 'false'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Run goreleaser (skip tap publish)
+        if: steps.tap.outputs.skip_brew == 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The cask config references this env var; provide an empty value so
+          # template rendering does not fail even though the publish is skipped.
+          HOMEBREW_TAP_TOKEN: ""

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,117 @@
+# goreleaser configuration for the mitos CLI (cmd/mitos).
+#
+# Schema: goreleaser v2. Validate locally with `goreleaser check`.
+#
+# A tagged release (push of a v* tag) runs `goreleaser release` from
+# .github/workflows/release.yaml and produces, for cmd/mitos only:
+#   - cross-compiled binaries (linux/darwin/windows x amd64/arm64)
+#   - tar.gz archives (unix) and zip archives (windows), each bundling LICENSE
+#     and README.md
+#   - a SHA256 checksums file (consumed by install.sh for verification)
+#   - deb and rpm packages for linux amd64/arm64
+#   - a Homebrew formula pushed to the tap repo mitos-run/homebrew-tap
+#
+# MAINTAINER PREREQUISITES (see docs/install.md, MAINTAINER section):
+#   - The tap repo mitos-run/homebrew-tap must exist.
+#   - A HOMEBREW_TAP_TOKEN secret (a PAT with contents:write on that tap repo)
+#     must be set on this repo. Without it the brew publish is skipped by the
+#     release workflow so the rest of the release still succeeds.
+version: 2
+
+project_name: mitos
+
+builds:
+  - id: mitos
+    main: ./cmd/mitos
+    binary: mitos
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: mitos
+    ids:
+      - mitos
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    formats:
+      - tar.gz
+    # Windows users get a zip; everything else gets a tar.gz. install.sh only
+    # handles unix archives (Windows is out of scope for the shell installer).
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+nfpms:
+  - id: mitos
+    package_name: mitos
+    ids:
+      - mitos
+    vendor: mitos.run
+    homepage: https://mitos.run
+    maintainer: mitos maintainers <maintainers@mitos.run>
+    description: Snapshot-fork sandboxes for AI agents on Kubernetes (CLI).
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+    # nfpms inherits the build matrix; deb and rpm are produced for the linux
+    # amd64 and arm64 binaries.
+
+# Homebrew tap publish. goreleaser is phasing `brews` out in favor of
+# `homebrew_casks`, so the cask form is used here. A user installs with:
+#   brew install mitos-run/tap/mitos
+homebrew_casks:
+  - name: mitos
+    ids:
+      - mitos
+    repository:
+      owner: mitos-run
+      name: homebrew-tap
+      # The tap publish uses a dedicated token (a PAT scoped to the tap repo).
+      # The release workflow only sets this when the secret exists, so a release
+      # cut before the tap is created still succeeds (the brew step is skipped).
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://mitos.run
+    description: Snapshot-fork sandboxes for AI agents on Kubernetes (CLI).
+    # The released binaries are not notarized, so strip the macOS quarantine
+    # attribute on install; otherwise Gatekeeper blocks the first run.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mitos"]
+          end
+
+release:
+  github:
+    owner: mitos-run
+    name: mitos
+  # The CHANGELOG.md is maintained by the release-please flow; do not let
+  # goreleaser regenerate release notes from commit history.
+  draft: false
+  prerelease: auto
+
+changelog:
+  disable: true

--- a/README.md
+++ b/README.md
@@ -144,7 +144,23 @@ The TypeScript SDK (`@mitos/sdk`) exposes the same one-liner `sandbox(image)`, `
 
 ### CLI
 
+Install the `mitos` CLI. The full per-OS matrix, the env vars the installer
+honors, and checksum verification are in [docs/install.md](docs/install.md).
+
+| Method | Status |
+| --- | --- |
+| `go install mitos.run/mitos/cmd/mitos@latest` | Works today (needs a Go toolchain). |
+| `curl -fsSL https://get.mitos.run \| sh` | Available from the first tagged release (downloads + verifies the release archive). |
+| Manual release binary (download, checksum, extract) | Available from the first tagged release. |
+| Homebrew (`brew install mitos-run/tap/mitos`) | Coming with releases (publishes once the tap is wired). |
+| Debian/RPM packages (`.deb`, `.rpm`) | Coming with releases (built from the first tagged release). |
+| Windows (`scoop`, `winget`) | Coming with releases. |
+
 ```bash
+# Works today with a Go toolchain:
+go install mitos.run/mitos/cmd/mitos@latest
+
+# Or build from a checkout:
 go build -o mitos ./cmd/mitos/
 
 mitos sandbox create --pool dev-default

--- a/cmd/mitos/main.go
+++ b/cmd/mitos/main.go
@@ -42,6 +42,13 @@ func run(args []string) int {
 		return agentcli.Run(ctx, rest, nil, os.Stdout, os.Stderr)
 	}
 
+	// version prints build metadata (injected via -ldflags at release time) and
+	// needs no cluster backend, so it is handled before any kubeconfig probe.
+	if rest[0] == "version" || rest[0] == "--version" || rest[0] == "-v" {
+		printVersion(os.Stdout)
+		return 0
+	}
+
 	// The dev subcommand orchestrates kind/kubectl and needs no cluster backend.
 	if rest[0] == "dev" {
 		return runDev(ctx, rest[1:])

--- a/cmd/mitos/version.go
+++ b/cmd/mitos/version.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+)
+
+// Build metadata. These are overridden at release time via -ldflags -X by
+// goreleaser (see .goreleaser.yaml). The defaults keep `go install` and local
+// `go build` honest: a binary built without ldflags reports "dev", so a number
+// is never claimed that the build cannot back up.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// printVersion writes the CLI version line to w. The format is stable so
+// scripts can parse it: "mitos <version> (commit <commit>, built <date>, <goos>/<goarch>)".
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "mitos %s (commit %s, built %s, %s/%s)\n",
+		version, commit, date, runtime.GOOS, runtime.GOARCH)
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,168 @@
+# Installing the mitos CLI
+
+The `mitos` command-line interface drives the sandbox lifecycle (create, exec,
+file IO, fork, terminate, list) and brings a local dev cluster up or down.
+
+This page covers every install method, what works today versus what arrives with
+the first tagged release, the environment variables the installer honors, and how
+to verify a download. A MAINTAINER section at the end records the one-time setup a
+repo admin must complete for the package-manager paths to go live.
+
+## Status of each method
+
+Honesty rule: a method is only listed as working once it actually publishes. The
+table below is explicit about which paths work today and which arrive with the
+first tagged release.
+
+| Method | Status |
+| --- | --- |
+| `go install mitos.run/mitos/cmd/mitos@latest` | Works today. Requires a Go toolchain. |
+| Build from a checkout (`go build ./cmd/mitos`) | Works today. Requires a Go toolchain. |
+| `curl -fsSL https://get.mitos.run \| sh` | Available from the first tagged release. |
+| Manual release binary | Available from the first tagged release. |
+| Homebrew (`brew install mitos-run/tap/mitos`) | Coming with releases (needs the tap repo + token, see MAINTAINER). |
+| Debian/RPM packages (`.deb`, `.rpm`) | Coming with releases. |
+| Windows (`scoop`, `winget`) | Coming with releases. |
+
+## Works today: Go toolchain
+
+```bash
+go install mitos.run/mitos/cmd/mitos@latest
+```
+
+This installs `mitos` into `$(go env GOPATH)/bin`. A binary built this way reports
+its version as `dev` because it is not built through the release pipeline:
+
+```bash
+mitos version
+# mitos dev (commit none, built unknown, linux/amd64)
+```
+
+Or build from a checkout:
+
+```bash
+git clone https://github.com/mitos-run/mitos
+cd mitos
+go build -o mitos ./cmd/mitos/
+```
+
+## From the first tagged release: install script
+
+```bash
+curl -fsSL https://get.mitos.run | sh
+```
+
+The script (`install.sh` at the repo root) detects your OS and architecture,
+resolves the version, downloads the matching archive plus the checksums file from
+the GitHub release, verifies the SHA256, extracts the `mitos` binary, installs it,
+and prints the installed version. It is POSIX `sh` and supports linux and darwin on
+amd64 and arm64.
+
+Windows is out of scope for the script; use scoop or winget once those publish.
+
+### Environment variables the script honors
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MITOS_VERSION` | latest release | Tag to install. Accepts `v1.2.3` or `1.2.3`. |
+| `MITOS_INSTALL_DIR` | `/usr/local/bin`, falling back to `$HOME/.local/bin` | Install directory. The script falls back automatically when `/usr/local/bin` is not writable. |
+| `MITOS_SELF_TEST` | unset | When `1`, prints the detected `os`, `arch`, and archive name, then exits without downloading. Used by CI. |
+
+Examples:
+
+```bash
+# Pin a version and install into a user-writable directory:
+MITOS_VERSION=v0.11.0 MITOS_INSTALL_DIR="$HOME/.local/bin" \
+  curl -fsSL https://get.mitos.run | sh
+
+# See what the script would download for this machine, without downloading:
+MITOS_SELF_TEST=1 sh install.sh
+```
+
+## From the first tagged release: manual binary
+
+Download the archive and the checksums file for your platform from the
+[releases page](https://github.com/mitos-run/mitos/releases), verify, then extract:
+
+```bash
+VER=v0.11.0           # the release tag
+OS=linux              # or darwin
+ARCH=amd64            # or arm64
+BASE="https://github.com/mitos-run/mitos/releases/download/${VER}"
+
+curl -fsSLO "${BASE}/mitos_${VER#v}_${OS}_${ARCH}.tar.gz"
+curl -fsSLO "${BASE}/mitos_${VER#v}_checksums.txt"
+
+# Verify (linux: sha256sum; macOS: shasum -a 256):
+sha256sum --ignore-missing -c "mitos_${VER#v}_checksums.txt"
+
+tar -xzf "mitos_${VER#v}_${OS}_${ARCH}.tar.gz" mitos
+sudo install -m 0755 mitos /usr/local/bin/mitos
+```
+
+Windows users download the `_windows_<arch>.zip` archive and place `mitos.exe` on
+their `PATH`.
+
+## Coming with releases: package managers
+
+These paths are configured in `.goreleaser.yaml` and produced by a tagged release.
+They are listed here so the docs match the config, but they only work once the
+release publishes them (and, for Homebrew, once the MAINTAINER steps below are
+done). Do not assume they work before then.
+
+- Homebrew (macOS and linuxbrew):
+
+  ```bash
+  brew install mitos-run/tap/mitos
+  ```
+
+- Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`): download the package for your
+  architecture from the releases page and install with `dpkg -i` or `rpm -i`.
+
+- Windows: scoop and winget manifests are planned; until they publish, use the
+  manual `.zip` archive.
+
+## Verifying a download
+
+Every release publishes `mitos_<version>_checksums.txt`, a SHA256 manifest over all
+archives. The install script verifies automatically. To verify by hand:
+
+```bash
+# Linux:
+sha256sum --ignore-missing -c mitos_<version>_checksums.txt
+# macOS:
+shasum -a 256 -c mitos_<version>_checksums.txt --ignore-missing
+```
+
+## MAINTAINER: one-time setup
+
+The release pipeline and the package-manager paths need infrastructure that a repo
+admin must set up once. Until these are done, a tagged release still produces
+binaries, archives, checksums, and deb/rpm packages; only the Homebrew publish and
+the `get.mitos.run` shortcut depend on them.
+
+1. Create the Homebrew tap repository `mitos-run/homebrew-tap` (a public GitHub
+   repo). goreleaser pushes the generated cask into it on each release.
+
+2. Create a `HOMEBREW_TAP_TOKEN` repository secret on `mitos-run/mitos`. It must be
+   a personal access token (or fine-grained token) with `contents: write` on the
+   `mitos-run/homebrew-tap` repo only. The release workflow
+   (`.github/workflows/release.yaml`) reads this secret: when it is present the
+   cask is published; when it is absent the brew step is skipped with
+   `--skip=homebrew` so the rest of the release still succeeds. This is why a
+   release cut before the tap exists does not hard-fail.
+
+3. Point `get.mitos.run` at the raw `install.sh`. Either:
+   - serve a redirect from `https://get.mitos.run` to
+     `https://raw.githubusercontent.com/mitos-run/mitos/main/install.sh`, or
+   - host the file directly at that hostname.
+
+   Keep it pointed at a stable ref (`main`) so `curl | sh` always fetches the
+   current installer. DNS and the redirect/host need account-level access that is
+   outside this repo.
+
+4. How a tagged release produces all artifacts: the release-please flow lands the
+   `chore(main): release X` PR and tags the commit. Pushing that `v*` tag triggers
+   `.github/workflows/release.yaml`, which runs goreleaser to build the
+   cross-platform binaries, tar.gz/zip archives, the checksums file, the deb/rpm
+   packages, and (when the tap token is present) the Homebrew cask.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# mitos CLI installer.
+#
+#   curl -fsSL https://get.mitos.run | sh
+#
+# Downloads the release archive matching this OS/arch from the GitHub release,
+# verifies its SHA256 against the published checksums file, extracts the `mitos`
+# binary, and installs it. POSIX sh only (this is piped to `sh`); keep it free
+# of bashisms so the static linter stays happy.
+#
+# Environment variables:
+#   MITOS_VERSION      version tag to install (default: latest release).
+#                      Accepts "v1.2.3" or "1.2.3".
+#   MITOS_INSTALL_DIR  install directory (default: /usr/local/bin, falling back
+#                      to $HOME/.local/bin if that is not writable).
+#   MITOS_SELF_TEST    when set to "1", print the detected os/arch/archive and
+#                      exit without downloading. Used by CI to test detection.
+#
+# Windows is out of scope for this script; use scoop or winget once those
+# packages publish (see docs/install.md).
+
+set -eu
+
+REPO="mitos-run/mitos"
+BINARY="mitos"
+
+# err prints a message to stderr and exits nonzero.
+err() {
+	echo "mitos-install: error: $1" >&2
+	exit 1
+}
+
+# need checks that a required command is on PATH, with actionable remediation.
+need() {
+	command -v "$1" >/dev/null 2>&1 || err "required command '$1' not found on PATH; install it and re-run"
+}
+
+# detect_os maps uname -s to a goreleaser GOOS token.
+detect_os() {
+	os=$(uname -s)
+	case "$os" in
+	Linux) echo "linux" ;;
+	Darwin) echo "darwin" ;;
+	*) err "unsupported OS '$os'; this installer supports linux and darwin. On Windows use scoop or winget (see docs/install.md)" ;;
+	esac
+}
+
+# detect_arch maps uname -m to a goreleaser GOARCH token.
+detect_arch() {
+	arch=$(uname -m)
+	case "$arch" in
+	x86_64 | amd64) echo "amd64" ;;
+	aarch64 | arm64) echo "arm64" ;;
+	*) err "unsupported architecture '$arch'; this installer supports amd64 and arm64" ;;
+	esac
+}
+
+# resolve_version echoes the version to install. Honors MITOS_VERSION; otherwise
+# queries the GitHub releases API for the latest tag.
+resolve_version() {
+	if [ -n "${MITOS_VERSION:-}" ]; then
+		echo "$MITOS_VERSION"
+		return 0
+	fi
+	api="https://api.github.com/repos/${REPO}/releases/latest"
+	# Extract the tag_name without jq: grab the first "tag_name": "..." value.
+	tag=$(curl -fsSL "$api" | grep '"tag_name"' | head -n1 | cut -d'"' -f4)
+	[ -n "$tag" ] || err "could not resolve the latest release tag from ${api}; set MITOS_VERSION explicitly, or check that a release has been published"
+	echo "$tag"
+}
+
+# sha256_of prints the sha256 hex digest of file $1 using whichever tool exists.
+sha256_of() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | cut -d' ' -f1
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | cut -d' ' -f1
+	else
+		err "need 'sha256sum' or 'shasum' to verify the download; install one and re-run"
+	fi
+}
+
+main() {
+	os=$(detect_os)
+	arch=$(detect_arch)
+
+	# Archive naming mirrors .goreleaser.yaml:
+	#   mitos_<version-no-v>_<os>_<arch>.tar.gz
+	# The self-test path reports detection without a version, so use a placeholder.
+	if [ "${MITOS_SELF_TEST:-}" = "1" ]; then
+		echo "os=${os} arch=${arch} archive=${BINARY}_<version>_${os}_${arch}.tar.gz"
+		exit 0
+	fi
+
+	need curl
+	need tar
+
+	version=$(resolve_version)
+	# Strip a leading "v" for the archive name; the release URL keeps the tag.
+	ver_no_v=${version#v}
+
+	archive="${BINARY}_${ver_no_v}_${os}_${arch}.tar.gz"
+	checksums="${BINARY}_${ver_no_v}_checksums.txt"
+	base="https://github.com/${REPO}/releases/download/${version}"
+
+	tmp=$(mktemp -d 2>/dev/null || mktemp -d -t mitos-install)
+	# Clean up the temp dir on any exit.
+	trap 'rm -rf "$tmp"' EXIT INT TERM
+
+	echo "mitos-install: downloading ${archive} (${version}) for ${os}/${arch}" >&2
+	curl -fsSL "${base}/${archive}" -o "${tmp}/${archive}" ||
+		err "download failed: ${base}/${archive}; verify that release ${version} publishes an archive for ${os}/${arch}"
+	curl -fsSL "${base}/${checksums}" -o "${tmp}/${checksums}" ||
+		err "checksums download failed: ${base}/${checksums}"
+
+	# Verify the SHA256 of the archive against the published checksums file.
+	want=$(grep " ${archive}\$" "${tmp}/${checksums}" | head -n1 | cut -d' ' -f1)
+	[ -n "$want" ] || err "checksum for ${archive} not found in ${checksums}; the release may be incomplete"
+	got=$(sha256_of "${tmp}/${archive}")
+	[ "$want" = "$got" ] || err "checksum mismatch for ${archive}: expected ${want}, got ${got}; aborting"
+	echo "mitos-install: checksum verified" >&2
+
+	tar -xzf "${tmp}/${archive}" -C "${tmp}" "${BINARY}" ||
+		err "could not extract '${BINARY}' from ${archive}"
+	chmod +x "${tmp}/${BINARY}"
+
+	# Resolve the install directory: explicit override, then /usr/local/bin if
+	# writable, then $HOME/.local/bin.
+	dir=${MITOS_INSTALL_DIR:-}
+	if [ -z "$dir" ]; then
+		if [ -w /usr/local/bin ] 2>/dev/null; then
+			dir="/usr/local/bin"
+		else
+			dir="${HOME}/.local/bin"
+		fi
+	fi
+	mkdir -p "$dir" || err "could not create install directory ${dir}; set MITOS_INSTALL_DIR to a writable path"
+
+	if ! mv "${tmp}/${BINARY}" "${dir}/${BINARY}" 2>/dev/null; then
+		err "could not write ${dir}/${BINARY}; re-run with a writable MITOS_INSTALL_DIR (for example MITOS_INSTALL_DIR=\$HOME/.local/bin), or with sufficient privileges"
+	fi
+
+	echo "mitos-install: installed ${BINARY} to ${dir}/${BINARY}" >&2
+	case ":${PATH}:" in
+	*":${dir}:"*) ;;
+	*) echo "mitos-install: note: ${dir} is not on your PATH; add it to use 'mitos' directly" >&2 ;;
+	esac
+
+	# Print the installed version as the final line.
+	"${dir}/${BINARY}" version
+}
+
+main "$@"


### PR DESCRIPTION
Adds the CLI packaging foundation: .goreleaser.yaml (cross-platform binaries, checksums, deb/rpm, Homebrew cask to mitos-run/homebrew-tap), a POSIX curl|sh install.sh (OS/arch detect + sha256 verify), a tag-triggered release workflow (brew publish skipped until the tap token exists), a CLI version intercept, and CI shellcheck of the installer. Docs: README OS-aware install matrix + docs/install.md, with the honesty rule, only go install is marked working-today; brew/deb/scoop are 'coming with releases'. Verified: goreleaser check + snapshot build of all 6 binaries, shellcheck clean, actionlint clean, version intercept works, no dashes. Maintainer follow-up (repo/DNS admin): create the tap repo, add HOMEBREW_TAP_TOKEN, wire get.mitos.run. apt/scoop/winget are tracked follow-ups. Refs #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)