### PR TITLE
Capitalize "Mitos" brand name

### DIFF
--- a/.github/workflows/cve-watch.yaml
+++ b/.github/workflows/cve-watch.yaml
@@ -1,6 +1,6 @@
 name: CVE watch
 
-# Weekly vulnerability watch across the three mitos CVE surfaces (issue #35):
+# Weekly vulnerability watch across the three Mitos CVE surfaces (issue #35):
 # Go dependencies (govulncheck, automated and blocking), and the guest kernel
 # plus Firecracker (a printed reminder of the pinned versions and the upstream
 # advisory sources, because no free authoritative API maps a pinned vmlinux or

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,6 +1,6 @@
 name: Release Helm chart
 
-# Package the mitos Helm chart and publish it to the gh-pages branch as a
+# Package the Mitos Helm chart and publish it to the gh-pages branch as a
 # classic HTTP Helm repository, plus attach the .tgz to a GitHub release. The
 # repository is served from https://mitos.run/charts via a Cloudflare rewrite to
 # this repo's GitHub Pages site (see docs/distribution.md). Artifact Hub then

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,6 +1,6 @@
 name: Helm chart
 
-# Lint and render the mitos Helm chart so it cannot drift from deploy/ or ship
+# Lint and render the Mitos Helm chart so it cannot drift from deploy/ or ship
 # broken. Runs on changes to the chart or the manifests it mirrors.
 on:
   push:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish:
-    # Build, push, cosign keyless-sign, and SBOM-attest the seven mitos images
+    # Build, push, cosign keyless-sign, and SBOM-attest the seven Mitos images
     # under ghcr.io/mitos-run (supply chain, issue #35). Keyless signing
     # uses the workflow GitHub OIDC identity (id-token: write); there is NO
     # private key in the repo or in secrets. Each image is pushed by digest and

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -10,7 +10,7 @@ spec:
     kubectl mitos inspects and operates mitos.run sandbox objects from your
     cluster: it lists sandbox claims and their copy-on-write forks, renders the
     fork lineage, reports per-sandbox memory metering, reads sandbox logs, and
-    runs commands inside a sandbox. mitos boots Firecracker microVMs and forks
+    runs commands inside a sandbox. Mitos boots Firecracker microVMs and forks
     them via memory snapshots into parallel attempts. The plugin reads the
     cluster connection from the standard kubeconfig resolution.
   caveats: |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -380,7 +380,7 @@ construction with a clear message and prints no number.
 
 ## 1-to-N live fork fan-out (issue #207)
 
-The defensible mitos claim is sub-second 1-to-N live copy-on-write fan-out:
+The defensible Mitos claim is sub-second 1-to-N live copy-on-write fan-out:
 forking ONE warmed base (the template snapshot, built with the repo loaded and
 deps installed) into N children cheaply, with each child a private COW fork of
 the same restored page set. This is a different shape from the single
@@ -426,12 +426,12 @@ unverifiable claim this harness exists to eliminate.**
 ## 1-to-N fan-out competitor comparison (issue #207)
 
 This is the contested-claim comparison. Benchmarking only against E2B would
-overstate the mitos edge (Daytona advertises 27-90 ms creates and Modal markets a
+overstate the Mitos edge (Daytona advertises 27-90 ms creates and Modal markets a
 sandbox snapshot/branch capability), so the honest comparison measures the SAME
 1-to-N fan-out shape on each system:
 
 - **Modal Sandboxes (snapshot/fork)** is the headline competitor: it is the
-  closest analogue to mitos's live COW fan-out (branch one snapshot into many).
+  closest analogue to Mitos's live COW fan-out (branch one snapshot into many).
   Modal is NOT self-hostable, so its number necessarily comes from Modal's hosted
   service, not the reference node; that asymmetry is recorded with any Modal
   figure.
@@ -449,9 +449,9 @@ honesty rule is the same as the create -> first-exec comparison: any competitor
 figure not measured here on the documented hardware is labeled
 **vendor-published** (with a citation), NOT our measurement.
 
-**What this comparison will plainly record.** It will record whether mitos fork
+**What this comparison will plainly record.** It will record whether Mitos fork
 actually beats Modal branching on wall-clock-to-N-ready and per-child
-time-to-ready. If mitos wins, the wedge includes raw fan-out speed. **If it does
+time-to-ready. If Mitos wins, the wedge includes raw fan-out speed. **If it does
 NOT win on raw speed, the wedge is self-hosting plus per-fork network isolation,
 not speed**, and this section will say so. No conclusion and no number is
 pre-written here: the result is OPEN, pending the #16 reference node and a
@@ -469,7 +469,7 @@ first-exec method, a reference adapter (`adapters/mitos.sh`) wired to this repo'
 own harness, and placeholder adapters for each competitor that a reproducer fills
 in (they exit non-zero until then, so a run can never emit a fabricated competitor
 number). The honesty rule is explicit in `bench/competitors/README.md`: we
-publish a mitos number only from our own harness on documented hardware, and any
+publish a Mitos number only from our own harness on documented hardware, and any
 competitor figure not measured here on the same hardware is labeled
 **vendor-published** (with a citation), NOT our measurement. **Status: scaffold +
 methodology in-repo; head-to-head numbers OPEN, pending the #16 reference node and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,6 @@ No em or en dashes anywhere; see the Coding Conventions section of [CLAUDE.md](C
 This repository is open source under the Apache License 2.0 (see `LICENSE`).
 Contributions are accepted under the DCO and stay under that license. There is
 no hosted or commercial offering today; the open-core boundary is described in
-[docs/open-core.md](docs/open-core.md). The "mitos" name and marks are reserved;
+[docs/open-core.md](docs/open-core.md). The "Mitos" name and marks are reserved;
 see [TRADEMARKS.md](TRADEMARKS.md). The code license does not grant trademark
 rights.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/mitos-mark-white.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/assets/mitos-mark-black.svg">
-    <img alt="mitos" src="docs/assets/mitos-mark-black.svg" width="120" height="120">
+    <img alt="Mitos" src="docs/assets/mitos-mark-black.svg" width="120" height="120">
   </picture>
 </p>
 
-<h1 align="center">mitos</h1>
+<h1 align="center">Mitos</h1>
 
 <p align="center">
   <b>Millisecond microVM sandbox forking for AI agents on Kubernetes.</b><br/>
@@ -32,11 +32,11 @@
 
 ---
 
-## What is mitos
+## What is Mitos
 
 Agent harnesses need fast, isolated environments where agents can read and write files, install packages, and run untrusted code. Every existing option forces a trade you should not have to make: speed without ownership, isolation without forking, Kubernetes-nativeness without warm starts, or durability as someone else's proprietary cloud.
 
-`mitos` is, as far as we know, the only open-source, self-hostable, Kubernetes-native runtime whose engine does N-way live copy-on-write fork of a running microVM, and it does so with a **warm-claim activate in the tens-of-ms class**: P50 ~27 ms on the bare-metal reference node, reproducible from [`bench/husk-activate-latency.sh`](bench/husk-activate-latency.sh). You drive the whole lifecycle through declarative CRDs (`mitos.run`) on your own cluster, or fully hosted by us.
+`Mitos` is, as far as we know, the only open-source, self-hostable, Kubernetes-native runtime whose engine does N-way live copy-on-write fork of a running microVM, and it does so with a **warm-claim activate in the tens-of-ms class**: P50 ~27 ms on the bare-metal reference node, reproducible from [`bench/husk-activate-latency.sh`](bench/husk-activate-latency.sh). You drive the whole lifecycle through declarative CRDs (`mitos.run`) on your own cluster, or fully hosted by us.
 
 Two ways to run it:
 
@@ -104,7 +104,7 @@ hosted signup, the free-tier credit, and the first API key come from the
 ### Python on Kubernetes (operators)
 
 On a cluster, the two-tier `AgentRun` path drives the CRDs (SandboxPool,
-Sandbox, Workspace) directly. Use this when you run the mitos operator yourself.
+Sandbox, Workspace) directly. Use this when you run the Mitos operator yourself.
 
 ```python
 from mitos import AgentRun
@@ -206,7 +206,7 @@ Streaming exec (`/v1/exec/stream`) and the interactive PTY (`/v1/pty`) require t
 
 ### Integrations
 
-Drop a mitos sandbox into the agent framework you already use; each adapter is a thin shim over the same native SDK ops (`exec`, `run_code`, `files`), with no hard dependency on the framework package.
+Drop a Mitos sandbox into the agent framework you already use; each adapter is a thin shim over the same native SDK ops (`exec`, `run_code`, `files`), with no hard dependency on the framework package.
 
 | Framework | Import | Docs |
 |---|---|---|
@@ -394,22 +394,22 @@ The local dev cluster uses the mock fork engine (no KVM): claims reconcile to `R
 
 ## Comparison
 
-A numbers table belongs here only when our benchmark harness can regenerate it against the actual competitors on the same hardware, with scripts in this repo so anyone can reproduce or refute it. That harness is [#15](https://github.com/mitos-run/mitos/issues/15). The differentiator is not a single fastest-number claim: `mitos` is, as far as we know, the only open-source, self-hostable, Kubernetes-native runtime whose engine does N-way live copy-on-write fork of a running microVM, with a warm-claim activate in the tens-of-ms class (P50 ~27 ms, reproducible from [`bench/husk-activate-latency.sh`](bench/husk-activate-latency.sh)).
+A numbers table belongs here only when our benchmark harness can regenerate it against the actual competitors on the same hardware, with scripts in this repo so anyone can reproduce or refute it. That harness is [#15](https://github.com/mitos-run/mitos/issues/15). The differentiator is not a single fastest-number claim: `Mitos` is, as far as we know, the only open-source, self-hostable, Kubernetes-native runtime whose engine does N-way live copy-on-write fork of a running microVM, with a warm-claim activate in the tens-of-ms class (P50 ~27 ms, reproducible from [`bench/husk-activate-latency.sh`](bench/husk-activate-latency.sh)).
 
 The figures below are **other vendors' published numbers, for different operations, on different hardware, measured with different methodology**; they are NOT measured by us and this is NOT a head-to-head claim. The matched-hardware comparison is [#15](https://github.com/mitos-run/mitos/issues/15).
 
 | Runtime | Published figure (theirs, not ours) | Operation they describe |
 |---|---|---|
-| mitos (ours, measured) | ~27 ms P50 | warm-claim activate (snapshot load + fork-correctness handshake + guest-ready) on the bare-metal reference node |
+| Mitos (ours, measured) | ~27 ms P50 | warm-claim activate (snapshot load + fork-correctness handshake + guest-ready) on the bare-metal reference node |
 | E2B | ~150 ms | sandbox create |
 | Daytona | sub-90 ms | create from snapshot |
 | Modal | sub-second | sandbox create |
 | CodeSandbox SDK | ~863 ms / ~495 ms | live fork / memory-resume |
 | Fly Machines | < 1 s | machine start |
 
-What is comparable and real today is the qualitative pareto map: the combination of open source, self-hostable, k8s-native, and live snapshot fork is the axis where `mitos` is alone.
+What is comparable and real today is the qualitative pareto map: the combination of open source, self-hostable, k8s-native, and live snapshot fork is the axis where `Mitos` is alone.
 
-| | mitos | E2B | Modal | Daytona | Morph | Cloudflare | Box | Agent Sandbox | Kata/KubeVirt | raw Firecracker |
+| | Mitos | E2B | Modal | Daytona | Morph | Cloudflare | Box | Agent Sandbox | Kata/KubeVirt | raw Firecracker |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Hardware isolation per session | KVM microVM | microVM | gVisor | container/VM | microVM | V8 isolate | VM | Kata option | KVM | KVM |
 | Snapshot fork of running state | yes, core primitive | snapshot/resume | memory snapshots | no | yes (Infinibranch) | no | disk fork | no | no | build it yourself |
@@ -421,7 +421,7 @@ What is comparable and real today is the qualitative pareto map: the combination
 | Your data stays on your infra | yes (self-hosted) | no | no | partial | no | no | no | yes | yes | yes |
 | Open source | Apache 2.0 | partial | no | partial | no | no | no | Apache 2.0 | Apache 2.0 | Apache 2.0 |
 
-SaaS runtimes (E2B, Modal, Daytona, Cloudflare) are fast but your agents' code, data, and credentials run on someone else's infrastructure with no self-host path at equivalent capability. Morph built the right state model (branch/restore) as a proprietary cloud, and our Workspace primitive targets the same semantics open source at fork(2) speeds. Box is a hosted-only disk-fork sandbox SaaS with an agent-native CLI, which validates the agent-native direction we take with `mitos` and MCP (Box publishes no latency benchmark, so we make no comparison claim there). Agent Sandbox (k8s-sigs) is winning the Kubernetes API standard without a snapshot-fork engine, which is why we ship a conformance facade (`cmd/facade`) to be its fastest backend rather than fighting it ([docs/facade-conformance.md](docs/facade-conformance.md)). Kata, KubeVirt, and raw Firecracker give you the isolation primitive and leave the pool, fork, distribution, and agent-API layers as your problem.
+SaaS runtimes (E2B, Modal, Daytona, Cloudflare) are fast but your agents' code, data, and credentials run on someone else's infrastructure with no self-host path at equivalent capability. Morph built the right state model (branch/restore) as a proprietary cloud, and our Workspace primitive targets the same semantics open source at fork(2) speeds. Box is a hosted-only disk-fork sandbox SaaS with an agent-native CLI, which validates the agent-native direction we take with `Mitos` and MCP (Box publishes no latency benchmark, so we make no comparison claim there). Agent Sandbox (k8s-sigs) is winning the Kubernetes API standard without a snapshot-fork engine, which is why we ship a conformance facade (`cmd/facade`) to be its fastest backend rather than fighting it ([docs/facade-conformance.md](docs/facade-conformance.md)). Kata, KubeVirt, and raw Firecracker give you the isolation primitive and leave the pool, fork, distribution, and agent-API layers as your problem.
 
 If an alternative beats us on an axis you care about and we have no roadmap line that closes it, that is a bug in our strategy: open an issue.
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,6 +1,6 @@
 # Trademarks
 
-The "mitos" name, logo, and any associated marks are reserved by the project
+The "Mitos" name, logo, and any associated marks are reserved by the project
 maintainer. This is a placeholder notice for the maintainer to formalize; it
 records intent, it is not a registered-trademark claim.
 
@@ -8,10 +8,10 @@ The code in this repository is licensed under the Apache License 2.0 (see
 `LICENSE`). The Apache 2.0 license grants rights to the code; it does NOT grant
 any right to use the project's name, logo, or marks. In particular:
 
-- Do not use the "mitos" name or marks in a way that implies endorsement,
+- Do not use the "Mitos" name or marks in a way that implies endorsement,
   affiliation, or that your fork or derivative is the official project.
-- Nominative, factual references are fine: for example, "compatible with mitos"
-  or "built on mitos", as long as they do not imply official status.
+- Nominative, factual references are fine: for example, "compatible with Mitos"
+  or "built on Mitos", as long as they do not imply official status.
 - A fork or redistribution that materially modifies the project should use its
   own name to avoid confusion.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -163,6 +163,6 @@ snapshot/fork, the headline competitor), `adapters/daytona-fanout.sh`, and
 `adapters/e2b-fanout.sh` (cold-start baseline) are placeholders that exit
 non-zero until filled in. Modal is not self-hostable, so a Modal number comes
 from its hosted service, not the reference node; that asymmetry is recorded with
-any Modal figure. The fan-out comparison will plainly record whether mitos fork
+any Modal figure. The fan-out comparison will plainly record whether Mitos fork
 beats Modal branching, and if it does not, that the wedge is self-hosting plus
 per-fork network isolation rather than raw speed; no conclusion is pre-written.

--- a/bench/claim-first-exec-latency.sh
+++ b/bench/claim-first-exec-latency.sh
@@ -19,7 +19,7 @@
 # it fails at client construction with a clear message and produces NO number
 # (CLAUDE.md operating principle 1: no unverified claims).
 #
-# Requirements: a running mitos cluster with the controller deployed and a warm
+# Requirements: a running Mitos cluster with the controller deployed and a warm
 # SandboxPool, plus Go (to build the harness) and a KUBECONFIG that can create
 # SandboxClaims and read the per-claim token Secret in the namespace.
 #

--- a/bench/competitors/README.md
+++ b/bench/competitors/README.md
@@ -1,7 +1,7 @@
 # Competitor comparison harness (scaffold + methodology)
 
 This directory is the **scaffold** and **methodology** for the head-to-head
-competitor comparison issue #15 item 5 asks for: mitos vs E2B (self-hosted),
+competitor comparison issue #15 item 5 asks for: Mitos vs E2B (self-hosted),
 Daytona (OSS), Agent Sandbox + Kata, and similar self-hostable sandbox systems,
 on identical hardware, regenerated from in-repo scripts so a third party can
 reproduce or refute the result.
@@ -22,7 +22,7 @@ checked into a `make test` path. What this directory provides:
 
 Per CLAUDE.md operating principle 1 (no unverified claims) and issue #15:
 
-- We publish a mitos number ONLY from our own harness in this repo
+- We publish a Mitos number ONLY from our own harness in this repo
   (`bench/claim-first-exec-latency.sh` and `cmd/bench`), on documented hardware.
 - We do NOT invent competitor numbers. Any competitor figure that this repo's
   scripts did not measure on the same hardware is labeled **vendor-published**
@@ -38,7 +38,7 @@ The single comparable metric is **create-sandbox -> first-exec** wall clock:
 from the API call that asks the system for a fresh sandbox to the first
 successful command execution inside it. This is the metric `cmd/bench`
 (`fork_to_first_exec`) and `bench/claim-first-exec-latency.sh`
-(`claim_to_first_exec`) already measure for mitos, so the comparison is
+(`claim_to_first_exec`) already measure for Mitos, so the comparison is
 apples-to-apples.
 
 For each system, on the SAME hardware:
@@ -63,8 +63,8 @@ reference implementation (which simply calls this repo's own harness).
 
 | system | what a reproducer must deploy | "warm" state | source of any quoted number until measured |
 | --- | --- | --- | --- |
-| mitos (this repo) | a mitos cluster + warm SandboxPool, or a KVM host for `cmd/bench` | warm pool / loaded template snapshot | OUR harness (`bench/claim-first-exec-latency.sh`, `cmd/bench`) |
-| mitos (bare metal, no cluster) | a KVM host with firecracker + a guest `vmlinux` + a reflink-capable data dir | running `sandbox-server` with a pre-built template snapshot | OUR harness (`adapters/mitos-direct.sh`); MEASURED on bare-metal KVM, see `results/2026-06-22-matched-hardware.md` |
+| Mitos (this repo) | a Mitos cluster + warm SandboxPool, or a KVM host for `cmd/bench` | warm pool / loaded template snapshot | OUR harness (`bench/claim-first-exec-latency.sh`, `cmd/bench`) |
+| Mitos (bare metal, no cluster) | a KVM host with firecracker + a guest `vmlinux` + a reflink-capable data dir | running `sandbox-server` with a pre-built template snapshot | OUR harness (`adapters/mitos-direct.sh`); MEASURED on bare-metal KVM, see `results/2026-06-22-matched-hardware.md` |
 | E2B (self-hosted) | the open-source E2B infra stack on the same hardware | pre-built E2B template, warm sandbox pool if configured | vendor-published until a maintainer runs `adapters/e2b.sh` here (out of timebox as of 2026-06-22, heavy multi-service stack) |
 | Daytona (OSS) | a self-hosted Daytona instance (`docker compose`) + a dashboard-minted API key | pre-pulled snapshot image, runner healthy | DEPLOYED 2026-06-22 (14/14 services up) but create -> first-exec blocked at headless auth; no number. See `results/2026-06-22-matched-hardware.md` and `adapters/daytona.sh` |
 | Agent Sandbox + Kata | the upstream Agent Sandbox controller with the Kata runtime class | pre-pulled image, Kata runtime ready | vendor-published until a maintainer runs `adapters/agent-sandbox-kata.sh` here |
@@ -73,14 +73,14 @@ reference implementation (which simply calls this repo's own harness).
 
 The first matched-method, matched-hardware comparison was run on 2026-06-22 on
 two identical Hetzner bare-metal KVM boxes (Intel i7-6700, 4c/8t, 62 GiB, host
-kernel 6.1.0-49, firecracker v1.15.0). The mitos column is OUR measurement; the
+kernel 6.1.0-49, firecracker v1.15.0). The Mitos column is OUR measurement; the
 competitor column is recorded honestly (deployed, but blocked at headless auth,
 no fabricated number). Full record, raw samples, and reproduction steps:
 [`results/2026-06-22-matched-hardware.md`](results/2026-06-22-matched-hardware.md).
 
 | system | create -> first-exec | source |
 | --- | --- | --- |
-| mitos (mitos-direct, bare-metal KVM) | min 164 / P50 180 / P90 202 / P99 204 / max 204 ms (N=20) | OUR measurement (`adapters/mitos-direct.sh`) |
+| Mitos (mitos-direct, bare-metal KVM) | min 164 / P50 180 / P90 202 / P99 204 / max 204 ms (N=20) | OUR measurement (`adapters/mitos-direct.sh`) |
 | Daytona OSS (self-hosted) | blocked: Dex OIDC, no password grant, no headless API key in timebox | deployed, no number (`adapters/daytona.sh`) |
 | E2B (self-hosted) | not measured (out of timebox) | vendor-published until `adapters/e2b.sh` is run here |
 
@@ -93,8 +93,8 @@ bare-metal, no-cluster `sandbox-server` path measured on 2026-06-22).
 
 ## What ships in-repo vs what is a reproducer step
 
-- In-repo and runnable now: the mitos cluster side (`adapters/mitos.sh` -> this
-  repo's harness), the mitos bare-metal side (`adapters/mitos-direct.sh` -> this
+- In-repo and runnable now: the Mitos cluster side (`adapters/mitos.sh` -> this
+  repo's harness), the Mitos bare-metal side (`adapters/mitos-direct.sh` -> this
   repo's `sandbox-server`, needs only a KVM host, no cluster), and the driver
   (`run-comparison.sh`).
 - Reproducer step (not in-repo, by design): standing up each competitor and
@@ -106,7 +106,7 @@ bare-metal, no-cluster `sandbox-server` path measured on 2026-06-22).
 
 The create -> first-exec metric above compares a single sandbox. Issue #207 adds
 the **contested-claim** comparison: the 1-to-N live fork fan-out shape, where ONE
-warmed base is fanned into N children. This is where mitos's defensible claim
+warmed base is fanned into N children. This is where Mitos's defensible claim
 lives (sub-second 1-to-N copy-on-write fan-out, self-hostable, per-fork network
 isolation), and benchmarking only against E2B would overstate the edge, so we
 measure the SAME fan-out shape on the systems that actually contest it.
@@ -122,7 +122,7 @@ fork-fanout`).
 
 | system | fan-out adapter | what its "fan-out" is | reproduction prerequisite | source until measured |
 | --- | --- | --- | --- | --- |
-| mitos (this repo) | `adapters/mitos-fanout.sh` | live COW fork of one warmed snapshot into N children | KVM host + a pre-built, verified WARMED template snapshot (repo + deps baked in) | OUR harness (`cmd/bench --mode fork-fanout`) |
+| Mitos (this repo) | `adapters/mitos-fanout.sh` | live COW fork of one warmed snapshot into N children | KVM host + a pre-built, verified WARMED template snapshot (repo + deps baked in) | OUR harness (`cmd/bench --mode fork-fanout`) |
 | Modal Sandboxes | `adapters/modal-fanout.sh` | branch/fork one snapshot into N (the headline competitor) | a Modal account + a warmed Modal snapshot; NOT self-hostable, so run against Modal's hosted service | vendor-published until a maintainer runs the adapter |
 | Daytona (OSS) | `adapters/daytona-fanout.sh` | N independent creates from one warmed image (cold-start baseline) | self-hosted Daytona on the reference node | vendor-published until a maintainer runs the adapter |
 | E2B (self-hosted) | `adapters/e2b-fanout.sh` | N creates from one warmed template (cold-start baseline) | self-hosted E2B on the reference node | vendor-published until a maintainer runs the adapter |
@@ -130,17 +130,17 @@ fork-fanout`).
 ### The honesty asymmetry to record (Modal)
 
 Modal is not self-hostable, so a Modal fan-out number necessarily comes from
-Modal's hosted service, not the same reference hardware as the mitos run. That is
+Modal's hosted service, not the same reference hardware as the Mitos run. That is
 NOT an apples-to-apples hardware comparison and must be recorded as such with any
-Modal figure: the Modal number measures hosted fan-out, the mitos number measures
+Modal figure: the Modal number measures hosted fan-out, the Mitos number measures
 self-hosted fan-out on the reference node. Until `adapters/modal-fanout.sh` is
 filled in and run, any Modal fan-out figure is **vendor-published**, not our
 measurement.
 
 ### What this comparison will plainly record (no conclusion pre-written)
 
-The fan-out comparison will record whether mitos fork actually beats Modal
-branching on wall-clock-to-N-ready and per-child time-to-ready. **If mitos wins,
+The fan-out comparison will record whether Mitos fork actually beats Modal
+branching on wall-clock-to-N-ready and per-child time-to-ready. **If Mitos wins,
 the wedge includes raw fan-out speed. If it does NOT win on raw speed, the wedge
 is self-hosting plus per-fork network isolation, not speed.** No conclusion and no
 number is written here in advance: the result is OPEN, to be filled on the #16

--- a/bench/competitors/adapters/daytona-fanout.sh
+++ b/bench/competitors/adapters/daytona-fanout.sh
@@ -6,10 +6,10 @@
 # rather than forking one warmed base, so its "fan-out" is N independent creates
 # from the same pre-pulled image. Measuring that SAME shape is exactly the honest
 # comparison issue #207 asks for: it shows the cold-start baseline against
-# mitos's live copy-on-write fan-out. To produce a Daytona number this repo can
+# Mitos's live copy-on-write fan-out. To produce a Daytona number this repo can
 # publish as OUR measurement, a reproducer must:
 #
-#   1. Stand up a self-hosted Daytona instance on the SAME hardware as the mitos
+#   1. Stand up a self-hosted Daytona instance on the SAME hardware as the Mitos
 #      run (issue #16 reference node).
 #   2. Pre-pull the workspace image and warm any pool Daytona supports (document
 #      what "warm" means; Daytona cold-creates a workspace per sandbox).

--- a/bench/competitors/adapters/e2b-fanout.sh
+++ b/bench/competitors/adapters/e2b-fanout.sh
@@ -5,11 +5,11 @@
 # This is a SCAFFOLD, not a runnable measurement. E2B starts sandboxes from a
 # pre-built template rather than forking one warmed base, so its "fan-out" is N
 # creates from the same template. Measuring that SAME shape is the honest cold-
-# start baseline against mitos's live copy-on-write fan-out. To produce an E2B
+# start baseline against Mitos's live copy-on-write fan-out. To produce an E2B
 # number this repo can publish as OUR measurement, a reproducer must:
 #
 #   1. Deploy the open-source E2B infrastructure stack on the SAME hardware as
-#      the mitos run (issue #16 reference node).
+#      the Mitos run (issue #16 reference node).
 #   2. Pre-build the E2B template and warm any sandbox pool E2B supports
 #      (document what "warm" means).
 #   3. Implement fanout(N) below to: create N E2B sandboxes from the same warmed

--- a/bench/competitors/adapters/modal-fanout.sh
+++ b/bench/competitors/adapters/modal-fanout.sh
@@ -4,7 +4,7 @@
 # snapshot/fork.
 #
 # This is a SCAFFOLD, not a runnable measurement. Modal markets a sandbox
-# snapshot and branch/fork capability, which is the closest competitor to mitos's
+# snapshot and branch/fork capability, which is the closest competitor to Mitos's
 # 1-to-N live copy-on-write fan-out, so it is the headline comparison for issue
 # #207. To produce a Modal number this repo can publish as OUR measurement, a
 # reproducer must:
@@ -19,9 +19,9 @@
 #        lines 2..N+1:  each child's time-to-ready MILLISECONDS (one per line)
 #
 # Modal is NOT self-hostable, so this comparison is necessarily run against
-# Modal's hosted service, not the same reference hardware as mitos. Record that
+# Modal's hosted service, not the same reference hardware as Mitos. Record that
 # asymmetry explicitly with any Modal number: it measures Modal's hosted fan-out,
-# and the mitos number measures self-hosted fan-out on the reference node. Until
+# and the Mitos number measures self-hosted fan-out on the reference node. Until
 # this adapter is filled in, any Modal figure is VENDOR-PUBLISHED (cite Modal's
 # own source), not our measurement.
 #

--- a/bench/competitors/results/2026-06-22-matched-hardware.md
+++ b/bench/competitors/results/2026-06-22-matched-hardware.md
@@ -1,6 +1,6 @@
 # Matched-hardware competitor comparison (2026-06-22)
 
-Issue #15 item 3 (the competitor comparison table). This run produces the mitos
+Issue #15 item 3 (the competitor comparison table). This run produces the Mitos
 column as OUR measurement on bare-metal KVM via the comparison harness, and
 records the competitor attempt honestly: deployed and brought up, but the
 create -> first-exec measurement blocked at headless authentication, with NO
@@ -93,7 +93,7 @@ Raw samples sorted:
 164 166 168 170 173 174 177 177 179 180 181 184 185 185 185 187 198 202 202 204
 ```
 
-This is mitos's matched-method create -> first-exec on bare-metal KVM: roughly a
+This is Mitos's matched-method create -> first-exec on bare-metal KVM: roughly a
 180 ms P50 warm fork-to-exec, no Kubernetes, no cluster, no pool. The full
 harness output (warm log, per-iter lines, percentiles) is reproducible by
 re-running the adapter; see "How to reproduce" below.
@@ -173,7 +173,7 @@ flows (no password grant), so no headless token in the timebox.** No number.
   from the vendor's hosted hardware, not this reference node; recorded as
   vendor-published, not our measurement (see the fan-out section of the
   competitors README).
-- **mitos cluster claim path (`adapters/mitos.sh`)**: not run here; it needs a
+- **Mitos cluster claim path (`adapters/mitos.sh`)**: not run here; it needs a
   kubeconfig + warm SandboxPool we do not have on these boxes. `mitos-direct.sh`
   is the bare-metal, no-cluster companion measured above.
 
@@ -181,7 +181,7 @@ flows (no password grant), so no headless token in the timebox.** No number.
 
 | system | create -> first-exec | source |
 | --- | --- | --- |
-| mitos (mitos-direct, bare-metal KVM) | min 164 / P50 180 / P90 202 / P99 204 / max 204 ms (N=20) | OUR measurement, this run (`adapters/mitos-direct.sh`) |
+| Mitos (mitos-direct, bare-metal KVM) | min 164 / P50 180 / P90 202 / P99 204 / max 204 ms (N=20) | OUR measurement, this run (`adapters/mitos-direct.sh`) |
 | Daytona OSS (self-hosted) | blocked: headless auth (Dex OIDC, no password grant) | deployed on box2 this run; no number, see above |
 | E2B (self-hosted) | not measured (out of timebox; heavy multi-service stack) | vendor-published until `adapters/e2b.sh` is run here |
 

--- a/bench/competitors/run-fanout-comparison.sh
+++ b/bench/competitors/run-fanout-comparison.sh
@@ -9,11 +9,11 @@
 # time-to-ready distribution. Every system is measured by the same method so the
 # comparison is apples-to-apples.
 #
-# This is the contested-claim harness. The defensible mitos claim is sub-second
+# This is the contested-claim harness. The defensible Mitos claim is sub-second
 # 1-to-N live copy-on-write fan-out: forking one warmed base into many children
 # cheaply. Modal markets a snapshot/branch capability and Daytona/E2B start cold
 # sandboxes; the only honest way to compare is to measure the SAME fan-out shape
-# on each and record whether mitos fork actually beats branching, or whether the
+# on each and record whether Mitos fork actually beats branching, or whether the
 # wedge is self-hosting plus per-fork network isolation rather than raw speed.
 # This driver does NOT decide that. It only runs the adapter the maintainer
 # points it at, on the maintainer's hardware, and never invents a number.

--- a/bench/husk-activate-latency.sh
+++ b/bench/husk-activate-latency.sh
@@ -2,7 +2,7 @@
 #
 # husk-activate-latency.sh
 #
-# Reproducible source for the warm-claim activate latency number mitos
+# Reproducible source for the warm-claim activate latency number Mitos
 # publishes (the "~27 ms P50" bare-metal reference figure, issue #16 / #18).
 #
 # What it measures: the time the controller reports for a warm-sandbox activation
@@ -24,7 +24,7 @@
 # sample list, so the published number is reproducible per the repo's
 # no-unverified-claims rule.
 #
-# Requirements: a running mitos cluster with the husk-pods path enabled and a
+# Requirements: a running Mitos cluster with the husk-pods path enabled and a
 # warm pool with dormant pods available, plus kubectl and a KUBECONFIG that can
 # create Sandboxes in the target namespace.
 #

--- a/bench/pool-rebuild-propagation.sh
+++ b/bench/pool-rebuild-propagation.sh
@@ -24,7 +24,7 @@
 # a REAL cluster; with no reachable cluster it fails with a clear message and
 # produces NO number (no unverified claims).
 #
-# Requirements: a running mitos cluster (ideally multi-node) with the controller
+# Requirements: a running Mitos cluster (ideally multi-node) with the controller
 # and an existing SandboxPool, Go, and a KUBECONFIG that can update the pool and
 # read its status.
 #

--- a/bench/results/2026-06-13-bare-metal-husk.md
+++ b/bench/results/2026-06-13-bare-metal-husk.md
@@ -137,7 +137,7 @@ The script creates N sequential `SandboxClaim`s against a warm pool, waits for
 each to reach Ready, parses the activate latency out of the Ready condition
 message, releases the claim between iterations so each is an independent warm
 activation, and prints min / P50 / P95 / max (nearest-rank) plus the raw sample
-list. It requires a running mitos cluster with the husk-pods path enabled and a
+list. It requires a running Mitos cluster with the husk-pods path enabled and a
 warm pool with dormant pods available.
 
 ### Cluster setup used for this run

--- a/bench/sleep-consolidation.sh
+++ b/bench/sleep-consolidation.sh
@@ -26,7 +26,7 @@
 #
 # It writes a result row to bench/results/ so the number is reproducible.
 #
-# Requirements: a running mitos cluster, kubectl + a KUBECONFIG that can create
+# Requirements: a running Mitos cluster, kubectl + a KUBECONFIG that can create
 # the demo objects in the namespace, python3 with the mitos SDK, the mitos CLI.
 #
 # Usage:

--- a/bench/sustained-claims-throughput.sh
+++ b/bench/sustained-claims-throughput.sh
@@ -23,7 +23,7 @@
 # per-node density) point. The p99 degradation point is where achieved/sec stops
 # tracking the target rate as you push the arrival rate up.
 #
-# Requirements: a running mitos cluster with the controller and a warm
+# Requirements: a running Mitos cluster with the controller and a warm
 # SandboxPool sized for the target concurrency, Go, and a KUBECONFIG that can
 # create and read SandboxClaims in the namespace.
 #

--- a/bench/workspace-fork-latency.sh
+++ b/bench/workspace-fork-latency.sh
@@ -22,7 +22,7 @@
 # revision-object create plus the reconcile to Committed), not a data-path
 # number; that is the point of the workspace fork design and what this asserts.
 #
-# Requirements: a running mitos cluster with at least one Workspace that has a
+# Requirements: a running Mitos cluster with at least one Workspace that has a
 # committed head revision, the mitos CLI on PATH (built from this repo), and
 # kubectl + a KUBECONFIG that can read/create the objects in the namespace.
 #

--- a/bench/workspace-hydrate-latency.sh
+++ b/bench/workspace-hydrate-latency.sh
@@ -28,7 +28,7 @@
 # It reuses the warm-pool wait pattern from bench/husk-activate-latency.sh so
 # each hydrate sample is a real warm bind and not blocked on pool refill.
 #
-# Requirements: a running mitos cluster with a warm pool, a Workspace object,
+# Requirements: a running Mitos cluster with a warm pool, a Workspace object,
 # kubectl + a KUBECONFIG that can create the objects in the namespace, and
 # python3 with the mitos SDK installed.
 #

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -495,7 +495,7 @@ func oneStormActivate(engine *fork.Engine, template, sandboxID string, pin *cpup
 // deps installed when the maintainer builds it that way) into N children, and
 // for each N in cfg.fanOutN record (a) each child's time-to-ready (fork ->
 // first successful exec) and (b) the wall clock from the fan-out start to the
-// instant the LAST child is ready. The defensible mitos claim under test is
+// instant the LAST child is ready. The defensible Mitos claim under test is
 // sub-second 1-to-N COW fan-out, so the headline number is wall-clock-to-N-ready
 // at the larger N.
 //

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -191,8 +191,8 @@ var indexLinks = []string{
 // plain quoted string (no raw string literal) so the HTML stays trivially
 // reviewable.
 var indexTmpl = template.Must(template.New("index").Parse(
-	"<!doctype html><html><head><title>mitos console</title></head><body>" +
-		"<h1>mitos console (dev)</h1>" +
+	"<!doctype html><html><head><title>Mitos console</title></head><body>" +
+		"<h1>Mitos console (dev)</h1>" +
 		"<p>This is the minimal wiring proof. The full SPA is a documented follow-up " +
 		"(docs/saas/console.md). Set the dev headers and call the BFF directly.</p>" +
 		"<ul>{{range .Links}}<li><a href=\"{{.}}\">{{.}}</a></li>{{end}}</ul>" +

--- a/cmd/console/spa/dist/index.html
+++ b/cmd/console/spa/dist/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>mitos console</title>
+    <title>Mitos console</title>
   </head>
   <body>
     <!-- Placeholder shell. The real bundle is built from web/app and copied over
          this file by Dockerfile.console before `go build`. The Go binary always
          has something to embed so it builds without the JS toolchain. -->
-    <div id="root">mitos console — build the SPA (pnpm -C web build) to replace this placeholder.</div>
+    <div id="root">Mitos console — build the SPA (pnpm -C web build) to replace this placeholder.</div>
   </body>
 </html>

--- a/cmd/console/spa/spa_test.go
+++ b/cmd/console/spa/spa_test.go
@@ -14,7 +14,7 @@ func TestServesIndexAtRoot(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "mitos console") {
+	if !strings.Contains(w.Body.String(), "Mitos console") {
 		t.Fatalf("index missing marker: %s", w.Body.String())
 	}
 }

--- a/deploy/charts/charttest/console_test.go
+++ b/deploy/charts/charttest/console_test.go
@@ -1,4 +1,4 @@
-// Package charttest renders the mitos Helm chart with `helm template` and
+// Package charttest renders the Mitos Helm chart with `helm template` and
 // asserts the console/gateway components behave per the spec: ONE chart, two
 // editions driven by values, the #208 gate enforced server-side (signup/billing
 // off by default), and the console gated by console.enabled. It skips when the

--- a/deploy/charts/mitos/README.md
+++ b/deploy/charts/mitos/README.md
@@ -1,4 +1,4 @@
-# mitos Helm chart
+# Mitos Helm chart
 
 Snapshot-fork sandboxes for AI agents on Kubernetes. This chart installs the
 mitos.run operator: the controller Deployment, the privileged forkd DaemonSet,
@@ -90,7 +90,7 @@ forkd DaemonSet reference the secret named by `imagePullSecret.name`.
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `image.registry` | `ghcr.io/mitos-run` | Registry hosting every mitos image. |
+| `image.registry` | `ghcr.io/mitos-run` | Registry hosting every Mitos image. |
 | `global.imageTag` | `""` | When set, overrides every per-component image tag. |
 | `controller.image.repository` | `mitos-controller` | Controller image repository. |
 | `controller.image.tag` | `v0.13.0` | Controller image tag. |

--- a/deploy/monitoring/dashboard-configmap.yaml
+++ b/deploy/monitoring/dashboard-configmap.yaml
@@ -66,7 +66,7 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "mitos control plane",
+      "title": "Mitos control plane",
       "uid": "mitos-control-plane",
       "version": 1,
       "weekStart": "",

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -7,7 +7,7 @@ compliance & observability addendum in ROADMAP.md ("residuals ship as ADRs in
 
 ## Context
 
-mitos already carried load-bearing design decisions in prose: the
+Mitos already carried load-bearing design decisions in prose: the
 `agents.x-k8s.io` facade and the our-vs-their naming collision (recorded ad hoc
 as ADR 0001), the Workspace-not-CSI choice (ADR 0002), and a set of RESIDUAL
 security decisions documented only inside docs/threat-model.md and CLAUDE.md
@@ -29,7 +29,7 @@ Two problems followed from having no adopted framework:
 
 ## Decision: adopt Architecture Decision Records
 
-We adopt ADRs (in the Nygard sense) as the way mitos records significant,
+We adopt ADRs (in the Nygard sense) as the way Mitos records significant,
 hard-to-reverse, or honesty-sensitive design decisions. The mechanics:
 
 - ADRs live in `docs/adr/` as Markdown, one file per decision, named
@@ -49,7 +49,7 @@ hard-to-reverse, or honesty-sensitive design decisions. The mechanics:
   to point at the superseding ADR. This preserves the decision history.
 - Every ADR decision must TRACE to something real: a line in the code, a row in
   docs/threat-model.md, a rule in CLAUDE.md, or a plan in
-  docs/superpowers/plans/. mitos has a no-unverified-claims operating principle
+  docs/superpowers/plans/. Mitos has a no-unverified-claims operating principle
   (CLAUDE.md, operating principle 1); an ADR that asserts a behavior the code
   does not yet implement must say so explicitly and cite the plan, exactly as a
   threat-model row distinguishes mitigated from open.

--- a/docs/adr/0004-node-flat-snapshot-trust-domain.md
+++ b/docs/adr/0004-node-flat-snapshot-trust-domain.md
@@ -10,7 +10,7 @@ the node-CAS row in section 3; the code is `internal/cas`,
 ## Context
 
 Snapshots are executable memory images: loading one is equivalent to running code
-at sandbox privilege. mitos stores them content-addressed in a per-node store
+at sandbox privilege. Mitos stores them content-addressed in a per-node store
 (`internal/cas`, under `<dataDir>`), and the run path shares them across pods on
 the same node:
 
@@ -32,7 +32,7 @@ today (section 7): snapshots on a node are a flat directory shared by all tenant
 there is no enforcement that a claim only forks snapshots its namespace published,
 and VMs of different namespaces share nodes, host kernel, and forkd.
 
-This needs a recorded decision because it sets the multi-tenancy posture mitos
+This needs a recorded decision because it sets the multi-tenancy posture Mitos
 commits to honestly: what a Kubernetes namespace boundary actually buys around
 snapshots today, and what it does not.
 

--- a/docs/adr/0005-raw-forkd-not-multitenant.md
+++ b/docs/adr/0005-raw-forkd-not-multitenant.md
@@ -11,7 +11,7 @@ docs/husk-pods.md.
 
 ## Context
 
-mitos has two per-sandbox execution engines:
+Mitos has two per-sandbox execution engines:
 
 - The HUSK pod (`cmd/husk-stub`): the default. One unprivileged, capability-
   dropped, PSA-restricted-minus-two pod per VM (ADR 0003).

--- a/docs/adr/0006-husk-netadmin-egress-firewall.md
+++ b/docs/adr/0006-husk-netadmin-egress-firewall.md
@@ -38,7 +38,7 @@ code, by design) could fetch the node's cloud IAM credentials. This was the TOP
 must-fix-first blocker for running untrusted code, now closed by the decision
 below.
 
-The enforcement model mitos already proved on the raw-forkd path is host-side
+The enforcement model Mitos already proved on the raw-forkd path is host-side
 nftables on the tap: a per-tap default-deny egress ruleset, accept
 established/related, accept the allowlisted destinations, accept DNS only to the
 controlled node resolver, terminal drop, with the policy rendered and applied

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,6 +76,6 @@ The compliance & observability addendum (ROADMAP.md) requires that residuals shi
 as ADRs in this directory. ADRs 0003 through 0006 are the first application: each
 records a RESIDUAL design decision grounded in docs/threat-model.md. The
 companion guardrail in [docs/compliance-claims.md](../compliance-claims.md)
-codifies the honest-claim rule that these residuals back: mitos never claims to be
+codifies the honest-claim rule that these residuals back: Mitos never claims to be
 "fully Kubernetes conformant", permitted claim language is bounded to what a CI
 job proves, and anything beyond that ships as a residual ADR here.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -142,7 +142,7 @@ proxy 502, a raw transport failure), the SDK synthesizes a code from the HTTP
 status (for example `unavailable` for 503, `rate_limited` for 429) and a
 status-derived remediation, so a caller still gets `code` + `remediation`. Those
 synthesized codes are SDK-local fallbacks for non-enveloped responses; the codes
-in the table above are the ones the mitos servers actually emit.
+in the table above are the ones the Mitos servers actually emit.
 
 ## gRPC status details
 

--- a/docs/api/runtime-protocol.md
+++ b/docs/api/runtime-protocol.md
@@ -35,7 +35,7 @@ and every SDK is generated from it.
 
 The v2 spec names the runtime protocol "Connect" because the END STATE wants
 Connect's HTTP semantics so a browser can stream exec output with no proxy tier
-(docs/api/v2-spec.md section 4). The mitos repo does NOT currently depend on
+(docs/api/v2-spec.md section 4). The Mitos repo does NOT currently depend on
 connect-go: go.mod has `google.golang.org/grpc` and `google.golang.org/protobuf`
 and the `make proto` target runs plain `protoc` with `protoc-gen-go` and
 `protoc-gen-go-grpc` (no buf, no `connectrpc.com/connect`). The existing

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -32,7 +32,7 @@ controller (namespace mitos)  ->  husk pods (namespace mitos-e2e, do the KVM)
 The runner itself does NOT need docker or KVM. The husk pods do the KVM (they
 request the `mitos.run/kvm` device-plugin resource, the production pod-native
 path). The runner only drives the cluster with `kubectl` and talks to each
-claim's sandbox HTTP API over the in-cluster pod network via the mitos Python
+claim's sandbox HTTP API over the in-cluster pod network via the Mitos Python
 SDK (`in_cluster=True`).
 
 Images are built and pushed to `ghcr.io/mitos-run/mitos-{controller,husk-stub,...}`
@@ -142,7 +142,7 @@ admin of the GitHub repo.
 ### 1. Build and push the runner image
 
 The runner image is the official `actions-runner` plus `kubectl`, `git`, `jq`,
-`python3`, and the mitos Python SDK. Build it on a trusted machine and push to
+`python3`, and the Mitos Python SDK. Build it on a trusted machine and push to
 GHCR:
 
 ```bash

--- a/docs/compliance-claims.md
+++ b/docs/compliance-claims.md
@@ -13,7 +13,7 @@ conformant'. Residuals ship as ADRs in `docs/adr/`."
 
 ## The rule
 
-> mitos NEVER claims to be "fully Kubernetes conformant". Permitted compliance
+> Mitos NEVER claims to be "fully Kubernetes conformant". Permitted compliance
 > claim language is bounded to exactly what a CI job proves. Anything beyond that
 > ships as a residual ADR in `docs/adr/`, not as a claim.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,6 +1,6 @@
 # Distribution and registries
 
-How the mitos artifacts reach public registries, and what is automated versus
+How the Mitos artifacts reach public registries, and what is automated versus
 what is a one-time manual or account step. Every listing is configured to
 backlink to https://mitos.run.
 
@@ -105,7 +105,7 @@ annotation lists them so Artifact Hub scans them.
 
 See the per-channel runbooks linked in the table above. The OLM bundle under
 `deploy/olm/bundle` is shared by both OperatorHub.io and the Red Hat certified
-path. Note the technical fit caveat for the Red Hat path: mitos needs KVM and
+path. Note the technical fit caveat for the Red Hat path: Mitos needs KVM and
 nested virtualization plus a privileged DaemonSet, which OpenShift restricts; the
 certified path is gated on real OpenShift-on-bare-metal demand. Details in
 [redhat-certification.md](redhat-certification.md).

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -3,7 +3,7 @@
 Status: mechanism done and CI-proven (PR1); key-custody hardening done (PR2).
 Issue #31 is addressed: mechanism in PR1, custody in PR2.
 
-This document describes how mitos encrypts template snapshots and volumes at
+This document describes how Mitos encrypts template snapshots and volumes at
 rest, why copy-on-write (CoW) page sharing across forks is preserved, how
 erasure becomes crypto-shredding, and the PR1 vs PR2 split. It is the design
 reference behind the threat-model row "Encryption at rest + crypto-shredding"

--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -204,14 +204,14 @@ controller run mode to make this decision (`gc.go:42`).
 - Bound: raw mode fails within one `Interval` of the node going unhealthy or
   leaving the registry; husk mode re-pends on the pod event (or the claim's own
   requeue).
-- Husk hard-node-loss latency is cluster-dependent, not a mitos GC interval. Husk
+- Husk hard-node-loss latency is cluster-dependent, not a Mitos GC interval. Husk
   node-loss recovery fires immediately on a pod delete or `DeletionTimestamp`
   event. But a HARD host loss where the pod object lingers `Running` with no
   `DeletionTimestamp` is bounded by the cluster's own unreachable-pod eviction
   setting (the `node.kubernetes.io/unreachable` taint toleration husk pods carry,
   `huskpod.go:1194`), since no pod event fires until the cluster evicts the pod.
   Operators wanting faster husk node-loss recovery should tune the unreachable
-  toleration or the pod-eviction timeout; mitos cannot shorten it.
+  toleration or the pod-eviction timeout; Mitos cannot shorten it.
 - Proving tests: `TestGCMarksNodeLost`, `TestGCLeavesHealthyNodeClaim`,
   `TestGCInHuskModeDoesNotFailNodeLostClaim`.
 

--- a/docs/integrations/paperclip.md
+++ b/docs/integrations/paperclip.md
@@ -1,9 +1,9 @@
 # Paperclip / OpenClaw / Hermes integration
 
-This document describes how mitos serves as the execution substrate for the
+This document describes how Mitos serves as the execution substrate for the
 Paperclip ecosystem (issue #20, workstream W3). The integration implements the
 upstream pluggable sandbox-provider contract (Environments plus a lease
-lifecycle) and maps it onto mitos Sandboxes instead of `batch/v1` Jobs.
+lifecycle) and maps it onto Mitos Sandboxes instead of `batch/v1` Jobs.
 
 The in-repo plugin lives at `plugins/paperclip`. It is a TypeScript Paperclip
 plugin (`@paperclipai/sandbox-provider-sandbox`) that registers an environment
@@ -14,7 +14,7 @@ backends, selected by `config.backend`:
   sandbox-server REST API (`/v1/fork`, `/v1/exec`, `/v1/sandboxes`). No
   Kubernetes.
 - `claim`: the workstream-A target. The provider contract is realized as a
-  mitos `Sandbox` (`mitos.run/v1`) on Kubernetes.
+  Mitos `Sandbox` (`mitos.run/v1`) on Kubernetes.
 
 ## Production gate (read first)
 
@@ -33,12 +33,12 @@ description as well.
 
 ## Provider-contract mapping (workstream A)
 
-The contract maps onto mitos as follows. The pure mapping is in
+The contract maps onto Mitos as follows. The pure mapping is in
 `plugins/paperclip/src/claim-mapping.ts`; the lifecycle orchestration is in
 `plugins/paperclip/src/claim-client.ts`. Both are unit tested with no cluster
 (`plugins/paperclip/test/*.test.ts`).
 
-| Provider contract | mitos mapping | Code |
+| Provider contract | Mitos mapping | Code |
 | --- | --- | --- |
 | create environment / acquire lease | create a `Sandbox` from a pool, wait Ready | `leaseToClaim`, `acquireWithAssertion` |
 | lease max lifetime | `sandbox.spec.lifetime.ttl` (wall-clock cap; zero is no limit) | `minutesToDuration` |
@@ -89,7 +89,7 @@ bridge entry first.
 
 Secret VALUES never travel through the plugin. `secretsToClaimMounts` maps each
 ref to a `SandboxSpec.Secrets` entry that carries only a Secret name and
-key; the mitos controller resolves the plaintext server-side at sandbox time
+key; the Mitos controller resolves the plaintext server-side at sandbox time
 (`internal/controller/sandboxclaim_controller.go` `resolveSecrets`). This
 enforces the secret-inheritance policy (`docs/fork-correctness.md` section 3):
 sandbox-time secrets are injected at sandbox time and are never baked into a pool

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP server (`mitos-mcp`)
 
-`mitos-mcp` exposes the mitos sandbox lifecycle as [Model Context
+`mitos-mcp` exposes the Mitos sandbox lifecycle as [Model Context
 Protocol](https://modelcontextprotocol.io) tools. Any MCP-speaking agent
 (Claude Desktop, an MCP client library, an agent framework with MCP support)
 can create sandboxes, run commands, read and write files, fork, and terminate,

--- a/docs/migrating-from-e2b.md
+++ b/docs/migrating-from-e2b.md
@@ -12,7 +12,7 @@ from e2b_code_interpreter import Sandbox
 from mitos.e2b import Sandbox
 ```
 
-The shim presents E2B's `Sandbox` surface over the standalone mitos
+The shim presents E2B's `Sandbox` surface over the standalone Mitos
 sandbox-server REST API (no Kubernetes required). It is an adapter over the
 native `DirectSandbox` surface, not a re-implementation, and it has no
 dependency on the `e2b` package. E2B's per-operation vocabulary is roughly 70%
@@ -78,7 +78,7 @@ for info in Sandbox.list(base_url="http://localhost:8080"):
 Every E2B method the shim exposes, what it maps to, and whether it works today
 against the standalone sandbox-server.
 
-| E2B method | mitos op | Status |
+| E2B method | Mitos op | Status |
 |---|---|---|
 | `Sandbox.create(template, ...)` | `mitos.create` / `DirectSandbox` | Supported |
 | `Sandbox.connect(id)` | `SandboxServer.list_sandboxes` lookup | Supported |
@@ -105,7 +105,7 @@ KVM CI job.
 
 ## The one vocabulary rename
 
-E2B's `files.make_dir(path)` maps to mitos `files.mkdir(path)`. The shim
+E2B's `files.make_dir(path)` maps to Mitos `files.mkdir(path)`. The shim
 exposes `make_dir` so your E2B script does not change; under the hood it calls
 `mkdir`.
 
@@ -128,7 +128,7 @@ that would not resolve.
 
 ## What you gain beyond E2B parity
 
-The underlying `DirectSandbox` (reachable via `sandbox.sandbox`) exposes mitos
+The underlying `DirectSandbox` (reachable via `sandbox.sandbox`) exposes Mitos
 superpowers E2B does not: `fork(n)` for branching / parallel runs at fork(2)
 speeds, `pause` / `resume`, and an interactive `pty`. The shim keeps your E2B
 script working; reach for the native handle when you want those.

--- a/docs/migration-to-mitos-org.md
+++ b/docs/migration-to-mitos-org.md
@@ -1,4 +1,4 @@
-# Migration runbook: move mitos to a dedicated GitHub org
+# Migration runbook: move Mitos to a dedicated GitHub org
 
 Status: prepared, not executed. This runbook moves the engine repo from
 `github.com/mitos-run/mitos` to a dedicated GitHub org, stands up the OSS

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -365,7 +365,7 @@ unit-tested without a cluster or KVM; the LIVE integrations are gated as noted.
 ### Layer 1: Cilium Hubble flow logs
 
 Hubble identifies an endpoint by its pod namespace, pod name, and pod labels.
-mitos husk pods (and any pod-backed sandbox) carry `mitos.run/claim` and
+Mitos husk pods (and any pod-backed sandbox) carry `mitos.run/claim` and
 `mitos.run/pool` labels, so `internal/observability.ResolveSandbox` maps a Hubble
 flow endpoint onto the claim it belongs to, and `ClassifyEgress` turns a flow
 into a per-sandbox egress event with a `Denied` flag (a `DROPPED` verdict is a
@@ -380,16 +380,16 @@ itself is unit-tested (`internal/observability/hubble_test.go`).
 
 ### Layer 2: OpenCost cost attribution
 
-OpenCost reports allocation cost per namespace. mitos meters each claim's
+OpenCost reports allocation cost per namespace. Mitos meters each claim's
 resource-seconds (cpu-core-seconds, memory-GB-seconds). `ReconcileNamespaceCost`
 prices the metered resource-seconds at the cluster rates and compares the sum
 against the OpenCost-reported namespace spend, flagging relative drift beyond a
-tolerance. This checks billing self-consistency: what mitos metered, priced at
+tolerance. This checks billing self-consistency: what Mitos metered, priced at
 cluster rates, should match what OpenCost attributes to the namespace.
 
 Enabling it (cluster-gated): install OpenCost, read the cluster pricing rates and
 the per-namespace allocation from its API, and feed the namespace spend plus the
-per-claim resource-seconds (from the mitos metering pipeline) into
+per-claim resource-seconds (from the Mitos metering pipeline) into
 `ReconcileNamespaceCost`. The namespace-spend-reconciles-within-tolerance
 acceptance test needs a live OpenCost cluster and is gated; the pricing and
 tolerance arithmetic is unit-tested (`internal/observability/opencost_test.go`).

--- a/docs/open-core.md
+++ b/docs/open-core.md
@@ -39,5 +39,5 @@ entity. Contributions stay under the repository's Apache 2.0 license.
 
 ## Trademark
 
-The "mitos" name and any associated marks are reserved; see TRADEMARKS.md. The
+The "Mitos" name and any associated marks are reserved; see TRADEMARKS.md. The
 open-source code license (Apache 2.0) does not grant trademark rights.

--- a/docs/operatorhub.md
+++ b/docs/operatorhub.md
@@ -1,6 +1,6 @@
-# Submitting mitos to OperatorHub.io
+# Submitting Mitos to OperatorHub.io
 
-This runbook covers packaging the mitos OLM bundle and submitting it to
+This runbook covers packaging the Mitos OLM bundle and submitting it to
 [operatorhub.io](https://operatorhub.io) via the
 [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators)
 repository.
@@ -33,7 +33,7 @@ project is migrating its registry from `ghcr.io/paperclipinc` to
 image MUST be published and pullable under `ghcr.io/mitos-run`. Confirm this
 first; OLM will report ImagePullBackOff otherwise.
 
-mitos also requires KVM nodes and a privileged DaemonSet (see the README and
+Mitos also requires KVM nodes and a privileged DaemonSet (see the README and
 `docs/redhat-certification.md`). Community OperatorHub does not test against
 your hardware, but reviewers will read the CSV requirements section. Keep it
 honest.
@@ -183,7 +183,7 @@ validation green. Sign-off (`-s`) and the DCO check are required.
 
 ## Notes
 
-- Channel: `alpha` only, default `alpha`. mitos is pre-1.0 and the CSV maturity
+- Channel: `alpha` only, default `alpha`. Mitos is pre-1.0 and the CSV maturity
   is `alpha`.
 - For the next version, add `operators/mitos/0.5.0/` and set the CSV
   `spec.replaces: mitos.v0.4.0` (or `spec.skips`) so the update graph is

--- a/docs/perf/cpu-pinning.md
+++ b/docs/perf/cpu-pinning.md
@@ -22,7 +22,7 @@ under a claim storm:
    readiness deadline and fail.
 
 Browser Use reported the shape of this on their stack (we cite it as motivation,
-not as a mitos measurement): pinning vCPUs FROM startup actually HURT, because it
+not as a Mitos measurement): pinning vCPUs FROM startup actually HURT, because it
 serialized the launch burst onto too few cores; the win came from leaving vCPUs
 unpinned during the launch burst so the kernel spreads them across cores, THEN
 pinning for predictable packing once the guest is ready, assigning BOTH

--- a/docs/perf/snapshot-prefetch.md
+++ b/docs/perf/snapshot-prefetch.md
@@ -36,7 +36,7 @@ Browser Use reported the shape of this on their stack: a "0.8ms restore plus
 2 MiB hugepages plus a userfaultfd handler that PRELOADS a captured hot-page
 working set before resume cut resume-to-ready from 9.8s to 3.1s and page faults
 from ~100k to ~1.1k. Those are their numbers on their workload; we cite them as
-the motivation, not as a mitos measurement.
+the motivation, not as a Mitos measurement.
 
 ## The two levers
 
@@ -55,7 +55,7 @@ it only exists on Linux/KVM.
 ### 2. userfaultfd prefetch of a captured hot-page set
 
 `userfaultfd(2)` lets a userspace handler service page faults for a memory
-range. On restore, mitos maps the guest memory file with userfaultfd registered
+range. On restore, Mitos maps the guest memory file with userfaultfd registered
 over its range and runs a handler. Before resuming the VM, the handler PRELOADS
 the snapshot's captured hot-page working set: it faults in exactly the pages the
 guest is known to touch first, so the post-resume fault storm is paid up front,

--- a/docs/platforms/host-prerequisites.md
+++ b/docs/platforms/host-prerequisites.md
@@ -1,6 +1,6 @@
 # Host kernel prerequisites for KVM nodes
 
-This is the host/kernel checklist every mitos KVM node must satisfy, the two
+This is the host/kernel checklist every Mitos KVM node must satisfy, the two
 failure modes a rescue/minimal kernel causes, and the one-shot verify. It is the
 companion to `prerequisites.md` (the distro-neutral node/install checklist) and
 `talos-hetzner.md` (one concrete realization). These were learned the hard way

--- a/docs/platforms/prerequisites.md
+++ b/docs/platforms/prerequisites.md
@@ -1,6 +1,6 @@
 # KVM node prerequisites (any Kubernetes distribution)
 
-mitos is a standard Kubernetes operator: the controller, the forkd DaemonSet, the
+Mitos is a standard Kubernetes operator: the controller, the forkd DaemonSet, the
 husk pods, and the device plugin run on any conformant cluster. The constraints
 are on the **nodes that run sandboxes** (the KVM nodes) and on the **install
 namespace**, NOT on the Kubernetes distribution. This page is the distro-neutral
@@ -42,7 +42,7 @@ exit $fail
 
 ## Running on <distro>: support matrix
 
-mitos is a standard operator and runs on any conformant Kubernetes. The KVM
+Mitos is a standard operator and runs on any conformant Kubernetes. The KVM
 nodes need the kernel + data-dir + privileged-namespace prep below; the operator
 side (controller, forkd DaemonSet, device plugin, husk pods) is identical across
 distributions.

--- a/docs/platforms/pvm-evaluation.md
+++ b/docs/platforms/pvm-evaluation.md
@@ -1,7 +1,7 @@
 # PVM as a no-nested-virt node tier: evaluation (issue #40)
 
 This document is the HONEST evaluation of PVM (pagetable-based virtual machine,
-Ant/Alibaba) as a mitos node tier that runs Firecracker on plain cloud VPS with
+Ant/Alibaba) as a Mitos node tier that runs Firecracker on plain cloud VPS with
 no nested virtualization. It is an EVALUATION, not an adoption. No PVM kernel was
 built and no measurement was taken; every number below is a target to be produced
 by the spike, never a claimed result (the no-unverified-claims rule).
@@ -20,7 +20,7 @@ ring 3 using pagetable switching instead of hardware virtualization. It needs no
 VMX (Intel VT-x) or SVM (AMD-V), exposes the standard `/dev/kvm` ABI, and runs
 Firecracker unmodified against that ABI. It is used in production at Alibaba/Ant.
 
-The consequence that matters to mitos: most cloud VPS (Hetzner Cloud and the
+The consequence that matters to Mitos: most cloud VPS (Hetzner Cloud and the
 majority of commodity providers) do NOT expose `/dev/kvm` because they do not
 offer nested virtualization. On such a host, Firecracker cannot start today. With
 a PVM host kernel, it can.
@@ -33,11 +33,11 @@ References:
 ## The benefit: run anywhere
 
 The single, real benefit is RUN-ANYWHERE. With a PVM tier, a self-hoster can run
-mitos's Firecracker snapshot-fork sandboxes on ANY cloud VPS that exposes no
+Mitos's Firecracker snapshot-fork sandboxes on ANY cloud VPS that exposes no
 nested virt: a plain Hetzner Cloud `cpx` instance, a generic DigitalOcean or
 Vultr droplet, a bare provider VM. That is a story no competitor offers
 self-hosters: the snapshot-fork primitive without requiring a metal host or a
-nested-virt-capable cloud tier. For mitos specifically, bare metal is already a
+nested-virt-capable cloud tier. For Mitos specifically, bare metal is already a
 first-class target; PVM extends the reach to the commodity-VPS long tail without
 asking the operator to find KVM-capable hosts.
 
@@ -52,7 +52,7 @@ it honest.
 PVM is not free. Each cost below is a real, recurring tax, not a one-time setup.
 
 1. **Out-of-tree HOST kernel patches.** PVM is a forked KVM module on an
-   out-of-tree, RFC kernel patch set. mitos targets Talos; every Talos release
+   out-of-tree, RFC kernel patch set. Mitos targets Talos; every Talos release
    would need a forked kernel build carrying the PVM patches. This DOUBLES the
    kernel-distributor tax already tracked in issue #35: a second kernel flavor to
    build, sign, distribute, and keep current with CVE fixes, forever, until (and
@@ -64,7 +64,7 @@ PVM is not free. Each cost below is a real, recurring tax, not a one-time setup.
    (issue #10): a second guest kernel to build and ship, and to keep aligned with
    the host module's ABI.
 
-3. **Core-primitive validation under PVM.** mitos's whole value is the
+3. **Core-primitive validation under PVM.** Mitos's whole value is the
    snapshot-fork primitive. Every core mechanism must be RE-VALIDATED under PVM,
    because PVM is a different execution substrate, not a drop-in:
    - snapshot/restore correctness,
@@ -150,7 +150,7 @@ are met; otherwise do not.
 
 **Strong signal to revisit:** PVM mainlines upstream (removes cost 1), OR a
 concrete customer requires Firecracker on a specific no-nested-virt VPS that
-mitos cannot otherwise serve.
+Mitos cannot otherwise serve.
 
 ## What ships now (the achievable, valuable slice)
 

--- a/docs/platforms/talos-hetzner.md
+++ b/docs/platforms/talos-hetzner.md
@@ -1,6 +1,6 @@
 # Talos + Hetzner AX: bare-metal provisioning runbook
 
-This document is the end-to-end guide for running the mitos operator on
+This document is the end-to-end guide for running the Mitos operator on
 Talos Linux atop Hetzner AX dedicated servers (Robot fleet). It covers hardware
 selection, OS install, machine configuration, operator deployment, KVM
 readiness checks, and capacity planning pointers.

--- a/docs/preview-urls.md
+++ b/docs/preview-urls.md
@@ -2,7 +2,7 @@
 
 A preview URL exposes a port inside a running sandbox to the caller through a
 single per-sandbox hostname, `<sandbox-id>.preview.<domain>`, served by a
-controller-managed reverse proxy with automatic TLS. It is the mitos equivalent
+controller-managed reverse proxy with automatic TLS. It is the Mitos equivalent
 of E2B `sandbox.getHost(port)` and Daytona signed, expiring preview URLs: one
 internet-facing entrypoint fronting many ephemeral per-sandbox backends,
 Kubernetes-native, with the same per-sandbox token gate as the sandbox API.
@@ -68,7 +68,7 @@ that matter, each unit-tested in `internal/preview/sign_test.go`:
 
 ### Why not a captoken
 
-mitos already has macaroon-style attenuated capability tokens
+Mitos already has macaroon-style attenuated capability tokens
 (`internal/captoken`, issue #25). A preview token needs no attenuation chain,
 only a single expiring binding of `(sandbox, port)`, so a focused signer keeps
 the scheme small and auditable. It reuses the SAME standard-library HMAC-SHA256

--- a/docs/recipes/agent-harness.md
+++ b/docs/recipes/agent-harness.md
@@ -1,9 +1,9 @@
 # Recipe: host an HTTP daemon (coding-agent harness) in a sandbox
 
-Issue #230 asks whether a mitos sandbox can host a coding-agent harness (a
+Issue #230 asks whether a Mitos sandbox can host a coding-agent harness (a
 Rivet `sandbox-agent` style daemon, `opencode` web, or any in-box HTTP server)
 and be driven from outside over HTTP. The integration surface such a harness
-needs is exactly two things: shell access (mitos has `exec` over vsock) and a
+needs is exactly two things: shell access (Mitos has `exec` over vsock) and a
 reachable network port. The port half shipped as the foundation slice of issue
 #228 (`docs/ports.md`): a TCP-over-vsock tunnel through the standalone
 `sandbox-server`. This recipe shows the end-to-end flow using what ships today,
@@ -48,7 +48,7 @@ The forward is per sandbox, loopback-only on the host, bounded by a per-sandbox
 concurrency cap, and torn down automatically when the sandbox terminates (see
 `docs/ports.md`).
 
-## The mitos fork angle
+## The Mitos fork angle
 
 The distinguishing property: you can warm one sandbox with the daemon installed
 and the harness's dependencies in place, then `fork(n)` it into a swarm. Each

--- a/docs/redhat-certification.md
+++ b/docs/redhat-certification.md
@@ -1,22 +1,22 @@
-# Red Hat Certified Operators path for mitos
+# Red Hat Certified Operators path for Mitos
 
-This runbook covers submitting mitos to the
+This runbook covers submitting Mitos to the
 [Red Hat Certified Operators catalog](https://catalog.redhat.com) via
 [redhat-openshift-ecosystem/certified-operators](https://github.com/redhat-openshift-ecosystem/certified-operators).
 
 ## Read this first: the fit risk
 
-mitos may not be a good fit for the certified (OpenShift) path, and we should
+Mitos may not be a good fit for the certified (OpenShift) path, and we should
 not claim OpenShift compatibility we have not verified. The certified catalog
 exists to certify operators that run on OpenShift, and OpenShift is deliberately
-locked down. mitos pulls in the opposite direction:
+locked down. Mitos pulls in the opposite direction:
 
-- **KVM / nested virtualization.** mitos boots and forks real Firecracker
+- **KVM / nested virtualization.** Mitos boots and forks real Firecracker
   microVMs. The `forkd` DaemonSet needs `/dev/kvm` on every sandbox node. Many
   OpenShift clusters, especially managed ones, run on virtualized infrastructure
   without nested virtualization, so `/dev/kvm` is simply absent. OpenShift
   Virtualization (CNV) addresses VM workloads but is a different model than
-  mitos's host-level Firecracker forking and does not automatically grant mitos
+  Mitos's host-level Firecracker forking and does not automatically grant Mitos
   what it needs.
 - **Privileged DaemonSet.** `forkd` runs privileged, touches host paths, and
   needs device access. OpenShift gates this behind Security Context Constraints
@@ -27,7 +27,7 @@ locked down. mitos pulls in the opposite direction:
   than the certified catalog's typical audience.
 
 Net: pursuing certification is only worthwhile once there is real demand for
-mitos on OpenShift-on-bare-metal with KVM and a privileged SCC available. Until
+Mitos on OpenShift-on-bare-metal with KVM and a privileged SCC available. Until
 then, prioritize the community OperatorHub path (`docs/operatorhub.md`) and the
 Helm chart. Do not advertise OpenShift support before it is verified on a real
 OpenShift-on-bare-metal cluster with nested virt.
@@ -58,7 +58,7 @@ likely do not meet yet:
 
 - **UBI base image.** Each certified image must be built `FROM` a Red Hat
   Universal Base Image (`registry.access.redhat.com/ubi9/ubi-minimal` or
-  similar). The mitos Go binaries are statically linkable, so rebasing onto
+  similar). The Mitos Go binaries are statically linkable, so rebasing onto
   `ubi9-minimal` is feasible, but it is a real build change and must be done
   before submission.
 - **Required labels.** Each image must carry:
@@ -69,7 +69,7 @@ likely do not meet yet:
   - `summary`
   - `description`
   - `maintainer`
-  and ship a license file under `/licenses` (Apache-2.0 for mitos).
+  and ship a license file under `/licenses` (Apache-2.0 for Mitos).
 - **No critical/important unresolved CVEs.** Red Hat scans the image; the UBI
   base keeps this tractable because Red Hat patches it.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,4 +1,4 @@
-# Releasing mitos
+# Releasing Mitos
 
 This page is the one place that documents every published artifact: the
 container images, the CLI, and the four language SDKs. It records what each

--- a/docs/saas/acceptable-use.md
+++ b/docs/saas/acceptable-use.md
@@ -1,6 +1,6 @@
 # Acceptable Use Policy (hosted offering)
 
-This Acceptable Use Policy (AUP) governs the hosted mitos sandbox cloud. It is
+This Acceptable Use Policy (AUP) governs the hosted Mitos sandbox cloud. It is
 the human-readable counterpart to the technical abuse controls (issue #213): the
 per-organization quotas, the per-org and per-IP rate limits, the per-tier egress
 policy, and the kill-switch. By using the hosted offering you agree to these
@@ -96,14 +96,14 @@ in the same change.
 
 ## Self-hoster template
 
-If you run your own mitos cluster you are the operator, and you set your own
+If you run your own Mitos cluster you are the operator, and you set your own
 acceptable-use policy. The hosted controls (quotas, rate limits, per-tier egress,
 kill-switch) ship as a reusable layer (`internal/saas/quota`), but the DEFAULTS
 above are the hosted service's, not yours. If you expose your cluster to
 untrusted or multi-tenant users you SHOULD adopt an equivalent policy. A minimal
 starting template:
 
-> ## Acceptable Use (self-hosted mitos at <your-org>)
+> ## Acceptable Use (self-hosted Mitos at <your-org>)
 >
 > Sandboxes on this cluster may not be used for cryptocurrency mining,
 > spam, denial-of-service, attacks against any host, malware distribution, or any

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -1,6 +1,6 @@
 # Billing-grade usage metering pipeline
 
-This document describes how mitos turns per-node CoW-aware operational metering
+This document describes how Mitos turns per-node CoW-aware operational metering
 (`internal/metering`, the forkd `GET /v1/metering` endpoint, docs/metering.md)
 into per-organization, time-integrated, auditable usage records, and the
 org-scoped public usage API on top of them. The implementation is

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,6 +1,6 @@
 # Secrets management (multi-tenant)
 
-This is the consolidated, operator-facing page for how mitos handles tenant
+This is the consolidated, operator-facing page for how Mitos handles tenant
 secrets, especially in a multi-tenant cluster. It pulls together what was
 scattered across `docs/threat-model.md`, `docs/encryption.md`, and
 `docs/fork-correctness.md`, and is explicit about what is implemented versus

--- a/docs/security/external-review-scope.md
+++ b/docs/security/external-review-scope.md
@@ -1,6 +1,6 @@
 # External security review: scope & package (G4, #194)
 
-mitos runs untrusted AI-agent code in Firecracker microVMs on shared Kubernetes
+Mitos runs untrusted AI-agent code in Firecracker microVMs on shared Kubernetes
 nodes. Before any 1.0 / production-tenant claim, an independent security review is
 a gating requirement (ROADMAP G4, issue #194). This page is the package to hand a
 reviewer: the trust model, the surfaces to examine, the threat model, and the

--- a/docs/superpowers/plans/2026-06-11-mitos-cli.md
+++ b/docs/superpowers/plans/2026-06-11-mitos-cli.md
@@ -1,4 +1,4 @@
-# mitos CLI Implementation Plan (issue #26)
+# Mitos CLI Implementation Plan (issue #26)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/superpowers/plans/2026-06-13-deploy-self-containedness.md
+++ b/docs/superpowers/plans/2026-06-13-deploy-self-containedness.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make `kubectl apply -k deploy/` bring up a fully working mitos stack on a real KVM node with no manual `kubectl` patches; bake in the eight runtime fixes that were applied by hand to go live tonight.
+**Goal:** Make `kubectl apply -k deploy/` bring up a fully working Mitos stack on a real KVM node with no manual `kubectl` patches; bake in the eight runtime fixes that were applied by hand to go live tonight.
 
 **Architecture:** Most fixes are declarative deploy/ changes: PodSecurity Admission labels on the namespace, an image pull secret + serviceaccount wiring, forkd DaemonSet adjustments (agent-bin arg, privileged securityContext, DOCKER_CONFIG + docker-config secret mount, jailer args removed for the husk path), and a kernel-staging DaemonSet that places `vmlinux` on each KVM node. One fix needs Go: the controller must replicate the CA and forkd-TLS Secrets from its namespace into any pool namespace where it creates husk pods, with the matching RBAC already present (secrets create/get/list/update exists). The namespace default (`mitos`) is already correct in code and deploy/; we verify it and only add a task if a gap remains.
 

--- a/docs/superpowers/plans/2026-06-13-security-ops-scaffolding.md
+++ b/docs/superpowers/plans/2026-06-13-security-ops-scaffolding.md
@@ -552,7 +552,7 @@ cosign verify-attestation --type spdxjson \
 
 ## Optional: admission-time enforcement
 
-A cluster that wants to refuse unsigned mitos images can enforce the same
+A cluster that wants to refuse unsigned Mitos images can enforce the same
 identity with a policy controller (sigstore policy-controller or Kyverno
 `verifyImages`) using the identity regexp and issuer above. This is a
 deployment choice, not a default; the project ships the signatures, the

--- a/docs/superpowers/specs/2026-06-22-mitos-console-design.md
+++ b/docs/superpowers/specs/2026-06-22-mitos-console-design.md
@@ -1,4 +1,4 @@
-# mitos Console — design spec
+# Mitos Console — design spec
 
 Date: 2026-06-22
 Status: design (brainstorm output). Implementation plan is a follow-up.
@@ -9,7 +9,7 @@ two net-new sub-issues (see §11).
 
 ## Summary
 
-The mitos repo already has the SaaS spine: a public API gateway (`cmd/gateway`,
+The Mitos repo already has the SaaS spine: a public API gateway (`cmd/gateway`,
 #210), an org-scoped backend-for-frontend (`cmd/console`, #214) that joins keys,
 usage/cost, billing, live sandboxes, templates, members and audit behind tested
 cross-tenant isolation, plus `internal/saas/{account,billing,console,gateway,
@@ -21,7 +21,7 @@ This spec designs that dashboard so that **the hosted SaaS and any self-hosted
 install run the same binary and the same UI bundle**, differing only by a
 runtime capabilities document the server advertises. It also designs first-class,
 provider-backed **secret management** (default Kubernetes, recommended external
-provider OpenBao) and a **proof surface** that makes mitos's Pareto position
+provider OpenBao) and a **proof surface** that makes Mitos's Pareto position
 visible and verifiable in-product.
 
 ## Goals
@@ -31,7 +31,7 @@ visible and verifiable in-product.
 - On-brand: the dashboard renders in the website's "Fluorescence" design system,
   shared via a versioned `@mitos/brand` package.
 - Competitor-grade breadth (match Daytona, beat both Daytona and E2B on live
-  sandbox inspection), plus mitos-only views (live fork tree, forkable
+  sandbox inspection), plus Mitos-only views (live fork tree, forkable
   workspaces, first-class secrets, proof panel).
 - Per-tenant secret management with a pluggable provider backend.
 - Honor the project's gating rules and integrity discipline (no unverified
@@ -125,14 +125,14 @@ cmd/console (one Go binary, one image)
 ## 6. Information architecture (grounded in competitors, mapped to CRDs)
 
 Nav follows the category convention so it reads as best-practice, but each item
-maps to a primitive mitos already has, plus mitos-only views.
+maps to a primitive Mitos already has, plus Mitos-only views.
 
 | Console section | Backed by | vs Daytona / E2B |
 | --- | --- | --- |
 | **Overview / Instruments** (home) | usage/metering (#211/#33) + activate-latency source | net-new proof surface (§9) |
 | **Sandboxes** (live) | `Sandbox`/`SandboxClaim` via `SandboxControl` seam | parity; fork is first-class |
 | → detail tabs | Overview · Logs (LogStreamer) · Terminal (existing PTY) · Filesystem (existing files API) · Metrics · Spending · **Fork tree** | Fork tree is unique |
-| **Workspaces** | `Workspace`/`WorkspaceRevision` CRDs | Daytona "Volumes" are static; mitos workspaces fork |
+| **Workspaces** | `Workspace`/`WorkspaceRevision` CRDs | Daytona "Volumes" are static; Mitos workspaces fork |
 | **Templates** | `SandboxTemplate` CRD (ties to #209 DX epic) | = Daytona Snapshots |
 | **Registries** | image-pull secrets (already in chart) | parity |
 | **Secrets** | `SecretStore` provider registry (§8) | neither competitor has this |
@@ -146,7 +146,7 @@ maps to a primitive mitos already has, plus mitos-only views.
 behind a `billingprovider.Provider` seam — the same pattern as `SecretStore`.
 Stripe is the first provider; a **Merchant of Record** (Polar / Paddle / Lemon
 Squeezy) is the planned second and likely end state, because an MoR becomes the
-legal seller and handles global sales-tax/VAT so mitos does not. The console
+legal seller and handles global sales-tax/VAT so Mitos does not. The console
 reads billing through the provider-neutral `BillingReader`; only the webhook
 (signature scheme + event names) and the portal/checkout link are
 provider-specific, and both live behind the seam. The neutral `WebhookHandler`
@@ -191,7 +191,7 @@ backend.
 - **`openbao` (recommended external):** OpenBao (the Linux-Foundation
   open-source fork of Vault). The same driver speaks the Vault HTTP API, so it
   also covers HashiCorp Vault. OpenBao is the default-recommended external
-  provider deliberately — mitos's Pareto thesis is open-source + self-hostable,
+  provider deliberately — Mitos's Pareto thesis is open-source + self-hostable,
   so the recommended secret backend must not be BSL-licensed.
 - **`aws_secrets_manager`** (optional, parity with paperclip).
 
@@ -206,13 +206,13 @@ backend.
 
 **Managed modes (both providers):**
 - *copy-in*: value encrypted at rest by the active provider.
-- *external_reference* (strong default for OpenBao): mitos stores only
+- *external_reference* (strong default for OpenBao): Mitos stores only
   `{path, versionRef, fingerprint}`; the **controller resolves it at sandbox
   materialization** through the provider with binding context, writes a
   **short-lived, sandbox-scoped k8s Secret** the husk pod consumes via the
   existing `SandboxTemplate.env valueFrom secretKeyRef` path, then **GCs it on
   terminate**. One injection mechanism, any backend behind it, value never
-  persisted in mitos.
+  persisted in Mitos.
 
 **Bindings:** secrets are not auto-env. A secret is bound into a Template /
 Sandbox / Workspace env field by key (`OPENAI_API_KEY` ← stored secret, `latest`
@@ -222,7 +222,7 @@ or pinned version). Binding key ≠ stored name.
 server-side → injected immediately before use → never returned to the UI. Every
 resolution emits a non-sensitive `secret` audit event (id, version, provider,
 consumer = sandbox id, outcome) to `/console/audit`. Matches paperclip's custody
-chain and mitos's existing no-secret-logging rule. Provider-config validation
+chain and Mitos's existing no-secret-logging rule. Provider-config validation
 rejects credential-shaped fields so provider creds never land in the store.
 
 **Storage decision (no new CRD):** secret *metadata* + provider-vault config +
@@ -238,7 +238,7 @@ managed OpenBao (per-org namespaces) or a KMS. Same binary, same registry code.
 
 ## 9. Proof surface: making the Pareto position visible and verifiable
 
-The README's Pareto thesis: mitos is the only runtime that is simultaneously
+The README's Pareto thesis: Mitos is the only runtime that is simultaneously
 open-source · self-hostable · Kubernetes-native · does live N-way CoW fork of a
 running microVM · warm-claim activate in the tens-of-ms class (P50 ~27 ms,
 measured) · ~3 MiB marginal memory per fork via CoW · data stays on your infra.
@@ -255,7 +255,7 @@ thesis ("only measured signal emits light").
 2. **Fork tree as live Pareto evidence:** annotates each fork's private-dirty
    (unique) set against the shared parent snapshot, proving CoW page-sharing in
    the one view no competitor can render.
-3. **Pareto map, honest:** a "Why mitos" panel in onboarding / empty states
+3. **Pareto map, honest:** a "Why Mitos" panel in onboarding / empty states
    renders the README capability matrix framed exactly as the README frames it
    (the axis is the combination; any competitor number carries the
    vendor-published / not-head-to-head label verbatim). Each axis links to live
@@ -264,7 +264,7 @@ thesis ("only measured signal emits light").
 4. **"Reproduce this"** affordance on every headline metric → points at the
    in-repo harness. Integrity-as-feature.
 5. **Ownership / portability badge** in the chrome: self-host shows "Running on
-   your infrastructure · data never leaves"; hosted shows "Hosted by mitos ·
+   your infrastructure · data never leaves"; hosted shows "Hosted by Mitos ·
    same engine, same API" plus a first-class "export / self-host this" path (and
    the E2B-migration shim). No-lock-in rendered as a feature.
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -55,7 +55,7 @@ cosign verify-attestation --type spdxjson \
 
 ## Optional: admission-time enforcement
 
-A cluster that wants to refuse unsigned mitos images can enforce the same
+A cluster that wants to refuse unsigned Mitos images can enforce the same
 identity with a policy controller (sigstore policy-controller or Kyverno
 `verifyImages`) using the identity regexp and issuer above. This is a
 deployment choice, not a default; the project ships the signatures, the

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -929,7 +929,7 @@ surface so it is not silently expanded when the device path lands.
 
 ### Isolation tiers: not every node is the same assurance (issue #40)
 
-mitos's default and strongest isolation is the hardware-virtualization microVM
+Mitos's default and strongest isolation is the hardware-virtualization microVM
 (KVM + Firecracker). Two WEAKER mechanisms exist as run-anywhere or fallback
 tiers, and the threat model's job is to make sure they are NEVER silently treated
 as equivalent to hardware virt:

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -269,7 +269,7 @@ docs/threat-model.md section 3.
 ## The revision change feed for external indexers
 
 The controller emits a CloudEvents 1.0 feed so an external indexer (a vector DB,
-a search index, an audit sink) can react to workspace changes WITHOUT mitos
+a search index, an audit sink) can react to workspace changes WITHOUT Mitos
 embedding any indexer of its own. There is no built-in vector store by design
 (ROADMAP.md, EPIC W4): indexing is the consumer's job, fed by this event.
 

--- a/examples/sleep-consolidation/README.md
+++ b/examples/sleep-consolidation/README.md
@@ -24,7 +24,7 @@ on a real cluster through the released surface.
 
 ```bash
 # From a machine with kubectl + the mitos CLI + the Python SDK installed,
-# pointed at a running mitos cluster.
+# pointed at a running Mitos cluster.
 examples/sleep-consolidation/run.sh mitos-e2e ~/.kube/config
 ```
 

--- a/internal/agentcli/backend.go
+++ b/internal/agentcli/backend.go
@@ -1,4 +1,4 @@
-// Package agentcli implements the mitos command-line interface: a thin,
+// Package agentcli implements the Mitos command-line interface: a thin,
 // dependency-free command tree over a Backend that drives the sandbox lifecycle
 // (create, exec, file IO, fork, terminate, list).
 //

--- a/internal/controller/isolation_tier.go
+++ b/internal/controller/isolation_tier.go
@@ -1,6 +1,6 @@
 package controller
 
-// Isolation tiers (issue #40). A mitos node isolates a sandbox with one of
+// Isolation tiers (issue #40). A Mitos node isolates a sandbox with one of
 // several mechanisms whose assurance levels are NOT equivalent, and the
 // controller must never silently treat a weaker tier as if it were a stronger
 // one. The tier is a property of the NODE (its kernel/runtime), declared via the
@@ -10,7 +10,7 @@ package controller
 // The assurance ordering, strongest to weakest:
 //
 //   - hardware-kvm: a hardware virtualization microVM (Firecracker on /dev/kvm
-//     backed by VMX/SVM). The strongest tier mitos offers and the default
+//     backed by VMX/SVM). The strongest tier Mitos offers and the default
 //     posture; the threat model's isolation assumptions (docs/threat-model.md)
 //     are written for it.
 //   - pvm: Firecracker on PVM (pagetable-based virtual machine, Ant/Alibaba), a

--- a/internal/observability/opencost.go
+++ b/internal/observability/opencost.go
@@ -21,9 +21,9 @@ type Rates struct {
 }
 
 // ClaimUsage is one claim's metered resource-seconds over the reconcile window:
-// cpu-core-seconds and memory-GB-seconds. These come from the mitos metering
+// cpu-core-seconds and memory-GB-seconds. These come from the Mitos metering
 // pipeline (the same resource-seconds the usage API and Stripe billing consume),
-// so the reconcile checks billing self-consistency: what mitos metered, priced
+// so the reconcile checks billing self-consistency: what Mitos metered, priced
 // at cluster rates, should match what OpenCost attributes to the namespace.
 type ClaimUsage struct {
 	Claim          string

--- a/internal/saas/billingprovider/billingprovider.go
+++ b/internal/saas/billingprovider/billingprovider.go
@@ -2,7 +2,7 @@
 // the same way console.SecretStore abstracts the secret backend. Stripe is one
 // provider; a Merchant of Record (Polar, Paddle, Lemon Squeezy) is another —
 // and an MoR is the likely end state, since it becomes the legal seller and
-// handles global sales-tax/VAT so mitos does not have to. The console reads
+// handles global sales-tax/VAT so Mitos does not have to. The console reads
 // billing through the provider-neutral BillingReader seam and never names a
 // provider; only the webhook (signature scheme + event names) and the
 // portal/checkout link are provider-specific, and both live behind this seam.

--- a/internal/saas/console/baosecrets/baosecrets.go
+++ b/internal/saas/console/baosecrets/baosecrets.go
@@ -8,7 +8,7 @@
 // per-org policy/AppRole to that prefix. The console BFF additionally enforces
 // org scope on top, so a session for org A can never reference org B's path.
 //
-// Secrets are external_reference from mitos's perspective: the value lives in
+// Secrets are external_reference from Mitos's perspective: the value lives in
 // OpenBao, and the console returns only metadata (version + a non-sensitive
 // fingerprint stored as custom_metadata); the value is never read back through
 // the BFF.

--- a/internal/saas/keys.go
+++ b/internal/saas/keys.go
@@ -14,7 +14,7 @@ import (
 )
 
 // keyPrefix is the tag every raw key carries so a leaked key is greppable and a
-// scanner can recognize a mitos credential. The masked Prefix stored on ApiKey
+// scanner can recognize a Mitos credential. The masked Prefix stored on ApiKey
 // is this tag plus a short non-secret slug.
 const keyPrefix = "mitos_live_"
 
@@ -27,7 +27,7 @@ const rawKeyBytes = 32
 // while internal logging and tests can still discriminate. None of these errors
 // ever carries the raw key value.
 var (
-	// ErrKeyMalformed: the presented credential is not a mitos key shape.
+	// ErrKeyMalformed: the presented credential is not a Mitos key shape.
 	ErrKeyMalformed = errors.New("saas: api key is malformed")
 	// ErrKeyUnknown: the key does not resolve to any stored key.
 	ErrKeyUnknown = errors.New("saas: api key is not recognized")

--- a/internal/saas/keys_test.go
+++ b/internal/saas/keys_test.go
@@ -91,7 +91,7 @@ func TestVerifyRejectsForgedKey(t *testing.T) {
 	}
 }
 
-// TestVerifyRejectsMalformedKey asserts a credential without the mitos prefix is
+// TestVerifyRejectsMalformedKey asserts a credential without the Mitos prefix is
 // rejected before any store lookup.
 func TestVerifyRejectsMalformedKey(t *testing.T) {
 	store := NewMemStore()

--- a/llms.txt
+++ b/llms.txt
@@ -1,4 +1,4 @@
-# mitos
+# Mitos
 
 > Snapshot-fork sandboxes for AI agents on Kubernetes. Boots Firecracker
 > microVMs, forks them via copy-on-write snapshots, and exposes the lifecycle

--- a/plugins/paperclip/src/claim-client.ts
+++ b/plugins/paperclip/src/claim-client.ts
@@ -1,4 +1,4 @@
-// The claim-mode orchestration: drives a minimal mitos cluster client through
+// The claim-mode orchestration: drives a minimal Mitos cluster client through
 // the Paperclip provider lifecycle (acquire -> assert installs -> teardown with
 // extract-then-delete). The MitosClaimClient interface is the thin seam this
 // logic talks to, so it is unit testable with a fake (no cluster, no Paperclip

--- a/plugins/paperclip/src/claim-mapping.ts
+++ b/plugins/paperclip/src/claim-mapping.ts
@@ -42,7 +42,7 @@ export interface SecretMount {
   envVar: string;
 }
 
-/** The mitos NetworkPolicy shape this plugin emits (a subset of #219). */
+/** The Mitos NetworkPolicy shape this plugin emits (a subset of #219). */
 export interface NetworkPolicy {
   /** Default verdict for traffic matching no allow rule. */
   egress: "deny" | "allow";
@@ -56,7 +56,7 @@ export interface OutputSpec {
   diff?: boolean;
 }
 
-/** The Sandbox object the plugin hands to a mitos cluster client. */
+/** The Sandbox object the plugin hands to a Mitos cluster client. */
 export interface MitosSandbox {
   apiVersion: string;
   kind: "Sandbox";

--- a/plugins/paperclip/src/plugin.ts
+++ b/plugins/paperclip/src/plugin.ts
@@ -108,7 +108,7 @@ export function setClaimClientFactory(
 function requireClaimClient(config: SandboxDriverConfig): MitosClaimClient {
   if (!claimClientFactory) {
     throw new Error(
-      "claim backend selected but no mitos cluster client is wired. " +
+      "claim backend selected but no Mitos cluster client is wired. " +
         "Inject one via setClaimClientFactory (the @mitos/sdk AgentRun binding " +
         "ships in the Paperclip monorepo; see docs/integrations/paperclip.md).",
     );
@@ -118,7 +118,7 @@ function requireClaimClient(config: SandboxDriverConfig): MitosClaimClient {
 
 /**
  * Build the claim-time secret references from the lease params. Only Secret
- * REFERENCES travel; the mitos controller resolves the plaintext server-side,
+ * REFERENCES travel; the Mitos controller resolves the plaintext server-side,
  * so values never enter the plugin, the logs, or a pool snapshot.
  */
 function secretRefsFor(

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,6 +1,6 @@
-# mitos Go SDK
+# Mitos Go SDK
 
-mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
+Mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
 restore from snapshots and fork into parallel attempts, so an agent can branch a
 warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
@@ -142,7 +142,7 @@ surfaces in `err.Error()`.
 ## Sandbox ids
 
 Sandbox ids must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` (the same allowlist
-every mitos SDK enforces). `Fork` validates the id (the explicit one or the
+every Mitos SDK enforces). `Fork` validates the id (the explicit one or the
 generated `sandbox-<hex>`) and returns a typed `invalid_sandbox_id` error before
 sending any request. `ValidSandboxID(id)` exposes the check.
 
@@ -167,9 +167,9 @@ this module: the files API (`/v1/files/*`), interactive PTY (`/v1/pty`),
 `run_code`, per-sandbox network posture, `set_timeout`, `pause` / `resume`, and
 `get_host(port)` preview URLs.
 
-## The mitos SDK family
+## The Mitos SDK family
 
-mitos ships native clients in six languages. All of them share the same
+Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) is Python and
 TypeScript only.

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -2,7 +2,7 @@ package mitos
 
 import "strings"
 
-// Error is the LLM-legible error returned by the mitos SDK. It mirrors the
+// Error is the LLM-legible error returned by the Mitos SDK. It mirrors the
 // server envelope {error:{code, message, cause, remediation}} and the Python
 // AgentRunError, the TypeScript AgentRunError, the Ruby MitosError, and the Java
 // MitosException.

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -1,6 +1,6 @@
-# mitos Java SDK
+# Mitos Java SDK
 
-mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
+Mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
 restore from snapshots and fork into parallel attempts, so an agent can branch a
 warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
@@ -121,7 +121,7 @@ rejected with code `invalid_sandbox_id` before any request is sent.
 ## Sandbox ids
 
 Sandbox ids must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` (the same allowlist
-every mitos SDK enforces). `fork` and `terminate` validate the id (the explicit
+every Mitos SDK enforces). `fork` and `terminate` validate the id (the explicit
 one or the generated `sandbox-<hex>`) and raise `invalid_sandbox_id` before
 sending any request.
 
@@ -135,9 +135,9 @@ WebSocket, `run_code` against the code-interpreter kernel, `pause` / `resume`,
 `set_timeout`, `get_host` preview URLs, per-sandbox `Network` posture, and
 sandbox-to-sandbox `fork` from a running handle.
 
-## The mitos SDK family
+## The Mitos SDK family
 
-mitos ships native clients in six languages. All of them share the same
+Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) is Python and
 TypeScript only.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
-# mitos Python SDK
+# Mitos Python SDK
 
-mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
+Mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
 restore from snapshots and fork into parallel attempts, so an agent can branch a
 warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
@@ -120,7 +120,7 @@ sandbox.terminate()
 
 Cluster mode drives the Kubernetes CRDs (`SandboxPool`, `Sandbox`, `Workspace`)
 in API group `mitos.run/v1` and execs through the forkd sandbox API. It is for
-operators who run the mitos cluster themselves.
+operators who run the Mitos cluster themselves.
 
 ```python
 from mitos import AgentRun
@@ -286,7 +286,7 @@ the base SDK installs and tests without it.
 ### LangChain / deepagents
 
 LangChain and deepagents let you pick a pluggable sandbox backend (they ship
-`E2BSandbox` and `DaytonaSandbox`). `MitosSandbox` is the mitos backend: change
+`E2BSandbox` and `DaytonaSandbox`). `MitosSandbox` is the Mitos backend: change
 the backend, keep your agent code.
 
 ```python
@@ -311,14 +311,14 @@ sb.close()                           # alias: sb.stop()
 
 Install the extra only if you use the integration:
 `pip install "mitos-run[langchain]"`. `MitosSandbox` does not subclass any
-langchain type and is fully usable without langchain installed. Fork is a mitos
+langchain type and is fully usable without langchain installed. Fork is a Mitos
 op the LangChain backend interface does not expose, so it is reached through the
 adapter's native `fork`, which returns sibling `MitosSandbox` backends.
 
 ### OpenAI Agents SDK
 
 `MitosSandboxTools` binds `run_command` / `read_file` / `write_file` /
-`run_code` to a mitos sandbox: give the tools to your agent and its tool calls
+`run_code` to a Mitos sandbox: give the tools to your agent and its tool calls
 run inside the sandbox.
 
 ```python
@@ -345,7 +345,7 @@ raises a clear error naming the extra when absent.
 ### Claude Agent SDK
 
 The Claude Agent SDK takes custom tools as an in-process MCP server.
-`MitosSandboxTools` binds the same four tools to a mitos sandbox and wraps them
+`MitosSandboxTools` binds the same four tools to a Mitos sandbox and wraps them
 as an MCP server you pass to the agent.
 
 ```python
@@ -370,7 +370,7 @@ raises a clear error naming the extra when absent.
 
 ### VibeKit
 
-`MitosVibeKitProvider` is the mitos provider against VibeKit's provider shape: a
+`MitosVibeKitProvider` is the Mitos provider against VibeKit's provider shape: a
 named provider that creates sandboxes exposing command execution, a filesystem,
 and a lifecycle.
 
@@ -394,7 +394,7 @@ mitos-native op via `sandbox.fork(n)`.
 
 ### ZenML
 
-`MitosSandboxComponent` is the framework-neutral mitos backend (config, flavor
+`MitosSandboxComponent` is the framework-neutral Mitos backend (config, flavor
 name, and the provision / run_command / files / run_code / deprovision logic the
 flavor wraps).
 
@@ -416,15 +416,15 @@ Install the extra only if you use the integration:
 testable without ZenML; only `MitosSandboxComponent.flavor()` needs it and
 raises a clear error naming the extra when absent.
 
-Listing mitos as a selectable provider inside VibeKit or ZenML is a contribution
+Listing Mitos as a selectable provider inside VibeKit or ZenML is a contribution
 to those projects' own repositories, not something installing this SDK does. The
 adapters above implement the backend each aggregator expects; you use them
 directly today, and the module docstrings spell out the contract each upstream
 contribution would conform to.
 
-## The mitos SDK family
+## The Mitos SDK family
 
-mitos ships native clients in six languages. All of them share the same
+Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) is Python and
 TypeScript only.

--- a/sdk/python/tests/test_vibekit_integration.py
+++ b/sdk/python/tests/test_vibekit_integration.py
@@ -2,9 +2,9 @@
 (issue #205).
 
 VibeKit is a provider aggregator over sandbox backends ("E2B today; Daytona,
-Modal, Fly.io coming soon"). Listing mitos there is near-free distribution. The
+Modal, Fly.io coming soon"). Listing Mitos there is near-free distribution. The
 external LISTING (a PR to VibeKit's repo) is a human step; what is implemented
-here is the mitos PROVIDER each aggregator expects, backed by the native
+here is the Mitos PROVIDER each aggregator expects, backed by the native
 ``DirectSandbox`` surface through the shared ``mitos.integrations._mapping`` op
 layer.
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -1,6 +1,6 @@
-# mitos Ruby SDK
+# Mitos Ruby SDK
 
-mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
+Mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
 restore from snapshots and fork into parallel attempts, so an agent can branch a
 warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
@@ -117,7 +117,7 @@ error cause.
 ## Sandbox ids
 
 Sandbox ids must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` (the same allowlist
-every mitos SDK enforces). `fork` and `terminate` validate the id and raise a
+every Mitos SDK enforces). `fork` and `terminate` validate the id and raise a
 typed `invalid_sandbox_id` error before sending any request.
 
 ## Tests
@@ -144,9 +144,9 @@ gem: the files API (`/v1/files/*`), interactive PTY (`/v1/pty`), `run_code`,
 per-sandbox network posture, `set_timeout`, `pause` / `resume`, and
 `get_host(port)` preview URLs.
 
-## The mitos SDK family
+## The Mitos SDK family
 
-mitos ships native clients in six languages. All of them share the same
+Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) is Python and
 TypeScript only.

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,6 +1,6 @@
-# mitos Rust SDK
+# Mitos Rust SDK
 
-mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
+Mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
 restore from snapshots and fork into parallel attempts, so an agent can branch a
 warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
@@ -127,7 +127,7 @@ error cause, and never appears in the `Display` output.
 ## Sandbox ids
 
 Sandbox ids must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` (the same allowlist
-every mitos SDK enforces). `fork` and `terminate` validate the id and return a
+every Mitos SDK enforces). `fork` and `terminate` validate the id and return a
 typed `invalid_sandbox_id` error before sending any request. Use
 `mitos::valid_sandbox_id` to check an id yourself.
 
@@ -153,9 +153,9 @@ crate: the files API (`/v1/files/*`), interactive PTY (`/v1/pty`), `run_code`,
 per-sandbox network posture, `set_timeout`, `pause` / `resume`, and
 `get_host(port)` preview URLs.
 
-## The mitos SDK family
+## The Mitos SDK family
 
-mitos ships native clients in six languages. All of them share the same
+Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) is Python and
 TypeScript only.

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -1,4 +1,4 @@
-//! The structured error type for the mitos SDK.
+//! The structured error type for the Mitos SDK.
 //!
 //! Every non-2xx response from the sandbox-server is turned into a
 //! [`MitosError`] that carries the server envelope
@@ -51,7 +51,7 @@ impl MitosError {
 
     /// Builds a [`MitosError`] from a non-2xx response body. Prefers the
     /// structured server envelope `{error:{code, message, cause, remediation}}`
-    /// and falls back to status-derived defaults for an older or non-mitos
+    /// and falls back to status-derived defaults for an older or non-Mitos
     /// server. Any occurrence of `token` in the body is redacted before it
     /// becomes the `cause`, so the bearer value never reaches an error field.
     pub(crate) fn from_response(status: u16, raw_body: &str, token: Option<&str>) -> Self {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,4 +1,4 @@
-//! Thin, direct-mode Rust client for the mitos standalone and hosted
+//! Thin, direct-mode Rust client for the Mitos standalone and hosted
 //! sandbox-server REST API.
 //!
 //! This crate mirrors the direct-mode surface of the Python SDK

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,6 +1,6 @@
-# mitos TypeScript SDK
+# Mitos TypeScript SDK
 
-mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
+Mitos gives AI agents isolated, forkable sandboxes: Firecracker microVMs that
 restore from snapshots and fork into parallel attempts, so an agent can branch a
 warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
@@ -181,9 +181,9 @@ Sandbox ids must match `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`. `fork` and
 and throw `invalid_sandbox_id` before sending any request. `validSandboxId(id)`
 exposes the check.
 
-## The mitos SDK family
+## The Mitos SDK family
 
-mitos ships native clients in six languages. All of them share the same
+Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) is Python and
 TypeScript only.

--- a/sdk/typescript/examples/cluster.ts
+++ b/sdk/typescript/examples/cluster.ts
@@ -1,7 +1,7 @@
 /**
  * Cluster-mode example: Kubernetes CRDs via AgentRun.
  *
- * Requires a running cluster with the mitos controller and forkd, and a
+ * Requires a running cluster with the Mitos controller and forkd, and a
  * kubeconfig that can reach it. Execute with ts-node or compile and run with
  * node. It is kept runnable-shaped (top-level async main) and type-checks
  * under npm run check:examples.

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,4 +1,4 @@
-// Errors for the mitos TypeScript SDK. AgentRunError carries an
+// Errors for the Mitos TypeScript SDK. AgentRunError carries an
 // LLM-legible code, cause, and remediation so a failure can be acted on
 // programmatically. fromResponse builds one from a non-2xx HTTP response and
 // redacts any echo of the bearer token from the body first, so a token a

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -1,4 +1,4 @@
-// HTTP transport for the mitos TypeScript SDK. A thin wrapper over the
+// HTTP transport for the Mitos TypeScript SDK. A thin wrapper over the
 // global fetch that attaches the per-sandbox bearer token, parses JSON, and
 // turns any non-2xx response into an AgentRunError with the token redacted from
 // the body. The token is held in memory only and is never logged.

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,4 @@
-// Public API for the mitos TypeScript SDK.
+// Public API for the Mitos TypeScript SDK.
 
 export type {
   ForkPolicy,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,4 +1,4 @@
-// Public types for the mitos TypeScript SDK. These mirror the Python SDK
+// Public types for the Mitos TypeScript SDK. These mirror the Python SDK
 // (sdk/python/mitos/types.py) with camelCased field names.
 
 /**

--- a/skills/mitos/SKILL.md
+++ b/skills/mitos/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: mitos-sandboxes
-description: Use when an agent needs isolated, forkable compute, running untrusted or model-written code safely, or exploring several attempts in parallel (best-of-N) and keeping the winner. mitos boots Firecracker microVMs and forks a running VM via copy-on-write snapshots, so a fan-out is cheap and each attempt is hardware-isolated. Pairs with the mitos-mcp server (the tools) and the Python/TypeScript SDKs.
+description: Use when an agent needs isolated, forkable compute, running untrusted or model-written code safely, or exploring several attempts in parallel (best-of-N) and keeping the winner. Mitos boots Firecracker microVMs and forks a running VM via copy-on-write snapshots, so a fan-out is cheap and each attempt is hardware-isolated. Pairs with the mitos-mcp server (the tools) and the Python/TypeScript SDKs.
 ---
 
-# Using mitos snapshot-fork sandboxes
+# Using Mitos snapshot-fork sandboxes
 
-mitos gives an agent isolated, forkable computers. Each sandbox is a Firecracker
+Mitos gives an agent isolated, forkable computers. Each sandbox is a Firecracker
 microVM. Forking copies a running VM with copy-on-write, so spawning N attempts
 from a warm base is fast and you pay only for the memory each attempt dirties.
 
@@ -16,7 +16,7 @@ prose: every failure is a structured envelope, branch on `code` and follow
 
 ## Connecting
 
-The hosted production mitos is at `https://mitos.run`. The simplest path is one
+The hosted production Mitos is at `https://mitos.run`. The simplest path is one
 login: run `mitos auth login --token <session>` once and it writes a shared
 credential file (`~/.config/mitos/credentials.json`, honoring `MITOS_CONFIG_DIR`).
 The Python and TypeScript SDKs, the `mitos` CLI, and `mitos-mcp` all pick up the

--- a/test/cluster-e2e/chaos-e2e.sh
+++ b/test/cluster-e2e/chaos-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mitos cluster CHAOS e2e (issue #163, ROADMAP G2 failure/GC semantics).
+# Mitos cluster CHAOS e2e (issue #163, ROADMAP G2 failure/GC semantics).
 #
 # Asserts the husk warm-pool's BORING FAILURE BEHAVIOR on real KVM:
 #   1. pool warms        a SandboxPool brings up dormant husk pods


### PR DESCRIPTION
## Capitalize the "Mitos" brand name

The brand is **Mitos**. This sweep capitalizes "mitos" → "Mitos" wherever it appears as a proper noun in human-readable text (prose, docs, titles, meta/OG/JSON-LD display names, nav/footer labels, alt text, RSS, comments, user-facing strings).

### Preserved lowercase (technical identifiers — unchanged)
- `mitos.run` domain, `mitos.run/mitos` Go vanity import, `mitos.run/*` CRD groups + label keys
- `mitos-run` org, `mitos-run/mitos` repo, `ghcr.io/mitos-run` registry
- `mitos` / `kubectl mitos` CLI binary, `@mitos/sdk` and other package names
- k8s namespaces (`mitos-ci`, `mitos-system`, …), `mitos_*` metrics, code identifiers, and everything inside code fences

All edits are 1:1 line swaps. Verified: no technical identifier was capitalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)