### PR TITLE
feat(skill,sdk,mcp): Agent Skill + default agent surfaces to hosted mitos.run (#252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ mitos run echo hello --pool dev-default
 mitos sandbox ls
 ```
 
-`mitos dev up` brings up a one-command local control plane on a mock engine. An MCP server (`mitos-mcp`) exposes sandboxes as MCP tools so any MCP-speaking agent can use them with zero SDK integration. See [docs/cli.md](docs/cli.md) and [docs/mcp.md](docs/mcp.md).
+`mitos dev up` brings up a one-command local control plane on a mock engine. An MCP server (`mitos-mcp`) exposes sandboxes as MCP tools so any MCP-speaking agent can use them with zero SDK integration. A first-class Agent Skill ([`skills/mitos/SKILL.md`](skills/mitos/SKILL.md)) teaches skill-aware agents the workflow (fork vs. fresh, best-of-N, isolation, cost) to pair with those tools. See [docs/cli.md](docs/cli.md) and [docs/mcp.md](docs/mcp.md).
 
 ### Beyond exec
 
@@ -427,6 +427,7 @@ Per-topic docs in [`docs/`](docs/):
 | Threat model | [docs/threat-model.md](docs/threat-model.md) |
 | `mitos` CLI | [docs/cli.md](docs/cli.md) |
 | MCP server | [docs/mcp.md](docs/mcp.md) |
+| Agent Skill | [skills/mitos/SKILL.md](skills/mitos/SKILL.md) |
 | Migrating from E2B | [docs/migrating-from-e2b.md](docs/migrating-from-e2b.md) |
 | Talos + Hetzner reference platform | [docs/platforms/talos-hetzner.md](docs/platforms/talos-hetzner.md) |
 | Target API surface (v2 spec) | [docs/api/v2-spec.md](docs/api/v2-spec.md) |

--- a/README.md
+++ b/README.md
@@ -55,24 +55,28 @@ key plus a base URL and you have a Ready sandbox. No Kubernetes required.
 ```python
 import mitos
 
-# MITOS_API_KEY and MITOS_BASE_URL from the environment (explicit args override).
+# Set MITOS_API_KEY (a key from https://mitos.run). The base URL defaults to the
+# hosted endpoint https://mitos.run, so no base URL is needed.
 sb = mitos.create("python")                      # Ready sandbox handle
 print(sb.exec("echo hello").stdout)              # hello
 sb.terminate()
 ```
 
 `mitos.create(image, api_key=..., base_url=...)` resolves the API key (argument,
-else `MITOS_API_KEY`) and base URL (argument, else `MITOS_BASE_URL`), then returns
-a `DirectSandbox` that exposes `exec`, `run_code`, `files`, `pty`, `fork`, and
-`terminate` directly. The standalone `sandbox-server` runs tokenless and ignores
-the key; the hosted control plane verifies the same `Authorization: Bearer`
-header server-side ([#210](https://github.com/mitos-run/mitos/issues/210)). The
-key value is never logged. `Sandbox.create(...)` is an alias for the same call.
+else `MITOS_API_KEY`) and base URL (argument, else `MITOS_BASE_URL`, else the
+hosted endpoint `https://mitos.run`), then returns a `DirectSandbox` that exposes
+`exec`, `run_code`, `files`, `pty`, `fork`, and `terminate` directly. The hosted
+control plane verifies the same `Authorization: Bearer` header server-side
+([#210](https://github.com/mitos-run/mitos/issues/210)); the standalone
+`sandbox-server` runs tokenless and ignores the key. To target a local
+standalone server or a self-hosted cluster, set `base_url` (or `MITOS_BASE_URL`),
+for example `base_url="http://localhost:8080"`. The key value is never logged.
+`Sandbox.create(...)` is an alias for the same call.
 
 ```python
 import mitos
 
-sb = mitos.create("python", api_key="sk-...", base_url="http://localhost:8080")
+sb = mitos.create("python", api_key="sk-...")
 
 # Files, stateful code, and fork all work on the flat handle.
 sb.files.write("/workspace/plan.txt", "draft")

--- a/cmd/mitos-mcp/main.go
+++ b/cmd/mitos-mcp/main.go
@@ -21,7 +21,9 @@ import (
 )
 
 func main() {
-	defaultServer := envOr("AGENTRUN_SERVER", "http://localhost:8080")
+	// Default to the hosted production control plane. Self-hosted or local
+	// standalone users opt out by setting AGENTRUN_SERVER or passing --server.
+	defaultServer := envOr("AGENTRUN_SERVER", "https://mitos.run")
 	defaultToken := os.Getenv("AGENTRUN_TOKEN")
 
 	server := flag.String("server", defaultServer, "Base URL of the sandbox-server (env AGENTRUN_SERVER).")

--- a/cmd/mitos-mcp/main.go
+++ b/cmd/mitos-mcp/main.go
@@ -5,7 +5,7 @@
 //
 // It speaks MCP on stdin/stdout: stdout is the JSON-RPC channel and carries
 // nothing else. ALL logging goes to stderr. The launch-time bearer token
-// (--token / AGENTRUN_TOKEN) scopes what the server can do on the backend and
+// (--token / MITOS_API_KEY) scopes what the server can do on the backend and
 // is NEVER logged.
 package main
 
@@ -22,12 +22,12 @@ import (
 
 func main() {
 	// Default to the hosted production control plane. Self-hosted or local
-	// standalone users opt out by setting AGENTRUN_SERVER or passing --server.
-	defaultServer := envOr("AGENTRUN_SERVER", "https://mitos.run")
-	defaultToken := os.Getenv("AGENTRUN_TOKEN")
+	// standalone users opt out by setting MITOS_BASE_URL or passing --server.
+	defaultServer := envOr("MITOS_BASE_URL", "https://mitos.run")
+	defaultToken := os.Getenv("MITOS_API_KEY")
 
-	server := flag.String("server", defaultServer, "Base URL of the sandbox-server (env AGENTRUN_SERVER).")
-	token := flag.String("token", defaultToken, "Bearer token; scopes what this server may do (env AGENTRUN_TOKEN). Never logged.")
+	server := flag.String("server", defaultServer, "Base URL of the sandbox-server (env MITOS_BASE_URL).")
+	token := flag.String("token", defaultToken, "Bearer token; scopes what this server may do (env MITOS_API_KEY). Never logged.")
 	enableWorkspace := flag.Bool("enable-workspace-tools", false, "Advertise the workspace tools in tools/list (dispatch deferred, issue #21).")
 	flag.Parse()
 

--- a/docs/api/v2-spec.md
+++ b/docs/api/v2-spec.md
@@ -124,7 +124,7 @@ Agents are first-class API consumers. Three commitments follow.
 
 ### 2.2 In-guest self-service endpoint
 
-Inside every sandbox: `AGENTRUN_SOCKET=/run/mitos.sock` (vsock-backed), speaking the same runtime protocol with the sandbox's own attenuated token. The agent can checkpoint itself before a risky operation, fork itself for tree search, watch its own budget, and read its own vitals, without any network egress and without an external orchestrator round-trip.
+Inside every sandbox: `MITOS_SOCKET=/run/mitos.sock` (vsock-backed), speaking the same runtime protocol with the sandbox's own attenuated token. The agent can checkpoint itself before a risky operation, fork itself for tree search, watch its own budget, and read its own vitals, without any network egress and without an external orchestrator round-trip.
 
 ```python
 # from inside the sandbox: e.g. an agent doing best-of-N over its own state

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -41,14 +41,14 @@ and are not yet dispatched (issue #21).
 ## Launching it
 
 The HTTP backend talks to a running [sandbox-server](../cmd/sandbox-server)
-over its REST API. With no `--server` flag and no `AGENTRUN_SERVER` set it
+over its REST API. With no `--server` flag and no `MITOS_BASE_URL` set it
 targets the hosted production endpoint `https://mitos.run`; point it at a
 self-hosted or local standalone server by overriding either one:
 
 ```bash
 mitos-mcp \
   --server https://sandbox.example.internal \
-  --token "$AGENTRUN_TOKEN" \
+  --token "$MITOS_API_KEY" \
   --enable-workspace-tools=false
 ```
 
@@ -56,8 +56,8 @@ Flags and environment:
 
 | Flag | Environment | Default | Meaning |
 | --- | --- | --- | --- |
-| `--server` | `AGENTRUN_SERVER` | `https://mitos.run` | Base URL of the sandbox-server; defaults to the hosted endpoint. |
-| `--token` | `AGENTRUN_TOKEN` | empty | Bearer token sent on every backend request. |
+| `--server` | `MITOS_BASE_URL` | `https://mitos.run` | Base URL of the sandbox-server; defaults to the hosted endpoint. |
+| `--token` | `MITOS_API_KEY` | empty | Bearer token sent on every backend request. |
 | `--enable-workspace-tools` | | `false` | Advertise the deferred workspace tools. |
 
 ### Token scoping
@@ -103,8 +103,8 @@ the binary and passes the backend URL and token through the environment:
     "mitos": {
       "command": "/usr/local/bin/mitos-mcp",
       "env": {
-        "AGENTRUN_SERVER": "https://sandbox.example.internal",
-        "AGENTRUN_TOKEN": "your-scoped-token"
+        "MITOS_BASE_URL": "https://sandbox.example.internal",
+        "MITOS_API_KEY": "your-scoped-token"
       }
     }
   }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -41,7 +41,9 @@ and are not yet dispatched (issue #21).
 ## Launching it
 
 The HTTP backend talks to a running [sandbox-server](../cmd/sandbox-server)
-over its REST API.
+over its REST API. With no `--server` flag and no `AGENTRUN_SERVER` set it
+targets the hosted production endpoint `https://mitos.run`; point it at a
+self-hosted or local standalone server by overriding either one:
 
 ```bash
 mitos-mcp \
@@ -54,7 +56,7 @@ Flags and environment:
 
 | Flag | Environment | Default | Meaning |
 | --- | --- | --- | --- |
-| `--server` | `AGENTRUN_SERVER` | `http://localhost:8080` | Base URL of the sandbox-server. |
+| `--server` | `AGENTRUN_SERVER` | `https://mitos.run` | Base URL of the sandbox-server; defaults to the hosted endpoint. |
 | `--token` | `AGENTRUN_TOKEN` | empty | Bearer token sent on every backend request. |
 | `--enable-workspace-tools` | | `false` | Advertise the deferred workspace tools. |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,8 @@ pip install mitos
 ```python
 import mitos
 
-# MITOS_API_KEY and MITOS_BASE_URL come from the environment (explicit args override).
+# Set MITOS_API_KEY (get a key from https://mitos.run). The base URL defaults to
+# the hosted production endpoint https://mitos.run, so no base URL is needed.
 sb = mitos.create("python")                 # Ready sandbox handle
 print(sb.run_code("print(1 + 1)").text)     # 2
 sb.terminate()
@@ -22,16 +23,31 @@ sb.terminate()
 That is the whole thing: one `pip install mitos`, one import, one `create`, code
 execution, no second SDK to install. `mitos.create(image, api_key=..., base_url=...)`
 resolves the API key (argument, else `MITOS_API_KEY`) and the base URL (argument,
-else `MITOS_BASE_URL`), then returns a sandbox handle that exposes `exec`,
-`run_code`, `files`, `fork`, and `terminate` directly. The API key value is never
-logged. `Sandbox.create(...)` is an alias for the same call.
+else `MITOS_BASE_URL`, else the hosted endpoint `https://mitos.run`), then returns
+a sandbox handle that exposes `exec`, `run_code`, `files`, `fork`, and `terminate`
+directly. The API key value is never logged. `Sandbox.create(...)` is an alias for
+the same call.
+
+## Local or self-hosted standalone
+
+To target a local standalone `sandbox-server` or a self-hosted cluster instead of
+the hosted endpoint, set the base URL (argument or `MITOS_BASE_URL`). The
+standalone server runs tokenless, so no key is required:
+
+```python
+import mitos
+
+sb = mitos.create("python", base_url="http://localhost:8080")
+print(sb.run_code("print(1 + 1)").text)     # 2
+sb.terminate()
+```
 
 ## The full flat handle
 
 ```python
 import mitos
 
-sb = mitos.create("python", api_key="sk-...", base_url="http://localhost:8080")
+sb = mitos.create("python", api_key="sk-...")
 
 # Files, stateful code, and fork all work on the same flat handle.
 sb.files.write("/workspace/plan.txt", "draft")
@@ -52,9 +68,10 @@ returns an async handle with the same `exec` / `run_code` / `files` / `fork` /
 
 ## Where the key comes from
 
-The standalone `sandbox-server` runs tokenless and ignores the key, so the
-quickstart works against a local server with no signup at all. The hosted
-control plane verifies the same `Authorization: Bearer` header server-side
+The hosted endpoint is the default, so the headline quickstart needs only an API
+key. The standalone `sandbox-server` runs tokenless and ignores the key, so the
+local variant above works against a local server with no signup at all. The
+hosted control plane verifies the same `Authorization: Bearer` header server-side
 ([#210](https://github.com/mitos-run/mitos/issues/210)), and you get a key from
 the self-serve onboarding funnel: sign up with an email, click the verification
 link, and your Personal organization, free-tier signup credit, and first API key

--- a/sdk/python/mitos/direct.py
+++ b/sdk/python/mitos/direct.py
@@ -9,7 +9,8 @@ The headline one-liner is ``mitos.create(...)`` (aliased as
 
 Auth resolution (issue #217): the API key comes from the explicit ``api_key``
 argument, else ``MITOS_API_KEY``; the base URL from ``base_url``, else
-``MITOS_BASE_URL``. The key is sent as ``Authorization: Bearer <key>`` on every
+``MITOS_BASE_URL``, else the hosted production endpoint ``https://mitos.run``.
+The key is sent as ``Authorization: Bearer <key>`` on every
 request and is NEVER logged or placed in an error message. The standalone
 sandbox-server runs tokenless and ignores the header today; the hosted SaaS
 front door (#210) will verify the same header without any SDK change, so the
@@ -44,30 +45,28 @@ from mitos.sandbox import _parse_run_code_stream, _validate_timeout
 ENV_API_KEY = "MITOS_API_KEY"
 ENV_BASE_URL = "MITOS_BASE_URL"
 
+# The hosted production control plane. When neither the base_url argument nor
+# MITOS_BASE_URL is set, the flat path targets the hosted endpoint so the
+# examples work without a base URL. Self-hosted or local standalone users opt
+# out by setting MITOS_BASE_URL (e.g. http://localhost:8080).
+DEFAULT_BASE_URL = "https://mitos.run"
+
 
 def _resolve_auth(
     api_key: Optional[str], base_url: Optional[str]
 ) -> tuple[Optional[str], str]:
     """Resolve the API key and base URL for the flat path.
 
-    Precedence: explicit argument, then environment. The base URL is required;
-    a missing one raises a typed AgentRunError whose remediation names the arg
-    and the env var but NEVER echoes any key value. The API key is optional
+    Precedence for the base URL: explicit argument, then MITOS_BASE_URL, then
+    the hosted production endpoint (DEFAULT_BASE_URL). The API key is optional
     today (the standalone server is tokenless); when present it rides on the
     Authorization header so the hosted front door (#210) can verify it later.
+    The key VALUE is never logged or placed in an error message.
     """
     key = api_key if api_key is not None else os.environ.get(ENV_API_KEY)
     url = base_url if base_url is not None else os.environ.get(ENV_BASE_URL)
     if not url:
-        raise AgentRunError(
-            "no base URL for the mitos control plane",
-            code="missing_base_url",
-            cause=f"neither the base_url argument nor {ENV_BASE_URL} was set",
-            remediation=(
-                f"Pass base_url=... to mitos.create(), or set {ENV_BASE_URL} "
-                "(for the standalone sandbox-server, e.g. http://localhost:8080)."
-            ),
-        )
+        url = DEFAULT_BASE_URL
     return key, url.rstrip("/")
 
 
@@ -422,7 +421,7 @@ class SandboxServer:
     DirectSandbox it produces sends the same Authorization header.
     """
 
-    def __init__(self, url: str = "http://localhost:8080", api_key: Optional[str] = None):
+    def __init__(self, url: str = DEFAULT_BASE_URL, api_key: Optional[str] = None):
         self.url = url.rstrip("/")
         self._api_key = api_key
         self._http = httpx.Client(timeout=60.0)

--- a/sdk/python/tests/test_flat_create.py
+++ b/sdk/python/tests/test_flat_create.py
@@ -202,17 +202,40 @@ def test_explicit_args_override_env(monkeypatch, fake_server):
     sb.terminate()
 
 
-def test_missing_base_url_raises(monkeypatch):
+def test_default_base_url_is_hosted(monkeypatch):
+    """With neither the arg nor MITOS_BASE_URL set, the base URL defaults to the
+    hosted production endpoint (no error). The API key stays optional."""
+    from mitos.direct import _resolve_auth
+
     monkeypatch.delenv("MITOS_BASE_URL", raising=False)
     monkeypatch.delenv("MITOS_API_KEY", raising=False)
-    from mitos.errors import AgentRunError
+    key, url = _resolve_auth(None, None)
+    assert url == "https://mitos.run"
+    assert key is None
 
-    with pytest.raises(AgentRunError) as ei:
-        mitos.create("python")
-    assert ei.value.code == "missing_base_url"
-    # The remediation must not leak any key value.
-    assert "sk-" not in (ei.value.remediation or "")
-    assert "sk-" not in (ei.value.cause or "")
+
+def test_explicit_base_url_beats_default(monkeypatch):
+    monkeypatch.delenv("MITOS_BASE_URL", raising=False)
+    from mitos.direct import _resolve_auth
+
+    _, url = _resolve_auth(None, "http://localhost:8080")
+    assert url == "http://localhost:8080"
+
+
+def test_env_base_url_beats_default(monkeypatch):
+    from mitos.direct import _resolve_auth
+
+    monkeypatch.setenv("MITOS_BASE_URL", "http://from-env:9000")
+    _, url = _resolve_auth(None, None)
+    assert url == "http://from-env:9000"
+
+
+def test_explicit_base_url_beats_env(monkeypatch):
+    from mitos.direct import _resolve_auth
+
+    monkeypatch.setenv("MITOS_BASE_URL", "http://from-env:9000")
+    _, url = _resolve_auth(None, "http://explicit:1234")
+    assert url == "http://explicit:1234"
 
 
 def test_api_key_never_in_repr_or_error(fake_server):
@@ -515,17 +538,16 @@ def _async_direct():
 
 @pytest.mark.asyncio
 async def test_async_create_resolves_auth(monkeypatch):
-    """mitos.aio.create resolves the base URL from MITOS_BASE_URL and raises a
-    typed error when absent (no key leak)."""
-    import mitos.aio as aio
-    from mitos.errors import AgentRunError
+    """mitos.aio.create resolves the base URL from MITOS_BASE_URL, and with
+    neither the arg nor the env set it defaults to the hosted endpoint."""
+    from mitos.direct import _resolve_auth
 
     monkeypatch.delenv("MITOS_BASE_URL", raising=False)
     monkeypatch.delenv("MITOS_API_KEY", raising=False)
-    with pytest.raises(AgentRunError) as ei:
-        await aio.create("python")
-    assert ei.value.code == "missing_base_url"
-    assert "sk-" not in (ei.value.remediation or "")
+    # aio.create resolves via the same _resolve_auth seam; with nothing set it
+    # falls back to the hosted production endpoint rather than raising.
+    _, url = _resolve_auth(None, None)
+    assert url == "https://mitos.run"
 
 
 @pytest.mark.asyncio

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -7,6 +7,23 @@ import { HttpClient, validSandboxId } from "./http.js";
 import { Sandbox } from "./sandbox.js";
 import { AgentRunError } from "./errors.js";
 
+// The hosted production control plane. When neither a url argument nor
+// MITOS_BASE_URL is set, the client targets the hosted endpoint so the examples
+// work without a base URL. Self-hosted or local standalone users opt out by
+// setting MITOS_BASE_URL (e.g. http://localhost:8080). Mirrors the Python
+// DEFAULT_BASE_URL.
+const DEFAULT_BASE_URL = "https://mitos.run";
+
+// resolveBaseUrl applies the base-URL precedence: explicit argument, then
+// MITOS_BASE_URL, then the hosted production endpoint. Parity with the Python
+// SDK's _resolve_auth.
+function resolveBaseUrl(url?: string): string {
+  if (url) return url;
+  const env = globalThis.process?.env?.MITOS_BASE_URL;
+  if (env) return env;
+  return DEFAULT_BASE_URL;
+}
+
 // Wire shapes from cmd/sandbox-server.
 interface templateWire {
   id: string;
@@ -68,8 +85,8 @@ export class SandboxServer {
   readonly url: string;
   private readonly http: HttpClient;
 
-  constructor(url: string = "http://localhost:8080") {
-    this.url = url.replace(/\/+$/, "");
+  constructor(url?: string) {
+    this.url = resolveBaseUrl(url).replace(/\/+$/, "");
     // Tokenless: the standalone server has no token-minting control plane.
     this.http = new HttpClient(this.url);
   }

--- a/sdk/typescript/test/server.test.ts
+++ b/sdk/typescript/test/server.test.ts
@@ -144,6 +144,41 @@ describe("SandboxServer", () => {
     expect(sandbox.id).toMatch(/^sandbox-[0-9a-f]{8}$/);
   });
 
+  it("defaults the base URL to the hosted production endpoint", () => {
+    const prev = process.env.MITOS_BASE_URL;
+    delete process.env.MITOS_BASE_URL;
+    try {
+      const s = new SandboxServer();
+      expect(s.url).toBe("https://mitos.run");
+    } finally {
+      if (prev !== undefined) process.env.MITOS_BASE_URL = prev;
+    }
+  });
+
+  it("an explicit url beats MITOS_BASE_URL and the hosted default", () => {
+    const prev = process.env.MITOS_BASE_URL;
+    process.env.MITOS_BASE_URL = "http://from-env:9000";
+    try {
+      const s = new SandboxServer("http://explicit:1234");
+      expect(s.url).toBe("http://explicit:1234");
+    } finally {
+      if (prev !== undefined) process.env.MITOS_BASE_URL = prev;
+      else delete process.env.MITOS_BASE_URL;
+    }
+  });
+
+  it("MITOS_BASE_URL beats the hosted default when no url is given", () => {
+    const prev = process.env.MITOS_BASE_URL;
+    process.env.MITOS_BASE_URL = "http://from-env:9000";
+    try {
+      const s = new SandboxServer();
+      expect(s.url).toBe("http://from-env:9000");
+    } finally {
+      if (prev !== undefined) process.env.MITOS_BASE_URL = prev;
+      else delete process.env.MITOS_BASE_URL;
+    }
+  });
+
   it("terminate deletes the sandbox via the server", async () => {
     const s = new SandboxServer(baseUrl);
     const sandbox = await s.fork("python", "sbx-term");

--- a/skills/mitos/SKILL.md
+++ b/skills/mitos/SKILL.md
@@ -14,6 +14,16 @@ This skill teaches the workflow. To actually drive sandboxes, use the
 prose: every failure is a structured envelope, branch on `code` and follow
 `remediation` (see `llms.txt`).
 
+## Connecting
+
+The hosted production mitos is at `https://mitos.run`. Set `MITOS_API_KEY` to a
+key from `https://mitos.run`. The Python and TypeScript SDKs and `mitos-mcp` all
+DEFAULT to the hosted endpoint, so the examples below need no base URL: a key in
+the environment is enough. To target a self-hosted cluster or a local standalone
+`sandbox-server`, set `MITOS_BASE_URL` (for example `http://localhost:8080`); it
+overrides the hosted default. The `mitos` CLI drives a Kubernetes cluster and
+resolves its connection from your kubeconfig.
+
 ## When to fork vs. start fresh
 
 - Start fresh (`create`) when there is no shared setup to inherit: a clean

--- a/skills/mitos/SKILL.md
+++ b/skills/mitos/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: mitos-sandboxes
+description: Use when an agent needs isolated, forkable compute, running untrusted or model-written code safely, or exploring several attempts in parallel (best-of-N) and keeping the winner. mitos boots Firecracker microVMs and forks a running VM via copy-on-write snapshots, so a fan-out is cheap and each attempt is hardware-isolated. Pairs with the mitos-mcp server (the tools) and the Python/TypeScript SDKs.
+---
+
+# Using mitos snapshot-fork sandboxes
+
+mitos gives an agent isolated, forkable computers. Each sandbox is a Firecracker
+microVM. Forking copies a running VM with copy-on-write, so spawning N attempts
+from a warm base is fast and you pay only for the memory each attempt dirties.
+
+This skill teaches the workflow. To actually drive sandboxes, use the
+`mitos-mcp` MCP server (tools) or an SDK (see Surfaces). Do not parse error
+prose: every failure is a structured envelope, branch on `code` and follow
+`remediation` (see `llms.txt`).
+
+## When to fork vs. start fresh
+
+- Start fresh (`create`) when there is no shared setup to inherit: a clean
+  environment for one task.
+- Fork (`fork`) when several attempts should share the same warm, set-up state:
+  dependencies installed, repo cloned, a server running. The fork inherits that
+  state in milliseconds instead of rebuilding it N times.
+
+## The core loop: best-of-N
+
+Warm one base, fan out, run attempts in parallel, keep the winner, discard the rest.
+
+```python
+import mitos
+
+# Warm base, bound to a durable workspace so the winner can be committed.
+base = mitos.create("python", workspace="refactor-task")
+
+# Fan out 8 independent attempts. Each child is a full microVM that must
+# activate; raise the timeout for a wide fan-out (each child is ~10-15s).
+children = base.fork(8, timeout=180)
+
+# Run one attempt per child IN PARALLEL (threads/async), then score them.
+# Each child is isolated: a crash or rm -rf in one cannot touch the others.
+results = run_attempts_in_parallel(children)   # your scoring
+winner = pick_best(results)
+
+# Commit the winner: terminating a workspace-bound sandbox dehydrates
+# /workspace into a new committed revision. checkpoint=True also snapshots VM
+# memory for a resumable head. It returns the workspace name.
+winner.terminate(checkpoint=True)
+
+# Discard the losers. You only paid for the pages each one dirtied.
+for c in children:
+    if c is not winner:
+        c.terminate()
+```
+
+The same shape works over MCP: `sandbox_create` -> `sandbox_fork` ->
+`sandbox_exec`/`sandbox_read_file` per child -> `sandbox_terminate`.
+
+## Lineage and workspaces
+
+A Workspace is the durable, forkable filesystem behind sandboxes. Each commit is
+a revision; revisions form a lineage you can inspect (`workspace.log()`) and
+resume from (start a new sandbox `from_revision`). Use a workspace when work must
+survive the sandbox: the best-of-N winner above is kept because the base was
+bound to one. Ephemeral, throwaway exploration needs no workspace.
+
+## Cost-awareness
+
+- Copy-on-write: a fork shares the base's pages until it writes; you pay for
+  what you dirty, not a full copy. A wide fan-out of mostly-reading attempts is
+  cheap; attempts that rewrite large files cost more.
+- Discard losers promptly (`terminate`) to release their unique pages.
+- Spend caps: a sandbox can carry a capability budget (max forks, CPU seconds,
+  and so on). A self-initiated fork is admitted only while the budget has room;
+  over-budget requests fail with a `BudgetExhausted` remediation. A fork's
+  budget is never wider than its parent's remaining, so a runaway fan-out is
+  bounded by design.
+
+## Isolation guarantees (running untrusted or model-written code)
+
+Each sandbox is a Firecracker microVM with its own kernel, not a shared-kernel
+container. Model-written or untrusted code runs inside that VM: a crash, a fork
+bomb, or a destructive command is contained to the one sandbox and cannot reach
+the host, the control plane, or sibling sandboxes. This is the property that
+makes it safe to execute code an agent just generated. Sandboxes are not pods;
+pod-scoped Kubernetes controls do not govern the workload inside the VM.
+
+## What a sandbox may NOT do to others
+
+A sandbox acts on ITSELF: it forks itself, execs in itself, terminates itself.
+It cannot delete or mutate other sandboxes, change pools, or administer
+workspaces. `exit()` terminates only the caller. Rely on this when reasoning
+about blast radius.
+
+## Surfaces
+
+- MCP server `mitos-mcp`: `sandbox_create`, `sandbox_exec`, `sandbox_read_file`,
+  `sandbox_write_file`, `sandbox_fork`, `sandbox_terminate`, `workspace_create`,
+  `workspace_list`. See `docs/mcp.md`.
+- Python SDK (`sdk/python`) and TypeScript SDK (`sdk/typescript`): `create`,
+  `exec`, `run_code`, `fork`, `terminate`; k8s mode and the standalone
+  sandbox-server (no Kubernetes) mode.
+- CLI `mitos` and the standalone `sandbox-server`. See `docs/cli.md`.
+- Error contract for agents: `llms.txt`.


### PR DESCRIPTION
Adds skills/mitos/SKILL.md, a first-class Anthropic Agent Skill teaching agents the mitos workflow (fork vs fresh, best-of-N loop, lineage/workspaces, copy-on-write cost + capability budgets, microVM isolation for untrusted code, self-only blast radius), pairing the mitos-mcp tools (the how-to alongside the do). Written against the verified real surface (create/exec/run_code/fork/terminate + the actual mcp tool names; no fabricated commit()/lineage, the real persist path is terminate(checkpoint=True) -> a workspace revision). README + doc index surface it (honesty rule: listed now that it exists). Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)