### PR TITLE
feat(sdk): official Ruby SDK (direct mode, hosted mitos.run) (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ await sb.terminate();
 
 The TypeScript SDK (`@mitos/sdk`) exposes the same one-liner `sandbox(image)`, `fromName` reconnect, streaming exec, and a server-envelope-aware `AgentRunError`. Parity table in [sdk/typescript/README.md](sdk/typescript/README.md).
 
+The Ruby SDK is a thin, dependency-free (standard-library only) client for the standalone and hosted sandbox-server REST API: create a template, fork a sandbox, run `exec`, and terminate. It covers direct mode only; cluster mode stays Python and TypeScript. See [sdk/ruby/README.md](sdk/ruby/README.md).
+
 ### CLI
 
 Install the `mitos` CLI. The full per-OS matrix, the env vars the installer
@@ -295,7 +297,7 @@ Each row is honest about where it runs. The husk pod-native path is the DEFAULT;
 | Streaming exec and PTY | Incremental stdout/stderr, background processes, and a token-gated interactive WebSocket terminal (engine path; husk wiring tracked [#24](https://github.com/mitos-run/mitos/issues/24)) | [#24](https://github.com/mitos-run/mitos/issues/24) |
 | Code interpreter | `run_code` with a stateful kernel and rich multi-MIME results, in both SDKs and the MCP server; fail-closed `KernelUnavailable` until the kernel ships in the husk base image | [docs/mcp.md](docs/mcp.md) |
 | LLM-legible errors | Every failure carries `{code, cause, remediation}`, parsed by both SDKs into a structured `AgentRunError` | [#28](https://github.com/mitos-run/mitos/issues/28) |
-| SDKs and surfaces | Python and TypeScript SDKs with a one-liner `sandbox(image)`, lazy default pool, `from_name` reconnect, and async Python client; plus the `mitos` CLI and an MCP server | [docs/cli.md](docs/cli.md) |
+| SDKs and surfaces | Python and TypeScript SDKs with a one-liner `sandbox(image)`, lazy default pool, `from_name` reconnect, and async Python client; a standard-library-only Ruby SDK for direct sandbox-server mode; plus the `mitos` CLI and an MCP server | [docs/cli.md](docs/cli.md) |
 
 ### Kubernetes-native
 
@@ -331,6 +333,7 @@ flowchart TB
   subgraph SDKs["SDKs and surfaces"]
     PY["Python SDK"]
     TS["TypeScript SDK / @mitos/sdk"]
+    RB["Ruby SDK (direct mode)"]
     CLI["mitos CLI / mitos-mcp"]
   end
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -1,0 +1,140 @@
+# mitos Ruby SDK
+
+A thin, dependency-free Ruby client for the standalone and hosted mitos
+sandbox-server REST API. It mirrors the direct-mode surface of the Python SDK
+(`sdk/python/mitos/direct.py`) and the TypeScript SDK
+(`sdk/typescript/src/server.ts`): create a template, fork a sandbox, run `exec`,
+and terminate.
+
+The SDK uses only the Ruby standard library (`net/http`, `json`, `uri`,
+`securerandom`), so there are no gem dependencies to build. It targets Ruby
+2.6 and later.
+
+## Scope
+
+This gem covers DIRECT mode only: the standalone `cmd/sandbox-server` and the
+hosted control plane at `https://mitos.run`. The Kubernetes / cluster mode (the
+controller, forkd, and the SandboxTemplate / SandboxPool / SandboxClaim /
+SandboxFork CRDs) is served by the Python and TypeScript SDKs only and is NOT
+part of this gem.
+
+## Install
+
+Not yet published to RubyGems. Install from source:
+
+```ruby
+# Gemfile
+gem "mitos", path: "path/to/mitos/sdk/ruby"
+```
+
+Or add the `lib` directory to the load path directly:
+
+```ruby
+$LOAD_PATH.unshift("path/to/mitos/sdk/ruby/lib")
+require "mitos"
+```
+
+## Quickstart (hosted)
+
+The base URL defaults to the hosted endpoint `https://mitos.run`. Set your API
+key in the environment; it is sent as `Authorization: Bearer <key>` and is never
+logged.
+
+```ruby
+require "mitos"
+
+ENV["MITOS_API_KEY"] = "sk-..."          # or pass api_key: to Mitos.server
+
+server = Mitos.server                     # base URL + API key from the env
+server.create_template("python")          # build (or get) the template
+sandbox = server.fork("python")           # fork a fresh sandbox
+
+result = sandbox.exec("echo hello")
+puts result.exit_code                     # 0
+puts result.stdout                        # "hello\n"
+
+sandbox.terminate
+```
+
+Point at a local standalone server by setting `MITOS_BASE_URL` (or passing
+`url:`):
+
+```ruby
+server = Mitos.server(url: "http://localhost:8080")
+```
+
+`exec` requires a Ready sandbox: the sandbox-server routes exec through the
+guest agent over vsock, so calling exec on a sandbox that is not yet up returns a
+typed `not_found` error.
+
+## Surface
+
+| Method | HTTP | Returns | Notes |
+| --- | --- | --- | --- |
+| `Mitos.server(url:, api_key:)` | - | `SandboxServer` | Base URL: arg, else `MITOS_BASE_URL`, else `https://mitos.run`. API key: arg, else `MITOS_API_KEY` (optional). |
+| `SandboxServer#create_template(id, init_wait_seconds:, idempotency_key:)` | `POST /v1/templates` | `Template` | Sends a fresh `Idempotency-Key`. |
+| `SandboxServer#list_templates` | `GET /v1/templates` | `Array<Template>` | |
+| `SandboxServer#fork(template, id:, idempotency_key:)` | `POST /v1/fork` | `Sandbox` | Generates a `sandbox-<hex>` id when `id` is nil; validates against the id allowlist. Sends a fresh `Idempotency-Key`. |
+| `SandboxServer#list_sandboxes` | `GET /v1/sandboxes` | `Array<ServerSandbox>` | |
+| `Sandbox#exec(command, timeout:)` | `POST /v1/exec` | `ExecResult` | Needs a Ready sandbox. |
+| `Sandbox#terminate` | `DELETE /v1/sandboxes/{id}` | `nil` | |
+
+Value objects:
+
+- `Template`: `id`, `ready` (`ready?`), `created_at`, `creation_time_ms`.
+- `ServerSandbox`: `id`, `template_id`, `endpoint`, `created_at`, `fork_time_ms`.
+- `ExecResult`: `exit_code`, `stdout`, `stderr`, `exec_time_ms` (`success?`).
+- `Sandbox`: `id`, `endpoint`.
+
+## Errors
+
+Every non-2xx response raises `Mitos::MitosError`, which parses the server
+envelope `{error:{code, message, cause, remediation}}`. Branch on `code`, never
+on the message text:
+
+```ruby
+begin
+  sandbox.exec("echo hi")
+rescue Mitos::MitosError => e
+  warn e.code         # e.g. "not_found"
+  warn e.status       # e.g. 404
+  warn e.remediation  # actionable hint
+end
+```
+
+The configured API key is redacted from any error body before it becomes the
+error cause.
+
+## The sandbox id allowlist
+
+Sandbox ids must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` (the same allowlist the
+Go daemon, the Python SDK, and the TypeScript SDK enforce). `fork` and
+`terminate` validate the id and raise a typed `invalid_sandbox_id` error before
+sending any request.
+
+## Tests
+
+The tests use only the standard library (`minitest`, `webrick`). They spin up a
+WEBrick stub reproducing the sandbox-server wire shapes and assert the SDK round
+trips them.
+
+```bash
+cd sdk/ruby
+ruby -Ilib -Itest test/sandbox_server_test.rb
+# or, with Rake:
+rake test
+```
+
+## Deferred
+
+Not yet implemented in the Ruby SDK (covered by the Python / TypeScript SDKs):
+
+- Kubernetes / cluster mode (controller, forkd, CRDs).
+- The files API (`/v1/files/*`).
+- Interactive PTY (`/v1/pty`).
+- `run_code`: the server exposes a streaming-only route
+  (`POST /v1/run_code/stream`); a synchronous Ruby wrapper is deferred until a
+  non-streaming contract exists.
+- Per-sandbox network posture, `set_timeout`, `pause` / `resume`, and
+  `get_host(port)` preview URLs.
+- RubyGems publishing.

--- a/sdk/ruby/Rakefile
+++ b/sdk/ruby/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "lib" << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = false
+end
+
+task default: :test

--- a/sdk/ruby/lib/mitos.rb
+++ b/sdk/ruby/lib/mitos.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "mitos/version"
+require "mitos/errors"
+require "mitos/sandbox"
+require "mitos/sandbox_server"
+
+# Mitos is the official Ruby SDK for mitos snapshot-fork sandboxes.
+#
+# This SDK is a thin DIRECT-mode client for the standalone / hosted
+# sandbox-server REST API. It mirrors the Python SandboxServer
+# (sdk/python/mitos/direct.py) and the TypeScript SandboxServer
+# (sdk/typescript/src/server.ts). The Kubernetes / cluster mode (the controller,
+# forkd, and the CRDs) is served by the Python and TypeScript SDKs only and is
+# NOT part of this gem.
+#
+# Quickstart:
+#
+#   require "mitos"
+#
+#   server = Mitos.server                # base URL and API key from the env
+#   server.create_template("python")
+#   sandbox = server.fork("python")
+#   puts sandbox.exec("echo hi").stdout
+#   sandbox.terminate
+module Mitos
+  # Builds a SandboxServer from the resolved base URL and API key. The base URL
+  # comes from +url+, else ENV['MITOS_BASE_URL'], else https://mitos.run; the
+  # api_key from +api_key+, else ENV['MITOS_API_KEY']. This is the canonical
+  # entry point: the standalone server has no template/fork bootstrap helper, so
+  # callers create the template and fork explicitly.
+  def self.server(url: nil, api_key: nil)
+    SandboxServer.new(url: url, api_key: api_key)
+  end
+end

--- a/sdk/ruby/lib/mitos/errors.rb
+++ b/sdk/ruby/lib/mitos/errors.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mitos
+  # MitosError is the LLM-legible error raised by the SDK. It mirrors the server
+  # envelope {error:{code, message, cause, remediation}} and the Python
+  # AgentRunError / TypeScript AgentRunError. +code+ is a stable machine
+  # identifier; +cause+ is the underlying detail; +remediation+ is a short
+  # actionable hint; +status+ is the HTTP status when the error came from a
+  # response. No bearer token or secret value ever appears in any field: the
+  # SDK redacts the configured api_key from the body before it becomes a cause.
+  #
+  # Callers branch on +code+, never on the message text.
+  class MitosError < StandardError
+    attr_reader :code, :cause_detail, :remediation, :status
+
+    def initialize(message, code:, cause: "", remediation: "", status: nil)
+      super(message)
+      @code = code
+      @cause_detail = cause
+      @remediation = remediation
+      @status = status
+    end
+
+    def to_s
+      parts = ["[#{@code}] #{super}"]
+      parts << "cause: #{@cause_detail}" unless @cause_detail.nil? || @cause_detail.empty?
+      unless @remediation.nil? || @remediation.empty?
+        parts << "remediation: #{@remediation}"
+      end
+      parts.join(" | ")
+    end
+  end
+end

--- a/sdk/ruby/lib/mitos/sandbox.rb
+++ b/sdk/ruby/lib/mitos/sandbox.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module Mitos
+  # The result of a Sandbox#exec call. Mirrors the Python ExecResult and the
+  # sandbox-server /v1/exec response {exit_code, stdout, stderr, exec_time_ms}.
+  ExecResult = Struct.new(:exit_code, :stdout, :stderr, :exec_time_ms, keyword_init: true) do
+    def success?
+      exit_code.zero?
+    end
+  end
+
+  # A sandbox handle returned by SandboxServer#fork. exec round-trips through the
+  # server URL (POST /v1/exec) and terminate issues DELETE /v1/sandboxes/{id}.
+  # The handle holds the SandboxServer it was forked from so requests carry the
+  # same base URL and optional bearer header.
+  class Sandbox
+    attr_reader :id, :endpoint
+
+    def initialize(id:, endpoint:, server:)
+      @id = id
+      @endpoint = endpoint
+      @server = server
+    end
+
+    # Runs +command+ in the sandbox and returns an ExecResult. Requires a Ready
+    # sandbox: the sandbox-server routes exec through the guest agent over vsock,
+    # so a sandbox that is not yet up returns a typed error.
+    def exec(command, timeout: 30)
+      body = { "sandbox" => @id, "command" => command, "timeout" => timeout }
+      data = @server.request_json(Net::HTTP::Post, "/v1/exec", body, {})
+      ExecResult.new(
+        exit_code: data["exit_code"],
+        stdout: data["stdout"] || "",
+        stderr: data["stderr"] || "",
+        exec_time_ms: data["exec_time_ms"] || 0
+      )
+    end
+
+    # Terminates the sandbox via DELETE /v1/sandboxes/{id}.
+    def terminate
+      @server.terminate(@id)
+    end
+
+    def to_s
+      "#<Mitos::Sandbox id=#{@id.inspect} endpoint=#{@endpoint.inspect}>"
+    end
+    alias inspect to_s
+  end
+end

--- a/sdk/ruby/lib/mitos/sandbox_server.rb
+++ b/sdk/ruby/lib/mitos/sandbox_server.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "securerandom"
+require "uri"
+
+require "mitos/errors"
+require "mitos/sandbox"
+
+module Mitos
+  # Client for the standalone / hosted sandbox-server REST API (direct mode, no
+  # Kubernetes). Mirrors the Python SandboxServer (sdk/python/mitos/direct.py)
+  # and the TypeScript SandboxServer (sdk/typescript/src/server.ts).
+  #
+  # fork() returns a Mitos::Sandbox bound to this server: exec round-trips
+  # through the server URL and terminate issues DELETE /v1/sandboxes/{id}.
+  #
+  # Base URL precedence: the +url+ argument, then ENV['MITOS_BASE_URL'], then the
+  # hosted production endpoint https://mitos.run. The api_key (argument, else
+  # ENV['MITOS_API_KEY']) is optional; when present it rides on the
+  # Authorization: Bearer header. The standalone server is tokenless and ignores
+  # it; the hosted front door verifies it. The key VALUE is never logged and is
+  # redacted from any error body before it becomes a cause.
+  class SandboxServer
+    # The hosted production control plane. Used when neither a url argument nor
+    # MITOS_BASE_URL is set, so the examples work without a base URL.
+    DEFAULT_BASE_URL = "https://mitos.run"
+
+    # The sandbox id allowlist: start with an alphanumeric, then up to 63
+    # alphanumeric, underscore, or hyphen characters. Mirrors daemon/validate.go,
+    # the Python SDK, and the TypeScript validSandboxId.
+    SANDBOX_ID_RE = /\A[A-Za-z0-9][A-Za-z0-9_-]{0,63}\z/.freeze
+
+    attr_reader :url
+
+    def initialize(url: nil, api_key: nil)
+      @url = resolve_base_url(url)
+      @api_key = api_key.nil? ? ENV["MITOS_API_KEY"] : api_key
+    end
+
+    # Lists the templates known to the server.
+    def list_templates
+      (get("/v1/templates") || []).map { |t| to_template(t) }
+    end
+
+    # Creates (or builds) a template named +id+. Sends a fresh Idempotency-Key so
+    # a retried create returns the same template rather than a duplicate
+    # (matching the Python and TypeScript SDKs). Returns a Template.
+    def create_template(id, init_wait_seconds: 5, idempotency_key: nil)
+      body = { "id" => id, "init_wait_seconds" => init_wait_seconds }
+      headers = { "Idempotency-Key" => idempotency_key || new_idempotency_key }
+      to_template(post("/v1/templates", body, headers))
+    end
+
+    # Forks a sandbox from a named template. When +id+ is nil a "sandbox-<hex>"
+    # id is generated. The id is validated against the allowlist; an invalid id
+    # raises a MitosError before any request. Sends a fresh Idempotency-Key so a
+    # retried fork returns the same sandbox rather than a duplicate. Returns a
+    # Mitos::Sandbox bound to this server.
+    def fork(template, id: nil, idempotency_key: nil)
+      sandbox_id = id || random_sandbox_id
+      unless valid_sandbox_id?(sandbox_id)
+        raise MitosError.new(
+          "invalid sandbox id: #{sandbox_id.inspect}",
+          code: "invalid_sandbox_id",
+          cause: "id must match #{SANDBOX_ID_RE.source}",
+          remediation: "Pass a sandbox id of alphanumerics, underscore, or hyphen, up to 64 chars."
+        )
+      end
+      body = { "template" => template, "id" => sandbox_id }
+      headers = { "Idempotency-Key" => idempotency_key || new_idempotency_key }
+      data = post("/v1/fork", body, headers)
+      resolved_id = (data["id"] && !data["id"].empty? ? data["id"] : sandbox_id)
+      Sandbox.new(
+        id: resolved_id,
+        endpoint: @url,
+        server: self
+      )
+    end
+
+    # Lists the live sandboxes known to the server.
+    def list_sandboxes
+      (get("/v1/sandboxes") || []).map { |s| to_server_sandbox(s) }
+    end
+
+    # Issues DELETE /v1/sandboxes/{id}. Called by Sandbox#terminate.
+    def terminate(id)
+      unless valid_sandbox_id?(id)
+        raise MitosError.new(
+          "invalid sandbox id: #{id.inspect}",
+          code: "invalid_sandbox_id",
+          cause: "id must match #{SANDBOX_ID_RE.source}",
+          remediation: "Terminate only ids that match the sandbox id allowlist."
+        )
+      end
+      request(Net::HTTP::Delete, "/v1/sandboxes/#{URI.encode_www_form_component(id)}", nil, {})
+      nil
+    end
+
+    # Sends a request through the sandbox-server. Exposed for Sandbox#exec, which
+    # posts to /v1/exec on the same server URL.
+    def request_json(method_class, path, body, extra_headers = {})
+      request(method_class, path, body, extra_headers)
+    end
+
+    def valid_sandbox_id?(id)
+      !id.nil? && SANDBOX_ID_RE.match?(id)
+    end
+
+    private
+
+    def resolve_base_url(url)
+      chosen = url
+      chosen = ENV["MITOS_BASE_URL"] if chosen.nil? || chosen.empty?
+      chosen = DEFAULT_BASE_URL if chosen.nil? || chosen.empty?
+      chosen.sub(%r{/+\z}, "")
+    end
+
+    def new_idempotency_key
+      SecureRandom.hex(16)
+    end
+
+    def random_sandbox_id
+      "sandbox-#{SecureRandom.hex(4)}"
+    end
+
+    def get(path)
+      request(Net::HTTP::Get, path, nil, {})
+    end
+
+    def post(path, body, extra_headers)
+      request(Net::HTTP::Post, path, body, extra_headers)
+    end
+
+    # request performs the HTTP call, attaches the optional bearer header, parses
+    # the JSON response, and raises a MitosError on any non-2xx status. The
+    # api_key VALUE is never logged and is redacted from the error body.
+    def request(method_class, path, body, extra_headers)
+      uri = URI.join(@url + "/", path.sub(%r{\A/}, ""))
+      req = method_class.new(uri)
+      if body
+        req["Content-Type"] = "application/json"
+        req.body = JSON.generate(body)
+      end
+      req["Authorization"] = "Bearer #{@api_key}" if @api_key && !@api_key.empty?
+      extra_headers.each { |k, v| req[k] = v }
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      resp = http.request(req)
+
+      status = resp.code.to_i
+      raise error_from_response(status, resp.body) unless status >= 200 && status < 300
+
+      text = resp.body
+      return nil if text.nil? || text.empty?
+
+      JSON.parse(text)
+    end
+
+    # error_from_response builds a MitosError from a non-2xx response. It prefers
+    # the structured server envelope {error:{code,message,cause,remediation}} and
+    # falls back to status-derived defaults for an older or non-mitos server. Any
+    # bearer token echoed in the body is redacted before it becomes a cause.
+    def error_from_response(status, raw_body)
+      body = redact(raw_body.to_s)
+      code = status_code(status)
+      message = "sandbox API request failed: HTTP #{status} (#{code})"
+      cause = body.strip.empty? ? "HTTP #{status}" : body.strip
+      remediation = status_remediation(status)
+
+      parsed = begin
+        JSON.parse(body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      if parsed.is_a?(Hash)
+        err = parsed["error"]
+        if err.is_a?(Hash)
+          code = nonempty(err["code"]) || code
+          message = nonempty(err["message"]) || message
+          cause = nonempty(redact(err["cause"].to_s)) || cause
+          remediation = nonempty(err["remediation"]) || remediation
+        elsif err.is_a?(String)
+          cause = nonempty(redact(err)) || cause
+        end
+      end
+
+      MitosError.new(message, code: code, cause: cause, remediation: remediation, status: status)
+    end
+
+    def nonempty(value)
+      value.nil? || value.empty? ? nil : value
+    end
+
+    def redact(text)
+      return text if @api_key.nil? || @api_key.empty?
+
+      text.gsub(@api_key, "[REDACTED]")
+    end
+
+    STATUS_CODE = {
+      400 => "bad_request",
+      401 => "unauthorized",
+      403 => "forbidden",
+      404 => "not_found",
+      409 => "conflict",
+      413 => "request_too_large",
+      429 => "rate_limited",
+      500 => "internal_error",
+      503 => "unavailable"
+    }.freeze
+
+    STATUS_REMEDIATION = {
+      401 => "Check the API key is set and authorizes this request.",
+      403 => "Check the API key is set and authorizes this request.",
+      404 => "Confirm the sandbox id exists and is Ready before calling.",
+      413 => "Reduce the request payload size.",
+      429 => "Back off and retry the request after a short delay."
+    }.freeze
+
+    def status_code(status)
+      return STATUS_CODE[status] if STATUS_CODE.key?(status)
+
+      status >= 500 ? "server_error" : "request_failed"
+    end
+
+    def status_remediation(status)
+      return STATUS_REMEDIATION[status] if STATUS_REMEDIATION.key?(status)
+      return "Retry the request; if it persists, inspect the sandbox-server logs." if status >= 500
+
+      "Inspect the request fields against the sandbox API contract."
+    end
+
+    def to_template(data)
+      Template.new(
+        id: data["id"],
+        ready: data["ready"],
+        created_at: data["created_at"],
+        creation_time_ms: data["creation_time_ms"]
+      )
+    end
+
+    def to_server_sandbox(data)
+      ServerSandbox.new(
+        id: data["id"],
+        template_id: data["template_id"],
+        endpoint: data["endpoint"],
+        created_at: data["created_at"],
+        fork_time_ms: data["fork_time_ms"]
+      )
+    end
+  end
+
+  # A template as reported by the sandbox-server.
+  Template = Struct.new(:id, :ready, :created_at, :creation_time_ms, keyword_init: true) do
+    def ready?
+      ready == true
+    end
+  end
+
+  # A sandbox summary as reported by GET /v1/sandboxes.
+  ServerSandbox = Struct.new(
+    :id, :template_id, :endpoint, :created_at, :fork_time_ms, keyword_init: true
+  )
+end

--- a/sdk/ruby/lib/mitos/version.rb
+++ b/sdk/ruby/lib/mitos/version.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Mitos
+  # The gem version. Not yet published to RubyGems; install from source.
+  VERSION = "0.1.0"
+end

--- a/sdk/ruby/mitos.gemspec
+++ b/sdk/ruby/mitos.gemspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "lib/mitos/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "mitos"
+  spec.version = Mitos::VERSION
+  spec.authors = ["mitos"]
+  spec.summary = "Ruby SDK for mitos snapshot-fork sandboxes (direct sandbox-server mode)."
+  spec.description =
+    "A thin, dependency-free Ruby client for the standalone and hosted mitos " \
+    "sandbox-server REST API: create templates, fork sandboxes, run exec, and " \
+    "terminate. Mirrors the Python and TypeScript direct-mode SDKs. Kubernetes " \
+    "cluster mode is served by the Python and TypeScript SDKs only."
+  spec.homepage = "https://mitos.run"
+  spec.license = "Apache-2.0"
+
+  spec.required_ruby_version = ">= 2.6.0"
+
+  spec.files = Dir["lib/**/*.rb"] + ["README.md"]
+  spec.require_paths = ["lib"]
+
+  # No runtime dependencies: the SDK uses only the Ruby standard library
+  # (net/http, json, uri, securerandom).
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/mitos-run/mitos/tree/main/sdk/ruby"
+  }
+end

--- a/sdk/ruby/test/sandbox_server_test.rb
+++ b/sdk/ruby/test/sandbox_server_test.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "webrick"
+require "json"
+require "socket"
+require "stringio"
+
+require "mitos"
+
+# A WEBrick stub reproducing the sandbox-server wire shapes
+# (cmd/sandbox-server/main.go), mirroring sdk/typescript/test/server.test.ts.
+# It records every request so the tests can assert headers and bodies.
+# AnyMethodServlet dispatches every HTTP method (including DELETE, which
+# WEBrick's default ProcHandler does not route) to a single proc.
+class AnyMethodServlet < WEBrick::HTTPServlet::AbstractServlet
+  def initialize(server, handler)
+    super(server)
+    @handler = handler
+  end
+
+  def service(req, res)
+    @handler.call(req, res)
+  end
+end
+
+class StubServer
+  Recorded = Struct.new(:method, :path, :body, :headers, keyword_init: true)
+
+  attr_reader :recorded, :base_url
+
+  def initialize
+    @recorded = []
+    @sandbox_ids = []
+    @server = WEBrick::HTTPServer.new(
+      BindAddress: "127.0.0.1",
+      Port: 0,
+      Logger: WEBrick::Log.new(StringIO.new),
+      AccessLog: []
+    )
+    mount
+    # Resolve the actual bound port BEFORE starting: with Port: 0 the OS assigns
+    # an ephemeral port at listener-creation time, so the listener socket already
+    # knows it even though config[:Port] stays 0 on Ruby 2.6.
+    port = @server.listeners.first.addr[1]
+    @base_url = "http://127.0.0.1:#{port}"
+    @thread = Thread.new { @server.start }
+    wait_until_ready(port)
+  end
+
+  def stop
+    @server.shutdown
+    @thread.join
+  end
+
+  private
+
+  # wait_until_ready blocks until the WEBrick accept loop is serving, so the
+  # first test request does not race the server start.
+  def wait_until_ready(port)
+    20.times do
+      begin
+        TCPSocket.new("127.0.0.1", port).close
+        return
+      rescue StandardError
+        sleep 0.05
+      end
+    end
+  end
+
+  def record(req)
+    body = req.body && !req.body.empty? ? JSON.parse(req.body) : nil
+    headers = {}
+    req.each { |k, v| headers[k.downcase] = v }
+    @recorded << Recorded.new(method: req.request_method, path: req.path, body: body, headers: headers)
+    body
+  end
+
+  def json(res, value, code = 200)
+    res.status = code
+    res["Content-Type"] = "application/json"
+    res.body = JSON.generate(value)
+  end
+
+  def mount_any(path, &block)
+    @server.mount(path, AnyMethodServlet, block)
+  end
+
+  def mount
+    mount_any("/v1/templates") do |req, res|
+      body = record(req)
+      if req.request_method == "GET"
+        json(res, [
+               { "id" => "python", "ready" => true,
+                 "created_at" => "2026-06-11T00:00:00Z", "creation_time_ms" => 120 }
+             ])
+      else
+        json(res, {
+               "id" => body["id"], "ready" => true,
+               "created_at" => "2026-06-11T00:00:00Z", "creation_time_ms" => 100
+             })
+      end
+    end
+
+    mount_any("/v1/fork") do |req, res|
+      body = record(req)
+      @sandbox_ids << body["id"]
+      json(res, {
+             "id" => body["id"], "template_id" => body["template"],
+             "endpoint" => "http://localhost:8080", "fork_time_ms" => 0.8
+           })
+    end
+
+    # Both GET /v1/sandboxes (list) and DELETE /v1/sandboxes/{id} (terminate)
+    # share the /v1/sandboxes prefix; WEBrick prefix-matches, so one handler
+    # dispatches on method, mirroring the Go server's two method-scoped routes.
+    mount_any("/v1/sandboxes") do |req, res|
+      record(req)
+      rest = req.path.sub(%r{\A/v1/sandboxes/?}, "")
+      if req.request_method == "DELETE"
+        @sandbox_ids.delete(rest)
+        json(res, { "status" => "terminated", "id" => rest })
+      else
+        json(res, @sandbox_ids.map do |id|
+          { "id" => id, "template_id" => "python",
+            "endpoint" => "http://localhost:8080",
+            "created_at" => "2026-06-11T00:00:00Z", "fork_time_ms" => 0.8 }
+        end)
+      end
+    end
+
+    mount_any("/v1/exec") do |req, res|
+      body = record(req)
+      if @sandbox_ids.include?(body["sandbox"])
+        json(res, { "exit_code" => 0, "stdout" => "2\n", "stderr" => "", "exec_time_ms" => 5 })
+      else
+        json(res, {
+               "error" => {
+                 "code" => "not_found",
+                 "message" => "sandbox not found",
+                 "cause" => "no sandbox registered",
+                 "remediation" => "Confirm the sandbox id exists and is Ready before calling."
+               }
+             }, 404)
+      end
+    end
+
+  end
+end
+
+class SandboxServerTest < Minitest::Test
+  def setup
+    @stub = StubServer.new
+  end
+
+  def teardown
+    @stub.stop
+  end
+
+  def server(api_key: nil)
+    Mitos::SandboxServer.new(url: @stub.base_url, api_key: api_key)
+  end
+
+  def test_list_templates
+    templates = server.list_templates
+    assert_equal 1, templates.length
+    assert_equal "python", templates.first.id
+    assert templates.first.ready?
+    assert_equal 120, templates.first.creation_time_ms
+  end
+
+  def test_create_template_returns_id_and_ready
+    template = server.create_template("node", init_wait_seconds: 3)
+    assert_equal "node", template.id
+    assert template.ready?
+
+    call = @stub.recorded.find { |r| r.method == "POST" && r.path == "/v1/templates" }
+    assert_equal({ "id" => "node", "init_wait_seconds" => 3 }, call.body)
+  end
+
+  def test_create_template_sends_idempotency_key
+    server.create_template("idem-tmpl")
+    call = @stub.recorded.find { |r| r.method == "POST" && r.path == "/v1/templates" }
+    refute_nil call.headers["idempotency-key"]
+    refute call.headers["idempotency-key"].empty?
+  end
+
+  def test_fork_returns_sandbox_with_right_id_and_sends_idempotency_key
+    sandbox = server.fork("python", id: "sbx-direct")
+    assert_instance_of Mitos::Sandbox, sandbox
+    assert_equal "sbx-direct", sandbox.id
+
+    call = @stub.recorded.find { |r| r.path == "/v1/fork" }
+    assert_equal "python", call.body["template"]
+    assert_equal "sbx-direct", call.body["id"]
+    refute_nil call.headers["idempotency-key"]
+    refute call.headers["idempotency-key"].empty?
+  end
+
+  def test_fork_generates_id_when_none_given
+    sandbox = server.fork("python")
+    assert_match(/\Asandbox-[0-9a-f]{8}\z/, sandbox.id)
+  end
+
+  def test_fork_rejects_invalid_id
+    err = assert_raises(Mitos::MitosError) do
+      server.fork("python", id: "../bad")
+    end
+    assert_equal "invalid_sandbox_id", err.code
+  end
+
+  def test_exec_round_trips_stdout_and_exit_code
+    sandbox = server.fork("python", id: "sbx-exec")
+    result = sandbox.exec("print(1 + 1)")
+    assert_equal 0, result.exit_code
+    assert_equal "2\n", result.stdout
+    assert result.success?
+
+    call = @stub.recorded.find { |r| r.path == "/v1/exec" }
+    assert_equal "sbx-exec", call.body["sandbox"]
+    assert_equal "print(1 + 1)", call.body["command"]
+  end
+
+  def test_exec_on_unknown_sandbox_raises_typed_error
+    sandbox = server.fork("python", id: "sbx-known")
+    sandbox.terminate
+    err = assert_raises(Mitos::MitosError) { sandbox.exec("echo hi") }
+    assert_equal "not_found", err.code
+    assert_equal 404, err.status
+  end
+
+  def test_terminate_issues_delete
+    sandbox = server.fork("python", id: "sbx-term")
+    sandbox.terminate
+    del = @stub.recorded.find { |r| r.method == "DELETE" }
+    assert_equal "/v1/sandboxes/sbx-term", del.path
+
+    remaining = server.list_sandboxes
+    assert_nil remaining.find { |s| s.id == "sbx-term" }
+  end
+
+  def test_base_url_defaults_to_hosted_endpoint
+    prev = ENV["MITOS_BASE_URL"]
+    ENV.delete("MITOS_BASE_URL")
+    begin
+      s = Mitos::SandboxServer.new
+      assert_equal "https://mitos.run", s.url
+    ensure
+      ENV["MITOS_BASE_URL"] = prev unless prev.nil?
+    end
+  end
+
+  def test_explicit_url_beats_env_and_default
+    prev = ENV["MITOS_BASE_URL"]
+    ENV["MITOS_BASE_URL"] = "http://from-env:9000"
+    begin
+      s = Mitos::SandboxServer.new(url: "http://explicit:1234")
+      assert_equal "http://explicit:1234", s.url
+    ensure
+      if prev.nil?
+        ENV.delete("MITOS_BASE_URL")
+      else
+        ENV["MITOS_BASE_URL"] = prev
+      end
+    end
+  end
+
+  def test_env_base_url_beats_default
+    prev = ENV["MITOS_BASE_URL"]
+    ENV["MITOS_BASE_URL"] = "http://from-env:9000"
+    begin
+      s = Mitos::SandboxServer.new
+      assert_equal "http://from-env:9000", s.url
+    ensure
+      if prev.nil?
+        ENV.delete("MITOS_BASE_URL")
+      else
+        ENV["MITOS_BASE_URL"] = prev
+      end
+    end
+  end
+
+  def test_non_2xx_envelope_raises_mitos_error_with_parsed_code
+    # Forking an unknown template id path is not modeled by the stub; instead
+    # drive a 404 through exec on a never-forked sandbox via a hand-built handle.
+    sandbox = Mitos::Sandbox.new(id: "never-forked", endpoint: @stub.base_url, server: server)
+    err = assert_raises(Mitos::MitosError) { sandbox.exec("echo hi") }
+    assert_equal "not_found", err.code
+    assert_equal 404, err.status
+    assert_match(/Ready/, err.remediation)
+  end
+
+  def test_bearer_header_sent_when_api_key_present
+    server(api_key: "sk-test-secret").create_template("with-key")
+    call = @stub.recorded.find { |r| r.method == "POST" && r.path == "/v1/templates" }
+    assert_equal "Bearer sk-test-secret", call.headers["authorization"]
+  end
+end


### PR DESCRIPTION
A thin stdlib-only Ruby SDK for the sandbox-server REST API, mirroring the Python/TS direct surface: SandboxServer (create_template/list_templates/fork/list_sandboxes) + Sandbox (exec/terminate), hosted https://mitos.run default, MITOS_API_KEY bearer (never logged), Idempotency-Key parity, typed MitosError from the envelope. 14 stdlib tests green on Ruby 2.6. Docs: sdk/ruby/README.md + a Ruby row in the main README. Deferred (noted): k8s mode, files/PTY, sync run_code, RubyGems publishing. Refs #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)