### PR TITLE
ci: let releases trigger downstream publish and OperatorHub automation

### DIFF
--- a/.github/workflows/operator-release.yaml
+++ b/.github/workflows/operator-release.yaml
@@ -2,18 +2,25 @@ name: Release operator bundle
 
 # Build and publish the OLM operator bundle for a release, and (optionally) open
 # the version PR to k8s-operatorhub/community-operators. The committed bundle
-# under deploy/olm/bundle is the 0.4.0 base; this workflow rewrites it to the
+# under deploy/olm/bundle is the version base; this workflow rewrites it to the
 # release version in a throwaway workspace, validates it, pushes the bundle
 # image, and prepares the community-operators contribution.
 #
 # Prerequisites and notes:
 #   * Images must already be published to ghcr.io/mitos-run for the version.
-#   * The first community-operators listing is still a manual PR; this automates
-#     subsequent versions once a fork and token exist.
+#   * The first community-operators listing (mitos 0.13.0) was submitted manually
+#     in k8s-operatorhub/community-operators#8488. This workflow handles every
+#     subsequent version automatically once the token below exists.
+#   * This fires on release: published, which only reaches this workflow when the
+#     release is cut with a non-default token; see RELEASE_PLEASE_TOKEN in
+#     release-please.yml. Without that, trigger it manually via workflow_dispatch.
 #   * To open the PR automatically, set the COMMUNITY_OPERATORS_TOKEN secret to a
 #     PAT (repo scope) whose account has a fork of k8s-operatorhub/community-
-#     operators. Without it, the versioned bundle is uploaded as an artifact.
-#   * Pass `previous` so the bundle gets a spec.replaces upgrade edge.
+#     operators (the stubbi/community-operators fork). Without it, the versioned
+#     bundle is uploaded as an artifact instead.
+#   * The operators/mitos/ci.yaml update graph is semver-mode, so a new version
+#     orders by semver and does not require a spec.replaces edge. Passing
+#     `previous` still adds an explicit replaces edge when you want one.
 
 on:
   release:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,14 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # A release or tag created with the default GITHUB_TOKEN does NOT
+          # trigger other workflows (GitHub blocks recursive token-driven runs),
+          # so the tag/release that release-please cuts would never start
+          # publish.yaml (images) or operator-release.yaml (OperatorHub bundle).
+          # Set the RELEASE_PLEASE_TOKEN secret to a PAT or GitHub App token with
+          # contents:write and workflow scope so the release event cascades to
+          # those workflows. It falls back to GITHUB_TOKEN when unset, which keeps
+          # today's behavior (the release PR still lands, downstream stays manual).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/operatorhub.md
+++ b/docs/operatorhub.md
@@ -5,6 +5,23 @@ This runbook covers packaging the Mitos OLM bundle and submitting it to
 [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators)
 repository.
 
+The initial listing (mitos 0.13.0) is already submitted. Every later version is
+meant to submit itself: the `Release operator bundle` workflow
+(`.github/workflows/operator-release.yaml`) rebuilds the bundle for the release,
+validates it, and opens the community-operators PR. Two repository secrets gate
+the automation:
+
+- `RELEASE_PLEASE_TOKEN` (on this repo): a PAT or GitHub App token used by
+  release-please so the release it cuts actually triggers downstream workflows.
+  A release cut with the default `GITHUB_TOKEN` does not start them.
+- `COMMUNITY_OPERATORS_TOKEN`: a PAT whose account owns a fork of
+  community-operators (the `stubbi/community-operators` fork), used to push the
+  branch and open the PR. Without it the bundle is uploaded as a CI artifact.
+
+The `operators/mitos/ci.yaml` update graph is `semver-mode` and lists the
+maintainer as a reviewer, so community-operators can fast-track later version
+bumps. The steps below are the manual fallback (and how the first PR was made).
+
 The bundle skeleton lives at `deploy/olm/bundle/`:
 
 ```


### PR DESCRIPTION
## Why

Investigating "auto-submit the operator on new versions" surfaced the root cause: **a tag/release created with the default `GITHUB_TOKEN` does not trigger other workflows** (GitHub blocks recursive token-driven runs). release-please cuts releases as `github-actions[bot]`, so:

- `publish.yaml` (`on: push: tags`) never auto-runs — every run is a manual `workflow_dispatch`. That is why `ghcr.io/mitos-run/mitos-controller:v0.14.0` does not exist despite the v0.14.0 release.
- `operator-release.yaml` (`on: release: published`) has never run at all.

## Change

- `release-please.yml`: use `token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}`. Safe no-op until the secret is added; with a PAT/App token the release cascades to image publishing and the OperatorHub bundle PR.
- `operator-release.yaml`: refresh the stale header (bundle base is the current version, not 0.4.0; the first listing is submitted; the update graph is semver-mode).
- `docs/operatorhub.md`: document the two gating secrets and that the first listing is done.

## Manual follow-up (secrets, maintainer-only)

To make it fully automatic you must add two repo secrets:
1. `RELEASE_PLEASE_TOKEN` - a PAT or GitHub App token (contents:write + workflow) so releases trigger downstream workflows.
2. `COMMUNITY_OPERATORS_TOKEN` - a PAT on the account that owns the `stubbi/community-operators` fork, so `operator-release.yaml` can push the branch and open the community-operators PR.

The first OperatorHub.io listing (mitos 0.13.0) is already open: k8s-operatorhub/community-operators#8488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)