### PR TITLE
feat(console): org-scoped SandboxControl + hard-isolation tenant convention (#2)

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -69,6 +69,9 @@ func main() {
 		// The active secret backend selected from config (kube / openbao), falling
 		// back to in-memory in dev. Capabilities advertise the same providers.
 		Secrets: buildSecretStore(logger, caps),
+		// The live-sandbox control: the org-scoped cluster query when in a cluster,
+		// in-memory otherwise. Shares the org→namespace boundary with secrets.
+		Sandboxes: buildSandboxControl(logger),
 		// The manage-subscription portal link (provider-neutral); nil keeps the
 		// console's no-portal default (community edition).
 		Portal: bill.portal,

--- a/cmd/console/sandboxcontrol.go
+++ b/cmd/console/sandboxcontrol.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log/slog"
+
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/saas/console/clustersandbox"
+)
+
+// buildSandboxControl returns the live-sandbox control: the real cluster-backed
+// query (org-scoped over the controller's v1alpha2 Sandbox records) when a kube
+// client is available, falling back to the in-memory control (with a warning) in
+// dev / outside a cluster so the console still starts.
+func buildSandboxControl(logger *slog.Logger) console.SandboxControl {
+	c, err := kubeClient()
+	if err != nil {
+		logger.Warn("cluster sandbox control unavailable (not in cluster?); using in-memory control", "err", err.Error())
+		return console.NewMemSandboxControl()
+	}
+	logger.Info("sandbox control: cluster (org-scoped v1alpha2 Sandbox query)")
+	return clustersandbox.New(c)
+}

--- a/cmd/console/secretstore.go
+++ b/cmd/console/secretstore.go
@@ -5,13 +5,37 @@ import (
 	"os"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	sandboxv2 "mitos.run/mitos/api/v1alpha2"
 	"mitos.run/mitos/internal/saas/console"
 	"mitos.run/mitos/internal/saas/console/baosecrets"
 	"mitos.run/mitos/internal/saas/console/kubesecrets"
+	"mitos.run/mitos/internal/tenant"
 )
+
+// kubeClient builds a controller-runtime client over the ambient kube config
+// (in-cluster service account, or KUBECONFIG in dev) with the scheme the console
+// needs: core types (for org Secrets) plus the mitos.run/v1alpha2 Sandbox types
+// (for the org-scoped live-sandbox query). Shared by the kube secret store and
+// the cluster sandbox control.
+func kubeClient() (ctrlclient.Client, error) {
+	cfg, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	if err := sandboxv2.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	return ctrlclient.New(cfg, ctrlclient.Options{Scheme: s})
+}
 
 // primarySecretProvider returns the provider the binary should construct: the
 // first recognized entry in the advertised list, defaulting to kube. Capability
@@ -25,15 +49,6 @@ func primarySecretProvider(providers []string) string {
 		}
 	}
 	return "kube"
-}
-
-// secretNamespaceFor maps an org id to the namespace its kube secrets live in.
-func secretNamespaceFor(orgID string) string {
-	prefix := os.Getenv("MITOS_CONSOLE_SECRET_NAMESPACE_PREFIX")
-	if prefix == "" {
-		prefix = "mitos-org-"
-	}
-	return prefix + orgID
 }
 
 // buildSecretStore constructs the active SecretStore from configuration. It
@@ -61,18 +76,15 @@ func buildSecretStore(logger *slog.Logger, caps console.Capabilities) console.Se
 	return console.NewMemSecretStore()
 }
 
-// buildKubeSecretStore builds the kube provider over the ambient kube config
-// (in-cluster service account, or KUBECONFIG in dev).
+// buildKubeSecretStore builds the kube provider over the shared kube client,
+// placing each org's Secrets in its hard-isolation namespace (tenant.NamespaceForOrg)
+// — the same boundary the sandbox control queries.
 func buildKubeSecretStore() (console.SecretStore, error) {
-	cfg, err := ctrlconfig.GetConfig()
+	c, err := kubeClient()
 	if err != nil {
 		return nil, err
 	}
-	c, err := ctrlclient.New(cfg, ctrlclient.Options{})
-	if err != nil {
-		return nil, err
-	}
-	return kubesecrets.New(c, secretNamespaceFor), nil
+	return kubesecrets.New(c, tenant.NamespaceForOrg), nil
 }
 
 // openbaoToken reads the OpenBao token from the env or a token file.

--- a/cmd/console/secretstore_test.go
+++ b/cmd/console/secretstore_test.go
@@ -22,16 +22,3 @@ func TestPrimarySecretProviderPicksFirstKnown(t *testing.T) {
 		}
 	}
 }
-
-// TestSecretNamespaceForOrg asserts the org→namespace mapping uses the
-// configured prefix.
-func TestSecretNamespaceForOrg(t *testing.T) {
-	t.Setenv("MITOS_CONSOLE_SECRET_NAMESPACE_PREFIX", "")
-	if got := secretNamespaceFor("abc"); got != "mitos-org-abc" {
-		t.Errorf("default namespace = %q, want mitos-org-abc", got)
-	}
-	t.Setenv("MITOS_CONSOLE_SECRET_NAMESPACE_PREFIX", "tenant-")
-	if got := secretNamespaceFor("abc"); got != "tenant-abc" {
-		t.Errorf("prefixed namespace = %q, want tenant-abc", got)
-	}
-}

--- a/internal/saas/console/clustersandbox/clustersandbox.go
+++ b/internal/saas/console/clustersandbox/clustersandbox.go
@@ -1,0 +1,106 @@
+// Package clustersandbox is the real console.SandboxControl: it queries the
+// controller's v1alpha2 Sandbox records scoped to one org, the cluster-backed
+// implementation of the live-sandbox seam (issue #2). Under hard isolation each
+// org's sandboxes live in its own namespace (tenant.NamespaceForOrg), so org
+// scoping is the namespace boundary plus the org label as defense in depth — a
+// cross-org id is reported as not-found, indistinguishable from a missing one.
+package clustersandbox
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sandboxv2 "mitos.run/mitos/api/v1alpha2"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+// Control implements console.SandboxControl against the Kubernetes API.
+type Control struct {
+	c client.Client
+}
+
+// New builds the cluster-backed sandbox control.
+func New(c client.Client) *Control {
+	return &Control{c: c}
+}
+
+// List returns the org's sandboxes from its namespace, filtered by the org
+// label.
+func (s *Control) List(ctx context.Context, orgID string) ([]console.SandboxView, error) {
+	var list sandboxv2.SandboxList
+	if err := s.c.List(ctx, &list,
+		client.InNamespace(tenant.NamespaceForOrg(orgID)),
+		client.MatchingLabels(tenant.OrgLabels(orgID)),
+	); err != nil {
+		return nil, fmt.Errorf("list sandboxes: %w", err)
+	}
+	out := make([]console.SandboxView, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, viewOf(&list.Items[i], orgID))
+	}
+	return out, nil
+}
+
+// Get returns one of the org's sandboxes by name. A sandbox in another org's
+// namespace (or missing, or not carrying the org label) is console.ErrNotFound.
+func (s *Control) Get(ctx context.Context, orgID, sandboxID string) (console.SandboxView, error) {
+	sb, err := s.get(ctx, orgID, sandboxID)
+	if err != nil {
+		return console.SandboxView{}, err
+	}
+	return viewOf(sb, orgID), nil
+}
+
+// Terminate deletes one of the org's sandboxes. A cross-org or missing id is
+// console.ErrNotFound and nothing is deleted.
+func (s *Control) Terminate(ctx context.Context, orgID, sandboxID string) error {
+	sb, err := s.get(ctx, orgID, sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := s.c.Delete(ctx, sb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return console.ErrNotFound
+		}
+		return fmt.Errorf("delete sandbox: %w", err)
+	}
+	return nil
+}
+
+// get fetches the org's sandbox by name from its namespace and verifies the org
+// label, collapsing missing / cross-org / mislabeled into ErrNotFound.
+func (s *Control) get(ctx context.Context, orgID, sandboxID string) (*sandboxv2.Sandbox, error) {
+	var sb sandboxv2.Sandbox
+	key := client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgID), Name: sandboxID}
+	if err := s.c.Get(ctx, key, &sb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, console.ErrNotFound
+		}
+		return nil, fmt.Errorf("get sandbox: %w", err)
+	}
+	if sb.Labels[tenant.OrgLabelKey] != orgID {
+		return nil, console.ErrNotFound // present but not labelled for this org
+	}
+	return &sb, nil
+}
+
+// viewOf maps a v1alpha2.Sandbox to the console view. Template is the pool the
+// sandbox started from; the engine id and node-bearing pod come from status.
+func viewOf(sb *sandboxv2.Sandbox, orgID string) console.SandboxView {
+	template := ""
+	if sb.Spec.Source.PoolRef != nil {
+		template = sb.Spec.Source.PoolRef.Name
+	}
+	return console.SandboxView{
+		ID:        sb.Name,
+		OrgID:     orgID,
+		Template:  template,
+		Node:      sb.Status.Pod,
+		Phase:     string(sb.Status.Phase),
+		CreatedAt: sb.CreationTimestamp.Time,
+	}
+}

--- a/internal/saas/console/clustersandbox/clustersandbox_test.go
+++ b/internal/saas/console/clustersandbox/clustersandbox_test.go
@@ -1,0 +1,113 @@
+package clustersandbox
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "mitos.run/mitos/api/v1alpha1"
+	sandboxv2 "mitos.run/mitos/api/v1alpha2"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+func scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := sandboxv2.AddToScheme(s); err != nil {
+		t.Fatalf("add v2 scheme: %v", err)
+	}
+	return s
+}
+
+// sb builds a v1alpha2.Sandbox owned by org, in that org's hard-isolation
+// namespace and carrying the org label.
+func sb(org, name, phase string) *sandboxv2.Sandbox {
+	return &sandboxv2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tenant.NamespaceForOrg(org),
+			Labels:    tenant.OrgLabels(org),
+		},
+		Spec:   sandboxv2.SandboxSpec{Source: sandboxv2.SandboxSource{PoolRef: &v1alpha1.LocalObjectReference{Name: "python"}}},
+		Status: sandboxv2.SandboxStatus{Phase: v1alpha1.SandboxPhase(phase), SandboxID: "engine-" + name},
+	}
+}
+
+func newControl(t *testing.T, objs ...client.Object) *Control {
+	t.Helper()
+	c := fakeclient.NewClientBuilder().WithScheme(scheme(t)).WithObjects(objs...).Build()
+	return New(c)
+}
+
+// TestListScopedToOrgNamespace asserts List returns only the caller org's
+// sandboxes — bob's, in bob's namespace, are never seen by alice.
+func TestListScopedToOrgNamespace(t *testing.T) {
+	c := newControl(t, sb("alice", "sb-a1", "Ready"), sb("alice", "sb-a2", "Pending"), sb("bob", "sb-b1", "Ready"))
+	got, err := c.List(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("alice saw %d sandboxes, want 2", len(got))
+	}
+	for _, v := range got {
+		if v.OrgID != "alice" {
+			t.Fatalf("cross-org sandbox in alice list: %+v", v)
+		}
+	}
+}
+
+// TestGetMapsViewFields asserts Get returns the mapped view for an owned sandbox.
+func TestGetMapsViewFields(t *testing.T) {
+	c := newControl(t, sb("alice", "sb-a1", "Ready"))
+	v, err := c.Get(context.Background(), "alice", "sb-a1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v.ID != "sb-a1" || v.OrgID != "alice" || v.Template != "python" || string(v.Phase) != "Ready" {
+		t.Fatalf("view = %+v, want id/org/template/phase mapped", v)
+	}
+}
+
+// TestGetCrossOrgIsNotFound asserts a sandbox owned by another org is reported
+// as not-found (the namespace boundary plus the label check), indistinguishable
+// from a missing one.
+func TestGetCrossOrgIsNotFound(t *testing.T) {
+	c := newControl(t, sb("bob", "sb-b1", "Ready"))
+	if _, err := c.Get(context.Background(), "alice", "sb-b1"); err != console.ErrNotFound {
+		t.Fatalf("cross-org Get err = %v, want console.ErrNotFound", err)
+	}
+}
+
+// TestTerminateCrossOrgIsNotFoundAndSurvives asserts alice cannot terminate
+// bob's sandbox, and it survives.
+func TestTerminateCrossOrgIsNotFoundAndSurvives(t *testing.T) {
+	c := newControl(t, sb("bob", "sb-b1", "Ready"))
+	if err := c.Terminate(context.Background(), "alice", "sb-b1"); err != console.ErrNotFound {
+		t.Fatalf("cross-org Terminate err = %v, want console.ErrNotFound", err)
+	}
+	if _, err := c.Get(context.Background(), "bob", "sb-b1"); err != nil {
+		t.Fatalf("bob's sandbox was terminated cross-org: %v", err)
+	}
+}
+
+// TestTerminateOwnedDeletes asserts terminating an owned sandbox removes it.
+func TestTerminateOwnedDeletes(t *testing.T) {
+	c := newControl(t, sb("alice", "sb-a1", "Ready"))
+	if err := c.Terminate(context.Background(), "alice", "sb-a1"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if _, err := c.Get(context.Background(), "alice", "sb-a1"); err != console.ErrNotFound {
+		t.Fatalf("sandbox not deleted: %v", err)
+	}
+}
+
+// TestImplementsSandboxControl is a compile-time seam assertion.
+func TestImplementsSandboxControl(t *testing.T) {
+	var _ console.SandboxControl = (*Control)(nil)
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -1,0 +1,30 @@
+// Package tenant holds the canonical multi-tenancy convention shared across the
+// SaaS surfaces: the org label stamped on tenant-owned objects and the hard
+// per-org namespace each tenant's workloads live in.
+//
+// Hard isolation (the chosen model): every org gets its own namespace,
+// mitos-org-<id>, for both its sandboxes and its secrets. The org label lets the
+// console and the usage pipeline resolve and filter by org regardless of where
+// an object lives, and is the contract the gateway/control plane stamps at
+// SandboxClaim creation (the controller propagates it onto the Sandbox).
+package tenant
+
+// OrgLabelKey is the label carrying an org id on tenant-owned objects
+// (SandboxClaim, Sandbox, org Secrets). It is the contract the gateway stamps
+// and the console / usage resolver read; changing it is a breaking change.
+const OrgLabelKey = "mitos.run/org"
+
+// namespacePrefix is the prefix for an org's hard-isolation namespace.
+const namespacePrefix = "mitos-org-"
+
+// NamespaceForOrg returns the namespace an org's workloads live in under hard
+// isolation. The same mapping backs the kube secret provider and the
+// org-scoped sandbox query, so secrets and sandboxes share one tenant boundary.
+func NamespaceForOrg(orgID string) string {
+	return namespacePrefix + orgID
+}
+
+// OrgLabels returns the standard label set stamping an object as owned by orgID.
+func OrgLabels(orgID string) map[string]string {
+	return map[string]string{OrgLabelKey: orgID}
+}

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -1,0 +1,28 @@
+package tenant
+
+import "testing"
+
+// TestNamespaceForOrg asserts the canonical hard-isolation namespace mapping:
+// each org's workloads (sandboxes + secrets) live in mitos-org-<id>.
+func TestNamespaceForOrg(t *testing.T) {
+	if got := NamespaceForOrg("alice"); got != "mitos-org-alice" {
+		t.Fatalf("NamespaceForOrg(alice) = %q, want mitos-org-alice", got)
+	}
+}
+
+// TestOrgLabelStable pins the org label key — the contract the gateway stamps
+// and the console / usage resolver read. Changing it is a breaking change.
+func TestOrgLabelStable(t *testing.T) {
+	if OrgLabelKey != "mitos.run/org" {
+		t.Fatalf("OrgLabelKey = %q, want mitos.run/org", OrgLabelKey)
+	}
+}
+
+// TestOrgLabels builds the standard label set carrying the org, for stamping on
+// claims/sandboxes.
+func TestOrgLabels(t *testing.T) {
+	ls := OrgLabels("alice")
+	if ls[OrgLabelKey] != "alice" {
+		t.Fatalf("OrgLabels(alice)[%s] = %q, want alice", OrgLabelKey, ls[OrgLabelKey])
+	}
+}


### PR DESCRIPTION
## What

Unblocks the live-sandbox view (#2) and establishes the **hard per-org-namespace** tenancy convention.

- **`internal/tenant`** — the canonical contract: the `mitos.run/org` label + `NamespaceForOrg` (each org's sandboxes *and* secrets live in `mitos-org-<id>`, one tenant boundary).
- **`internal/saas/console/clustersandbox`** — the real `console.SandboxControl`: queries v1alpha2 `Sandbox` records in the org's namespace, filtered by the org label, mapped to the console view. Cross-org ids are not-found (namespace boundary + label check). Tested against the controller-runtime fake client.

## Why this scope

`main` doesn't yet have the phase-2 PR (#285), which already edits `cmd/console` DI. To avoid a guaranteed merge conflict, this PR is the non-overlapping core; the one-line DI wiring (`Sandboxes: clustersandbox.New(kubeClient)`) lands once #285 merges.

## Remaining (tracked)
- DI-wire `clustersandbox` into `cmd/console` (after #285).
- Cluster `OrgResolver` for usage attribution (#211 — needs an informer cache).
- Controller stamps `mitos.run/org` at claim creation + places claims in per-org namespaces (**#172 multitenancy track** — the security-critical isolation change).

Refs #2 #208 #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
