### PR TITLE
fix(console): pin pnpm so the console image builds reproducibly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -253,6 +253,16 @@ jobs:
       # pod-native default, issue #18). It is referenced by the controller
       # Deployment's --husk-stub-image, so it must build cleanly here.
       - run: docker build -f Dockerfile.husk-stub -t mitos-husk-stub:ci .
+      # Mirror the full publish.yaml image matrix here so a release-only image
+      # can never break unseen. console, facade, gateway, and kvm-device-plugin
+      # were previously built only at tag time, so a broken Dockerfile (for
+      # example the console SPA build) shipped a release with a missing image
+      # and a chart that referenced it. Building them on every PR turns that
+      # into a red required check instead.
+      - run: docker build -f Dockerfile.kvm-device-plugin -t mitos-kvm-device-plugin:ci .
+      - run: docker build -f Dockerfile.facade -t mitos-facade:ci .
+      - run: docker build -f Dockerfile.console -t mitos-console:ci .
+      - run: docker build -f Dockerfile.gateway -t mitos-gateway:ci .
       # Trivy scans each locally built image for known OS/library CVEs (CVE
       # pipeline, issue #35). Installed directly from a pinned release (the
       # marketplace action's binary installer proved flaky in CI). Phased in as
@@ -274,7 +284,7 @@ jobs:
             exit 0
           fi
           trivy --version || { echo "::warning::Trivy not runnable; skipping advisory image scan"; exit 0; }
-          for img in mitos-controller:ci mitos-forkd:ci mitos-husk-stub:ci; do
+          for img in mitos-controller:ci mitos-forkd:ci mitos-husk-stub:ci mitos-kvm-device-plugin:ci mitos-facade:ci mitos-console:ci mitos-gateway:ci; do
             echo "=== Trivy scan ${img} (HIGH,CRITICAL, fixable) ==="
             trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
               --ignorefile .trivyignore "${img}" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -115,3 +115,51 @@ jobs:
         with:
           name: sbom-${{ matrix.name }}
           path: sbom-${{ matrix.name }}.spdx.json
+
+  verify-public-images:
+    # Release guard: after publishing, assert that every image the chart points
+    # at (the artifacthub.io/images annotation, which is exactly what Artifact
+    # Hub scans and what `helm install` pulls) actually exists in GHCR AND is
+    # anonymously pullable, i.e. public. A brand new component package defaults
+    # to private, and a failed build leaves no image at all; either way this job
+    # turns that into a loud red release here instead of a silent Artifact Hub
+    # scan-failure email weeks later. Anonymous-pullable is the precise contract:
+    # if the GHCR token endpoint denies an anonymous pull scope, the package is
+    # private or missing, and this fails.
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Every chart-referenced image is public and pullable
+        run: |
+          set -euo pipefail
+          imgs=$(grep -oE 'ghcr\.io/mitos-run/[a-z0-9-]+:[A-Za-z0-9._-]+' \
+            deploy/charts/mitos/Chart.yaml | sort -u)
+          echo "Chart-referenced images:"; echo "${imgs}"
+          fail=0
+          for ref in ${imgs}; do
+            repo="${ref%:*}"; tag="${ref##*:}"; path="${repo#ghcr.io/}"
+            # An anonymous bearer token is only granted for public packages; a 403
+            # here means private or nonexistent (GHCR returns DENIED for both).
+            token=$(curl -fsSL \
+              "https://ghcr.io/token?scope=repository:${path}:pull&service=ghcr.io" \
+              | sed -E 's/.*"token":"([^"]+)".*/\1/') || token=""
+            if [ -z "${token}" ]; then
+              echo "::error::${ref} is not anonymously pullable (private or missing package)"
+              fail=1; continue
+            fi
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H "Authorization: Bearer ${token}" \
+              -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+              "https://ghcr.io/v2/${path}/manifests/${tag}")
+            if [ "${code}" != "200" ]; then
+              echo "::error::${ref} manifest is not publicly resolvable (HTTP ${code})"
+              fail=1
+            else
+              echo "ok: ${ref}"
+            fi
+          done
+          if [ "${fail}" != "0" ]; then
+            echo "::error::One or more chart-referenced images are missing or private in GHCR"
+            exit 1
+          fi

--- a/Dockerfile.console
+++ b/Dockerfile.console
@@ -4,6 +4,13 @@
 # 1) Build the SPA bundle from the web/ pnpm workspace.
 FROM node:22-bookworm AS spa
 WORKDIR /web
+# Corepack provisions pnpm from the "packageManager" field in web/package.json,
+# so the build uses the exact pinned pnpm (and matching lockfile semantics)
+# everywhere: local, CI, and release. Without the pin, corepack fetches the
+# latest major (pnpm 11), whose supply-chain policy check and relocated build
+# allowlist reject this lockfile and fail the build. Disable the interactive
+# download prompt so a no-TTY build provisions pnpm without blocking.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable
 # Install with the lockfile first for caching, then build.
 COPY web/pnpm-workspace.yaml web/package.json web/pnpm-lock.yaml ./

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "description": "mitos console SPA workspace (the @mitos/brand package + the console app).",
+  "packageManager": "pnpm@10.24.0",
   "scripts": {
     "build": "pnpm -C app build",
     "dev": "pnpm -C app dev",


### PR DESCRIPTION
## What happened
\`mitos-console\` was never published at v0.13.0: its publish job failed while the other six succeeded, so the chart shipped an \`artifacthub.io/images\` reference to an image that does not exist. That is what Artifact Hub's Trivy scan emailed about, and it also breaks \`helm install\` (ImagePullBackOff on the console Deployment).

## Root cause
\`Dockerfile.console\` runs \`corepack enable\` with no pinned pnpm version and \`web/package.json\` had no \`packageManager\` field, so corepack provisioned the latest major (pnpm 11) instead of the pnpm 10.24.0 that matches the committed lockfile and local dev. pnpm 11 breaks the build two ways: a network-dependent supply-chain policy check on the lockfile, and the relocation of \`onlyBuiltDependencies\` out of \`package.json\` (dropping esbuild's native build). The lockfile was never stale; the unpinned pnpm was the bug.

## Fix
- Pin \`packageManager: pnpm@10.24.0\` in \`web/package.json\` so corepack uses the same pnpm everywhere: local, CI, release.
- \`COREPACK_ENABLE_DOWNLOAD_PROMPT=0\` in \`Dockerfile.console\` so a no-TTY build provisions pnpm without blocking.

## Prevention (automated, enforced)
- \`ci.yaml\` \`docker-build\` now builds the full publish image matrix (adds console, facade, gateway, kvm-device-plugin). \`docker-build\` is a required check, so a broken release-only Dockerfile becomes a red PR instead of a silent hole found at tag time.
- \`publish.yaml\` gains a \`verify-public-images\` job that, after publishing, asserts every chart-referenced image is anonymously pullable (public). A missing or private image fails the release loudly.

## Verification
\`docker build -f Dockerfile.console\` builds end to end (SPA bundle + Go binary + distroless image), confirmed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)