### PR TITLE
feat(console): phase 2 — billing portal, secret provider selection, billing webhook

### DIFF
--- a/cmd/console/billing.go
+++ b/cmd/console/billing.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"mitos.run/mitos/internal/saas/billing"
+	"mitos.run/mitos/internal/saas/billingprovider"
+	"mitos.run/mitos/internal/saas/billingprovider/stripe"
+	"mitos.run/mitos/internal/saas/console"
+)
+
+// portalLinker adapts a billingprovider.Provider + an org→customer map into the
+// console.PortalLinker seam: it resolves the org's customer ref, then asks the
+// provider for that customer's manage-subscription URL. An org with no linked
+// customer is console.ErrNotFound (the BFF returns 404).
+type portalLinker struct {
+	provider  billingprovider.Provider
+	customers billingprovider.OrgCustomers
+}
+
+func (p portalLinker) PortalURL(ctx context.Context, orgID string) (string, error) {
+	cust, ok := p.customers.CustomerForOrg(ctx, orgID)
+	if !ok {
+		return "", console.ErrNotFound
+	}
+	return p.provider.PortalURL(ctx, cust)
+}
+
+// billingWiring is the result of setupBilling: the portal seam for the BFF and
+// the (unauthenticated, signature-verified) webhook handler to mount publicly.
+type billingWiring struct {
+	portal  console.PortalLinker
+	webhook http.Handler
+}
+
+// setupBilling builds the billing provider wiring when billing is enabled. The
+// provider is currently Stripe (selected like the secret providers); a Merchant
+// of Record plugs in here as a sibling. The webhook is fully functional
+// (signature-verified status sync); the live portal-session API call is injected
+// via the provider's Portal func and is the remaining external adapter, so until
+// it is set the portal endpoint simply 404s.
+func setupBilling(logger *slog.Logger, status billing.StatusStore) billingWiring {
+	if !envBool("MITOS_CONSOLE_BILLING") {
+		return billingWiring{portal: nil} // console fills the no-portal default
+	}
+	provider := stripe.New(stripe.Config{
+		SigningSecret: os.Getenv("MITOS_CONSOLE_STRIPE_WEBHOOK_SECRET"),
+		Tolerance:     5 * time.Minute,
+	})
+	customers := billingprovider.NewMemCustomers() // durable mapping is a follow-up
+	logger.Info("billing enabled", "provider", provider.Name())
+	return billingWiring{
+		portal:  portalLinker{provider: provider, customers: customers},
+		webhook: billingprovider.NewWebhookHandler(provider, customers, status),
+	}
+}

--- a/cmd/console/billing_test.go
+++ b/cmd/console/billing_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"mitos.run/mitos/internal/saas/billingprovider"
+	"mitos.run/mitos/internal/saas/console"
+)
+
+// stubProvider is a billingprovider.Provider whose PortalURL echoes the customer
+// ref, so the adapter's org→customer→URL composition is observable.
+type stubProvider struct{}
+
+func (stubProvider) Name() string { return "stub" }
+func (stubProvider) VerifyWebhook(*http.Request, []byte) (billingprovider.Event, error) {
+	return billingprovider.Event{}, nil
+}
+func (stubProvider) PortalURL(_ context.Context, customerRef string) (string, error) {
+	return "https://portal/" + customerRef, nil
+}
+
+// TestPortalLinkerResolvesOrgToCustomer asserts the adapter maps org→customer
+// (via OrgCustomers) and then asks the provider for that customer's portal URL.
+func TestPortalLinkerResolvesOrgToCustomer(t *testing.T) {
+	customers := billingprovider.NewMemCustomers()
+	customers.Link("org-alice", "cus_alice")
+	pl := portalLinker{provider: stubProvider{}, customers: customers}
+
+	url, err := pl.PortalURL(context.Background(), "org-alice")
+	if err != nil {
+		t.Fatalf("PortalURL: %v", err)
+	}
+	if url != "https://portal/cus_alice" {
+		t.Fatalf("url = %q, want https://portal/cus_alice", url)
+	}
+}
+
+// TestPortalLinkerUnknownOrgIsNotFound asserts an org with no linked customer is
+// reported as not-found (the BFF turns this into a 404).
+func TestPortalLinkerUnknownOrgIsNotFound(t *testing.T) {
+	pl := portalLinker{provider: stubProvider{}, customers: billingprovider.NewMemCustomers()}
+	if _, err := pl.PortalURL(context.Background(), "org-nope"); err != console.ErrNotFound {
+		t.Fatalf("err = %v, want console.ErrNotFound", err)
+	}
+}

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -52,6 +52,7 @@ func main() {
 	keys := saas.NewKeyService(store)
 	accounts := saas.NewAccountService(store, keys)
 
+	caps := capabilitiesFromEnv()
 	con := console.New(console.Deps{
 		Accounts: accounts,
 		Usage:    usage.NewMemUsageStore(),
@@ -61,9 +62,12 @@ func main() {
 			Caps:   billing.NewMemSpendCapStore(),
 			Rates:  billing.DefaultRates(),
 		},
+		// The active secret backend selected from config (kube / openbao), falling
+		// back to in-memory in dev. Capabilities advertise the same providers.
+		Secrets: buildSecretStore(logger, caps),
 		// Edition + feature flags from the server-controlled environment the chart
 		// sets; the SAME binary serves both editions.
-		Capabilities: capabilitiesFromEnv(),
+		Capabilities: caps,
 		Log:          logger,
 	})
 

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -53,18 +53,25 @@ func main() {
 	accounts := saas.NewAccountService(store, keys)
 
 	caps := capabilitiesFromEnv()
+	// One status store is shared by the BFF billing view and the billing webhook
+	// so a provider event (payment failed / canceled) is reflected in the console.
+	statusStore := billing.NewMemStatusStore()
+	bill := setupBilling(logger, statusStore)
 	con := console.New(console.Deps{
 		Accounts: accounts,
 		Usage:    usage.NewMemUsageStore(),
 		Billing: console.BillingReader{
 			Ledger: billing.NewMemCreditLedger(),
-			Status: billing.NewMemStatusStore(),
+			Status: statusStore,
 			Caps:   billing.NewMemSpendCapStore(),
 			Rates:  billing.DefaultRates(),
 		},
 		// The active secret backend selected from config (kube / openbao), falling
 		// back to in-memory in dev. Capabilities advertise the same providers.
 		Secrets: buildSecretStore(logger, caps),
+		// The manage-subscription portal link (provider-neutral); nil keeps the
+		// console's no-portal default (community edition).
+		Portal: bill.portal,
 		// Edition + feature flags from the server-controlled environment the chart
 		// sets; the SAME binary serves both editions.
 		Capabilities: caps,
@@ -93,6 +100,13 @@ func main() {
 		} else {
 			logger.Warn("MITOS_CONSOLE_OIDC_ISSUER unset; /auth login flow not mounted (BFF requires a session)")
 		}
+	}
+	// The billing webhook is PUBLIC by design: it is authenticated by the
+	// provider's signature, not a session, so it is mounted OUTSIDE the session
+	// middleware. It verifies the signature before touching any billing state.
+	if bill.webhook != nil {
+		mux.Handle("/webhooks/billing", bill.webhook)
+		logger.Info("billing webhook mounted at /webhooks/billing")
 	}
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/console/secretstore.go
+++ b/cmd/console/secretstore.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/saas/console/baosecrets"
+	"mitos.run/mitos/internal/saas/console/kubesecrets"
+)
+
+// primarySecretProvider returns the provider the binary should construct: the
+// first recognized entry in the advertised list, defaulting to kube. Capability
+// advertisement (what the SPA shows) and the active backend stay in sync because
+// both derive from MITOS_CONSOLE_SECRET_PROVIDERS.
+func primarySecretProvider(providers []string) string {
+	for _, p := range providers {
+		switch p {
+		case "kube", "openbao", "aws_secrets_manager":
+			return p
+		}
+	}
+	return "kube"
+}
+
+// secretNamespaceFor maps an org id to the namespace its kube secrets live in.
+func secretNamespaceFor(orgID string) string {
+	prefix := os.Getenv("MITOS_CONSOLE_SECRET_NAMESPACE_PREFIX")
+	if prefix == "" {
+		prefix = "mitos-org-"
+	}
+	return prefix + orgID
+}
+
+// buildSecretStore constructs the active SecretStore from configuration. It
+// falls back to the in-memory store (with a warning) when the configured
+// provider cannot be built — e.g. running outside a cluster in dev — so the
+// console still starts.
+func buildSecretStore(logger *slog.Logger, caps console.Capabilities) console.SecretStore {
+	switch primarySecretProvider(caps.Secrets.Providers) {
+	case "openbao":
+		addr := os.Getenv("MITOS_CONSOLE_OPENBAO_ADDR")
+		token := openbaoToken()
+		if addr != "" && token != "" {
+			logger.Info("secret store: openbao", "addr", addr)
+			return baosecrets.New(baosecrets.Config{Address: addr, Token: token, Mount: envOr("MITOS_CONSOLE_OPENBAO_MOUNT", "secret")})
+		}
+		logger.Warn("openbao is the primary secret provider but MITOS_CONSOLE_OPENBAO_ADDR/TOKEN are unset; using in-memory store")
+	case "kube":
+		if store, err := buildKubeSecretStore(); err == nil {
+			logger.Info("secret store: kube (org-namespaced Secrets)")
+			return store
+		} else {
+			logger.Warn("kube secret store unavailable (not in cluster?); using in-memory store", "err", err.Error())
+		}
+	}
+	return console.NewMemSecretStore()
+}
+
+// buildKubeSecretStore builds the kube provider over the ambient kube config
+// (in-cluster service account, or KUBECONFIG in dev).
+func buildKubeSecretStore() (console.SecretStore, error) {
+	cfg, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := ctrlclient.New(cfg, ctrlclient.Options{})
+	if err != nil {
+		return nil, err
+	}
+	return kubesecrets.New(c, secretNamespaceFor), nil
+}
+
+// openbaoToken reads the OpenBao token from the env or a token file.
+func openbaoToken() string {
+	if t := os.Getenv("MITOS_CONSOLE_OPENBAO_TOKEN"); t != "" {
+		return t
+	}
+	if f := os.Getenv("MITOS_CONSOLE_OPENBAO_TOKEN_FILE"); f != "" {
+		if b, err := os.ReadFile(f); err == nil {
+			return strings.TrimSpace(string(b))
+		}
+	}
+	return ""
+}

--- a/cmd/console/secretstore_test.go
+++ b/cmd/console/secretstore_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+// TestPrimarySecretProviderPicksFirstKnown asserts the primary provider is the
+// first recognized entry in the advertised list, defaulting to kube.
+func TestPrimarySecretProviderPicksFirstKnown(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{nil, "kube"},
+		{[]string{}, "kube"},
+		{[]string{"kube"}, "kube"},
+		{[]string{"openbao", "kube"}, "openbao"},
+		{[]string{"bogus", "openbao"}, "openbao"},
+		{[]string{"bogus"}, "kube"},
+	}
+	for _, c := range cases {
+		if got := primarySecretProvider(c.in); got != c.want {
+			t.Errorf("primarySecretProvider(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestSecretNamespaceForOrg asserts the org→namespace mapping uses the
+// configured prefix.
+func TestSecretNamespaceForOrg(t *testing.T) {
+	t.Setenv("MITOS_CONSOLE_SECRET_NAMESPACE_PREFIX", "")
+	if got := secretNamespaceFor("abc"); got != "mitos-org-abc" {
+		t.Errorf("default namespace = %q, want mitos-org-abc", got)
+	}
+	t.Setenv("MITOS_CONSOLE_SECRET_NAMESPACE_PREFIX", "tenant-")
+	if got := secretNamespaceFor("abc"); got != "tenant-abc" {
+		t.Errorf("prefixed namespace = %q, want tenant-abc", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/saas/billingprovider/customers.go
+++ b/internal/saas/billingprovider/customers.go
@@ -1,0 +1,52 @@
+package billingprovider
+
+import (
+	"context"
+	"sync"
+)
+
+// OrgCustomers resolves an org to its provider customer id — the direction the
+// portal link needs (the webhook needs the inverse, CustomerResolver). A
+// durable mapping (recorded at checkout) is a follow-up; MemCustomers is the
+// tested default.
+type OrgCustomers interface {
+	CustomerForOrg(ctx context.Context, orgID string) (customerRef string, ok bool)
+}
+
+// MemCustomers is the in-memory bidirectional org↔customer map. It satisfies
+// both CustomerResolver (customer→org, for the webhook) and OrgCustomers
+// (org→customer, for the portal). Safe for concurrent use.
+type MemCustomers struct {
+	mu         sync.RWMutex
+	byOrg      map[string]string
+	byCustomer map[string]string
+}
+
+// NewMemCustomers returns an empty bidirectional map.
+func NewMemCustomers() *MemCustomers {
+	return &MemCustomers{byOrg: map[string]string{}, byCustomer: map[string]string{}}
+}
+
+// Link records the org↔customer association (made at checkout/subscription).
+func (m *MemCustomers) Link(orgID, customerRef string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byOrg[orgID] = customerRef
+	m.byCustomer[customerRef] = orgID
+}
+
+// OrgForCustomer implements CustomerResolver.
+func (m *MemCustomers) OrgForCustomer(_ context.Context, customerRef string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	o, ok := m.byCustomer[customerRef]
+	return o, ok
+}
+
+// CustomerForOrg implements OrgCustomers.
+func (m *MemCustomers) CustomerForOrg(_ context.Context, orgID string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	c, ok := m.byOrg[orgID]
+	return c, ok
+}

--- a/internal/saas/billingprovider/customers_test.go
+++ b/internal/saas/billingprovider/customers_test.go
@@ -1,0 +1,27 @@
+package billingprovider
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMemCustomersBidirectional asserts the in-memory map resolves both
+// directions (the webhook needs customer→org, the portal needs org→customer)
+// and reports unknowns as not-found.
+func TestMemCustomersBidirectional(t *testing.T) {
+	m := NewMemCustomers()
+	m.Link("org-alice", "cus_alice")
+
+	if org, ok := m.OrgForCustomer(context.Background(), "cus_alice"); !ok || org != "org-alice" {
+		t.Fatalf("OrgForCustomer = %q,%v; want org-alice,true", org, ok)
+	}
+	if cust, ok := m.CustomerForOrg(context.Background(), "org-alice"); !ok || cust != "cus_alice" {
+		t.Fatalf("CustomerForOrg = %q,%v; want cus_alice,true", cust, ok)
+	}
+	if _, ok := m.OrgForCustomer(context.Background(), "cus_nope"); ok {
+		t.Fatal("unknown customer resolved")
+	}
+	if _, ok := m.CustomerForOrg(context.Background(), "org-nope"); ok {
+		t.Fatal("unknown org resolved")
+	}
+}

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -49,6 +49,7 @@ type Deps struct {
 	Logs        LogStreamer
 	Secrets     SecretStore
 	Instruments InstrumentsSource
+	Portal      PortalLinker
 	// Capabilities is the deployment edition + feature flags the console
 	// advertises at GET /console/capabilities. Left zero, it defaults to the
 	// self-hosted community edition.
@@ -83,6 +84,9 @@ func New(deps Deps) *Console {
 	}
 	if deps.Instruments == nil {
 		deps.Instruments = NewMemInstruments()
+	}
+	if deps.Portal == nil {
+		deps.Portal = noPortal{}
 	}
 	if deps.Logs == nil {
 		// Default to an authorizing streamer over the (already-defaulted)
@@ -122,6 +126,7 @@ func (c *Console) routes() {
 	mux.HandleFunc("POST /console/keys/{id}/revoke", c.handleRevokeKey)
 	mux.HandleFunc("GET /console/usage", c.handleUsage)
 	mux.HandleFunc("GET /console/billing", c.handleBilling)
+	mux.HandleFunc("GET /console/billing/portal", c.handleBillingPortal)
 	mux.HandleFunc("GET /console/sandboxes", c.handleListSandboxes)
 	mux.HandleFunc("GET /console/sandboxes/{id}", c.handleInspectSandbox)
 	mux.HandleFunc("DELETE /console/sandboxes/{id}", c.handleTerminateSandbox)

--- a/internal/saas/console/portal.go
+++ b/internal/saas/console/portal.go
@@ -1,0 +1,47 @@
+package console
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"mitos.run/mitos/internal/apierr"
+)
+
+// PortalLinker returns the provider-hosted "manage subscription" URL for an org
+// (the Stripe Customer Portal, or a Merchant-of-Record equivalent). It is the
+// provider-NEUTRAL seam the console deep-links to instead of rebuilding payment
+// UI; the real implementation resolves the org's customer ref and calls the
+// configured billingprovider. A community/self-host install has none, so the
+// default returns ErrNotFound and the console hides the affordance.
+type PortalLinker interface {
+	PortalURL(ctx context.Context, orgID string) (string, error)
+}
+
+// noPortal is the default PortalLinker: no billing portal is configured.
+type noPortal struct{}
+
+func (noPortal) PortalURL(context.Context, string) (string, error) { return "", ErrNotFound }
+
+// handleBillingPortal returns the caller org's manage-subscription URL. When no
+// portal is configured (community edition, or no customer yet) it is a 404, so
+// the UI never shows a fabricated link.
+func (c *Console) handleBillingPortal(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	url, err := c.deps.Portal.PortalURL(r.Context(), orgID)
+	if err != nil || url == "" {
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			apierr.Encode(w, apierr.Get(apierr.CodeInternal).WithCause("the billing portal link could not be created"))
+			return
+		}
+		apierr.Encode(w, apierr.Get(apierr.CodeNotFound).WithCause("no billing portal is available for this organization"))
+		return
+	}
+	writeJSON(w, http.StatusOK, struct {
+		URL string `json:"url"`
+	}{URL: url})
+}

--- a/internal/saas/console/portal_test.go
+++ b/internal/saas/console/portal_test.go
@@ -1,0 +1,46 @@
+package console
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// fakePortal returns a fixed URL for one org and ErrNotFound otherwise.
+type fakePortal struct{ org, url string }
+
+func (f fakePortal) PortalURL(_ context.Context, orgID string) (string, error) {
+	if orgID == f.org {
+		return f.url, nil
+	}
+	return "", ErrNotFound
+}
+
+// TestBillingPortalReturnsURLForOrg asserts the endpoint returns the caller
+// org's manage-subscription URL from the provider-neutral PortalLinker seam.
+func TestBillingPortalReturnsURLForOrg(t *testing.T) {
+	f := newFixture(t)
+	f.con = New(Deps{Accounts: f.accounts, Portal: fakePortal{org: f.aliceOrg, url: "https://billing.example/portal/abc"}})
+	w := f.req(t, "GET", "/console/billing/portal", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		URL string `json:"url"`
+	}
+	decode(t, w, &resp)
+	if resp.URL != "https://billing.example/portal/abc" {
+		t.Fatalf("url = %q, want the portal URL", resp.URL)
+	}
+}
+
+// TestBillingPortalUnavailableIs404 asserts that when no portal is configured
+// (the default, e.g. community edition), the endpoint is a 404 rather than a
+// fabricated link.
+func TestBillingPortalUnavailableIs404(t *testing.T) {
+	f := newFixture(t) // default Portal seam → not configured
+	w := f.req(t, "GET", "/console/billing/portal", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no portal is configured", w.Code)
+	}
+}


### PR DESCRIPTION
## What

Phase 2 of the console: wires the end-to-end gaps the Phase-1 PR (#277) scaffolded behind seams.

- **Billing portal** — `GET /console/billing/portal` returns the org's manage-subscription URL via a provider-neutral `PortalLinker` seam (Stripe Customer Portal / MoR equivalent). 404 when none configured; no fabricated links.
- **Secret provider selection** — `cmd/console` constructs the real kube or OpenBao `SecretStore` from config instead of always using the in-memory default.
- **Billing webhook** — mounts the signature-verified `billingprovider.WebhookHandler` at `/webhooks/billing` (outside session auth) when billing is enabled.

Builds on the merged seams; nothing flips the #208 gate. TDD throughout.

## Tasks
- [x] `/console/billing/portal` endpoint + `PortalLinker` seam
- [ ] secret provider selection in cmd/console
- [ ] mount billing webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
