### PR TITLE
fix(krew): point plugin homepage at the GitHub repo for the stars badge

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mitos
 spec:
   version: "{{ .TagName }}"
-  homepage: https://mitos.run
+  homepage: https://github.com/mitos-run/mitos
   shortDescription: Operate mitos.run sandboxes for AI agents
   description: |
     kubectl mitos inspects and operates mitos.run sandbox objects from your


### PR DESCRIPTION
## What

Point the krew plugin `homepage` at `https://github.com/mitos-run/mitos` instead of `https://mitos.run`.

## Why

The krew.sigs.k8s.io plugin listing derives the GitHub stars badge from the `homepage` field, but only when it is a `github.com` URL. With `homepage: https://mitos.run` the site has no repo to query, so the mitos plugin shows no stars badge while its neighbors do.

The mitos.run install link is preserved in the plugin `caveats` ("See https://mitos.run for installation"), so the referral link is not lost.

## Note

The live badge updates only after this ships in a tagged release and the manifest is merged into kubernetes-sigs/krew-index; it is not instant on merge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)