### PR TITLE
docs(readme): point to the published Helm repo, not the chart source

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The E2B shim is a "change one import" bridge for self-hosted, regulated, or air-
 kubectl apply -k deploy/
 ```
 
-The self-contained kustomize base installs the CRDs, the controller (husk mode), the forkd DaemonSet, the `/dev/kvm` device plugin, and the PKI bootstrap, and applies on a real KVM node with no manual patches. Nodes need `/dev/kvm` and the label `mitos.run/kvm=true`. A Helm chart is available under [deploy/charts/mitos](deploy/charts/mitos/README.md).
+The self-contained kustomize base installs the CRDs, the controller (husk mode), the forkd DaemonSet, the `/dev/kvm` device plugin, and the PKI bootstrap, and applies on a real KVM node with no manual patches. Nodes need `/dev/kvm` and the label `mitos.run/kvm=true`. The Helm chart is published at `https://mitos.run/charts` and listed on Artifact Hub: `helm repo add mitos https://mitos.run/charts`. See [deploy/charts/mitos](deploy/charts/mitos/README.md) for the install command and values.
 
 ```yaml
 apiVersion: mitos.run/v1


### PR DESCRIPTION
## What

Follow-up to #331. That PR's README edit said "A Helm chart is available under `deploy/charts/mitos`" (the source dir). The chart is actually **published**, so this points readers at the real install path.

Verified live:
- `https://mitos.run/charts/index.yaml` serves a real index (chart versions through `mitos-0.4.0`, images `v0.13.0`), served from `gh-pages` by the `helm-release.yaml` chart-releaser workflow.
- Listed on Artifact Hub.

Now reads: `helm repo add mitos https://mitos.run/charts`, deferring the full install command and values to the chart README (which carries the required `-n mitos --set namespace.create=false` flags, so no incomplete one-liner is duplicated here).

OperatorHub.io is **not** claimed: `k8s-operatorhub/community-operators` has no `operators/mitos` entry yet, so the submission is not live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)