### PR TITLE
fix(controller): bootstrap PKI in the operator's own namespace

### DIFF
--- a/deploy/charts/mitos/Chart.yaml
+++ b/deploy/charts/mitos/Chart.yaml
@@ -5,7 +5,7 @@ name: mitos
 # lifecycle through the mitos.run CRDs.
 description: Snapshot-fork sandboxes for AI agents on Kubernetes.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v0.13.0"
 kubeVersion: ">=1.29.0-0"
 keywords:

--- a/deploy/charts/mitos/templates/controller-deployment.yaml
+++ b/deploy/charts/mitos/templates/controller-deployment.yaml
@@ -51,6 +51,17 @@ spec:
             {{- with .Values.controller.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          env:
+            # Run the control plane (PKI bootstrap, forkd discovery) in the
+            # namespace the controller is deployed into, so an install into any
+            # namespace works without crash-looping on a missing "mitos" default.
+            - name: FORKD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- with .Values.controller.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -62,6 +62,9 @@ controller:
   poolSecretsClusterRoleName: mitos-pool-secrets
   # Extra args appended verbatim to the controller container args.
   extraArgs: []
+  # Extra env vars appended verbatim to the controller container. FORKD_NAMESPACE
+  # is always set to the controller's own namespace via the downward API.
+  extraEnv: []
 
 # huskStub image: the image husk pods run; passed to the controller via
 # --husk-stub-image. No standalone workload is rendered for it.

--- a/deploy/olm/bundle/manifests/mitos.clusterserviceversion.yaml
+++ b/deploy/olm/bundle/manifests/mitos.clusterserviceversion.yaml
@@ -416,6 +416,16 @@ spec:
                       - --enable-husk-pods
                       - --husk-stub-image=ghcr.io/mitos-run/mitos-husk-stub:v0.13.0
                       - --husk-data-dir=/var/lib/mitos
+                    env:
+                      # Run the control plane (PKI bootstrap, forkd discovery) in
+                      # the namespace OLM installs the operator into, not the
+                      # hardcoded default. Without this the controller tries to
+                      # create its CA Secret in a "mitos" namespace that does not
+                      # exist under OLM and crash-loops.
+                      - name: FORKD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                     ports:
                       - name: metrics
                         containerPort: 8080


### PR DESCRIPTION
## Problem

The OperatorHub "Full operator test" (`kiwi`) failed on [k8s-operatorhub/community-operators#8488](https://github.com/k8s-operatorhub/community-operators/pull/8488). The `mitos-controller` pod CrashLoopBackOff'd:

```
ERROR setup  PKI bootstrap failed; refusing to start with unauthenticated forkd dialing
  {"error": "create CA secret mitos/mitos-ca: namespaces \"mitos\" not found"}
```

The controller resolves its control plane namespace from `FORKD_NAMESPACE`, defaulting to `"mitos"` when unset (`cmd/controller/main.go`). Neither the OLM CSV nor the Helm chart set it, so the controller only works when it happens to run in a namespace literally named `mitos`. OLM installs into `test-operators` (or any operator namespace), so it tried to create its CA Secret in a `mitos` namespace that does not exist and crash-looped with `InstallCheckFailed`.

## Fix

Set `FORKD_NAMESPACE` from the downward API (`metadata.namespace`) in both:
- `deploy/olm/bundle/manifests/mitos.clusterserviceversion.yaml`
- `deploy/charts/mitos/templates/controller-deployment.yaml`

In the default `mitos` install this resolves to `mitos`, so existing deployments are unchanged; installs into any other namespace (and OLM) now work. Adds `controller.extraEnv` passthrough and bumps the chart to `0.4.1` so it republishes. Bundle re-validated with `operator-sdk bundle validate --select-optional suite=operatorframework`.

The same fix is being applied to the `0.13.0` bundle on #8488 to make that submission pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)