### PR TITLE
fix(ci): restore warm.min on husk-mode e2e SandboxPools (v1 migration regression, #299)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -732,6 +732,8 @@ jobs:
                 memory: 512Mi
             snapshots:
               replicasPerNode: 2
+            warm:
+              min: 2
           YAML
           kubectl -n default get sandboxpool husk-e2e
       - name: The pool creates husk pods that schedule onto the KVM node

--- a/test/cluster-e2e/placement-e2e.sh
+++ b/test/cluster-e2e/placement-e2e.sh
@@ -114,6 +114,8 @@ spec:
     resources: { cpu: "250m", memory: "512Mi" }
   snapshots:
     replicasPerNode: 2
+  warm:
+    min: 2
   placement:
     nodeSelector:
       ${TENANT_KEY}: "${TENANT_VAL}"


### PR DESCRIPTION
## Root cause

The v1 API migration in #299 renamed `spec.replicas` to `spec.snapshots.replicasPerNode` (the snapshot side) but silently dropped `spec.warm.min`, the warm pool driver. Without `warm.min` the controller computes `desiredWarm=0`, creates no husk pods, and both `kind-e2e-husk` and `kind-e2e-placement` fail with:

> HUSK-FAILED: the pool reconcile created no husk pods (controller husk mode did not place the warm pool)

Both jobs were green on commit `e2a721a2` (pre-#299) and have been red since `30a04844`.

## Fix

Restore `warm.min: 2` on the two husk-mode SandboxPool manifests whose CI steps assert warm husk pods:

- `.github/workflows/ci.yaml` line 734: inline `husk-e2e` pool used by the `kind-e2e-husk` job. The job asserts husk pods are created and bound to the KVM node; without `warm.min` no pods are created.
- `test/cluster-e2e/placement-e2e.sh` line 116: placed pool used by the `kind-e2e-placement` job. Stage 1 waits for at least one scheduled husk pod; without `warm.min` none are scheduled.

`snapshots.replicasPerNode: 2` is left untouched on both; it drives the snapshot side, which is separate.

No controller Go logic was changed. `warm.min` is the documented driver for the desiredWarm autoscaler (`internal/controller/sandboxpool_controller.go`) and was present in all pre-#299 manifests.

## Pools NOT modified

`chaos-e2e.sh`, `workspace-e2e.sh`, `husk-network-e2e.sh`, and `husk-e2e.sh` (standalone script) also have husk-mode pools. They are exercised by separate CI jobs not in scope here. That is a follow-up if those jobs are also red.

## Verification

CI will verify the real fix via the `kind-e2e-husk` and `kind-e2e-placement` jobs on this PR.

Local: `kubectl kustomize deploy/` and `python3 -c "import yaml,sys; list(yaml.safe_load_all(open('.github/workflows/ci.yaml')))"` both pass clean.

---
Generated with [Claude Code](https://claude.ai/claude-code)