### PR TITLE
feat(sdk-ruby): Kubernetes cluster mode (AgentRun) (#304)

### DIFF
--- a/.github/workflows/sdk-tests.yaml
+++ b/.github/workflows/sdk-tests.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install test-only deps (webrick left the stdlib in Ruby 3.0)
         run: gem install webrick --no-document
       - name: minitest suite
-        run: ruby -Ilib -Itest test/sandbox_server_test.rb
+        run: ruby -Ilib -Itest test/sandbox_server_test.rb && ruby -Ilib -Itest test/cluster_test.rb
 
   sdk-rust:
     needs: changes

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -6,10 +6,17 @@ warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
 cluster.
 
-This is the Ruby client for the direct sandbox API: create a template, fork a
-sandbox, run `exec`, and terminate. It uses only the Ruby standard library
-(`net/http`, `json`, `uri`, `securerandom`), so there are no gem dependencies. It
-targets Ruby 2.6 and later.
+This is the Ruby client for both modes mitos ships:
+
+- **Direct mode** (`Mitos.server`): the standalone or hosted sandbox-server REST
+  API. Create a template, fork a sandbox, run `exec`, and terminate.
+- **Cluster mode** (`Mitos::AgentRun`): drive the Kubernetes `mitos.run` CRDs
+  (`SandboxPool`, `Sandbox`, `Workspace`) directly over the Kubernetes REST API.
+
+Both modes use only the Ruby standard library, so there are no gem dependencies.
+Direct mode uses `net/http`, `json`, `uri`, and `securerandom`; cluster mode adds
+`openssl` (TLS and the cluster CA), `yaml` (kubeconfig parsing), and `base64`
+(in-cluster and Secret token decoding). It targets Ruby 2.6 and later.
 
 ## Install
 
@@ -80,6 +87,66 @@ Value objects:
 agent over vsock, so calling exec on a sandbox that is not yet up returns a typed
 `not_found` error.
 
+## Cluster mode (Kubernetes)
+
+When mitos is installed on your own Kubernetes cluster (the controller, forkd,
+and the `mitos.run` CRDs), `Mitos::AgentRun` drives the CRDs directly. It speaks
+the Kubernetes REST API itself, with no Kubernetes client gem: configuration
+comes from a kubeconfig (the `kubeconfig:` path, else `KUBECONFIG`, else
+`~/.kube/config`) or, in a pod, from the service-account mount
+(`in_cluster: true`). It is the Ruby port of the Python `AgentRun`.
+
+```ruby
+require "mitos"
+
+run = Mitos.cluster(namespace: "agents")          # or in_cluster: true in a pod
+
+# One-liner: lazily get-or-create the default pool mitos-default-python-3.12,
+# then start a Sandbox from it and block until it is Ready.
+sb = run.sandbox(image: "python:3.12", ready: true)
+puts sb.endpoint
+
+# Or start from an existing pool with env, secrets, a TTL, and a workspace.
+sb = run.create(
+  pool: "my-pool",
+  env: { "LOG_LEVEL" => "debug" },
+  secrets: { "OPENAI_API_KEY" => %w[my-secret api-key] },  # env var => [secret, key]
+  ttl: "30m",
+  workspace: "ws-1"
+)
+
+run.list(pool: "my-pool")                          # reconnect handles
+again = run.from_name(sb.name)                     # durable reconnect by name
+run.pool_status("my-pool").ready_snapshots         # warm capacity
+sb.terminate                                       # returns the bound workspace, if any
+```
+
+The default pool name is derived deterministically from the image and matches the
+Python and TypeScript SDKs byte for byte (lowercased; `/` and `:` and other
+unsafe characters become `-`; bounded and trimmed; prefixed `mitos-default-`), so
+the same image maps to the same default pool across every SDK. A reused default
+pool is checked against the requested image, so a slug collision serving a
+different image raises `pool_image_mismatch` rather than silently running the
+wrong image.
+
+| Method | Resource | Returns |
+| --- | --- | --- |
+| `Mitos.cluster(namespace:, kubeconfig:, in_cluster:)` | none | `AgentRun` |
+| `AgentRun#sandbox(image:/pool:, env:, secrets:, ttl:, workspace:, ready:)` | get-or-create pool + create Sandbox | `ClusterSandbox` |
+| `AgentRun#create(pool:, name:, env:, secrets:, ttl:, workspace:)` | create Sandbox | `ClusterSandbox` |
+| `AgentRun#get(name)` / `#from_name(name)` | read Sandbox | `ClusterSandbox` |
+| `AgentRun#list(pool:)` | list Sandboxes | `Array<ClusterSandbox>` |
+| `AgentRun#create_workspace(name)` / `#workspace(name)` / `#get_workspace(name)` / `#list_workspaces` | Workspaces | `Workspace` |
+| `AgentRun#pool_status(name)` | read SandboxPool status | `PoolStatus` |
+| `ClusterSandbox#wait_until_ready(timeout:)` | poll Sandbox status | `self` |
+| `ClusterSandbox#info` | read Sandbox status | `SandboxInfo` |
+| `ClusterSandbox#terminate` | delete Sandbox | workspace name or `nil` |
+
+The per-sandbox bearer token is read from the `<name>-sandbox-token` Secret, held
+in memory only, and never logged. Cluster-mode `exec` / `files` / `run_code` over
+the sandbox HTTP API are served by the Python and TypeScript SDKs and are not yet
+part of this gem (see Scope below).
+
 ## Auth and base URL precedence
 
 Resolution order, highest precedence first:
@@ -122,41 +189,43 @@ typed `invalid_sandbox_id` error before sending any request.
 
 ## Tests
 
-The tests spin up a WEBrick stub reproducing the sandbox-server wire shapes and
-assert the SDK round trips them. They need `minitest` and `webrick`; on Ruby 3.0+
-install `webrick` first (`gem install webrick`). The SDK itself has no runtime
-dependencies.
+The tests spin up WEBrick stubs reproducing the wire shapes and assert the SDK
+round trips them: `test/sandbox_server_test.rb` stubs the sandbox-server REST API
+(direct mode) and `test/cluster_test.rb` stubs the Kubernetes API server (cluster
+mode). They need `minitest` and `webrick`; on Ruby 3.0+ install `webrick` first
+(`gem install webrick`). The SDK itself has no runtime dependencies.
 
 ```bash
 cd sdk/ruby
 gem install webrick   # only needed on Ruby 3.0+
 ruby -Ilib -Itest test/sandbox_server_test.rb
-# or, with Rake:
+ruby -Ilib -Itest test/cluster_test.rb
+# or, with Rake (runs every test/**/*_test.rb):
 rake test
 ```
 
 ## Scope
 
-This gem is direct-mode only today. Cluster mode (driving the Kubernetes CRDs)
-ships in the Python and TypeScript SDKs and is planned for this gem too, for full
-parity. Beyond the create / fork / exec /
-terminate surface above, the following direct-mode endpoints are not part of this
-gem: the files API (`/v1/files/*`), interactive PTY (`/v1/pty`), `run_code`,
-per-sandbox network posture, `set_timeout`, `pause` / `resume`, and
-`get_host(port)` preview URLs.
+This gem ships direct mode (create / fork / exec / terminate) and cluster mode
+(the `mitos.run` CRD lifecycle: pools, sandboxes, and workspaces). The following
+sandbox HTTP API surface is not yet part of this gem, in either mode: the files
+API (`/v1/files/*`), interactive PTY (`/v1/pty`), `run_code`, per-sandbox network
+posture, `set_timeout`, `pause` / `resume`, and `get_host(port)` preview URLs.
+These are served by the Python and TypeScript SDKs and are planned here for full
+parity.
 
 ## The Mitos SDK family
 
 Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
-1:1 across languages; cluster mode (driving the Kubernetes CRDs) ships in Python
-and TypeScript today and is planned for the rest, for full parity.
+1:1 across languages; cluster mode (driving the Kubernetes CRDs) ships in Python,
+TypeScript, and Ruby today and is planned for the rest, for full parity.
 
 | Language | Install | Covers |
 | --- | --- | --- |
 | Python | `pip install mitos-run` | direct + cluster + async |
 | TypeScript | `npm install @mitos/sdk` | direct + cluster |
-| Ruby | `gem install mitos` | direct |
+| Ruby | `gem install mitos` | direct + cluster |
 | Rust | `cargo add mitos` | direct |
 | Go | `go get github.com/mitos-run/mitos/sdk/go` | direct |
 | Java | build from source | direct |

--- a/sdk/ruby/lib/mitos.rb
+++ b/sdk/ruby/lib/mitos.rb
@@ -4,15 +4,22 @@ require "mitos/version"
 require "mitos/errors"
 require "mitos/sandbox"
 require "mitos/sandbox_server"
+require "mitos/k8s"
+require "mitos/cluster_sandbox"
+require "mitos/workspace"
+require "mitos/agent_run"
 
 # Mitos is the official Ruby SDK for mitos snapshot-fork sandboxes.
 #
-# This SDK is a thin DIRECT-mode client for the standalone / hosted
-# sandbox-server REST API. It mirrors the Python SandboxServer
-# (sdk/python/mitos/direct.py) and the TypeScript SandboxServer
-# (sdk/typescript/src/server.ts). The Kubernetes / cluster mode (the controller,
-# forkd, and the CRDs) is served by the Python and TypeScript SDKs only and is
-# NOT part of this gem.
+# It ships two modes, both dependency free (Ruby standard library only):
+#
+# - DIRECT mode (Mitos.server / Mitos::SandboxServer): a thin client for the
+#   standalone / hosted sandbox-server REST API. Mirrors the Python
+#   SandboxServer (sdk/python/mitos/direct.py) and the TypeScript SandboxServer.
+# - CLUSTER mode (Mitos::AgentRun): drives the Kubernetes mitos.run CRDs
+#   (SandboxPool, Sandbox, Workspace) over the Kubernetes REST API, with no
+#   Kubernetes client gem. Mirrors the Python AgentRun (sdk/python/mitos/client.py)
+#   and the TypeScript AgentRun.
 #
 # Quickstart:
 #
@@ -31,5 +38,20 @@ module Mitos
   # callers create the template and fork explicitly.
   def self.server(url: nil, api_key: nil)
     SandboxServer.new(url: url, api_key: api_key)
+  end
+
+  # Builds an AgentRun, the Kubernetes cluster-mode client that drives the
+  # mitos.run CRDs. With in_cluster: true the config comes from the pod
+  # service-account mount; otherwise from a kubeconfig (kubeconfig: path, else
+  # KUBECONFIG, else ~/.kube/config). namespace defaults to the kubeconfig /
+  # in-cluster namespace, else "default".
+  #
+  #   run = Mitos.cluster(namespace: "agents")
+  #   sb  = run.sandbox(image: "python:3.12", ready: true)
+  def self.cluster(namespace: nil, kubeconfig: nil, in_cluster: false, allow_default_pool: true)
+    AgentRun.new(
+      namespace: namespace, kubeconfig: kubeconfig,
+      in_cluster: in_cluster, allow_default_pool: allow_default_pool
+    )
   end
 end

--- a/sdk/ruby/lib/mitos/agent_run.rb
+++ b/sdk/ruby/lib/mitos/agent_run.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require "base64"
+require "securerandom"
+
+require "mitos/errors"
+require "mitos/k8s"
+
+module Mitos
+  # The mitos.run CRD API group and the single stable version. Mirrors the
+  # Python and TypeScript SDKs (API_GROUP / API_VERSION).
+  API_GROUP = "mitos.run"
+  API_VERSION = "v1"
+
+  # Prefix for the deterministic default-pool name. Mirrors the Python
+  # _DEFAULT_POOL_PREFIX and the TypeScript default-pool prefix.
+  DEFAULT_POOL_PREFIX = "mitos-default-"
+
+  # Any run of characters NOT in the safe object-name set collapses to a single
+  # "-". Mirrors the Python _SLUG_RE (re.compile(r"[^a-z0-9.-]+")) byte for byte.
+  SLUG_RE = /[^a-z0-9.-]+/.freeze
+
+  # Derives a deterministic default-pool name for an image. The image is
+  # lowercased, "/" and ":" become "-", any other unsafe character collapses to
+  # "-", the slug is bounded to 40 characters, then leading and trailing "-" and
+  # "." are stripped (a trailing "." or "-" is an invalid object-name tail), and
+  # the result is prefixed with "mitos-default-". Kept byte-for-byte equivalent
+  # to the Python default_pool_name and the TypeScript defaultPoolName so the
+  # same image maps to the same default pool across every SDK.
+  def self.default_pool_name(image)
+    slug = image.to_s.downcase.tr("/", "-").tr(":", "-")
+    slug = slug.gsub(SLUG_RE, "-")
+    # Bound first, then strip trailing/leading "-" and "." so truncation can
+    # never leave a name ending in "." or "-" (both invalid object-name tails).
+    slug = slug[0, 40] || ""
+    slug = slug.gsub(/\A[-.]+/, "").gsub(/[-.]+\z/, "")
+    DEFAULT_POOL_PREFIX + slug
+  end
+
+  # The status of a SandboxPool as reported by its .status. Mirrors the Python
+  # PoolStatus dataclass.
+  PoolStatus = Struct.new(
+    :name, :ready_snapshots, :desired, :node_distribution, keyword_init: true
+  )
+
+  # AgentRun is the Kubernetes cluster-mode client: it drives the mitos.run CRDs
+  # (SandboxPool, Sandbox, Workspace) over the Kubernetes REST API. It is the
+  # Ruby port of the Python AgentRun (sdk/python/mitos/client.py) and the
+  # TypeScript AgentRun, and it stays dependency free by talking to the API
+  # server through the stdlib-only Mitos::K8sClient.
+  #
+  # Direct mode (Mitos.server / Mitos::SandboxServer) is unrelated: it speaks the
+  # standalone sandbox-server REST API and needs no Kubernetes.
+  #
+  #   run = Mitos::AgentRun.new(namespace: "agents")     # from ~/.kube/config
+  #   sb  = run.sandbox(image: "python:3.12")            # lazy default pool
+  #   sb  = run.create(pool: "my-pool", ttl: "30m")      # explicit pool
+  #   run.list(pool: "my-pool")                          # reconnect handles
+  class AgentRun
+    attr_reader :namespace
+
+    # Build the client. With in_cluster: true the configuration comes from the
+    # pod service-account mount; otherwise it comes from a kubeconfig (the
+    # kubeconfig: path, else KUBECONFIG, else ~/.kube/config). namespace defaults
+    # to the kubeconfig / in-cluster namespace when set, else "default". Pass a
+    # ready-made client: as Mitos::K8sClient for tests. allow_default_pool gates
+    # the lazy sandbox(image:) path.
+    def initialize(namespace: nil, kubeconfig: nil, in_cluster: false,
+                   allow_default_pool: true, client: nil)
+      @k8s = client || (in_cluster ? K8sClient.in_cluster : K8sClient.from_kubeconfig(kubeconfig))
+      @namespace = namespace || @k8s.default_namespace || "default"
+      @allow_default_pool = allow_default_pool
+    end
+
+    # The one-liner entry point. Pass image: for the lazy path: ensure a default
+    # pool named mitos-default-<image-slug> exists (creating it with an inline
+    # template if absent and allowed), then start a Sandbox from it. Pass pool:
+    # for the explicit path, which never creates a pool. Exactly one of image: or
+    # pool: is required. With ready: true the call blocks until the sandbox is
+    # Ready (or raises); with ready: false (default) the first exec lazily waits.
+    def sandbox(image: nil, pool: nil, name: nil, env: nil, secrets: nil,
+                ttl: nil, workspace: nil, ready: false)
+      if pool.nil? && image.nil?
+        raise MitosError.new(
+          "sandbox needs an image or a pool",
+          code: "missing_image_or_pool",
+          remediation: 'Pass image: "python" for a lazy default pool, or pool: "my-pool" for an existing pool.'
+        )
+      end
+      if pool.nil?
+        unless @allow_default_pool
+          raise MitosError.new(
+            "default pools are disabled on this client",
+            code: "no_default_pool",
+            remediation: "Pass pool: <name> for an existing pool, or construct AgentRun(allow_default_pool: true)."
+          )
+        end
+        pool = ensure_default_pool(image)
+      end
+
+      sb = create(pool: pool, name: name, env: env, secrets: secrets, ttl: ttl, workspace: workspace)
+      sb.wait_until_ready if ready
+      sb
+    end
+
+    # Create a sandbox from a pool. name is generated when omitted. env injects
+    # plain environment variables; secrets maps an env var name to a
+    # [secret_name, secret_key] pair sourced from a Kubernetes Secret; ttl sets
+    # the maximum lifetime (for example "30m", "1h"); workspace binds the sandbox
+    # to a durable Workspace by name. Returns a ClusterSandbox handle.
+    def create(pool:, name: nil, env: nil, secrets: nil, ttl: nil, workspace: nil)
+      name ||= "sandbox-#{SecureRandom.hex(4)}"
+
+      spec = { "source" => { "poolRef" => { "name" => pool } } }
+      if env && !env.empty?
+        spec["env"] = env.map { |k, v| { "name" => k.to_s, "value" => v.to_s } }
+      end
+      if secrets && !secrets.empty?
+        spec["secrets"] = secrets.map do |env_var, (secret_name, secret_key)|
+          {
+            "name" => env_var.to_s,
+            "secretRef" => { "name" => secret_name, "key" => secret_key },
+            "envVar" => env_var.to_s
+          }
+        end
+      end
+      (spec["lifetime"] ||= {})["ttl"] = ttl if ttl
+      spec["workspaceRef"] = { "name" => workspace } if workspace
+
+      body = {
+        "apiVersion" => "#{API_GROUP}/#{API_VERSION}",
+        "kind" => "Sandbox",
+        "metadata" => { "name" => name, "namespace" => @namespace },
+        "spec" => spec
+      }
+      @k8s.create_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes", body)
+
+      ClusterSandbox.new(name: name, namespace: @namespace, pool: pool, k8s: @k8s)
+    end
+
+    # Reconnect to an existing sandbox by name, returning a live handle. Alias of
+    # get, named for the durable-handle / reconnect use case.
+    def from_name(name)
+      get(name)
+    end
+
+    # Get an existing sandbox by name. Reads spec.source.poolRef for the pool and
+    # status for the phase and endpoint, loading the per-sandbox token when Ready.
+    def get(name)
+      obj = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes", name)
+      status = obj["status"] || {}
+      pool = dig(obj, "spec", "source", "poolRef", "name") || ""
+      sb = ClusterSandbox.new(
+        name: name, namespace: @namespace, pool: pool, k8s: @k8s,
+        endpoint: status["endpoint"], phase: status["phase"] || "Pending"
+      )
+      sb.send(:load_token) if sb.phase == "Ready"
+      sb
+    end
+
+    # List sandboxes, optionally filtered by pool (spec.source.poolRef.name).
+    def list(pool: nil)
+      objs = @k8s.list_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes")
+      out = []
+      (objs["items"] || []).each do |obj|
+        obj_pool = dig(obj, "spec", "source", "poolRef", "name") || ""
+        next if pool && obj_pool != pool
+
+        status = obj["status"] || {}
+        out << ClusterSandbox.new(
+          name: dig(obj, "metadata", "name"), namespace: @namespace, pool: obj_pool,
+          k8s: @k8s, endpoint: status["endpoint"], phase: status["phase"] || "Pending"
+        )
+      end
+      out
+    end
+
+    # Create an empty durable Workspace.
+    def create_workspace(name)
+      body = {
+        "apiVersion" => "#{API_GROUP}/#{API_VERSION}", "kind" => "Workspace",
+        "metadata" => { "name" => name, "namespace" => @namespace }, "spec" => {}
+      }
+      @k8s.create_namespaced(API_GROUP, API_VERSION, @namespace, "workspaces", body)
+      Workspace.new(name, @namespace, @k8s)
+    end
+
+    # A lazy handle to a workspace; it does not touch the cluster until a verb is
+    # called. Use create_workspace when the workspace must be created.
+    def workspace(name)
+      Workspace.new(name, @namespace, @k8s)
+    end
+
+    # Reconnect to an existing workspace, raising workspace_not_found if absent.
+    def get_workspace(name)
+      ws = Workspace.new(name, @namespace, @k8s)
+      ws.send(:fetch) # raises workspace_not_found when absent
+      ws
+    end
+
+    # List the workspaces in the client's namespace as lazy handles.
+    def list_workspaces
+      objs = @k8s.list_namespaced(API_GROUP, API_VERSION, @namespace, "workspaces")
+      (objs["items"] || []).map { |o| Workspace.new(dig(o, "metadata", "name"), @namespace, @k8s) }
+    end
+
+    # Get the status of a SandboxPool: ready snapshots, desired replicas, and the
+    # per-node distribution.
+    def pool_status(name)
+      obj = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxpools", name)
+      status = obj["status"] || {}
+      spec = obj["spec"] || {}
+      PoolStatus.new(
+        name: name,
+        ready_snapshots: status["readySnapshots"] || 0,
+        desired: spec["replicas"] || 0,
+        node_distribution: status["nodeDistribution"] || {}
+      )
+    end
+
+    private
+
+    # get-or-create the default SandboxPool for an image; returns the pool name.
+    # A pre-existing pool is reused after verifying its inline image matches; a
+    # missing one is created as a single SandboxPool with an inline
+    # spec.template (v1 has no separate SandboxTemplate object). A concurrent
+    # creator's 409 is tolerated and the existing pool reused.
+    def ensure_default_pool(image)
+      name = Mitos.default_pool_name(image)
+      begin
+        existing = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxpools", name)
+        verify_pool_image(existing, name, image)
+        return name
+      rescue ApiError => e
+        raise unless e.status == 404
+      end
+
+      pool = {
+        "apiVersion" => "#{API_GROUP}/#{API_VERSION}",
+        "kind" => "SandboxPool",
+        "metadata" => { "name" => name, "namespace" => @namespace },
+        "spec" => { "template" => { "image" => image }, "replicas" => 1 }
+      }
+      create_or_reuse(pool, "sandboxpools")
+      name
+    end
+
+    # Guard the default-pool reuse path against a slug collision serving the
+    # wrong image. Two distinct images can normalize to one default pool (for
+    # example "python:3.11" and "python-3.11"), so reading the inline
+    # spec.template.image and comparing it to the requested image proves a reused
+    # pool runs the requested image; a mismatch or an unreadable image fails
+    # closed rather than silently running the first caller's image.
+    def verify_pool_image(pool, name, image)
+      existing = dig(pool, "spec", "template", "image")
+      if existing.nil? || existing.to_s.empty?
+        raise MitosError.new(
+          "default pool #{name} has no readable inline template image",
+          code: "pool_image_mismatch",
+          cause: "pool #{name} spec.template.image is absent or unreadable",
+          remediation: "Pass pool: #{name.inspect} explicitly to reuse this pool, or use a distinct image."
+        )
+      end
+      return if existing == image
+
+      raise MitosError.new(
+        "default pool #{name} already exists for a different image",
+        code: "pool_image_mismatch",
+        cause: "pool #{name} runs image #{existing.inspect}, not the requested #{image.inspect} (the image slug collides)",
+        remediation: "Pass pool: #{name.inspect} explicitly to reuse this pool, or use a distinct image."
+      )
+    end
+
+    # Create a namespaced custom object, tolerating a 409 from a concurrent
+    # creator (the object is reused untouched).
+    def create_or_reuse(body, plural)
+      @k8s.create_namespaced(API_GROUP, API_VERSION, @namespace, plural, body)
+    rescue ApiError => e
+      raise unless e.status == 409 # raced another creator; reuse it
+    end
+
+    # dig that tolerates nil intermediate Hashes from the parsed JSON.
+    def dig(hash, *keys)
+      keys.reduce(hash) { |acc, k| acc.is_a?(Hash) ? acc[k] : nil }
+    end
+  end
+end

--- a/sdk/ruby/lib/mitos/cluster_sandbox.rb
+++ b/sdk/ruby/lib/mitos/cluster_sandbox.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "base64"
+
+require "mitos/errors"
+
+module Mitos
+  # A cluster-mode sandbox handle returned by AgentRun. It is the Ruby port of
+  # the Python Sandbox (sdk/python/mitos/sandbox.py) reduced to the lifecycle
+  # surface the dependency-free gem ships: it resolves phase, endpoint, and the
+  # per-sandbox bearer token from the cluster, waits for Ready, reports info, and
+  # terminates. exec / files / run_code over the sandbox HTTP API are served by
+  # the Python and TypeScript SDKs and are out of scope here (see README).
+  #
+  # The per-sandbox token is read from the <name>-sandbox-token Secret, held in
+  # memory only, and never logged or placed in any error message.
+  class ClusterSandbox
+    # How often wait_until_ready polls the Sandbox status, in seconds.
+    POLL_INTERVAL = 0.2
+
+    attr_reader :name, :namespace, :pool
+
+    def initialize(name:, namespace:, pool:, k8s:, endpoint: nil, phase: "Pending")
+      @name = name
+      @namespace = namespace
+      @pool = pool
+      @k8s = k8s
+      @endpoint = endpoint
+      @phase = phase
+      @sandbox_id = nil
+      @token = nil
+    end
+
+    def phase
+      @phase
+    end
+
+    # The sandbox HTTP endpoint, resolving readiness first if it is not yet
+    # known. Raises ready_timeout / sandbox_failed via wait_until_ready.
+    def endpoint
+      wait_until_ready unless @endpoint
+      @endpoint
+    end
+
+    # Block until the sandbox is Ready, then return self so it chains. Raises a
+    # MitosError with code sandbox_failed or ready_timeout otherwise. Idempotent:
+    # returns immediately when already Ready with an endpoint.
+    def wait_until_ready(timeout: 30.0)
+      return self if @phase == "Ready" && @endpoint
+
+      deadline = monotonic + timeout
+      while monotonic < deadline
+        obj = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes", @name)
+        status = obj["status"] || {}
+        @phase = status["phase"] || "Pending"
+        @endpoint = status["endpoint"]
+        @sandbox_id = status["sandboxID"]
+
+        if @phase == "Ready" && @endpoint
+          load_token
+          return self
+        end
+        if @phase == "Failed"
+          raise MitosError.new(
+            "sandbox #{@name} failed",
+            code: "sandbox_failed",
+            cause: "sandbox #{@name} reached the Failed phase",
+            remediation: "Inspect the Sandbox status conditions and the pool capacity."
+          )
+        end
+        sleep POLL_INTERVAL
+      end
+
+      raise MitosError.new(
+        "sandbox #{@name} not ready after #{timeout}s",
+        code: "ready_timeout",
+        cause: "sandbox #{@name} did not reach Ready within #{timeout}s",
+        remediation: "Raise the timeout, or check the controller is reconciling and the pool has capacity."
+      )
+    end
+
+    # Current sandbox info from the cluster: phase, endpoint, node, sandbox id,
+    # startup latency, and pool.
+    def info
+      obj = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes", @name)
+      status = obj["status"] || {}
+      SandboxInfo.new(
+        name: @name,
+        phase: status["phase"] || "Pending",
+        endpoint: status["endpoint"] || "",
+        node: status["node"] || "",
+        sandbox_id: status["sandboxID"] || "",
+        fork_time_ms: status["startupLatencyMs"] || 0,
+        pool: @pool
+      )
+    end
+
+    # Terminate the sandbox (DELETE the Sandbox object). When bound to a
+    # Workspace the controller dehydrates /workspace into a new committed
+    # revision on the way out. Returns the bound workspace name (discoverable
+    # with workspace.log) or nil when the sandbox is unbound.
+    def terminate
+      obj = begin
+        @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes", @name)
+      rescue ApiError => e
+        raise unless e.status == 404
+
+        {}
+      end
+      ws_ref = ((obj["spec"] || {})["workspaceRef"] || {})["name"]
+      begin
+        @k8s.delete_namespaced(API_GROUP, API_VERSION, @namespace, "sandboxes", @name)
+      rescue ApiError => e
+        raise unless e.status == 404
+      end
+      @phase = "Terminating"
+      ws_ref
+    end
+
+    def to_s
+      "#<Mitos::ClusterSandbox name=#{@name.inspect} phase=#{@phase.inspect} endpoint=#{@endpoint.inspect}>"
+    end
+    alias inspect to_s
+
+    private
+
+    # Read the sandbox API bearer token from the <name>-sandbox-token Secret. The
+    # controller creates the Secret alongside the Ready sandbox. A missing Secret
+    # is tolerated: the sandbox stays tokenless and the API answers 401, which
+    # surfaces the misconfiguration without crashing here. The token VALUE is
+    # held in memory only and never logged.
+    def load_token
+      secret = begin
+        @k8s.get_secret(@namespace, "#{@name}-sandbox-token")
+      rescue ApiError
+        return
+      end
+      data = secret["data"] || {}
+      token_b64 = data["token"]
+      @token = Base64.decode64(token_b64) if token_b64 && !token_b64.empty?
+    end
+
+    def monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+
+  # SandboxInfo is a point-in-time snapshot of a cluster sandbox's status.
+  # Mirrors the Python SandboxInfo dataclass.
+  SandboxInfo = Struct.new(
+    :name, :phase, :endpoint, :node, :sandbox_id, :fork_time_ms, :pool, keyword_init: true
+  )
+end

--- a/sdk/ruby/lib/mitos/k8s.rb
+++ b/sdk/ruby/lib/mitos/k8s.rb
@@ -1,0 +1,358 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "net/http"
+require "openssl"
+require "uri"
+require "yaml"
+
+require "mitos/errors"
+
+module Mitos
+  # A minimal Kubernetes REST client built on the Ruby standard library only
+  # (net/http for transport, openssl for TLS and the CA bundle, json for the
+  # bodies, yaml for kubeconfig parsing, base64 for the in-cluster and secret
+  # token decoding). It exists so the Ruby SDK's cluster mode stays dependency
+  # free: there is no equivalent of the Python "kubernetes" client or the
+  # TypeScript "@kubernetes/client-node" here, just direct REST against the API
+  # server.
+  #
+  # The client speaks only the namespaced custom-resource and Secret endpoints
+  # the AgentRun surface needs:
+  #
+  #   GET    /apis/{group}/{version}/namespaces/{ns}/{plural}
+  #   GET    /apis/{group}/{version}/namespaces/{ns}/{plural}/{name}
+  #   POST   /apis/{group}/{version}/namespaces/{ns}/{plural}
+  #   DELETE /apis/{group}/{version}/namespaces/{ns}/{plural}/{name}
+  #   GET    /api/v1/namespaces/{ns}/secrets/{name}
+  #
+  # Auth is a bearer token (in-cluster service-account token or a kubeconfig
+  # token) or client-certificate mTLS (a kubeconfig client cert and key). The
+  # token VALUE is never logged and never placed in an error message.
+  class K8sClient
+    # The in-cluster service-account mount, mounted into every pod by the
+    # kubelet. The token rotates; it is re-read on each request so a rotated
+    # token is picked up without recreating the client.
+    SA_DIR = "/var/run/secrets/kubernetes.io/serviceaccount"
+    SA_TOKEN = "#{SA_DIR}/token"
+    SA_CA = "#{SA_DIR}/ca.crt"
+    SA_NAMESPACE = "#{SA_DIR}/namespace"
+
+    attr_reader :server, :default_namespace
+
+    # Build the client from a resolved config Hash (see .in_cluster and
+    # .from_kubeconfig). The config carries: :server (the API base URL),
+    # :ca_data (PEM string or nil for the system store), :token (bearer, or
+    # nil), :token_file (a path re-read per request, or nil), :client_cert_data
+    # and :client_key_data (PEM strings for mTLS, or nil), :insecure (skip TLS
+    # verification, only honored when a kubeconfig explicitly sets it), and
+    # :namespace (the default namespace, or nil).
+    def initialize(config)
+      @server = config[:server].to_s.sub(%r{/+\z}, "")
+      @ca_data = config[:ca_data]
+      @token = config[:token]
+      @token_file = config[:token_file]
+      @client_cert_data = config[:client_cert_data]
+      @client_key_data = config[:client_key_data]
+      @insecure = config[:insecure] ? true : false
+      @default_namespace = config[:namespace]
+      raise config_error("the resolved Kubernetes server URL is empty") if @server.empty?
+    end
+
+    # Resolve the in-cluster configuration from the service-account mount and
+    # the KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT environment the
+    # kubelet injects. Raises a typed MitosError naming the missing piece when
+    # not running inside a pod.
+    def self.in_cluster
+      host = ENV["KUBERNETES_SERVICE_HOST"]
+      port = ENV["KUBERNETES_SERVICE_PORT"]
+      if host.nil? || host.empty? || port.nil? || port.empty?
+        raise MitosError.new(
+          "not running in a Kubernetes cluster",
+          code: "k8s_config_error",
+          cause: "KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT are not set",
+          remediation: "Run inside a pod with a service account, or pass kubeconfig: to AgentRun."
+        )
+      end
+      unless File.file?(SA_TOKEN)
+        raise MitosError.new(
+          "in-cluster service-account token is not mounted",
+          code: "k8s_config_error",
+          cause: "#{SA_TOKEN} is absent",
+          remediation: "Run inside a pod whose service account token is mounted, or pass kubeconfig:."
+        )
+      end
+      ca = File.file?(SA_CA) ? File.read(SA_CA) : nil
+      ns = File.file?(SA_NAMESPACE) ? File.read(SA_NAMESPACE).strip : nil
+      new(
+        server: "https://#{host}:#{port}",
+        ca_data: ca,
+        token_file: SA_TOKEN,
+        namespace: (ns unless ns.nil? || ns.empty?)
+      )
+    end
+
+    # Resolve configuration from a kubeconfig YAML file. +path+ defaults to
+    # ENV['KUBECONFIG'] (first entry if it is a list) then ~/.kube/config. The
+    # current-context cluster (server, CA) and user (token or client cert/key)
+    # are read; relative file references inside the kubeconfig are resolved and
+    # inlined. Raises a typed MitosError when the file or the named context is
+    # missing.
+    def self.from_kubeconfig(path = nil)
+      resolved = resolve_kubeconfig_path(path)
+      unless resolved && File.file?(resolved)
+        raise MitosError.new(
+          "kubeconfig not found",
+          code: "k8s_config_error",
+          cause: "no kubeconfig at #{resolved || '(unset)'}",
+          remediation: "Set KUBECONFIG, pass kubeconfig: to AgentRun, or run AgentRun(in_cluster: true) in a pod."
+        )
+      end
+      doc = YAML.safe_load(File.read(resolved), permitted_classes: [], aliases: false) || {}
+      new(parse_kubeconfig(doc, File.dirname(File.expand_path(resolved))))
+    end
+
+    def self.resolve_kubeconfig_path(path)
+      return path unless path.nil? || (path.respond_to?(:empty?) && path.empty?)
+
+      env = ENV["KUBECONFIG"]
+      unless env.nil? || env.empty?
+        # KUBECONFIG may be a path list; the first existing entry wins, matching
+        # the client-go merge order closely enough for the single-file case.
+        first = env.split(File::PATH_SEPARATOR).find { |p| !p.empty? }
+        return first if first
+      end
+      home = Dir.home
+      return nil if home.nil? || home.empty?
+
+      File.join(home, ".kube", "config")
+    rescue StandardError
+      nil
+    end
+
+    # Turn a parsed kubeconfig document into the config Hash initialize expects.
+    # base_dir resolves relative certificate-authority / client-certificate /
+    # token file references.
+    def self.parse_kubeconfig(doc, base_dir)
+      current = doc["current-context"]
+      raise config_error_class("kubeconfig has no current-context") if current.nil? || current.to_s.empty?
+
+      context = find_named(doc["contexts"], current)
+      raise config_error_class("kubeconfig context #{current} not found") unless context
+
+      ctx = context["context"] || {}
+      cluster = find_named(doc["clusters"], ctx["cluster"]) || {}
+      user = find_named(doc["users"], ctx["user"]) || {}
+      c = cluster["cluster"] || {}
+      u = user["user"] || {}
+
+      {
+        server: c["server"],
+        ca_data: read_inline_or_file(c["certificate-authority-data"], c["certificate-authority"], base_dir),
+        token: kubeconfig_token(u),
+        client_cert_data: read_inline_or_file(u["client-certificate-data"], u["client-certificate"], base_dir),
+        client_key_data: read_inline_or_file(u["client-key-data"], u["client-key"], base_dir),
+        insecure: c["insecure-skip-tls-verify"] ? true : false,
+        namespace: (ctx["namespace"] unless ctx["namespace"].nil? || ctx["namespace"].to_s.empty?)
+      }
+    end
+
+    # Read a base64 "*-data" field if present, else read the referenced file
+    # (relative paths resolved against the kubeconfig directory). Returns a PEM
+    # / raw string or nil.
+    def self.read_inline_or_file(data_b64, file_ref, base_dir)
+      unless data_b64.nil? || data_b64.to_s.empty?
+        return Base64.decode64(data_b64)
+      end
+      return nil if file_ref.nil? || file_ref.to_s.empty?
+
+      path = File.expand_path(file_ref, base_dir)
+      File.file?(path) ? File.read(path) : nil
+    end
+
+    # The kubeconfig user token: an inline "token", else a "tokenFile" read from
+    # disk. Exec-plugin and auth-provider credential helpers are out of scope
+    # for the dependency-free client; their absence surfaces as a 401 from the
+    # API server with an actionable message rather than a silent tokenless call.
+    def self.kubeconfig_token(user)
+      tok = user["token"]
+      return tok unless tok.nil? || tok.to_s.empty?
+
+      tf = user["tokenFile"]
+      return File.read(tf).strip if !tf.nil? && !tf.to_s.empty? && File.file?(tf)
+
+      nil
+    end
+
+    def self.find_named(list, name)
+      return nil unless list.is_a?(Array)
+
+      list.find { |e| e.is_a?(Hash) && e["name"] == name }
+    end
+
+    def self.config_error_class(detail)
+      MitosError.new(
+        "invalid kubeconfig",
+        code: "k8s_config_error",
+        cause: detail,
+        remediation: "Point KUBECONFIG / kubeconfig: at a valid config, or run AgentRun(in_cluster: true) in a pod."
+      )
+    end
+
+    # GET a namespaced custom-object collection. Returns the decoded list body
+    # (a Hash with an "items" array).
+    def list_namespaced(group, version, namespace, plural)
+      request(Net::HTTP::Get, custom_path(group, version, namespace, plural), nil)
+    end
+
+    # GET a single namespaced custom object by name. Returns the decoded body.
+    def get_namespaced(group, version, namespace, plural, name)
+      request(Net::HTTP::Get, custom_path(group, version, namespace, plural, name), nil)
+    end
+
+    # POST a namespaced custom object. +body+ is the object Hash. Returns the
+    # decoded created body.
+    def create_namespaced(group, version, namespace, plural, body)
+      request(Net::HTTP::Post, custom_path(group, version, namespace, plural), body)
+    end
+
+    # DELETE a namespaced custom object by name. Returns the decoded body.
+    def delete_namespaced(group, version, namespace, plural, name)
+      request(Net::HTTP::Delete, custom_path(group, version, namespace, plural, name), nil)
+    end
+
+    # GET a core/v1 Secret by name. Returns the decoded Secret body (with the
+    # base64 "data" map). The caller decodes only the key it needs and never
+    # logs the value.
+    def get_secret(namespace, name)
+      path = "/api/v1/namespaces/#{esc(namespace)}/secrets/#{esc(name)}"
+      request(Net::HTTP::Get, path, nil)
+    end
+
+    # The HTTP status of the last raised ApiError, exposed so callers can branch
+    # on 404 / 409 without parsing a message. Set on the exception, not here.
+
+    private
+
+    def custom_path(group, version, namespace, plural, name = nil)
+      base = "/apis/#{esc(group)}/#{esc(version)}/namespaces/#{esc(namespace)}/#{esc(plural)}"
+      name.nil? || name.empty? ? base : "#{base}/#{esc(name)}"
+    end
+
+    def esc(segment)
+      URI.encode_www_form_component(segment.to_s)
+    end
+
+    # Perform the request: build the URI, attach auth (bearer or mTLS), set the
+    # TLS verification mode and CA, send the JSON body, and decode the JSON
+    # response. A non-2xx status raises a typed ApiError carrying the parsed
+    # Kubernetes Status (reason + code) so callers branch on .status, never the
+    # message. Auth material is never logged.
+    def request(method_class, path, body)
+      uri = URI.parse(@server + path)
+      req = method_class.new(uri.request_uri)
+      req["Accept"] = "application/json"
+      if body
+        req["Content-Type"] = "application/json"
+        req.body = JSON.generate(body)
+      end
+      apply_auth(req)
+
+      http = build_http(uri)
+      resp = http.request(req)
+      status = resp.code.to_i
+      raise api_error(status, resp.body) unless status >= 200 && status < 300
+
+      text = resp.body
+      return {} if text.nil? || text.empty?
+
+      JSON.parse(text)
+    end
+
+    # Attach the bearer token. The token file is re-read per request so a
+    # rotated in-cluster token is honored. mTLS users carry no bearer; the cert
+    # is attached on the transport in build_http.
+    def apply_auth(req)
+      token = current_token
+      req["Authorization"] = "Bearer #{token}" if token && !token.empty?
+    end
+
+    def current_token
+      return @token if @token && !@token.empty?
+      return nil if @token_file.nil? || @token_file.empty?
+
+      File.read(@token_file).strip
+    rescue StandardError
+      nil
+    end
+
+    def build_http(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      return http unless uri.scheme == "https"
+
+      if @insecure
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      else
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        if @ca_data && !@ca_data.empty?
+          store = OpenSSL::X509::Store.new
+          store.add_cert(OpenSSL::X509::Certificate.new(@ca_data))
+          http.cert_store = store
+        end
+      end
+      if @client_cert_data && !@client_cert_data.empty? && @client_key_data && !@client_key_data.empty?
+        http.cert = OpenSSL::X509::Certificate.new(@client_cert_data)
+        http.key = OpenSSL::PKey.read(@client_key_data)
+      end
+      http
+    end
+
+    # Build a typed ApiError from a non-2xx response, preferring the Kubernetes
+    # Status object {kind:"Status", reason, code, message}. The token VALUE is
+    # never echoed: only the API server's own Status text is surfaced.
+    def api_error(status, raw_body)
+      reason = nil
+      message = "Kubernetes API request failed: HTTP #{status}"
+      parsed = begin
+        JSON.parse(raw_body.to_s)
+      rescue StandardError
+        nil
+      end
+      if parsed.is_a?(Hash) && parsed["kind"] == "Status"
+        reason = parsed["reason"]
+        message = parsed["message"] unless parsed["message"].nil? || parsed["message"].to_s.empty?
+      end
+      ApiError.new(message, status: status, reason: reason)
+    end
+
+    def config_error(detail)
+      MitosError.new(
+        "invalid Kubernetes client configuration",
+        code: "k8s_config_error",
+        cause: detail,
+        remediation: "Pass a valid kubeconfig: or run AgentRun(in_cluster: true) inside a pod."
+      )
+    end
+  end
+
+  # ApiError is raised for a non-2xx Kubernetes API response. +status+ is the
+  # HTTP status (callers branch on 404 / 409, never the message) and +reason+ is
+  # the Kubernetes Status reason (for example "NotFound", "AlreadyExists"). It is
+  # a MitosError so a caller that only rescues Mitos::MitosError still catches it.
+  class ApiError < MitosError
+    attr_reader :reason
+
+    def initialize(message, status:, reason: nil)
+      super(
+        message,
+        code: "k8s_api_error",
+        cause: reason.to_s,
+        remediation: "Inspect the Kubernetes API server response and RBAC for this resource.",
+        status: status
+      )
+      @reason = reason
+    end
+  end
+end

--- a/sdk/ruby/lib/mitos/workspace.rb
+++ b/sdk/ruby/lib/mitos/workspace.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "mitos/errors"
+
+module Mitos
+  # Info about a single committed WorkspaceRevision, as reported by Workspace#log.
+  # Mirrors the Python RevisionInfo dataclass.
+  RevisionInfo = Struct.new(
+    :name, :phase, :lineage, :resumable, :created, keyword_init: true
+  )
+
+  # A content diff summary for a revision, as reported by Workspace#diff. Mirrors
+  # the Python DiffInfo dataclass.
+  DiffInfo = Struct.new(:parent, :added, :removed, :modified, keyword_init: true)
+
+  # A durable, forkable agent workspace handle. Lazy: it does not touch the
+  # cluster until a verb is called. Verbs are git-shaped (log, diff, fork,
+  # revert). The Ruby port of the Python Workspace (sdk/python/mitos/workspace.py).
+  class Workspace
+    attr_reader :name, :namespace
+
+    def initialize(name, namespace, k8s)
+      @name = name
+      @namespace = namespace
+      @k8s = k8s
+    end
+
+    # The current head revision name (status.head), or "" when unset.
+    def head
+      (fetch["status"] || {})["head"] || ""
+    end
+
+    # Whether the workspace head is resumable (status.resumable).
+    def resumable
+      ((fetch["status"] || {})["resumable"] ? true : false)
+    end
+
+    # The revision log, newest first. Each entry is a RevisionInfo. Filters the
+    # WorkspaceRevision collection to this workspace by spec.workspaceRef.name.
+    def log
+      objs = @k8s.list_namespaced(API_GROUP, API_VERSION, @namespace, "workspacerevisions")
+      revs = []
+      (objs["items"] || []).each do |o|
+        spec = o["spec"] || {}
+        next if dig(spec, "workspaceRef", "name") != @name
+
+        revs << RevisionInfo.new(
+          name: dig(o, "metadata", "name"),
+          phase: dig(o, "status", "phase") || "",
+          lineage: lineage(spec),
+          resumable: !spec["memorySnapshotRef"].nil?,
+          created: dig(o, "metadata", "creationTimestamp") || ""
+        )
+      end
+      revs.sort_by { |r| r.created }.reverse
+    end
+
+    # The recorded content diff for +revision+. Raises no_diff when the revision
+    # carries no diff summary (it was not captured with a diff output).
+    def diff(revision)
+      o = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "workspacerevisions", revision)
+      summary = dig(o, "status", "diffSummary")
+      if summary.nil?
+        raise MitosError.new(
+          "revision #{revision} has no recorded diff",
+          code: "no_diff",
+          cause: "the revision was not captured with a diff output",
+          remediation: "Terminate with the diff output enabled to record a diff."
+        )
+      end
+      DiffInfo.new(
+        parent: summary["parentRevision"] || "",
+        added: summary["added"] || [],
+        removed: summary["removed"] || [],
+        modified: summary["modified"] || []
+      )
+    end
+
+    # Branch a committed revision into dst_workspace (a content-addressed
+    # branch). Returns the new revision name. dst_workspace must exist. Raises
+    # revision_not_committed for an uncommitted source.
+    def fork(revision, dst_workspace)
+      parent = @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "workspacerevisions", revision)
+      manifest = dig(parent, "spec", "contentManifest") || ""
+      if dig(parent, "status", "phase") != "Committed" || manifest.empty?
+        raise MitosError.new(
+          "cannot fork uncommitted revision #{revision}",
+          code: "revision_not_committed",
+          cause: "revision #{revision} is not committed",
+          remediation: "Wait for the revision to commit before forking it."
+        )
+      end
+      body = {
+        "apiVersion" => "#{API_GROUP}/#{API_VERSION}", "kind" => "WorkspaceRevision",
+        "metadata" => {
+          "generateName" => "#{dst_workspace}-", "namespace" => @namespace,
+          "labels" => { "mitos.run/workspace" => dst_workspace }
+        },
+        "spec" => {
+          "workspaceRef" => { "name" => dst_workspace },
+          "source" => { "fromWorkspaceRevision" => { "workspace" => @name, "revision" => revision } },
+          "contentManifest" => manifest
+        }
+      }
+      created = @k8s.create_namespaced(API_GROUP, API_VERSION, @namespace, "workspacerevisions", body)
+      dig(created, "metadata", "name")
+    end
+
+    # Set this workspace head to a past revision by creating a new tip that
+    # shares its content (revisions are immutable; a revert is a new tip).
+    def revert(revision)
+      fork(revision, @name)
+    end
+
+    # checkout is an alias for revert: make a past state the new head.
+    alias checkout revert
+
+    private
+
+    def fetch
+      @k8s.get_namespaced(API_GROUP, API_VERSION, @namespace, "workspaces", @name)
+    rescue ApiError => e
+      raise MitosError.new(
+        "workspace #{@name} not found",
+        code: "workspace_not_found",
+        cause: e.reason.to_s,
+        remediation: "Create it with create_workspace(name) first.",
+        status: e.status
+      )
+    end
+
+    def lineage(spec)
+      src = spec["source"] || {}
+      return "fromClaim:#{src['fromClaim']}" if src["fromClaim"]
+
+      fwr = src["fromWorkspaceRevision"]
+      return "fromWorkspaceRevision:#{fwr['revision'] || ''}" if fwr
+
+      "root"
+    end
+
+    def dig(hash, *keys)
+      keys.reduce(hash) { |acc, k| acc.is_a?(Hash) ? acc[k] : nil }
+    end
+  end
+end

--- a/sdk/ruby/mitos.gemspec
+++ b/sdk/ruby/mitos.gemspec
@@ -6,12 +6,14 @@ Gem::Specification.new do |spec|
   spec.name = "mitos"
   spec.version = Mitos::VERSION
   spec.authors = ["mitos"]
-  spec.summary = "Ruby SDK for mitos snapshot-fork sandboxes (direct sandbox-server mode)."
+  spec.summary = "Ruby SDK for mitos snapshot-fork sandboxes (direct and Kubernetes cluster mode)."
   spec.description =
-    "A thin, dependency-free Ruby client for the standalone and hosted mitos " \
-    "sandbox-server REST API: create templates, fork sandboxes, run exec, and " \
-    "terminate. Mirrors the Python and TypeScript direct-mode SDKs. Kubernetes " \
-    "cluster mode is served by the Python and TypeScript SDKs only."
+    "A thin, dependency-free Ruby client for mitos. Direct mode talks to the " \
+    "standalone and hosted sandbox-server REST API (create templates, fork " \
+    "sandboxes, run exec, terminate). Cluster mode (Mitos::AgentRun) drives the " \
+    "Kubernetes mitos.run CRDs (SandboxPool, Sandbox, Workspace) over the " \
+    "Kubernetes REST API with no Kubernetes client gem. Mirrors the Python and " \
+    "TypeScript SDKs."
   spec.homepage = "https://mitos.run"
   spec.license = "Apache-2.0"
 
@@ -20,8 +22,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb"] + ["README.md"]
   spec.require_paths = ["lib"]
 
-  # No runtime dependencies: the SDK uses only the Ruby standard library
-  # (net/http, json, uri, securerandom).
+  # No runtime dependencies: the SDK uses only the Ruby standard library.
+  # Direct mode uses net/http, json, uri, securerandom; cluster mode adds
+  # openssl (TLS / CA), yaml (kubeconfig), and base64 (in-cluster and Secret
+  # token decoding), all stdlib.
   spec.metadata = {
     "homepage_uri" => "https://mitos.run",
     "documentation_uri" => "https://mitos.run/docs",

--- a/sdk/ruby/test/cluster_test.rb
+++ b/sdk/ruby/test/cluster_test.rb
@@ -1,0 +1,380 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "webrick"
+require "json"
+require "socket"
+require "stringio"
+require "base64"
+require "securerandom"
+
+require "mitos"
+
+# Dispatches every HTTP method (including DELETE, which WEBrick's default
+# mount_proc does not route) to a single proc.
+class AnyMethodServlet < WEBrick::HTTPServlet::AbstractServlet
+  def initialize(server, handler)
+    super(server)
+    @handler = handler
+  end
+
+  def service(req, res)
+    @handler.call(req, res)
+  end
+end
+
+# A WEBrick stub of the Kubernetes API server, serving only the namespaced
+# custom-resource and Secret endpoints the AgentRun surface touches. It keeps an
+# in-memory object store keyed by "{plural}/{namespace}/{name}", records every
+# request so the tests can assert path + method + body, and returns Kubernetes
+# Status objects (with reason + code) for 404 / 409 so the SDK's ApiError carries
+# the right status. Mirrors the Python tests' mocked CustomObjectsApi.
+class K8sStub
+  Recorded = Struct.new(:method, :path, :body, keyword_init: true)
+
+  attr_reader :recorded, :base_url, :store
+
+  def initialize
+    @recorded = []
+    @store = {}
+    @server = WEBrick::HTTPServer.new(
+      BindAddress: "127.0.0.1",
+      Port: 0,
+      Logger: WEBrick::Log.new(StringIO.new),
+      AccessLog: []
+    )
+    @server.mount("/", AnyMethodServlet, method(:dispatch))
+    port = @server.listeners.first.addr[1]
+    @base_url = "http://127.0.0.1:#{port}"
+    @thread = Thread.new { @server.start }
+    wait_until_ready(port)
+  end
+
+  def stop
+    @server.shutdown
+    @thread.join
+  end
+
+  # Seed an object directly into the store (bypassing a POST), used to set up
+  # pre-existing pools / sandboxes / workspaces for read paths.
+  def seed(plural, namespace, name, object)
+    @store[key(plural, namespace, name)] = object
+  end
+
+  def client
+    Mitos::K8sClient.new(server: @base_url, namespace: "default")
+  end
+
+  private
+
+  def key(plural, namespace, name)
+    "#{plural}/#{namespace}/#{name}"
+  end
+
+  def wait_until_ready(port)
+    20.times do
+      TCPSocket.new("127.0.0.1", port).close
+      return
+    rescue StandardError
+      sleep 0.05
+    end
+  end
+
+  def status_obj(reason, code, message)
+    { "kind" => "Status", "apiVersion" => "v1", "status" => "Failure",
+      "reason" => reason, "code" => code, "message" => message }
+  end
+
+  def json(res, value, code = 200)
+    res.status = code
+    res["Content-Type"] = "application/json"
+    res.body = JSON.generate(value)
+  end
+
+  # Parse /apis/{group}/{version}/namespaces/{ns}/{plural}[/{name}] and
+  # /api/v1/namespaces/{ns}/secrets/{name}. Returns a Hash or nil.
+  def parse_path(path)
+    if (m = path.match(%r{\A/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)(?:/([^/]+))?\z}))
+      { kind: :custom, namespace: m[1], plural: m[2], name: m[3] }
+    elsif (m = path.match(%r{\A/api/v1/namespaces/([^/]+)/secrets/([^/]+)\z}))
+      { kind: :secret, namespace: m[1], name: m[2] }
+    end
+  end
+
+  def dispatch(req, res)
+    body = req.body && !req.body.empty? ? JSON.parse(req.body) : nil
+    @recorded << Recorded.new(method: req.request_method, path: req.path, body: body)
+
+    route = parse_path(req.path)
+    return json(res, status_obj("NotFound", 404, "unknown path"), 404) unless route
+
+    if route[:kind] == :secret
+      return serve_secret(res, route)
+    end
+
+    case req.request_method
+    when "GET"  then serve_get(res, route)
+    when "POST" then serve_post(res, route, body)
+    when "DELETE" then serve_delete(res, route)
+    else json(res, status_obj("MethodNotAllowed", 405, "method not allowed"), 405)
+    end
+  end
+
+  def serve_secret(res, route)
+    obj = @store[key("secrets", route[:namespace], route[:name])]
+    return json(res, status_obj("NotFound", 404, "secret not found"), 404) unless obj
+
+    json(res, obj)
+  end
+
+  def serve_get(res, route)
+    if route[:name]
+      obj = @store[key(route[:plural], route[:namespace], route[:name])]
+      return json(res, status_obj("NotFound", 404, "#{route[:plural]} #{route[:name]} not found"), 404) unless obj
+
+      json(res, obj)
+    else
+      items = @store.select { |k, _| k.start_with?("#{route[:plural]}/#{route[:namespace]}/") }.values
+      json(res, { "apiVersion" => "v1", "kind" => "List", "items" => items })
+    end
+  end
+
+  def serve_post(res, route, body)
+    name = (body["metadata"] || {})["name"]
+    name ||= "#{(body['metadata'] || {})['generateName']}#{SecureRandom.hex(3)}" if (body["metadata"] || {})["generateName"]
+    k = key(route[:plural], route[:namespace], name)
+    if @store.key?(k)
+      return json(res, status_obj("AlreadyExists", 409, "#{route[:plural]} #{name} already exists"), 409)
+    end
+
+    stored = body.dup
+    (stored["metadata"] ||= {})["name"] = name
+    @store[k] = stored
+    json(res, stored, 201)
+  end
+
+  def serve_delete(res, route)
+    k = key(route[:plural], route[:namespace], route[:name])
+    obj = @store.delete(k)
+    return json(res, status_obj("NotFound", 404, "not found"), 404) unless obj
+
+    json(res, obj)
+  end
+end
+
+class DefaultPoolNameTest < Minitest::Test
+  # The seven exact vectors that MUST match the Python default_pool_name byte
+  # for byte (and the TypeScript defaultPoolName).
+  VECTORS = {
+    "python:3.12" => "mitos-default-python-3.12",
+    "ghcr.io/Acme/Foo-Bar:latest" => "mitos-default-ghcr.io-acme-foo-bar-latest",
+    "busybox" => "mitos-default-busybox",
+    "UPPER/Case:TAG" => "mitos-default-upper-case-tag",
+    ("a" * 60 + ":x") => ("mitos-default-" + "a" * 40),
+    "registry.io/x@sha256:abc" => "mitos-default-registry.io-x-sha256-abc",
+    "node_18" => "mitos-default-node-18"
+  }.freeze
+
+  def test_vectors
+    VECTORS.each do |image, expected|
+      assert_equal expected, Mitos.default_pool_name(image),
+                   "default_pool_name(#{image.inspect})"
+    end
+  end
+end
+
+class AgentRunTest < Minitest::Test
+  def setup
+    @stub = K8sStub.new
+    @run = Mitos::AgentRun.new(namespace: "default", client: @stub.client)
+  end
+
+  def teardown
+    @stub.stop
+  end
+
+  def find(method, path_re)
+    @stub.recorded.find { |r| r.method == method && r.path.match?(path_re) }
+  end
+
+  def test_sandbox_get_or_creates_default_pool_then_sandbox
+    sb = @run.sandbox(image: "python:3.12")
+    assert_instance_of Mitos::ClusterSandbox, sb
+
+    # The default pool was created at the right path with an inline template.
+    pool_post = find("POST", %r{\A/apis/mitos.run/v1/namespaces/default/sandboxpools\z})
+    refute_nil pool_post
+    assert_equal "mitos-default-python-3.12", pool_post.body["metadata"]["name"]
+    assert_equal "python:3.12", pool_post.body["spec"]["template"]["image"]
+    assert_equal 1, pool_post.body["spec"]["replicas"]
+
+    # The sandbox was created with a poolRef to that pool.
+    sb_post = find("POST", %r{\A/apis/mitos.run/v1/namespaces/default/sandboxes\z})
+    refute_nil sb_post
+    assert_equal "mitos-default-python-3.12", sb_post.body["spec"]["source"]["poolRef"]["name"]
+  end
+
+  def test_sandbox_reuses_existing_default_pool_without_recreate
+    @stub.seed("sandboxpools", "default", "mitos-default-busybox", {
+                 "apiVersion" => "mitos.run/v1", "kind" => "SandboxPool",
+                 "metadata" => { "name" => "mitos-default-busybox" },
+                 "spec" => { "template" => { "image" => "busybox" }, "replicas" => 1 }
+               })
+    @run.sandbox(image: "busybox")
+    # No POST to sandboxpools: the existing pool was reused.
+    assert_nil find("POST", %r{/sandboxpools\z})
+  end
+
+  def test_sandbox_image_collision_raises
+    @stub.seed("sandboxpools", "default", "mitos-default-python-3.12", {
+                 "metadata" => { "name" => "mitos-default-python-3.12" },
+                 "spec" => { "template" => { "image" => "python-3.12-other" }, "replicas" => 1 }
+               })
+    err = assert_raises(Mitos::MitosError) { @run.sandbox(image: "python:3.12") }
+    assert_equal "pool_image_mismatch", err.code
+  end
+
+  def test_create_with_pool_env_secrets_ttl_workspace
+    sb = @run.create(
+      pool: "my-pool", name: "sb-1",
+      env: { "FOO" => "bar" },
+      secrets: { "TOKEN" => %w[my-secret api-key] },
+      ttl: "30m", workspace: "ws-1"
+    )
+    assert_equal "sb-1", sb.name
+    post = find("POST", %r{/sandboxes\z})
+    spec = post.body["spec"]
+    assert_equal "my-pool", spec["source"]["poolRef"]["name"]
+    assert_equal [{ "name" => "FOO", "value" => "bar" }], spec["env"]
+    assert_equal "my-secret", spec["secrets"][0]["secretRef"]["name"]
+    assert_equal "api-key", spec["secrets"][0]["secretRef"]["key"]
+    assert_equal "TOKEN", spec["secrets"][0]["envVar"]
+    assert_equal "30m", spec["lifetime"]["ttl"]
+    assert_equal "ws-1", spec["workspaceRef"]["name"]
+  end
+
+  def test_create_generates_name_when_omitted
+    sb = @run.create(pool: "p")
+    assert_match(/\Asandbox-[0-9a-f]{8}\z/, sb.name)
+  end
+
+  def test_409_on_pool_create_is_tolerated
+    # Pre-seed the pool so the GET 404 path is skipped is NOT what we want here:
+    # simulate a race by making the GET miss but the POST conflict. Seed AFTER
+    # the lookup by intercepting: simplest is to pre-store under a name that the
+    # GET also finds, so instead drive create_or_reuse directly via a fresh
+    # AgentRun against a store that 409s. We seed the pool so POST conflicts; the
+    # GET would find it, so to exercise the 409 path we delete-after-get is not
+    # possible. Instead assert that a concurrent existing object never raises.
+    @stub.seed("sandboxpools", "default", "mitos-default-busybox", {
+                 "metadata" => { "name" => "mitos-default-busybox" },
+                 "spec" => { "template" => { "image" => "busybox" }, "replicas" => 1 }
+               })
+    # Reuse path: existing pool, verified image, no raise.
+    assert_equal "mitos-default-busybox", @run.send(:ensure_default_pool, "busybox")
+  end
+
+  def test_409_raw_create_or_reuse_swallows_conflict
+    # Seed an object so POST returns 409, then call create_or_reuse directly and
+    # assert it does not raise (the AlreadyExists race is tolerated).
+    @stub.seed("sandboxpools", "default", "raced", { "metadata" => { "name" => "raced" } })
+    body = { "metadata" => { "name" => "raced" }, "spec" => {} }
+    assert_nil @run.send(:create_or_reuse, body, "sandboxpools")
+  end
+
+  def test_get_and_from_name_read_poolref_and_status
+    @stub.seed("sandboxes", "default", "sb-x", {
+                 "metadata" => { "name" => "sb-x" },
+                 "spec" => { "source" => { "poolRef" => { "name" => "pool-x" } } },
+                 "status" => { "phase" => "Pending", "endpoint" => nil }
+               })
+    sb = @run.get("sb-x")
+    assert_equal "pool-x", sb.pool
+    assert_equal "Pending", sb.phase
+
+    same = @run.from_name("sb-x")
+    assert_equal "pool-x", same.pool
+  end
+
+  def test_get_ready_sandbox_loads_token
+    @stub.seed("sandboxes", "default", "sb-ready", {
+                 "metadata" => { "name" => "sb-ready" },
+                 "spec" => { "source" => { "poolRef" => { "name" => "p" } } },
+                 "status" => { "phase" => "Ready", "endpoint" => "1.2.3.4:9091" }
+               })
+    @stub.seed("secrets", "default", "sb-ready-sandbox-token", {
+                 "data" => { "token" => Base64.strict_encode64("super-secret-token") }
+               })
+    sb = @run.get("sb-ready")
+    assert_equal "Ready", sb.phase
+    # The token is read into memory; assert the Secret GET happened and the
+    # token VALUE never appears in the recorded request paths.
+    assert find("GET", %r{/secrets/sb-ready-sandbox-token\z})
+    refute(@stub.recorded.any? { |r| r.path.include?("super-secret-token") })
+  end
+
+  def test_list_filters_by_pool
+    @stub.seed("sandboxes", "default", "a", {
+                 "metadata" => { "name" => "a" },
+                 "spec" => { "source" => { "poolRef" => { "name" => "p1" } } }, "status" => {}
+               })
+    @stub.seed("sandboxes", "default", "b", {
+                 "metadata" => { "name" => "b" },
+                 "spec" => { "source" => { "poolRef" => { "name" => "p2" } } }, "status" => {}
+               })
+    all = @run.list
+    assert_equal 2, all.length
+    only_p1 = @run.list(pool: "p1")
+    assert_equal ["a"], only_p1.map(&:name)
+  end
+
+  def test_pool_status_reads_status
+    @stub.seed("sandboxpools", "default", "p", {
+                 "metadata" => { "name" => "p" },
+                 "spec" => { "replicas" => 5 },
+                 "status" => { "readySnapshots" => 3, "nodeDistribution" => { "node-a" => 2, "node-b" => 1 } }
+               })
+    ps = @run.pool_status("p")
+    assert_equal "p", ps.name
+    assert_equal 3, ps.ready_snapshots
+    assert_equal 5, ps.desired
+    assert_equal({ "node-a" => 2, "node-b" => 1 }, ps.node_distribution)
+  end
+
+  def test_sandbox_without_image_or_pool_raises
+    err = assert_raises(Mitos::MitosError) { @run.sandbox }
+    assert_equal "missing_image_or_pool", err.code
+  end
+
+  def test_default_pool_disabled_raises
+    run = Mitos::AgentRun.new(namespace: "default", client: @stub.client, allow_default_pool: false)
+    err = assert_raises(Mitos::MitosError) { run.sandbox(image: "python") }
+    assert_equal "no_default_pool", err.code
+  end
+
+  def test_terminate_returns_workspace_ref_and_deletes
+    @stub.seed("sandboxes", "default", "sb-ws", {
+                 "metadata" => { "name" => "sb-ws" },
+                 "spec" => { "source" => { "poolRef" => { "name" => "p" } },
+                             "workspaceRef" => { "name" => "ws-9" } },
+                 "status" => {}
+               })
+    sb = @run.get("sb-ws")
+    ws = sb.terminate
+    assert_equal "ws-9", ws
+    assert find("DELETE", %r{/sandboxes/sb-ws\z})
+  end
+
+  def test_create_workspace_and_list
+    @run.create_workspace("ws-1")
+    post = find("POST", %r{/workspaces\z})
+    assert_equal "ws-1", post.body["metadata"]["name"]
+    names = @run.list_workspaces.map(&:name)
+    assert_includes names, "ws-1"
+  end
+
+  def test_get_workspace_missing_raises_typed_error
+    err = assert_raises(Mitos::MitosError) { @run.get_workspace("nope") }
+    assert_equal "workspace_not_found", err.code
+  end
+end


### PR DESCRIPTION
## What

Port the Python `AgentRun` cluster surface to the Ruby SDK so the gem drives the `mitos.run` CRDs (`SandboxPool`, `Sandbox`, `Workspace`) on Kubernetes, not only the standalone sandbox-server REST API. Reference: `sdk/python/mitos/client.py` and `sdk/python/mitos/_k8s.py`.

## Dependency free, by construction

The hard constraint is that the gem has no runtime dependencies. Cluster mode therefore talks to the Kubernetes REST API through a new stdlib-only client (`lib/mitos/k8s.rb`): `net/http` for transport, `openssl` for TLS and the cluster CA, `json` for bodies, `yaml` for kubeconfig parsing, `base64` for in-cluster and Secret token decoding. There is no Kubernetes client gem. Config resolves from the in-cluster service-account mount (`in_cluster: true`) or a kubeconfig (token or client-certificate mTLS). Direct mode is untouched and stays dep free.

## Surface

`Mitos::AgentRun`, `Mitos::ClusterSandbox`, `Mitos::Workspace`:

- `Mitos.default_pool_name(image)`: deterministic default-pool slug, byte for byte equivalent to the Python and TypeScript implementations.
- `sandbox(image:/pool:, name:, env:, secrets:, ttl:, workspace:, ready:)`: lazy get-or-create default pool then create a `Sandbox`, with a slug-collision image guard; or an explicit pool that creates nothing.
- `create` / `get` / `from_name` / `list(pool:)`: `spec.source.poolRef`, env, secrets (`env var => [secret, key]`), `lifetime.ttl`, `workspaceRef`.
- `create_workspace` / `workspace` / `get_workspace` / `list_workspaces`; `pool_status(name)`.
- `ClusterSandbox`: `wait_until_ready`, `info`, `terminate` (returns the bound workspace, if any). The per-sandbox bearer token is read from the `<name>-sandbox-token` Secret, held in memory only, never logged.

A 409 from a concurrent pool creator is tolerated; a default pool reused for a different image raises `pool_image_mismatch`.

## Tests

`sdk/ruby/test/cluster_test.rb` (minitest) covers:

- the seven `default_pool_name` vectors;
- the AgentRun CRD ops against a WEBrick mock of the Kubernetes API server: `sandbox()` get-or-creates the pool (asserting path + body) then creates a `Sandbox` with a `poolRef`; `create()` with env / secrets / ttl / workspace; `from_name` / `get` / `list` reading `spec.source.poolRef`; 409 tolerated; `pool_status` reading `status`; and token load that asserts the Secret GET happened without the token value leaking into any recorded request.

Wired into `.github/workflows/sdk-tests.yaml` alongside the existing direct-mode suite. Local run: 35 runs, 94 assertions, 0 failures, 0 errors (full Ruby SDK suite via `rake test`).

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)