### PR TITLE
ci(sdk): publish Python as mitos-run + OIDC trusted publishing (PyPI, crates.io)

### DIFF
--- a/.github/workflows/publish-sdks.yaml
+++ b/.github/workflows/publish-sdks.yaml
@@ -11,16 +11,22 @@ name: Publish SDKs
 #   2. It asks the registry whether that exact version already exists; if so it
 #      logs "already published" and exits 0 (idempotent: a re-run never errors on
 #      a duplicate upload).
-#   3. If the registry token secret is empty it logs "token not configured" and
-#      exits 0, so the workflow never hard-fails before a maintainer wires the
-#      secrets. This mirrors the Homebrew-tap token skip in release.yaml.
+#   3. The token-based jobs additionally skip when their secret is empty, logging
+#      "token not configured" and exiting 0 so the workflow never hard-fails
+#      before a maintainer wires the secrets. This mirrors the Homebrew-tap token
+#      skip in release.yaml. The OIDC jobs do not need a secret.
 #
-# The four registries and the secrets they need:
+# The four registries and how they authenticate:
 #
-#   Python      -> PyPI       secret PYPI_API_TOKEN
+#   Python      -> PyPI       Trusted Publishing (OIDC), no secret. The PyPI
+#                             project is "mitos-run" (the bare "mitos" name is
+#                             taken on PyPI by an unrelated project); the import
+#                             package stays "mitos".
 #   TypeScript  -> npm        secret NPM_TOKEN
 #   Ruby        -> RubyGems   secret RUBYGEMS_API_KEY
-#   Rust        -> crates.io  secret CARGO_REGISTRY_TOKEN
+#   Rust        -> crates.io  Trusted Publishing (OIDC) via
+#                             rust-lang/crates-io-auth-action, after a one-time
+#                             token-based first publish to claim the crate name.
 #
 # Path filters scope each push so a Python-only change does not run the npm job,
 # and workflow_dispatch lets a maintainer force one SDK (or all) by hand.
@@ -122,11 +128,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # id-token: write is NOT required for the API-token publish below. Once the
-      # PyPI project "mitos" is configured for Trusted Publishing (OIDC), the
-      # recommended migration is to add `id-token: write` here, drop the
-      # PYPI_API_TOKEN secret, and remove the `password:` line from the publish
-      # step so gh-action-pypi-publish mints a short-lived OIDC token instead.
+      # id-token: write lets gh-action-pypi-publish mint a short-lived OIDC token
+      # for PyPI Trusted Publishing; no PYPI_API_TOKEN secret is involved. The
+      # PyPI project "mitos-run" has the matching trusted publisher configured
+      # (this repository, workflow publish-sdks.yaml).
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -146,7 +152,7 @@ jobs:
             exit 1
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "mitos (PyPI) declared version: ${version}"
+          echo "mitos-run (PyPI) declared version: ${version}"
 
       - name: Skip if already on PyPI
         id: exists
@@ -154,33 +160,20 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
-          # HTTP 200 from the per-version JSON endpoint means the release exists.
-          code="$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/mitos/${VERSION}/json")"
+          # The PyPI distribution is named "mitos-run" (the import package stays
+          # "mitos"). HTTP 200 from the per-version JSON endpoint means the
+          # release exists.
+          code="$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/mitos-run/${VERSION}/json")"
           if [ "${code}" = "200" ]; then
-            echo "mitos ${VERSION} already published to PyPI; skipping."
+            echo "mitos-run ${VERSION} already published to PyPI; skipping."
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else
-            echo "mitos ${VERSION} not on PyPI (HTTP ${code}); will build and publish."
+            echo "mitos-run ${VERSION} not on PyPI (HTTP ${code}); will build and publish."
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Skip if token not configured
-        id: token
-        if: steps.exists.outputs.publish == 'true'
-        env:
-          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -n "${PYPI_API_TOKEN:-}" ]; then
-            echo "have_token=true" >> "$GITHUB_OUTPUT"
-            echo "PYPI_API_TOKEN present; will publish."
-          else
-            echo "have_token=false" >> "$GITHUB_OUTPUT"
-            echo "No PYPI_API_TOKEN secret; skipping the PyPI publish."
-          fi
-
       - name: Build the distribution
-        if: steps.exists.outputs.publish == 'true' && steps.token.outputs.have_token == 'true'
+        if: steps.exists.outputs.publish == 'true'
         run: |
           set -euo pipefail
           python -m pip install --upgrade build
@@ -188,11 +181,12 @@ jobs:
           ls -l sdk/python/dist
 
       - name: Publish to PyPI
-        if: steps.exists.outputs.publish == 'true' && steps.token.outputs.have_token == 'true'
+        if: steps.exists.outputs.publish == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdk/python/dist
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          # No password: Trusted Publishing (OIDC) authenticates via the
+          # id-token: write permission above.
           # Belt and suspenders: even if two runs race, do not fail on a version
           # that already exists on the index.
           skip-existing: true
@@ -369,6 +363,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # id-token: write lets rust-lang/crates-io-auth-action mint a short-lived
+      # crates.io token for Trusted Publishing (OIDC); no CARGO_REGISTRY_TOKEN
+      # secret is involved.
+      #
+      # One-time bootstrap (maintainer, by hand): the FIRST publish of the
+      # "mitos" crate must use a token to claim the name, because crates.io
+      # cannot pre-register a Trusted Publisher for a crate that does not exist
+      # yet. From sdk/rust, run `cargo login <temporary-token>` then
+      # `cargo publish`. After that first publish, add a GitHub Trusted Publisher
+      # in the crate settings (owner mitos-run, repo mitos, workflow
+      # publish-sdks.yaml); every later release then uses the OIDC path below
+      # with no token.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -426,25 +433,20 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Skip if token not configured
-        id: token
+      - name: Authenticate to crates.io (OIDC)
+        id: auth
         if: steps.guard.outputs.present == 'true' && steps.exists.outputs.publish == 'true'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -n "${CARGO_REGISTRY_TOKEN:-}" ]; then
-            echo "have_token=true" >> "$GITHUB_OUTPUT"
-            echo "CARGO_REGISTRY_TOKEN present; will publish."
-          else
-            echo "have_token=false" >> "$GITHUB_OUTPUT"
-            echo "No CARGO_REGISTRY_TOKEN secret; skipping the crates.io publish."
-          fi
+        uses: rust-lang/crates-io-auth-action@v1
 
       - name: Publish to crates.io
-        if: steps.guard.outputs.present == 'true' && steps.exists.outputs.publish == 'true' && steps.token.outputs.have_token == 'true'
+        if: steps.guard.outputs.present == 'true' && steps.exists.outputs.publish == 'true'
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # rust-lang/crates-io-auth-action exposes the temporary token on its
+          # `token` output; cargo reads it from CARGO_REGISTRY_TOKEN. The action
+          # revokes the token in its post step. See
+          # https://github.com/rust-lang/crates-io-auth-action and
+          # https://crates.io/docs/trusted-publishing
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
           cargo publish --manifest-path sdk/rust/Cargo.toml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,12 @@ quickstart; the README headline points here.
 ## One package, one snippet
 
 ```bash
-pip install mitos
+pip install mitos-run
 ```
+
+The PyPI distribution is named `mitos-run` (the bare `mitos` name is taken by an
+unrelated project), but the import package stays `mitos`: you `pip install
+mitos-run` and `import mitos`.
 
 ```python
 import mitos
@@ -20,7 +24,7 @@ print(sb.run_code("print(1 + 1)").text)     # 2
 sb.terminate()
 ```
 
-That is the whole thing: one `pip install mitos`, one import, one `create`, code
+That is the whole thing: one `pip install mitos-run`, one import, one `create`, code
 execution, no second SDK to install. `mitos.create(image, api_key=..., base_url=...)`
 resolves the API key (argument, else `MITOS_API_KEY`) and the base URL (argument,
 else `MITOS_BASE_URL`, else the hosted endpoint `https://mitos.run`), then returns

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,10 +16,14 @@ skips with a clear log.
 | --- | --- | --- | --- |
 | Container images (controller, forkd, husk-stub, kvm-device-plugin) | ghcr.io/mitos-run, cosign-signed, SBOM-attested | `.github/workflows/publish.yaml` | `v*` tag push, or manual dispatch with a tag input |
 | CLI (`mitos`): binaries, archives, checksums, deb/rpm, Homebrew cask | GitHub Releases plus the Homebrew tap | `.github/workflows/release.yaml` (goreleaser) | `v*` tag push |
-| Python SDK (`mitos`) | PyPI | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/python/pyproject.toml` merged to main |
+| Python SDK (dist `mitos-run`, import `mitos`) | PyPI | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/python/pyproject.toml` merged to main |
 | TypeScript SDK (`@mitos/sdk`) | npm | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/typescript/package.json` merged to main |
 | Ruby SDK (`mitos`) | RubyGems | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/ruby/lib/mitos/version.rb` merged to main |
 | Rust SDK (`mitos`) | crates.io | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/rust/Cargo.toml` merged to main |
+
+The Python distribution publishes as `mitos-run` because the bare `mitos` name on
+PyPI is taken by an unrelated project; the import package stays `mitos`, so users
+`pip install mitos-run` and `import mitos`.
 
 The container image and CLI versions are driven by release-please, which tracks
 the root Go module only. The four SDK versions are independent and bumped by
@@ -50,21 +54,23 @@ Every SDK job follows the same safe sequence:
 1. Read the version the SDK declares in its manifest.
 2. Ask the registry whether that exact version already exists. If it does, the
    job logs "already published" and exits successfully without uploading.
-3. If the registry token secret is empty, the job logs "token not configured"
-   and exits successfully without uploading. This mirrors the Homebrew-tap token
-   skip in `release.yaml`, so the workflow never hard-fails before the secrets
-   are wired.
+3. The token-based jobs (npm, RubyGems) additionally skip when their secret is
+   empty, logging "token not configured" and exiting successfully without
+   uploading. This mirrors the Homebrew-tap token skip in `release.yaml`, so the
+   workflow never hard-fails before the secrets are wired. The OIDC jobs (PyPI,
+   crates.io) need no secret.
 4. Otherwise it builds and publishes that version.
 
 Because of steps 2 and 3, re-running the workflow or pushing an unrelated change
 to an SDK directory never errors on a duplicate upload. The publish only happens
-once per version, when the version is new and the token is present.
+once per version, when the version is new and (for the token-based jobs) the
+token is present.
 
 The version-existence checks per registry:
 
 | SDK | Existence check |
 | --- | --- |
-| Python | HTTP 200 from `https://pypi.org/pypi/mitos/<version>/json` |
+| Python | HTTP 200 from `https://pypi.org/pypi/mitos-run/<version>/json` |
 | TypeScript | non-empty output from `npm view @mitos/sdk@<version> version` |
 | Ruby | the version appears in `https://rubygems.org/api/v1/versions/mitos.json` |
 | Rust | HTTP 200 from `https://crates.io/api/v1/crates/mitos/<version>` |
@@ -74,43 +80,73 @@ manifest is absent (for example before that SDK lands) the job no-ops cleanly.
 
 ## One-time maintainer setup
 
-The SDK publish paths stay dormant (logging "token not configured") until a
-maintainer completes the steps below for each registry. Do them once.
+PyPI and crates.io authenticate via Trusted Publishing (OIDC), so they need no
+Actions secret. The npm and RubyGems jobs stay dormant (logging "token not
+configured") until a maintainer adds their token. Do the steps below once.
 
 ### Reserve the names
 
 Reserve these names before the first publish so they cannot be taken:
 
-- PyPI project: `mitos`
+- PyPI project: `mitos-run` (the import package stays `mitos`; the bare `mitos`
+  name on PyPI is taken by an unrelated project)
 - npm package: `@mitos/sdk` (the `@mitos` scope must exist and be public)
 - RubyGems gem: `mitos`
 - crates.io crate: `mitos`
 
-### Create accounts and tokens, then add the secrets
+### How each registry authenticates
+
+| Registry | Auth | Secret |
+| --- | --- | --- |
+| PyPI | Trusted Publishing (OIDC) | none |
+| crates.io | Trusted Publishing (OIDC), after a one-time token-based first publish | none (after bootstrap) |
+| npm | Automation access token | `NPM_TOKEN` |
+| RubyGems | API key with the "Push rubygem" scope | `RUBYGEMS_API_KEY` |
+
+### Tokens to add as Actions secrets
 
 Add each token as a repository (or organization) Actions secret with the exact
-name below.
+name below. Only npm and RubyGems still need a token; PyPI and crates.io are
+tokenless via OIDC.
 
 | Secret | Registry | How to mint it |
 | --- | --- | --- |
-| `PYPI_API_TOKEN` | PyPI | Create a PyPI account, then an API token scoped to the `mitos` project (Account settings -> API tokens). |
 | `NPM_TOKEN` | npm | Create the `@mitos` org/scope, then an Automation access token (Access Tokens -> Generate -> Automation). |
 | `RUBYGEMS_API_KEY` | RubyGems | Create a RubyGems account, then an API key with the "Push rubygem" scope (Profile -> API keys). |
-| `CARGO_REGISTRY_TOKEN` | crates.io | Sign in to crates.io with GitHub, then create an API token (Account settings -> API tokens) with the publish scope. |
 
 When a secret is present and the SDK's declared version is new, the next merge
 that touches that SDK (or a manual dispatch) publishes it.
 
-### Recommended: PyPI Trusted Publishing (OIDC)
+### PyPI Trusted Publishing (OIDC)
 
-Once the PyPI `mitos` project exists, the recommended hardening is to switch the
-Python job from an API token to Trusted Publishing (OIDC). Configure the project
-on PyPI to trust this repository and the `publish-sdks.yaml` workflow, then in
-the Python job add `id-token: write` to its `permissions`, remove the
-`password:` line from the publish step, and delete the `PYPI_API_TOKEN` secret.
-`pypa/gh-action-pypi-publish` then mints a short-lived OIDC token per run, so
-there is no long-lived secret to rotate. The job's comments point to the exact
-lines to change.
+The Python job publishes via Trusted Publishing: the `python` job carries
+`id-token: write`, and `pypa/gh-action-pypi-publish` mints a short-lived OIDC
+token per run, so there is no long-lived secret to rotate. The PyPI project
+`mitos-run` already has a trusted publisher configured for this repository and
+the `publish-sdks.yaml` workflow, so no further maintainer action is needed.
+
+To recreate it from scratch: on PyPI, add a trusted publisher to the `mitos-run`
+project (or a pending publisher before the project exists) pointing at owner
+`mitos-run`, repo `mitos`, workflow `publish-sdks.yaml`.
+
+### crates.io Trusted Publishing (OIDC)
+
+crates.io cannot pre-register a Trusted Publisher for a crate that does not exist
+yet, so the very first publish of the `mitos` crate is a one-time, token-based
+step done by hand:
+
+1. Mint a temporary crates.io API token with the publish scope (Account settings
+   -> API tokens) and run `cargo login <temporary-token>`.
+2. From `sdk/rust`, run `cargo publish` to claim the `mitos` crate name.
+3. In the crate settings on crates.io, add a GitHub Trusted Publisher with owner
+   `mitos-run`, repo `mitos`, and workflow `publish-sdks.yaml`.
+4. Revoke the temporary token.
+
+After that bootstrap, every later release uses the OIDC path: the `rust` job
+carries `id-token: write` and runs `rust-lang/crates-io-auth-action`, which mints
+a short-lived token (its `token` output is passed to `cargo publish` via
+`CARGO_REGISTRY_TOKEN`) and revokes it after the job. No `CARGO_REGISTRY_TOKEN`
+secret is stored.
 
 ## Cutting an image or CLI release
 

--- a/docs/saas/onboarding.md
+++ b/docs/saas/onboarding.md
@@ -29,7 +29,8 @@ In open self-serve mode the flow is:
    the org via #210; the raw key is shown exactly once.
 
 The user then drops straight into the [quickstart](../quickstart.md): one
-`pip install mitos`, one `mitos.create(...)`, code execution, no second SDK.
+`pip install mitos-run` (installs the `mitos-run` distribution; you still `import
+mitos`), one `mitos.create(...)`, code execution, no second SDK.
 
 ### Idempotency and rejection
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,6 +3,15 @@
 Python client for [mitos-run/mitos](https://github.com/mitos-run/mitos):
 snapshot-fork sandboxes for AI agents on Kubernetes.
 
+```bash
+pip install mitos-run
+```
+
+The PyPI distribution is named `mitos-run` (the bare `mitos` name is taken by an
+unrelated project), but the import package stays `mitos`: you `pip install
+mitos-run` and `import mitos`. Optional extras keep the same import name, for
+example `pip install "mitos-run[k8s]"` for cluster mode.
+
 Two modes:
 
 - `mitos.create` (flat one-liner): API key plus base URL, returns a Ready
@@ -258,7 +267,7 @@ sb.close()                           # alias: sb.stop(); lifecycle close
 ```
 
 Install the optional extra only if you use the integration:
-`pip install "mitos[langchain]"`. `MitosSandbox` does not subclass any langchain
+`pip install "mitos-run[langchain]"`. `MitosSandbox` does not subclass any langchain
 type and is fully usable without langchain installed.
 
 Fork is a mitos superpower the LangChain sandbox-backend interface does not
@@ -302,7 +311,7 @@ tools.close()
 ```
 
 Install the optional extra only if you use the integration:
-`pip install "mitos[openai-agents]"`. The adapter is fully usable and testable
+`pip install "mitos-run[openai-agents]"`. The adapter is fully usable and testable
 without `openai-agents`; only `as_function_tools()` needs it and it raises a
 clear error naming the extra when absent.
 
@@ -331,7 +340,7 @@ tools.close()
 ```
 
 Install the optional extra only if you use the integration:
-`pip install "mitos[claude-agent]"`. The adapter is fully usable and testable
+`pip install "mitos-run[claude-agent]"`. The adapter is fully usable and testable
 without `claude-agent-sdk`; only `as_mcp_server()` needs it and it raises a clear
 error naming the extra when absent.
 
@@ -356,7 +365,7 @@ sandbox.kill()                            # alias: sandbox.close()
 ```
 
 Install the optional extra only if you use the integration:
-`pip install "mitos[vibekit]"`. The provider does not subclass any VibeKit type
+`pip install "mitos-run[vibekit]"`. The provider does not subclass any VibeKit type
 and is fully usable and testable without VibeKit installed. Fork stays reachable
 as a mitos-native op via `sandbox.fork(n)`, which VibeKit's provider interface
 does not expose.
@@ -382,7 +391,7 @@ comp.deprovision()
 ```
 
 Install the optional extra only if you use the integration:
-`pip install "mitos[zenml]"`. The component backend is fully usable and testable
+`pip install "mitos-run[zenml]"`. The component backend is fully usable and testable
 without ZenML; only `MitosSandboxComponent.flavor()` needs it and raises a clear
 error naming the extra when absent.
 

--- a/sdk/python/mitos/_k8s.py
+++ b/sdk/python/mitos/_k8s.py
@@ -60,7 +60,7 @@ def k8s() -> "_K8s":
             code="kubernetes_not_installed",
             cause=f"importing the kubernetes package failed: {exc}",
             remediation=(
-                "Install it with 'pip install kubernetes' or 'pip install mitos[k8s]'. "
+                "Install it with 'pip install kubernetes' or 'pip install mitos-run[k8s]'. "
                 "Direct mode (mitos.create / mitos.direct) and the in-guest SDK "
                 "(mitos.guest) do not need it."
             ),

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,5 +1,11 @@
+# PyPI distribution name. The bare `mitos` name on PyPI is taken by an
+# unrelated bioinformatics tool, so the distribution publishes as `mitos-run`.
+# The import package stays `mitos` (see the `mitos/` directory and the
+# [tool.hatch.build.targets.wheel] packages list below): you `pip install
+# mitos-run` but `import mitos`, the same dist-name != import-name pattern as
+# scikit-learn -> sklearn.
 [project]
-name = "mitos"
+name = "mitos-run"
 version = "0.1.0"
 description = "Python SDK for mitos: sub-millisecond sandbox forking on Kubernetes"
 keywords = ["sandbox", "firecracker", "microvm", "ai-agents", "kubernetes", "code-interpreter", "mitos"]
@@ -21,8 +27,8 @@ Issues = "https://github.com/mitos-run/mitos/issues"
 # Cluster mode (mitos.client.AgentRun, mitos.aio, mitos.sandbox, mitos.workspace)
 # needs the Kubernetes client. Direct mode (mitos.create / mitos.direct over the
 # sandbox-server REST API) and the in-guest SDK (mitos.guest) speak only httpx
-# and never import it, so it is an optional extra: 'pip install mitos' stays
-# light and 'pip install mitos[k8s]' adds cluster support (issue #22).
+# and never import it, so it is an optional extra: 'pip install mitos-run' stays
+# light and 'pip install mitos-run[k8s]' adds cluster support (issue #22).
 k8s = [
     "kubernetes>=31.0.0",
 ]


### PR DESCRIPTION
PyPI's 'mitos' is taken, so the Python distribution publishes as **mitos-run** (import stays `import mitos`). The PyPI job switches to **Trusted Publishing / OIDC** (matching the pending publisher already configured for project mitos-run): id-token: write, no token/password, existence check at pypi.org/pypi/mitos-run. All `pip install mitos` docs become `pip install mitos-run`. crates.io ('mitos' is free) gains the OIDC path via rust-lang/crates-io-auth-action, with a documented one-time token publish to claim the crate first. RubyGems/npm stay token-based. docs/releasing.md updated. Verified: `python -m build` produces mitos_run-0.1.0 containing the `mitos` package; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)