### PR TITLE
feat(sdk-java): Kubernetes cluster mode (AgentRun) (#306)

### DIFF
--- a/sdk/java/.gitignore
+++ b/sdk/java/.gitignore
@@ -4,3 +4,6 @@ target/
 # Ad-hoc javac output used to compile and run the tests without a build tool.
 out/
 *.class
+
+# The source argfile the CI build (and the local javac one-liner) writes.
+sources.txt

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -6,12 +6,21 @@ warm environment instead of rebuilding it. Run it fully hosted at
 [https://mitos.run](https://mitos.run) or self-hosted on your own Kubernetes
 cluster.
 
-This is the Java client for the direct sandbox API: create a template, fork a
-sandbox, run `exec`, and terminate. It uses only the JDK standard library
-(`java.net.http.HttpClient` for HTTP, `java.nio` for the credential file, and a
-small hand-rolled JSON helper for the flat wire shapes), so it has no runtime
-dependencies. It targets the Java 17 language level and is usable on Java 17 and
-later.
+This is the Java client for both modes Mitos runs in:
+
+- **Direct mode** (`SandboxServer`): talk to the standalone or hosted
+  sandbox-server REST API. Create a template, fork a sandbox, run `exec`, and
+  terminate.
+- **Cluster mode** (`AgentRun`): drive the `mitos.run/v1` Kubernetes CRDs
+  (`SandboxPool`, `Sandbox`, `Workspace`) directly, the operator path. This is
+  the same surface the Python and TypeScript SDKs expose.
+
+It uses only the JDK standard library, so it has no runtime dependencies:
+`java.net.http.HttpClient` for HTTP, `javax.net.ssl` for the cluster CA and
+optional client-certificate mutual TLS, `java.util.Base64` for the
+service-account and Secret payloads, and a small hand-rolled JSON helper (plus a
+minimal kubeconfig YAML reader) for the wire shapes. It targets the Java 17
+language level and is usable on Java 17 and later.
 
 ## Install
 
@@ -58,6 +67,103 @@ to the constructor:
 ```java
 SandboxServer server = new SandboxServer("http://localhost:8080", null);
 ```
+
+## Cluster mode (AgentRun)
+
+When you run Mitos on your own Kubernetes cluster, `AgentRun` is the operator
+path: it reconciles the `mitos.run/v1` CRDs directly, so a `Sandbox` is born from
+a `SandboxPool` and the controller drives it to Ready. This is the Java port of
+the Python `AgentRun`, with the same surface and the same
+`mitos-default-<image-slug>` lazy-pool naming, byte-for-byte.
+
+It speaks the Kubernetes REST API on the JDK standard library alone, with no
+`fabric8` and no official client: `HttpClient` for REST and `SSLContext` for the
+cluster CA (and client-certificate mutual TLS for kind/minikube). Direct mode
+above is untouched and pulls in none of it.
+
+### The one-liner
+
+```java
+import run.mitos.sdk.AgentRun;
+import run.mitos.sdk.ClusterSandbox;
+import run.mitos.sdk.SandboxParams;
+
+// In a pod: load the in-cluster service-account mount.
+AgentRun agent = AgentRun.inCluster("agents");        // namespace "agents"
+
+// Lazy default pool: ensures a SandboxPool named mitos-default-python-3.12
+// exists (creating it with an inline template if absent), then starts a Sandbox.
+ClusterSandbox sb = agent.sandbox("python:3.12").waitUntilReady();
+
+System.out.println(sb.phase());     // READY
+System.out.println(sb.endpoint());  // 10.0.0.7:9091
+String token = sb.token();          // per-sandbox bearer token, never logged
+
+sb.terminate();
+```
+
+From outside the cluster, load a kubeconfig instead:
+
+```java
+// null path falls back to $KUBECONFIG, then ~/.kube/config.
+AgentRun agent = AgentRun.fromKubeconfig(null, "agents");
+```
+
+### The full surface
+
+```java
+// Explicit pool, plus env/secrets/ttl/workspace via the params builder.
+ClusterSandbox sb = agent.create(SandboxParams.builder()
+        .pool("warm-python")
+        .name("worker-1")
+        .env("MODE", "fast")
+        .secret("API_KEY", "my-creds", "key")  // (env var) -> Secret name + key
+        .ttl("30m")
+        .workspace("project-x")
+        .build());
+
+// Reconnect across processes by name.
+ClusterSandbox again = agent.fromName("worker-1");
+
+// List, optionally filtered by pool (null lists all).
+for (ClusterSandbox s : agent.list("warm-python")) {
+    System.out.println(s.name() + " " + s.phase());
+}
+
+// Pool status.
+var status = agent.poolStatus("warm-python");
+System.out.println(status.readySnapshots() + "/" + status.desired());
+
+// Durable workspaces (git-shaped).
+var ws = agent.createWorkspace("project-x");
+System.out.println(ws.head());      // current head revision
+ws.log().forEach(r -> System.out.println(r.name() + " " + r.phase()));
+```
+
+### Auth modes
+
+| Mode | Construct with | Auth | TLS |
+| --- | --- | --- | --- |
+| In-cluster | `AgentRun.inCluster([namespace])` | the projected service-account token (`/var/run/secrets/.../token`) | the mounted cluster CA (`.../ca.crt`) |
+| Kubeconfig | `AgentRun.fromKubeconfig(path[, namespace])` | the current context's bearer token, or its client cert/key | the cluster `certificate-authority(-data)`, else system roots |
+
+The kubeconfig reader parses a common subset: the current context's cluster
+(`server`, inline `certificate-authority-data` or a `certificate-authority`
+file) and user (a bearer `token`, or `client-certificate-data` +
+`client-key-data` for mutual-TLS clusters). It does not support exec credential
+plugins or `auth-provider` blocks; inside a cluster use `inCluster()`. The
+service-account and per-sandbox token values are held in memory only and are
+never logged.
+
+### Default-pool naming
+
+`AgentRun.defaultPoolName(image)` is the deterministic slug behind the lazy
+`sandbox(image)` path, identical to the Python and TypeScript SDKs: lowercase,
+`/` and `:` become `-`, any other unsafe character collapses to `-`, the slug is
+bounded to 40 characters, leading/trailing `-` and `.` are stripped, and the
+result is prefixed with `mitos-default-`. For example `python:3.12` maps to
+`mitos-default-python-3.12` and `ghcr.io/Acme/Foo-Bar:latest` to
+`mitos-default-ghcr.io-acme-foo-bar-latest`.
 
 ## Surface
 
@@ -127,30 +233,37 @@ sending any request.
 
 ## Scope
 
-This SDK is direct-mode only today. Cluster mode (driving the Kubernetes CRDs)
-ships in the Python and TypeScript SDKs and is planned for this SDK too, for full
-parity. Beyond the create / fork / exec /
-terminate surface above, the following are not part of this SDK: file operations
-(`files.read` / `write` / `list` / `remove` / `mkdir`), interactive PTY over
-WebSocket, `run_code` against the code-interpreter kernel, `pause` / `resume`,
-`set_timeout`, `get_host` preview URLs, per-sandbox `Network` posture, and
-sandbox-to-sandbox `fork` from a running handle.
+This SDK covers both direct mode (the create / fork / exec / terminate surface
+above) and cluster mode (`AgentRun` driving the `mitos.run/v1` CRDs:
+`SandboxPool`, `Sandbox`, `Workspace`). The cluster surface ports the Python
+`AgentRun`: `sandbox` / `create` / `get` / `fromName` / `list`, `poolStatus`,
+`waitUntilReady` / `info` / `terminate`, and the workspace verbs
+(`createWorkspace` / `workspace` / `getWorkspace` / `listWorkspaces`,
+`head` / `resumable` / `log`).
+
+Beyond those, the following are not part of this SDK yet: direct-mode file
+operations (`files.read` / `write` / `list` / `remove` / `mkdir`), interactive
+PTY over WebSocket, `run_code` against the code-interpreter kernel,
+`pause` / `resume`, `set_timeout`, `get_host` preview URLs, per-sandbox
+`Network` posture, and sandbox-to-sandbox `fork` from a running handle. The
+cluster `ClusterSandbox` resolves its endpoint and per-sandbox token so a caller
+can drive the sandbox HTTP API directly.
 
 ## The Mitos SDK family
 
 Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
-1:1 across languages; cluster mode (driving the Kubernetes CRDs) ships in Python
-and TypeScript today and is planned for the rest, for full parity.
+1:1 across languages; cluster mode (driving the Kubernetes CRDs) ships in Python,
+TypeScript, and Java, for full parity (#296).
 
 | Language | Install | Covers |
 | --- | --- | --- |
 | Python | `pip install mitos-run` | direct + cluster + async |
 | TypeScript | `npm install @mitos/sdk` | direct + cluster |
+| Java | build from source | direct + cluster |
 | Ruby | `gem install mitos` | direct |
 | Rust | `cargo add mitos` | direct |
 | Go | `go get github.com/mitos-run/mitos/sdk/go` | direct |
-| Java | build from source | direct |
 
 Project home: [https://mitos.run](https://mitos.run). Source and all six SDKs:
 [github.com/mitos-run/mitos](https://github.com/mitos-run/mitos).

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -10,7 +10,7 @@
   <packaging>jar</packaging>
 
   <name>mitos Java SDK</name>
-  <description>A thin, dependency-free Java client for the standalone and hosted mitos sandbox-server REST API: create templates, fork snapshot-fork sandboxes, run exec, and terminate. Mirrors the Python, TypeScript, Ruby, and Rust direct-mode SDKs. Kubernetes cluster mode is served by the Python and TypeScript SDKs only.</description>
+  <description>A thin, dependency-free Java client for Mitos snapshot-fork sandboxes. Direct mode talks to the standalone and hosted sandbox-server REST API (create templates, fork sandboxes, run exec, terminate); cluster mode (AgentRun) drives the mitos.run/v1 Kubernetes CRDs (SandboxPool, Sandbox, Workspace) with in-cluster or kubeconfig auth. Built on the JDK standard library alone, with no runtime dependencies.</description>
   <url>https://mitos.run</url>
 
   <licenses>

--- a/sdk/java/src/main/java/run/mitos/sdk/AgentRun.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/AgentRun.java
@@ -1,0 +1,447 @@
+// Kubernetes cluster mode for the Java SDK: the AgentRun client drives the
+// mitos.run/v1 CRDs (SandboxPool, Sandbox, Workspace) directly, the same surface
+// the Python AgentRun (sdk/python/mitos/client.py) and the TypeScript AgentRun
+// expose. It is the operator path: a Sandbox is born from a pool (or forked from
+// another sandbox) and the controller drives it to Ready.
+//
+// Cluster mode is built on the minimal stdlib Kubernetes client in K8s.java; it
+// pulls NO third-party dependency (no fabric8, no official client, no YAML lib)
+// and leaves direct mode (SandboxServer) entirely untouched.
+package run.mitos.sdk;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * The Kubernetes cluster-mode client. It reconciles with the {@code mitos.run/v1}
+ * CRDs directly, the Java analogue of the Python {@code AgentRun}. Construct it
+ * with {@link #inCluster()} inside a pod or {@link #fromKubeconfig(String)} from
+ * a kubeconfig file, then call {@link #sandbox(String)} for the one-liner path.
+ *
+ * <p>This is a separate surface from the direct-mode {@link SandboxServer}; the
+ * two never interact. The per-sandbox bearer token is read from the
+ * {@code <name>-sandbox-token} Secret, held in memory only, and never logged.
+ */
+public final class AgentRun {
+
+    static final String API_GROUP = K8s.API_GROUP;
+    static final String API_VERSION = K8s.API_VERSION;
+
+    private static final String DEFAULT_POOL_PREFIX = "mitos-default-";
+
+    // Collapses any run of characters outside [a-z0-9.-] into a single "-".
+    // Mirrors the Python _SLUG_RE and the TypeScript slug regex byte-for-byte.
+    private static final Pattern SLUG_RE = Pattern.compile("[^a-z0-9.-]+");
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private final K8s k8s;
+    private final String namespace;
+    private final boolean allowDefaultPool;
+
+    private AgentRun(K8s k8s, String namespace, boolean allowDefaultPool) {
+        this.k8s = k8s;
+        this.namespace = namespace;
+        this.allowDefaultPool = allowDefaultPool;
+    }
+
+    // ---- construction ----
+
+    /**
+     * Builds a cluster-mode client from the in-cluster service-account mount
+     * (KUBERNETES_SERVICE_HOST/PORT, the projected token, and the mounted CA),
+     * operating in the {@code default} namespace. Use it inside a Kubernetes pod.
+     */
+    public static AgentRun inCluster() {
+        return inCluster("default");
+    }
+
+    /** As {@link #inCluster()} but operating in {@code namespace}. */
+    public static AgentRun inCluster(String namespace) {
+        return new AgentRun(K8s.inCluster(), namespace, true);
+    }
+
+    /**
+     * Builds a cluster-mode client from a kubeconfig file (the current context),
+     * operating in the {@code default} namespace. A null or empty path falls
+     * back to {@code $KUBECONFIG} then {@code $HOME/.kube/config}. The SDK parses
+     * a common kubeconfig subset (server, CA, bearer token or inline client
+     * cert/key); it does not support exec credential plugins.
+     */
+    public static AgentRun fromKubeconfig(String path) {
+        return fromKubeconfig(path, "default");
+    }
+
+    /** As {@link #fromKubeconfig(String)} but operating in {@code namespace}. */
+    public static AgentRun fromKubeconfig(String path, String namespace) {
+        return new AgentRun(K8s.fromKubeconfig(path), namespace, true);
+    }
+
+    /**
+     * Builds a cluster-mode client over an already-resolved {@link K8s}
+     * connection, for example one pointed at a local test server. The namespace
+     * and the default-pool toggle are explicit.
+     */
+    static AgentRun of(K8s k8s, String namespace, boolean allowDefaultPool) {
+        return new AgentRun(k8s, namespace, allowDefaultPool);
+    }
+
+    /** Returns this client with the lazy default-pool convenience toggled. When
+     * disabled, {@link #sandbox(String)} requires an explicit pool. */
+    public AgentRun allowDefaultPool(boolean allow) {
+        return new AgentRun(k8s, namespace, allow);
+    }
+
+    /** The namespace this client operates in. */
+    public String namespace() {
+        return namespace;
+    }
+
+    // ---- default-pool naming ----
+
+    /**
+     * Derives the deterministic default-pool name for an image. The image is
+     * lowercased, "/" and ":" become "-", any other unsafe character collapses
+     * to "-", the slug is bounded to 40 characters, and leading/trailing "-" and
+     * "." are stripped (a trailing "." is an invalid object-name tail). The
+     * result is prefixed with "mitos-default-". It is kept byte-for-byte
+     * identical to the Python {@code default_pool_name} and the TypeScript
+     * {@code defaultPoolName}.
+     */
+    public static String defaultPoolName(String image) {
+        String slug = image.toLowerCase().replace("/", "-").replace(":", "-");
+        slug = SLUG_RE.matcher(slug).replaceAll("-");
+        // Bound first, then strip trailing/leading "-" and "." so truncation can
+        // never leave a name ending in "." or "-" (both invalid object-name tails).
+        if (slug.length() > 40) {
+            slug = slug.substring(0, 40);
+        }
+        slug = stripChars(slug, "-.");
+        return DEFAULT_POOL_PREFIX + slug;
+    }
+
+    // stripChars removes any leading and trailing characters that appear in
+    // chars, mirroring Python's str.strip(chars).
+    private static String stripChars(String s, String chars) {
+        int start = 0;
+        int end = s.length();
+        while (start < end && chars.indexOf(s.charAt(start)) >= 0) {
+            start++;
+        }
+        while (end > start && chars.indexOf(s.charAt(end - 1)) >= 0) {
+            end--;
+        }
+        return s.substring(start, end);
+    }
+
+    // ---- the one-liner entry point ----
+
+    /** The one-liner entry point: ensure the default pool for {@code image}
+     * exists, then create a Sandbox from it. */
+    public ClusterSandbox sandbox(String image) {
+        return sandbox(image, SandboxParams.none());
+    }
+
+    /**
+     * The one-liner entry point. With {@link SandboxParams#pool()} set it claims
+     * from that existing pool and creates nothing else. Otherwise it ensures the
+     * default pool for {@code image} exists (creating it with an inline template
+     * when absent and allowed), then creates a Sandbox from it. Exactly one of
+     * {@code image} or {@code params.pool()} is required.
+     */
+    public ClusterSandbox sandbox(String image, SandboxParams params) {
+        String pool = params.pool();
+        if ((pool == null || pool.isEmpty()) && (image == null || image.isEmpty())) {
+            throw new MitosException(
+                    "sandbox() needs an image or a pool",
+                    "missing_image_or_pool",
+                    "neither image nor a pool was provided",
+                    "Pass an image like \"python\" for a lazy default pool, or a pool name for an existing pool.",
+                    0);
+        }
+        if (pool == null || pool.isEmpty()) {
+            if (!allowDefaultPool) {
+                throw new MitosException(
+                        "default pools are disabled on this client",
+                        "no_default_pool",
+                        "allowDefaultPool(false) was set",
+                        "Pass a pool name for an existing pool, or construct AgentRun without allowDefaultPool(false).",
+                        0);
+            }
+            pool = ensureDefaultPool(image);
+        }
+        SandboxParams.Builder b = SandboxParams.builder().pool(pool);
+        if (params.name() != null) {
+            b.name(params.name());
+        }
+        if (params.env() != null) {
+            b.env(params.env());
+        }
+        if (params.secrets() != null) {
+            b.secrets(params.secrets());
+        }
+        if (params.ttl() != null) {
+            b.ttl(params.ttl());
+        }
+        if (params.workspace() != null) {
+            b.workspace(params.workspace());
+        }
+        if (params.replicas() != 0) {
+            b.replicas(params.replicas());
+        }
+        return create(b.build());
+    }
+
+    // ensureDefaultPool get-or-creates the default SandboxPool for an image and
+    // returns its name. A pre-existing pool is reused untouched (its inline image
+    // is verified against the requested image to guard a slug collision); a
+    // missing one is created as a single SandboxPool with inline spec.template.
+    // A 409 from a concurrent creator is tolerated.
+    private String ensureDefaultPool(String image) {
+        String name = defaultPoolName(image);
+        try {
+            Map<String, Object> existing = k8s.getObject(namespace, "sandboxpools", name);
+            verifyPoolImage(existing, name, image);
+            return name;
+        } catch (MitosException e) {
+            if (e.getStatus() != 404) {
+                throw e;
+            }
+        }
+
+        Map<String, Object> pool = new LinkedHashMap<>();
+        pool.put("apiVersion", API_GROUP + "/" + API_VERSION);
+        pool.put("kind", "SandboxPool");
+        pool.put("metadata", metadata(name));
+        Map<String, Object> spec = new LinkedHashMap<>();
+        spec.put("template", Map.of("image", image));
+        spec.put("replicas", 1);
+        pool.put("spec", spec);
+
+        try {
+            k8s.createObject(namespace, "sandboxpools", pool);
+        } catch (MitosException e) {
+            if (e.getStatus() != 409) { // raced another creator; reuse it
+                throw e;
+            }
+        }
+        return name;
+    }
+
+    // verifyPoolImage guards the default-pool reuse path against a slug collision
+    // serving the wrong image. It reads the reused pool's inline
+    // spec.template.image and fails closed when it is absent or does not match.
+    private static void verifyPoolImage(Map<String, Object> pool, String name, String image) {
+        String existing = K8s.nestedString(pool, "spec", "template", "image");
+        if (existing.isEmpty()) {
+            throw new MitosException(
+                    "default pool " + name + " has no readable inline template image",
+                    "pool_image_mismatch",
+                    "pool " + name + " spec.template.image is absent or unreadable",
+                    "Pass pool=\"" + name + "\" explicitly to reuse this pool, or use a distinct image that maps to a different default pool.",
+                    0);
+        }
+        if (!existing.equals(image)) {
+            throw new MitosException(
+                    "default pool " + name + " already exists for a different image",
+                    "pool_image_mismatch",
+                    "pool " + name + " runs image \"" + existing + "\", not the requested \"" + image
+                            + "\" (the image slug collides)",
+                    "Pass pool=\"" + name + "\" explicitly to reuse this pool, or use a distinct image that maps to a different default pool.",
+                    0);
+        }
+    }
+
+    // ---- create / get / list ----
+
+    /** Creates a Sandbox from a pool ({@link SandboxParams#pool()} required). */
+    public ClusterSandbox create(SandboxParams params) {
+        String pool = params.pool();
+        if (pool == null || pool.isEmpty()) {
+            throw new MitosException(
+                    "create() needs a pool",
+                    "missing_pool",
+                    "no pool was provided",
+                    "Pass a pool via SandboxParams.builder().pool(name); or use sandbox(image) for the lazy default-pool path.",
+                    0);
+        }
+        String name = params.name();
+        if (name == null || name.isEmpty()) {
+            name = "sandbox-" + randomHex(4);
+        }
+
+        Map<String, Object> spec = new LinkedHashMap<>();
+        spec.put("source", Map.of("poolRef", Map.of("name", pool)));
+        if (params.replicas() != 0) {
+            spec.put("replicas", params.replicas());
+        }
+        if (params.env() != null && !params.env().isEmpty()) {
+            List<Object> envList = new ArrayList<>();
+            for (Map.Entry<String, String> e : params.env().entrySet()) {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("name", e.getKey());
+                entry.put("value", e.getValue());
+                envList.add(entry);
+            }
+            spec.put("env", envList);
+        }
+        if (params.secrets() != null && !params.secrets().isEmpty()) {
+            List<Object> secretList = new ArrayList<>();
+            for (Map.Entry<String, SecretRef> e : params.secrets().entrySet()) {
+                String envVar = e.getKey();
+                SecretRef ref = e.getValue();
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("name", envVar);
+                entry.put("secretRef", Map.of("name", ref.secretName(), "key", ref.key()));
+                entry.put("envVar", envVar);
+                secretList.add(entry);
+            }
+            spec.put("secrets", secretList);
+        }
+        if (params.ttl() != null && !params.ttl().isEmpty()) {
+            spec.put("lifetime", new LinkedHashMap<>(Map.of("ttl", params.ttl())));
+        }
+        if (params.workspace() != null && !params.workspace().isEmpty()) {
+            spec.put("workspaceRef", Map.of("name", params.workspace()));
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("apiVersion", API_GROUP + "/" + API_VERSION);
+        body.put("kind", "Sandbox");
+        body.put("metadata", metadata(name));
+        body.put("spec", spec);
+
+        k8s.createObject(namespace, "sandboxes", body);
+        return new ClusterSandbox(name, namespace, pool, SandboxPhase.PENDING, "", k8s);
+    }
+
+    /** Reconnects to an existing sandbox by name, returning a live handle. An
+     * alias for {@link #get(String)}, named for the reconnect use case. */
+    public ClusterSandbox fromName(String name) {
+        return get(name);
+    }
+
+    /**
+     * Reads an existing sandbox by name and returns a handle carrying its
+     * resolved pool, phase, and endpoint. When the sandbox is Ready its
+     * per-sandbox bearer token is loaded from the {@code <name>-sandbox-token}
+     * Secret.
+     */
+    public ClusterSandbox get(String name) {
+        Map<String, Object> obj = k8s.getObject(namespace, "sandboxes", name);
+        String pool = K8s.nestedString(obj, "spec", "source", "poolRef", "name");
+        SandboxPhase phase = SandboxPhase.fromWire(K8s.nestedString(obj, "status", "phase"));
+        String endpoint = K8s.nestedString(obj, "status", "endpoint");
+        ClusterSandbox sb = new ClusterSandbox(name, namespace, pool, phase, endpoint, k8s);
+        if (phase == SandboxPhase.READY) {
+            sb.loadToken();
+        }
+        return sb;
+    }
+
+    /** Lists sandboxes in the namespace, optionally filtered by pool. A null or
+     * empty pool returns every sandbox. */
+    public List<ClusterSandbox> list(String pool) {
+        List<Object> items = k8s.listObjects(namespace, "sandboxes");
+        List<ClusterSandbox> out = new ArrayList<>();
+        for (Object item : items) {
+            Map<String, Object> obj = K8s.asMap(item);
+            String objPool = K8s.nestedString(obj, "spec", "source", "poolRef", "name");
+            if (pool != null && !pool.isEmpty() && !objPool.equals(pool)) {
+                continue;
+            }
+            out.add(new ClusterSandbox(
+                    K8s.nestedString(obj, "metadata", "name"),
+                    namespace,
+                    objPool,
+                    SandboxPhase.fromWire(K8s.nestedString(obj, "status", "phase")),
+                    K8s.nestedString(obj, "status", "endpoint"),
+                    k8s));
+        }
+        return out;
+    }
+
+    // ---- pool status ----
+
+    /** Reads the status of a SandboxPool. */
+    public PoolStatus poolStatus(String name) {
+        Map<String, Object> obj = k8s.getObject(namespace, "sandboxpools", name);
+        Map<String, Integer> dist = new LinkedHashMap<>();
+        Object raw = K8s.nested(obj, "status", "nodeDistribution");
+        if (raw instanceof Map<?, ?>) {
+            for (Map.Entry<String, Object> e : K8s.asMap(raw).entrySet()) {
+                dist.put(e.getKey(), K8s.asInt(e.getValue()));
+            }
+        }
+        return new PoolStatus(
+                name,
+                K8s.asInt(K8s.nested(obj, "status", "readySnapshots")),
+                K8s.asInt(K8s.nested(obj, "spec", "replicas")),
+                dist);
+    }
+
+    // ---- workspaces ----
+
+    /** Creates an empty durable Workspace and returns a handle. */
+    public ClusterWorkspace createWorkspace(String name) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("apiVersion", API_GROUP + "/" + API_VERSION);
+        body.put("kind", "Workspace");
+        body.put("metadata", metadata(name));
+        body.put("spec", new LinkedHashMap<>());
+        k8s.createObject(namespace, "workspaces", body);
+        return new ClusterWorkspace(name, namespace, k8s);
+    }
+
+    /** Returns a lazy handle to a workspace by name. It does not touch the
+     * cluster until a verb is called; use {@link #createWorkspace(String)} to
+     * create one or {@link #getWorkspace(String)} to reconnect and verify. */
+    public ClusterWorkspace workspace(String name) {
+        return new ClusterWorkspace(name, namespace, k8s);
+    }
+
+    /** Reconnects to an existing workspace, raising {@code workspace_not_found}
+     * when it is absent. */
+    public ClusterWorkspace getWorkspace(String name) {
+        ClusterWorkspace ws = new ClusterWorkspace(name, namespace, k8s);
+        ws.get(); // raises workspace_not_found when absent
+        return ws;
+    }
+
+    /** Lists the workspaces in the client's namespace. */
+    public List<ClusterWorkspace> listWorkspaces() {
+        List<Object> items = k8s.listObjects(namespace, "workspaces");
+        List<ClusterWorkspace> out = new ArrayList<>();
+        for (Object item : items) {
+            Map<String, Object> obj = K8s.asMap(item);
+            out.add(new ClusterWorkspace(
+                    K8s.nestedString(obj, "metadata", "name"), namespace, k8s));
+        }
+        return out;
+    }
+
+    // ---- helpers ----
+
+    private Map<String, Object> metadata(String name) {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("name", name);
+        meta.put("namespace", namespace);
+        return meta;
+    }
+
+    private static String randomHex(int bytes) {
+        byte[] buf = new byte[bytes];
+        RANDOM.nextBytes(buf);
+        char[] out = new char[bytes * 2];
+        for (int i = 0; i < bytes; i++) {
+            out[i * 2] = HEX[(buf[i] >> 4) & 0xf];
+            out[i * 2 + 1] = HEX[buf[i] & 0xf];
+        }
+        return new String(out);
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/ClusterSandbox.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/ClusterSandbox.java
@@ -1,0 +1,198 @@
+// A cluster-mode Sandbox handle (a CRD-backed sandbox), as opposed to the
+// direct-mode Sandbox. It carries the cluster identity (name, namespace, pool)
+// and the last-observed phase and endpoint, and reads the per-sandbox bearer
+// token from the <name>-sandbox-token Secret. Mirrors the Python cluster
+// Sandbox surface (sdk/python/mitos/sandbox.py): waitUntilReady, info,
+// terminate, and the token for callers driving the sandbox HTTP API themselves.
+package run.mitos.sdk;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A running cluster-mode sandbox (a {@code mitos.run/v1} Sandbox object). Unlike
+ * the direct-mode {@link Sandbox}, exec and file traffic flow through the
+ * controller-assigned endpoint gated by the per-sandbox token; this handle owns
+ * the cluster lifecycle (wait for Ready, read status, terminate) and exposes the
+ * resolved endpoint and token so a caller can drive the sandbox HTTP API. The
+ * token value is held in memory only and is never logged.
+ */
+public final class ClusterSandbox {
+
+    /** The default wait for a sandbox to reach Ready, in milliseconds. */
+    public static final long DEFAULT_READY_TIMEOUT_MS = 30_000;
+
+    // The poll interval while waiting for a phase transition, in milliseconds.
+    private static final long POLL_INTERVAL_MS = 50;
+
+    private final String name;
+    private final String namespace;
+    private final String pool;
+    private final K8s k8s;
+
+    private SandboxPhase phase;
+    private String endpoint;
+    private String token; // per-sandbox bearer token; in memory only, never logged
+
+    ClusterSandbox(String name, String namespace, String pool, SandboxPhase phase,
+                   String endpoint, K8s k8s) {
+        this.name = name;
+        this.namespace = namespace;
+        this.pool = pool;
+        this.phase = phase;
+        this.endpoint = endpoint;
+        this.k8s = k8s;
+    }
+
+    /** The Sandbox object name. */
+    public String name() {
+        return name;
+    }
+
+    /** The Sandbox object namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    /** The SandboxPool this sandbox was claimed from. */
+    public String pool() {
+        return pool;
+    }
+
+    /** The last-observed lifecycle phase. */
+    public SandboxPhase phase() {
+        return phase;
+    }
+
+    /** The last-observed serving endpoint (host:port), empty until Ready. */
+    public String endpoint() {
+        return endpoint;
+    }
+
+    /**
+     * The per-sandbox bearer token, if one has been loaded, for callers that
+     * drive the sandbox HTTP API themselves. It is empty when the sandbox is not
+     * Ready or has no token Secret. The token value is never logged.
+     */
+    public String token() {
+        return token == null ? "" : token;
+    }
+
+    /**
+     * Blocks until the sandbox is Ready (then returns this so it chains), or
+     * raises {@link MitosException} with code {@code sandbox_failed} or
+     * {@code ready_timeout}. Idempotent: returns immediately when already Ready
+     * with an endpoint. Uses the default {@value #DEFAULT_READY_TIMEOUT_MS} ms
+     * timeout.
+     */
+    public ClusterSandbox waitUntilReady() {
+        return waitUntilReady(DEFAULT_READY_TIMEOUT_MS);
+    }
+
+    /** As {@link #waitUntilReady()} but waits up to {@code timeoutMs}. */
+    public ClusterSandbox waitUntilReady(long timeoutMs) {
+        if (phase == SandboxPhase.READY && !endpoint.isEmpty()) {
+            return this;
+        }
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            Map<String, Object> obj = k8s.getObject(namespace, "sandboxes", name);
+            phase = SandboxPhase.fromWire(K8s.nestedString(obj, "status", "phase"));
+            endpoint = K8s.nestedString(obj, "status", "endpoint");
+
+            if (phase == SandboxPhase.READY && !endpoint.isEmpty()) {
+                loadToken();
+                return this;
+            }
+            if (phase == SandboxPhase.FAILED) {
+                throw new MitosException(
+                        "sandbox " + name + " failed",
+                        "sandbox_failed",
+                        "sandbox " + name + " reached the Failed phase",
+                        "Inspect the Sandbox status conditions and the pool capacity.",
+                        0);
+            }
+            sleep();
+        }
+        throw new MitosException(
+                "sandbox " + name + " not ready after " + timeoutMs + "ms",
+                "ready_timeout",
+                "sandbox " + name + " did not reach Ready within " + timeoutMs + "ms",
+                "Raise the timeout, or check the controller is reconciling and the pool has capacity.",
+                0);
+    }
+
+    /** Reads the current sandbox status from the cluster as a {@link SandboxInfo}. */
+    public SandboxInfo info() {
+        Map<String, Object> obj = k8s.getObject(namespace, "sandboxes", name);
+        phase = SandboxPhase.fromWire(K8s.nestedString(obj, "status", "phase"));
+        endpoint = K8s.nestedString(obj, "status", "endpoint");
+        return new SandboxInfo(
+                name,
+                phase,
+                endpoint,
+                K8s.nestedString(obj, "status", "node"),
+                K8s.nestedString(obj, "status", "sandboxID"),
+                pool);
+    }
+
+    /**
+     * Terminates the sandbox by deleting the Sandbox object. The controller
+     * drives teardown (and, for a workspace-bound sandbox, the dehydrate on the
+     * way out). Returns the bound workspace name, or empty when unbound.
+     */
+    public String terminate() {
+        String wsRef = "";
+        try {
+            Map<String, Object> obj = k8s.getObject(namespace, "sandboxes", name);
+            wsRef = K8s.nestedString(obj, "spec", "workspaceRef", "name");
+        } catch (MitosException e) {
+            if (e.getStatus() != 404) {
+                throw e;
+            }
+        }
+        k8s.deleteObject(namespace, "sandboxes", name);
+        phase = SandboxPhase.TERMINATING;
+        return wsRef;
+    }
+
+    // loadToken reads the per-sandbox bearer token from the <name>-sandbox-token
+    // Secret. A missing Secret is tolerated (the sandbox stays tokenless). The
+    // token VALUE is held in memory only and is never logged.
+    void loadToken() {
+        Map<String, String> data;
+        try {
+            data = k8s.readSecret(namespace, name + "-sandbox-token");
+        } catch (MitosException e) {
+            return; // a missing token Secret is tolerated
+        }
+        String value = data.get("token");
+        if (value != null && !value.isEmpty()) {
+            token = value;
+        }
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(POLL_INTERVAL_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MitosException(
+                    "interrupted while waiting for the sandbox",
+                    "interrupted",
+                    "the waiting thread was interrupted",
+                    "Retry the wait from a thread that is not interrupted.",
+                    0);
+        }
+    }
+
+    @Override
+    public String toString() {
+        // The token is never included in the string form.
+        Map<String, Object> repr = new LinkedHashMap<>();
+        repr.put("name", name);
+        repr.put("phase", phase.wire());
+        repr.put("endpoint", endpoint);
+        return "ClusterSandbox" + repr;
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/ClusterWorkspace.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/ClusterWorkspace.java
@@ -1,0 +1,100 @@
+// A durable, forkable agent workspace handle in cluster mode. Lazy: it does not
+// touch the cluster until a verb is called. Mirrors the Python Workspace
+// (sdk/python/mitos/workspace.py): git-shaped verbs (head, resumable, log).
+package run.mitos.sdk;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A durable, forkable workspace ({@code mitos.run/v1} Workspace). It is lazy: no
+ * cluster call happens until a verb is called. Verbs are git-shaped, mirroring
+ * the Python {@code Workspace}.
+ */
+public final class ClusterWorkspace {
+
+    private final String name;
+    private final String namespace;
+    private final K8s k8s;
+
+    ClusterWorkspace(String name, String namespace, K8s k8s) {
+        this.name = name;
+        this.namespace = namespace;
+        this.k8s = k8s;
+    }
+
+    /** The Workspace object name. */
+    public String name() {
+        return name;
+    }
+
+    /** The Workspace object namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    // get reads the Workspace object, mapping a 404 to a typed
+    // workspace_not_found error.
+    Map<String, Object> get() {
+        try {
+            return k8s.getObject(namespace, "workspaces", name);
+        } catch (MitosException e) {
+            if (e.getStatus() == 404) {
+                throw new MitosException(
+                        "workspace " + name + " not found",
+                        "workspace_not_found",
+                        e.getCauseDetail(),
+                        "Create it with AgentRun.createWorkspace(name) first.",
+                        404);
+            }
+            throw e;
+        }
+    }
+
+    /** The workspace head revision name (status.head). */
+    public String head() {
+        return K8s.nestedString(get(), "status", "head");
+    }
+
+    /** Whether the workspace head is resumable (status.resumable). */
+    public boolean resumable() {
+        Object v = K8s.nested(get(), "status", "resumable");
+        return v instanceof Boolean b && b;
+    }
+
+    /** Lists the workspace's revisions, newest first by creation timestamp. */
+    public List<RevisionInfo> log() {
+        List<Object> items = k8s.listObjects(namespace, "workspacerevisions");
+        List<RevisionInfo> revs = new ArrayList<>();
+        for (Object item : items) {
+            Map<String, Object> obj = K8s.asMap(item);
+            if (!K8s.nestedString(obj, "spec", "workspaceRef", "name").equals(name)) {
+                continue;
+            }
+            boolean hasSnap = K8s.nested(obj, "spec", "memorySnapshotRef") != null;
+            revs.add(new RevisionInfo(
+                    K8s.nestedString(obj, "metadata", "name"),
+                    K8s.nestedString(obj, "status", "phase"),
+                    lineage(obj),
+                    hasSnap,
+                    K8s.nestedString(obj, "metadata", "creationTimestamp")));
+        }
+        // Newest first by creation timestamp (RFC3339 strings sort lexically).
+        revs.sort((a, b) -> b.created().compareTo(a.created()));
+        return revs;
+    }
+
+    // lineage describes a revision's source, mirroring the Python _lineage.
+    private static String lineage(Map<String, Object> obj) {
+        String fromClaim = K8s.nestedString(obj, "spec", "source", "fromClaim");
+        if (!fromClaim.isEmpty()) {
+            return "fromClaim:" + fromClaim;
+        }
+        Object fwr = K8s.nested(obj, "spec", "source", "fromWorkspaceRevision");
+        if (fwr instanceof Map<?, ?>) {
+            return "fromWorkspaceRevision:" + K8s.nestedString(K8s.asMap(fwr), "revision");
+        }
+        return "root";
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/K8s.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/K8s.java
@@ -1,0 +1,675 @@
+// Minimal Kubernetes REST client for cluster mode. The Java SDK stays
+// dependency-free: direct mode (SandboxServer) is untouched and pulls nothing,
+// and cluster mode here is built on the JDK standard library alone
+// (java.net.http.HttpClient, javax.net.ssl/SSLContext for the cluster CA and
+// optional client-cert mTLS, java.util.Base64, and the hand-rolled Json
+// helper). It does NOT pull fabric8, the official client, or any YAML library,
+// which would drag a transitive dependency tree into every consumer.
+//
+// The client speaks the custom-resource REST paths directly:
+//
+//   /apis/mitos.run/v1/namespaces/{ns}/{plural}            (list, create)
+//   /apis/mitos.run/v1/namespaces/{ns}/{plural}/{name}     (get, delete, patch)
+//
+// and reads core Secrets at /api/v1/namespaces/{ns}/secrets/{name}. Auth is a
+// bearer token; TLS trusts the cluster CA. The token VALUE is never logged.
+package run.mitos.sdk;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A minimal Kubernetes API client used by cluster mode. It resolves a
+ * connection (in-cluster or from a kubeconfig), trusts the cluster CA, attaches
+ * the bearer token, and drives the namespaced custom-resource and Secret REST
+ * endpoints. The token value is held in memory only and is never logged.
+ */
+final class K8s {
+
+    static final String API_GROUP = "mitos.run";
+    static final String API_VERSION = "v1";
+
+    // The in-cluster service-account mount paths (the standard Kubernetes
+    // locations). These are file paths, not secret values.
+    private static final String IN_CLUSTER_TOKEN_PATH =
+            "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    private static final String IN_CLUSTER_CA_PATH =
+            "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+
+    private final String server;
+    private final String token; // bearer token; in memory only, never logged
+    private final HttpClient http;
+
+    private K8s(String server, String token, HttpClient http) {
+        this.server = server.replaceAll("/+$", "");
+        this.token = (token == null || token.isEmpty()) ? null : token;
+        this.http = http;
+    }
+
+    /** The resolved API server base URL. Package-private for tests/inspection. */
+    String server() {
+        return server;
+    }
+
+    /** The resolved bearer token, or null. Package-private for redaction reuse. */
+    String token() {
+        return token;
+    }
+
+    // ---- connection construction ----
+
+    /**
+     * Builds a client over an already-resolved server URL, bearer token, and
+     * an HttpClient (whose SSLContext trusts the right CA). Used by the loaders
+     * below and injected directly by tests pointing at a local HTTP stub.
+     */
+    static K8s of(String server, String token, HttpClient http) {
+        return new K8s(server, token, http);
+    }
+
+    /**
+     * Builds a client from the in-cluster service-account mount: the API server
+     * from KUBERNETES_SERVICE_HOST/PORT, the bearer token from the projected
+     * token file, and the CA from the mounted ca.crt. Raises an actionable
+     * MitosException when run outside a cluster.
+     */
+    static K8s inCluster() {
+        String host = System.getenv("KUBERNETES_SERVICE_HOST");
+        String port = System.getenv("KUBERNETES_SERVICE_PORT");
+        if (host == null || host.isEmpty() || port == null || port.isEmpty()) {
+            throw new MitosException(
+                    "in-cluster config requested but KUBERNETES_SERVICE_HOST/PORT are not set",
+                    "not_in_cluster",
+                    "the in-cluster service-account environment is not present",
+                    "Run inside a Kubernetes pod, or pass a kubeconfig path to AgentRun.fromKubeconfig(path).",
+                    0);
+        }
+        String tokenValue;
+        byte[] caPem;
+        try {
+            tokenValue = Files.readString(Path.of(IN_CLUSTER_TOKEN_PATH)).strip();
+        } catch (Exception e) {
+            throw new MitosException(
+                    "could not read the in-cluster service-account token",
+                    "incluster_token_unreadable",
+                    String.valueOf(e),
+                    "Ensure the pod mounts a service-account token at " + IN_CLUSTER_TOKEN_PATH + ".",
+                    0);
+        }
+        try {
+            caPem = Files.readAllBytes(Path.of(IN_CLUSTER_CA_PATH));
+        } catch (Exception e) {
+            throw new MitosException(
+                    "could not read the in-cluster CA certificate",
+                    "incluster_ca_unreadable",
+                    String.valueOf(e),
+                    "Ensure the pod mounts the cluster CA at " + IN_CLUSTER_CA_PATH + ".",
+                    0);
+        }
+        HttpClient client = httpClientFor(caPem, null, null);
+        String serverUrl = "https://" + hostPort(host, port);
+        return new K8s(serverUrl, tokenValue, client);
+    }
+
+    /**
+     * Builds a client from a kubeconfig file (the current context). An empty
+     * path falls back to $KUBECONFIG, then $HOME/.kube/config. The SDK parses a
+     * common kubeconfig subset (server, CA, bearer token or inline client
+     * cert/key); it does not support exec credential plugins or auth-provider
+     * blocks.
+     */
+    static K8s fromKubeconfig(String path) {
+        String resolved = path;
+        if (resolved == null || resolved.isEmpty()) {
+            resolved = System.getenv("KUBECONFIG");
+        }
+        if (resolved == null || resolved.isEmpty()) {
+            String home = System.getProperty("user.home");
+            if (home != null && !home.isEmpty()) {
+                resolved = Path.of(home, ".kube", "config").toString();
+            }
+        }
+        if (resolved == null || resolved.isEmpty()) {
+            throw new MitosException(
+                    "no kubeconfig path and no home directory to derive ~/.kube/config",
+                    "kubeconfig_not_found",
+                    "neither an explicit path nor $KUBECONFIG nor a home directory is set",
+                    "Pass a path to AgentRun.fromKubeconfig(path), set $KUBECONFIG, or use AgentRun.inCluster() inside a pod.",
+                    0);
+        }
+        String raw;
+        Path file = Path.of(resolved);
+        try {
+            raw = Files.readString(file);
+        } catch (Exception e) {
+            throw new MitosException(
+                    "could not read the kubeconfig file",
+                    "kubeconfig_unreadable",
+                    String.valueOf(e),
+                    "Check the kubeconfig path is correct and readable: " + resolved,
+                    0);
+        }
+        Map<String, Object> doc;
+        try {
+            doc = Yaml.parse(raw);
+        } catch (RuntimeException e) {
+            throw new MitosException(
+                    "could not parse the kubeconfig file",
+                    "kubeconfig_parse_failed",
+                    String.valueOf(e),
+                    "The SDK parses a common kubeconfig subset (no exec/auth-provider plugins); check the file or use AgentRun.inCluster().",
+                    0);
+        }
+        Path baseDir = file.toAbsolutePath().getParent();
+        return resolveKubeconfig(doc, baseDir);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static K8s resolveKubeconfig(Map<String, Object> doc, Path baseDir) {
+        String currentContext = asStr(doc.get("current-context"));
+        if (currentContext.isEmpty()) {
+            throw new MitosException(
+                    "the kubeconfig has no current-context",
+                    "kubeconfig_no_context",
+                    "current-context is empty",
+                    "Set a current context with kubectl config use-context <name>.",
+                    0);
+        }
+        // Resolve the current context to its cluster + user names.
+        String clusterName = "";
+        String userName = "";
+        for (Object c : asList(doc.get("contexts"))) {
+            Map<String, Object> ctx = asMap(c);
+            if (currentContext.equals(asStr(ctx.get("name")))) {
+                Map<String, Object> inner = asMap(ctx.get("context"));
+                clusterName = asStr(inner.get("cluster"));
+                userName = asStr(inner.get("user"));
+                break;
+            }
+        }
+        if (clusterName.isEmpty()) {
+            throw new MitosException(
+                    "the current-context is not defined in the kubeconfig",
+                    "kubeconfig_context_missing",
+                    "no contexts entry matches current-context " + currentContext,
+                    "Check the kubeconfig contexts list includes " + currentContext + ".",
+                    0);
+        }
+
+        String server = "";
+        byte[] caPem = null;
+        for (Object c : asList(doc.get("clusters"))) {
+            Map<String, Object> cl = asMap(c);
+            if (!clusterName.equals(asStr(cl.get("name")))) {
+                continue;
+            }
+            Map<String, Object> inner = asMap(cl.get("cluster"));
+            server = asStr(inner.get("server"));
+            String caData = asStr(inner.get("certificate-authority-data"));
+            String caFile = asStr(inner.get("certificate-authority"));
+            if (!caData.isEmpty()) {
+                try {
+                    caPem = Base64.getDecoder().decode(caData);
+                } catch (IllegalArgumentException e) {
+                    throw new MitosException(
+                            "certificate-authority-data is not valid base64",
+                            "kubeconfig_ca_invalid",
+                            String.valueOf(e),
+                            "Regenerate the kubeconfig or check the certificate-authority-data field.",
+                            0);
+                }
+            } else if (!caFile.isEmpty()) {
+                Path p = Path.of(caFile);
+                if (!p.isAbsolute() && baseDir != null) {
+                    p = baseDir.resolve(caFile);
+                }
+                try {
+                    caPem = Files.readAllBytes(p);
+                } catch (Exception e) {
+                    throw new MitosException(
+                            "could not read the certificate-authority file",
+                            "kubeconfig_ca_unreadable",
+                            String.valueOf(e),
+                            "Check the certificate-authority path in the kubeconfig: " + p,
+                            0);
+                }
+            }
+            break;
+        }
+        if (server.isEmpty()) {
+            throw new MitosException(
+                    "the current cluster has no server URL",
+                    "kubeconfig_no_server",
+                    "cluster " + clusterName + " has an empty server field",
+                    "Check the kubeconfig clusters entry for " + clusterName + ".",
+                    0);
+        }
+
+        String token = "";
+        byte[] clientCertPem = null;
+        byte[] clientKeyPem = null;
+        for (Object u : asList(doc.get("users"))) {
+            Map<String, Object> user = asMap(u);
+            if (!userName.equals(asStr(user.get("name")))) {
+                continue;
+            }
+            Map<String, Object> inner = asMap(user.get("user"));
+            token = asStr(inner.get("token"));
+            String certData = asStr(inner.get("client-certificate-data"));
+            String keyData = asStr(inner.get("client-key-data"));
+            if (!certData.isEmpty() && !keyData.isEmpty()) {
+                try {
+                    clientCertPem = Base64.getDecoder().decode(certData);
+                    clientKeyPem = Base64.getDecoder().decode(keyData);
+                } catch (IllegalArgumentException e) {
+                    throw new MitosException(
+                            "the kubeconfig client certificate or key is not valid base64",
+                            "kubeconfig_client_cert_invalid",
+                            String.valueOf(e),
+                            "Check client-certificate-data and client-key-data in the kubeconfig.",
+                            0);
+                }
+            }
+            break;
+        }
+
+        HttpClient client = httpClientFor(caPem, clientCertPem, clientKeyPem);
+        return new K8s(server, token, client);
+    }
+
+    /**
+     * Builds an HttpClient whose SSLContext trusts caPem (the system default
+     * trust store when caPem is null/empty) and, when clientCertPem/clientKeyPem
+     * are present, presents a client certificate for mutual-TLS clusters (kind,
+     * minikube). A CA or client cert that fails to load is a typed error so the
+     * misconfiguration is legible.
+     */
+    private static HttpClient httpClientFor(byte[] caPem, byte[] clientCertPem, byte[] clientKeyPem) {
+        HttpClient.Builder builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30));
+        boolean wantTls = (caPem != null && caPem.length > 0)
+                || (clientCertPem != null && clientCertPem.length > 0);
+        if (wantTls) {
+            builder.sslContext(buildSslContext(caPem, clientCertPem, clientKeyPem));
+        }
+        return builder.build();
+    }
+
+    private static SSLContext buildSslContext(byte[] caPem, byte[] clientCertPem, byte[] clientKeyPem) {
+        try {
+            TrustManagerFactory tmf = null;
+            if (caPem != null && caPem.length > 0) {
+                KeyStore trust = KeyStore.getInstance(KeyStore.getDefaultType());
+                trust.load(null, null);
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                int idx = 0;
+                for (Certificate cert : cf.generateCertificates(new ByteArrayInputStream(caPem))) {
+                    trust.setCertificateEntry("ca-" + idx, cert);
+                    idx++;
+                }
+                if (idx == 0) {
+                    throw new MitosException(
+                            "the cluster CA certificate could not be parsed",
+                            "ca_parse_failed",
+                            "no X.509 certificate was found in the CA PEM",
+                            "Check the CA certificate is valid PEM (certificate-authority-data or the mounted ca.crt).",
+                            0);
+                }
+                tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                tmf.init(trust);
+            }
+
+            KeyManagerFactory kmf = null;
+            if (clientCertPem != null && clientCertPem.length > 0
+                    && clientKeyPem != null && clientKeyPem.length > 0) {
+                kmf = clientKeyManager(clientCertPem, clientKeyPem);
+            }
+
+            SSLContext ctx = SSLContext.getInstance("TLS");
+            ctx.init(
+                    kmf == null ? null : kmf.getKeyManagers(),
+                    tmf == null ? null : tmf.getTrustManagers(),
+                    null);
+            return ctx;
+        } catch (MitosException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MitosException(
+                    "could not build the cluster TLS context",
+                    "tls_context_failed",
+                    String.valueOf(e),
+                    "Check the cluster CA and any client certificate in the kubeconfig are valid PEM.",
+                    0);
+        }
+    }
+
+    // clientKeyManager assembles a KeyManagerFactory from a PEM client
+    // certificate and an unencrypted PKCS#8 private key (the form
+    // client-key-data carries in a kubeconfig).
+    private static KeyManagerFactory clientKeyManager(byte[] certPem, byte[] keyPem) throws Exception {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        List<Certificate> chain = new ArrayList<>(
+                cf.generateCertificates(new ByteArrayInputStream(certPem)));
+        if (chain.isEmpty()) {
+            throw new MitosException(
+                    "the kubeconfig client certificate could not be parsed",
+                    "kubeconfig_client_cert_invalid",
+                    "no X.509 certificate was found in client-certificate-data",
+                    "Check client-certificate-data in the kubeconfig is valid PEM.",
+                    0);
+        }
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pemKeyToDer(keyPem));
+        java.security.PrivateKey key = loadPrivateKey(keySpec);
+
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        ks.load(null, null);
+        ks.setKeyEntry("client", key, new char[0],
+                chain.toArray(new Certificate[0]));
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+                KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, new char[0]);
+        return kmf;
+    }
+
+    // pemKeyToDer strips the PEM armor and base64-decodes the DER body of a
+    // PKCS#8 private key. The header may be "PRIVATE KEY" (PKCS#8) which is what
+    // kubeconfig client-key-data carries; encrypted or PKCS#1 keys are not
+    // supported (a clear error surfaces from the KeyFactory).
+    private static byte[] pemKeyToDer(byte[] keyPem) {
+        String text = new String(keyPem, StandardCharsets.UTF_8);
+        StringBuilder body = new StringBuilder();
+        boolean inBody = false;
+        for (String line : text.split("\\R")) {
+            String t = line.trim();
+            if (t.startsWith("-----BEGIN")) {
+                inBody = true;
+                continue;
+            }
+            if (t.startsWith("-----END")) {
+                break;
+            }
+            if (inBody) {
+                body.append(t);
+            }
+        }
+        return Base64.getMimeDecoder().decode(body.toString());
+    }
+
+    private static java.security.PrivateKey loadPrivateKey(PKCS8EncodedKeySpec spec) {
+        // Try the common algorithms a kubeconfig client key uses. The first that
+        // accepts the PKCS#8 encoding wins.
+        for (String algo : new String[] {"RSA", "EC"}) {
+            try {
+                return KeyFactory.getInstance(algo).generatePrivate(spec);
+            } catch (Exception ignored) {
+                // Try the next algorithm.
+            }
+        }
+        throw new MitosException(
+                "the kubeconfig client key could not be loaded",
+                "kubeconfig_client_cert_invalid",
+                "client-key-data is not an unencrypted PKCS#8 RSA or EC key",
+                "Provide an unencrypted PKCS#8 client key, or use a bearer-token kubeconfig.",
+                0);
+    }
+
+    // ---- REST operations ----
+
+    /** Builds the namespaced custom-resource path; name is omitted for the
+     * collection (list, create). */
+    static String crdPath(String namespace, String plural, String name) {
+        String base = "/apis/" + API_GROUP + "/" + API_VERSION
+                + "/namespaces/" + namespace + "/" + plural;
+        return (name == null || name.isEmpty()) ? base : base + "/" + name;
+    }
+
+    /** Builds the core Secret item path. */
+    static String secretPath(String namespace, String name) {
+        return "/api/v1/namespaces/" + namespace + "/secrets/" + name;
+    }
+
+    /** GETs a single custom object. A 404 surfaces as a MitosException with
+     * status 404 so callers can tell absent from a real failure. */
+    Map<String, Object> getObject(String namespace, String plural, String name) {
+        Object out = send("GET", crdPath(namespace, plural, name), null, null);
+        return asMap(out);
+    }
+
+    /** GETs the collection of custom objects, returning the items list. */
+    List<Object> listObjects(String namespace, String plural) {
+        Object out = send("GET", crdPath(namespace, plural, ""), null, null);
+        Object items = asMap(out).get("items");
+        return items instanceof List<?> ? asList(items) : new ArrayList<>();
+    }
+
+    /** POSTs a custom object to the collection. */
+    Map<String, Object> createObject(String namespace, String plural, Map<String, Object> body) {
+        Object out = send("POST", crdPath(namespace, plural, ""), body, "application/json");
+        return asMap(out);
+    }
+
+    /** PATCHes a custom object with a strategic-merge patch. */
+    Map<String, Object> patchObject(String namespace, String plural, String name,
+                                    Map<String, Object> patch) {
+        Object out = send("PATCH", crdPath(namespace, plural, name), patch,
+                "application/merge-patch+json");
+        return asMap(out);
+    }
+
+    /** DELETEs a single custom object. */
+    void deleteObject(String namespace, String plural, String name) {
+        send("DELETE", crdPath(namespace, plural, name), null, null);
+    }
+
+    /**
+     * Reads a core Secret and returns its data decoded to UTF-8 strings keyed by
+     * the Secret key. A 404 surfaces as a MitosException with status 404 so a
+     * caller can tolerate a missing token Secret. Secret VALUES are held in
+     * memory only and are NEVER logged.
+     */
+    Map<String, String> readSecret(String namespace, String name) {
+        Object out = send("GET", secretPath(namespace, name), null, null);
+        Map<String, Object> data = asMap(asMap(out).get("data"));
+        Map<String, String> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : data.entrySet()) {
+            try {
+                byte[] decoded = Base64.getDecoder().decode(asStr(e.getValue()));
+                result.put(e.getKey(), new String(decoded, StandardCharsets.UTF_8));
+            } catch (IllegalArgumentException ignored) {
+                // A non-base64 Secret value is unexpected; skip it rather than
+                // surfacing the raw value (which could be a secret).
+            }
+        }
+        return result;
+    }
+
+    // send issues an API request with the bearer token and parses a 2xx JSON
+    // body. A non-2xx response becomes a typed MitosException carrying the
+    // Kubernetes Status reason/code and the HTTP status. The bearer token never
+    // appears in an error.
+    private Object send(String method, String path, Object body, String contentType) {
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create(server + path))
+                .header("Accept", "application/json");
+        if (token != null) {
+            b.header("Authorization", "Bearer " + token);
+        }
+        if (body != null) {
+            String json = Json.encode(body);
+            if (contentType != null) {
+                b.header("Content-Type", contentType);
+            }
+            b.method(method, HttpRequest.BodyPublishers.ofString(json));
+        } else {
+            b.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+
+        HttpResponse<String> resp;
+        try {
+            resp = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new MitosException(
+                    "kubernetes API request failed: " + redact(e.getMessage()),
+                    "k8s_transport_error",
+                    redact(String.valueOf(e)),
+                    "Check the API server URL is reachable and the kubeconfig/in-cluster auth is valid.",
+                    0);
+        }
+        int status = resp.statusCode();
+        if (status < 200 || status >= 300) {
+            throw errorFromStatus(status, resp.body());
+        }
+        String text = resp.body();
+        if (text == null || text.isBlank()) {
+            return new LinkedHashMap<String, Object>();
+        }
+        return Json.parse(text);
+    }
+
+    // errorFromStatus turns a non-2xx Kubernetes response into a typed
+    // MitosException. The HTTP status is preserved so callers can branch on 404
+    // (absent) versus 409 (already exists). A Status body carries no token, so
+    // only defensive redaction is applied.
+    private MitosException errorFromStatus(int status, String rawBody) {
+        String body = redact(rawBody == null ? "" : rawBody);
+        String reason = "";
+        String message = "kubernetes API returned HTTP " + status;
+        try {
+            Object parsed = Json.parse(body);
+            if (parsed instanceof Map<?, ?> m) {
+                Map<String, Object> obj = asMap(parsed);
+                reason = asStr(obj.get("reason"));
+                String msg = asStr(obj.get("message"));
+                if (!msg.isEmpty()) {
+                    message = msg;
+                } else if (!reason.isEmpty()) {
+                    message = reason;
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Not JSON: keep the status-derived message with the body as cause.
+        }
+        String code = "k8s_" + statusCodeSuffix(status, reason);
+        String cause = "kubernetes API returned " + status
+                + (reason.isEmpty() ? "" : " " + reason);
+        return new MitosException(message, code, cause, statusRemediation(status), status);
+    }
+
+    private static String statusCodeSuffix(int status, String reason) {
+        switch (status) {
+            case 404:
+                return "not_found";
+            case 409:
+                return "conflict";
+            case 403:
+                return "forbidden";
+            case 401:
+                return "unauthorized";
+            default:
+                return reason.isEmpty() ? "error" : reason.toLowerCase();
+        }
+    }
+
+    private static String statusRemediation(int status) {
+        switch (status) {
+            case 404:
+                return "Check the object name and namespace; create it first if it does not exist.";
+            case 401:
+            case 403:
+                return "Check the service-account RBAC grants access to mitos.run resources in this namespace.";
+            default:
+                return "";
+        }
+    }
+
+    /** Replaces every occurrence of the configured token with [REDACTED]. */
+    String redact(String text) {
+        if (text == null) {
+            return "";
+        }
+        if (token == null || token.isEmpty()) {
+            return text;
+        }
+        return text.replace(token, "[REDACTED]");
+    }
+
+    // ---- small coercion helpers, shared with the cluster classes ----
+
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> asMap(Object o) {
+        if (o instanceof Map<?, ?> m) {
+            return (Map<String, Object>) m;
+        }
+        return new LinkedHashMap<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<Object> asList(Object o) {
+        if (o instanceof List<?> l) {
+            return (List<Object>) l;
+        }
+        return new ArrayList<>();
+    }
+
+    static String asStr(Object o) {
+        return o == null ? "" : o.toString();
+    }
+
+    static int asInt(Object o) {
+        if (o instanceof Number n) {
+            return n.intValue();
+        }
+        return 0;
+    }
+
+    /** Walks the nested maps along keys and returns the value, or null when any
+     * segment is absent or not a map. */
+    static Object nested(Map<String, Object> obj, String... keys) {
+        Object cur = obj;
+        for (String k : keys) {
+            if (!(cur instanceof Map<?, ?>)) {
+                return null;
+            }
+            cur = asMap(cur).get(k);
+            if (cur == null) {
+                return null;
+            }
+        }
+        return cur;
+    }
+
+    /** Reads a string at the nested path, or "" when absent or not a string. */
+    static String nestedString(Map<String, Object> obj, String... keys) {
+        Object v = nested(obj, keys);
+        return v == null ? "" : v.toString();
+    }
+
+    private static String hostPort(String host, String port) {
+        // Bracket a bare IPv6 literal so the URL host parses.
+        if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
+            return "[" + host + "]:" + port;
+        }
+        return host + ":" + port;
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/PoolStatus.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/PoolStatus.java
@@ -1,0 +1,19 @@
+// The observed status of a SandboxPool, mirroring the Python PoolStatus.
+package run.mitos.sdk;
+
+import java.util.Map;
+
+/**
+ * The observed status of a SandboxPool.
+ *
+ * @param name             the pool name
+ * @param readySnapshots   the number of warm snapshots ready to fork from
+ * @param desired          the pool's spec.replicas
+ * @param nodeDistribution node name to ready-snapshot count on that node
+ */
+public record PoolStatus(
+        String name,
+        int readySnapshots,
+        int desired,
+        Map<String, Integer> nodeDistribution) {
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/RevisionInfo.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/RevisionInfo.java
@@ -1,0 +1,20 @@
+// One Workspace revision as listed in a workspace log. Mirrors the Python
+// RevisionInfo dataclass.
+package run.mitos.sdk;
+
+/**
+ * One revision in a workspace's history.
+ *
+ * @param name      the WorkspaceRevision object name
+ * @param phase     the revision phase (for example "Committed")
+ * @param lineage   a short description of the revision's source
+ * @param resumable whether the revision carries a memory snapshot
+ * @param created   the creation timestamp (RFC3339)
+ */
+public record RevisionInfo(
+        String name,
+        String phase,
+        String lineage,
+        boolean resumable,
+        String created) {
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/SandboxInfo.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/SandboxInfo.java
@@ -1,0 +1,22 @@
+// A snapshot of a cluster-mode sandbox's status, returned by
+// ClusterSandbox.info(). Mirrors the Python SandboxInfo fields.
+package run.mitos.sdk;
+
+/**
+ * A snapshot of a cluster-mode sandbox's observed status.
+ *
+ * @param name      the Sandbox object name
+ * @param phase     the lifecycle phase
+ * @param endpoint  the serving endpoint (host:port), empty until Ready
+ * @param node      the node the sandbox is scheduled on
+ * @param sandboxId the runtime sandbox id reported by forkd
+ * @param pool      the SandboxPool the sandbox was claimed from
+ */
+public record SandboxInfo(
+        String name,
+        SandboxPhase phase,
+        String endpoint,
+        String node,
+        String sandboxId,
+        String pool) {
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/SandboxParams.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/SandboxParams.java
@@ -1,0 +1,164 @@
+// A small builder for the optional fields of AgentRun.sandbox and
+// AgentRun.create: pool, name, env, secrets, ttl, workspace, and replicas. It
+// mirrors the Python keyword arguments (pool=, name=, env=, secrets=, timeout=,
+// workspace=) as an idiomatic Java builder so the common one-liner path stays
+// argument-free while the full surface is still reachable.
+package run.mitos.sdk;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Optional parameters for creating a sandbox. Build it fluently and pass it to
+ * {@link AgentRun#sandbox(String, SandboxParams)} or
+ * {@link AgentRun#create(SandboxParams)}:
+ *
+ * <pre>{@code
+ * var params = SandboxParams.builder()
+ *         .name("worker-1")
+ *         .env("MODE", "fast")
+ *         .ttl("30m")
+ *         .build();
+ * var sb = agent.sandbox("python:3.12", params);
+ * }</pre>
+ */
+public final class SandboxParams {
+
+    private final String pool;
+    private final String name;
+    private final Map<String, String> env;
+    private final Map<String, SecretRef> secrets;
+    private final String ttl;
+    private final String workspace;
+    private final int replicas;
+
+    private SandboxParams(Builder b) {
+        this.pool = b.pool;
+        this.name = b.name;
+        this.env = b.env;
+        this.secrets = b.secrets;
+        this.ttl = b.ttl;
+        this.workspace = b.workspace;
+        this.replicas = b.replicas;
+    }
+
+    /** An empty parameter set (all defaults). */
+    public static SandboxParams none() {
+        return builder().build();
+    }
+
+    /** A new builder. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    String pool() {
+        return pool;
+    }
+
+    String name() {
+        return name;
+    }
+
+    Map<String, String> env() {
+        return env;
+    }
+
+    Map<String, SecretRef> secrets() {
+        return secrets;
+    }
+
+    String ttl() {
+        return ttl;
+    }
+
+    String workspace() {
+        return workspace;
+    }
+
+    int replicas() {
+        return replicas;
+    }
+
+    /** Fluent builder for {@link SandboxParams}. */
+    public static final class Builder {
+        private String pool;
+        private String name;
+        private Map<String, String> env;
+        private Map<String, SecretRef> secrets;
+        private String ttl;
+        private String workspace;
+        private int replicas;
+
+        private Builder() {
+        }
+
+        /** Selects an existing SandboxPool to claim from. With a pool set, the
+         * lazy default-pool path is never taken. */
+        public Builder pool(String pool) {
+            this.pool = pool;
+            return this;
+        }
+
+        /** Sets an explicit sandbox name. When omitted a sandbox-&lt;hex&gt; name
+         * is generated. */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /** Replaces the environment map injected into the sandbox (spec.env). */
+        public Builder env(Map<String, String> env) {
+            this.env = env;
+            return this;
+        }
+
+        /** Adds a single environment variable injected into the sandbox. */
+        public Builder env(String key, String value) {
+            if (this.env == null) {
+                this.env = new LinkedHashMap<>();
+            }
+            this.env.put(key, value);
+            return this;
+        }
+
+        /** Replaces the Secret-backed environment map (spec.secrets): env-var
+         * name to the {@link SecretRef} it reads. */
+        public Builder secrets(Map<String, SecretRef> secrets) {
+            this.secrets = secrets;
+            return this;
+        }
+
+        /** Adds a single Secret-backed environment variable. */
+        public Builder secret(String envVar, String secretName, String key) {
+            if (this.secrets == null) {
+                this.secrets = new LinkedHashMap<>();
+            }
+            this.secrets.put(envVar, new SecretRef(secretName, key));
+            return this;
+        }
+
+        /** Bounds the sandbox lifetime (spec.lifetime.ttl), for example "30m". */
+        public Builder ttl(String ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        /** Binds the sandbox to a durable Workspace by name (spec.workspaceRef). */
+        public Builder workspace(String workspace) {
+            this.workspace = workspace;
+            return this;
+        }
+
+        /** Sets spec.replicas on the created Sandbox. */
+        public Builder replicas(int replicas) {
+            this.replicas = replicas;
+            return this;
+        }
+
+        /** Builds the immutable parameter set. */
+        public SandboxParams build() {
+            return new SandboxParams(this);
+        }
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/SandboxPhase.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/SandboxPhase.java
@@ -1,0 +1,43 @@
+// The lifecycle phase of a cluster-mode Sandbox, as reported in status.phase.
+// Mirrors the Python SandboxPhase enum and the controller's phase values.
+package run.mitos.sdk;
+
+/** A Sandbox lifecycle phase reported by the controller in status.phase. */
+public enum SandboxPhase {
+
+    /** The initial phase before the controller schedules and activates it. */
+    PENDING("Pending"),
+    /** The phase while the snapshot is being restored. */
+    RESTORING("Restoring"),
+    /** The phase once the sandbox is serving its API. */
+    READY("Ready"),
+    /** The phase after a terminate is requested. */
+    TERMINATING("Terminating"),
+    /** The terminal failure phase. */
+    FAILED("Failed");
+
+    private final String wire;
+
+    SandboxPhase(String wire) {
+        this.wire = wire;
+    }
+
+    /** The wire string the controller uses for this phase (for example "Ready"). */
+    public String wire() {
+        return wire;
+    }
+
+    /** Maps a status.phase wire string to a phase, defaulting to PENDING when
+     * absent or unrecognized. */
+    static SandboxPhase fromWire(String value) {
+        if (value == null || value.isEmpty()) {
+            return PENDING;
+        }
+        for (SandboxPhase p : values()) {
+            if (p.wire.equals(value)) {
+                return p;
+            }
+        }
+        return PENDING;
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/SecretRef.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/SecretRef.java
@@ -1,0 +1,15 @@
+// A reference to a key in a Kubernetes Secret to inject as an environment
+// variable, mirroring the Python secrets={env: (secret, key)} mapping. Secret
+// VALUES never pass through the SDK; only these references do.
+package run.mitos.sdk;
+
+/**
+ * A reference to a Kubernetes Secret key, injected into a sandbox as an
+ * environment variable. The SDK never reads or carries the secret value; the
+ * controller resolves the reference inside the cluster.
+ *
+ * @param secretName the name of the Secret object
+ * @param key        the key within the Secret's data
+ */
+public record SecretRef(String secretName, String key) {
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/Yaml.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/Yaml.java
@@ -1,0 +1,215 @@
+// A tiny, dependency-free YAML reader for the kubeconfig subset cluster mode
+// needs. It is deliberately minimal: it covers the block-style maps, block-style
+// lists, and scalar values a kubeconfig uses (clusters/contexts/users lists of
+// nested maps, plus current-context and the server/CA/token/cert scalars). It is
+// NOT a general YAML implementation: it does not handle flow style ({}/[]),
+// anchors, multi-document streams, or block scalars, none of which appear in a
+// kubeconfig. Keeping the SDK dependency-free means no SnakeYAML; this stands in
+// for the small surface we read.
+package run.mitos.sdk;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal block-style YAML parsing: {@link #parse(String)} returns a Map / List
+ * / String tree, the same shape {@link Json} produces, so the kubeconfig
+ * resolver can read it with the same accessors. Scalars are returned as Strings;
+ * the resolver coerces where needed.
+ */
+final class Yaml {
+
+    private Yaml() {
+    }
+
+    /** Parses a block-style YAML document into a String-keyed map tree. */
+    static Map<String, Object> parse(String text) {
+        List<Line> lines = new ArrayList<>();
+        for (String raw : text.split("\\R", -1)) {
+            String noComment = stripComment(raw);
+            if (noComment.strip().isEmpty()) {
+                continue;
+            }
+            if (noComment.strip().equals("---") || noComment.strip().equals("...")) {
+                // A document marker; the first document is all a kubeconfig has.
+                continue;
+            }
+            int indent = indentOf(noComment);
+            lines.add(new Line(indent, noComment.strip()));
+        }
+        int[] pos = {0};
+        Object root = parseBlock(lines, pos, 0);
+        if (root instanceof Map<?, ?>) {
+            return K8s.asMap(root);
+        }
+        return new LinkedHashMap<>();
+    }
+
+    // parseBlock parses a run of sibling lines at minIndent (or deeper) into a
+    // Map or a List, advancing pos past the consumed lines.
+    private static Object parseBlock(List<Line> lines, int[] pos, int minIndent) {
+        if (pos[0] >= lines.size()) {
+            return new LinkedHashMap<String, Object>();
+        }
+        int indent = lines.get(pos[0]).indent;
+        if (lines.get(pos[0]).text.startsWith("- ") || lines.get(pos[0]).text.equals("-")) {
+            return parseList(lines, pos, indent);
+        }
+        return parseMap(lines, pos, indent);
+    }
+
+    private static Map<String, Object> parseMap(List<Line> lines, int[] pos, int indent) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        while (pos[0] < lines.size()) {
+            Line line = lines.get(pos[0]);
+            if (line.indent < indent) {
+                break;
+            }
+            if (line.indent > indent) {
+                // Shouldn't happen at a well-formed map start; skip defensively.
+                pos[0]++;
+                continue;
+            }
+            String content = line.text;
+            int colon = keyColon(content);
+            if (colon < 0) {
+                // Not a key: value line at this level; stop the map.
+                break;
+            }
+            String key = unquote(content.substring(0, colon).strip());
+            String rest = content.substring(colon + 1).strip();
+            pos[0]++;
+            if (!rest.isEmpty()) {
+                map.put(key, scalar(rest));
+            } else {
+                // The value is a nested block on the following deeper lines.
+                if (pos[0] < lines.size() && lines.get(pos[0]).indent > indent) {
+                    map.put(key, parseBlock(lines, pos, lines.get(pos[0]).indent));
+                } else if (pos[0] < lines.size()
+                        && lines.get(pos[0]).indent == indent
+                        && (lines.get(pos[0]).text.startsWith("- ")
+                            || lines.get(pos[0]).text.equals("-"))) {
+                    // A list whose items sit at the same indent as the key (the
+                    // common kubeconfig style for clusters/contexts/users).
+                    map.put(key, parseList(lines, pos, indent));
+                } else {
+                    map.put(key, "");
+                }
+            }
+        }
+        return map;
+    }
+
+    private static List<Object> parseList(List<Line> lines, int[] pos, int indent) {
+        List<Object> list = new ArrayList<>();
+        while (pos[0] < lines.size()) {
+            Line line = lines.get(pos[0]);
+            if (line.indent != indent
+                    || !(line.text.startsWith("- ") || line.text.equals("-"))) {
+                break;
+            }
+            String afterDash = line.text.equals("-") ? "" : line.text.substring(2).strip();
+            if (afterDash.isEmpty()) {
+                // The item is a nested block on the following deeper lines.
+                pos[0]++;
+                if (pos[0] < lines.size() && lines.get(pos[0]).indent > indent) {
+                    list.add(parseBlock(lines, pos, lines.get(pos[0]).indent));
+                } else {
+                    list.add("");
+                }
+                continue;
+            }
+            int colon = keyColon(afterDash);
+            if (colon >= 0) {
+                // An inline "- key: value" begins a map item. Rewrite the line so
+                // its first key sits at indent+2 and parse the item as a map.
+                int itemIndent = indent + 2;
+                List<Line> sub = new ArrayList<>();
+                sub.add(new Line(itemIndent, afterDash));
+                pos[0]++;
+                // Pull in the following lines that belong to this item (deeper
+                // than the dash indent).
+                while (pos[0] < lines.size() && lines.get(pos[0]).indent > indent) {
+                    sub.add(lines.get(pos[0]));
+                    pos[0]++;
+                }
+                int[] subPos = {0};
+                list.add(parseMap(sub, subPos, itemIndent));
+            } else {
+                // A scalar list item.
+                list.add(scalar(afterDash));
+                pos[0]++;
+            }
+        }
+        return list;
+    }
+
+    // keyColon returns the index of the colon that separates a map key from its
+    // value, or -1 when the line is not a "key:" line. The colon must be followed
+    // by a space or end-of-line (so a URL "https://x" is not mistaken for a key).
+    private static int keyColon(String s) {
+        boolean inSingle = false;
+        boolean inDouble = false;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\'' && !inDouble) {
+                inSingle = !inSingle;
+            } else if (c == '"' && !inSingle) {
+                inDouble = !inDouble;
+            } else if (c == ':' && !inSingle && !inDouble) {
+                if (i + 1 >= s.length() || s.charAt(i + 1) == ' ') {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static Object scalar(String s) {
+        return unquote(s);
+    }
+
+    private static String unquote(String s) {
+        if (s.length() >= 2) {
+            char f = s.charAt(0);
+            char l = s.charAt(s.length() - 1);
+            if ((f == '"' && l == '"') || (f == '\'' && l == '\'')) {
+                return s.substring(1, s.length() - 1);
+            }
+        }
+        return s;
+    }
+
+    private static String stripComment(String line) {
+        boolean inSingle = false;
+        boolean inDouble = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '\'' && !inDouble) {
+                inSingle = !inSingle;
+            } else if (c == '"' && !inSingle) {
+                inDouble = !inDouble;
+            } else if (c == '#' && !inSingle && !inDouble) {
+                // A comment starts at # only when preceded by whitespace or at the
+                // line start, matching YAML.
+                if (i == 0 || line.charAt(i - 1) == ' ' || line.charAt(i - 1) == '\t') {
+                    return line.substring(0, i);
+                }
+            }
+        }
+        return line;
+    }
+
+    private static int indentOf(String line) {
+        int n = 0;
+        while (n < line.length() && line.charAt(n) == ' ') {
+            n++;
+        }
+        return n;
+    }
+
+    private record Line(int indent, String text) {
+    }
+}

--- a/sdk/java/src/test/java/run/mitos/sdk/ClusterTest.java
+++ b/sdk/java/src/test/java/run/mitos/sdk/ClusterTest.java
@@ -1,0 +1,397 @@
+// Cluster-mode (AgentRun) tests for the Java SDK. They run inside the same
+// main-based runner as the direct-mode SdkTest: SdkTest.main calls
+// ClusterTest.run(), and the assertions share SdkTest's pass/fail counters and
+// its in-process com.sun.net.httpserver.HttpServer stub, here reproducing the
+// Kubernetes custom-resource REST wire shapes:
+//
+//   /apis/mitos.run/v1/namespaces/{ns}/{plural}            (list, create)
+//   /apis/mitos.run/v1/namespaces/{ns}/{plural}/{name}     (get, delete)
+//
+// No real cluster, kubeconfig, or in-cluster mount is needed: AgentRun is wired
+// to the stub with K8s.of(url, token, HttpClient), the same seam the direct-mode
+// SandboxServer uses. defaultPoolName is a pure function and is asserted against
+// the exact vectors the issue specifies, byte-for-byte with the Python slug.
+package run.mitos.sdk;
+
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static run.mitos.sdk.SdkTest.assertEquals;
+import static run.mitos.sdk.SdkTest.assertTrue;
+import static run.mitos.sdk.SdkTest.ok;
+
+final class ClusterTest {
+
+    private ClusterTest() {
+    }
+
+    static void run() throws Exception {
+        testDefaultPoolNameVectors();
+        testSandboxGetOrCreatesDefaultPool();
+        testSandboxReusesExistingPool();
+        testSandboxToleratesPoolConflict();
+        testCreateWritesPoolRef();
+        testGetReadsPoolRefAndPhase();
+        testListFiltersByPool();
+        testPoolStatusReadsStatus();
+        testReadyTokenFromSecretNeverLogged();
+        testWorkspaceCreateAndNotFound();
+        testKubeconfigBearerTokenParse();
+    }
+
+    // The minimal kubeconfig parser resolves the current context's server and
+    // bearer token, selecting by context name (not position). No CA is set, so
+    // the system trust store is used. This exercises the Yaml block parser and
+    // the K8s.fromKubeconfig resolver without needing a live cluster.
+    private static void testKubeconfigBearerTokenParse() throws Exception {
+        String kube = "apiVersion: v1\n"
+                + "kind: Config\n"
+                + "current-context: prod\n"
+                + "clusters:\n"
+                + "- name: dev\n"
+                + "  cluster:\n"
+                + "    server: https://dev.example:6443\n"
+                + "- name: prod\n"
+                + "  cluster:\n"
+                + "    server: https://prod.example:6443\n"
+                + "contexts:\n"
+                + "- name: dev\n"
+                + "  context:\n"
+                + "    cluster: dev\n"
+                + "    user: dev-user\n"
+                + "- name: prod\n"
+                + "  context:\n"
+                + "    cluster: prod\n"
+                + "    user: prod-user\n"
+                + "    namespace: agents\n"
+                + "users:\n"
+                + "- name: dev-user\n"
+                + "  user:\n"
+                + "    token: dev-token\n"
+                + "- name: prod-user\n"
+                + "  user:\n"
+                + "    token: prod-token\n";
+        java.nio.file.Path tmp = java.nio.file.Files.createTempFile("kubeconfig", ".yaml");
+        java.nio.file.Files.writeString(tmp, kube);
+        try {
+            K8s k8s = K8s.fromKubeconfig(tmp.toString());
+            assertEquals("https://prod.example:6443", k8s.server(),
+                    "kubeconfig resolves the current context's server by name");
+            assertEquals("prod-token", k8s.token(),
+                    "kubeconfig resolves the current context's bearer token by name");
+        } finally {
+            java.nio.file.Files.deleteIfExists(tmp);
+        }
+        ok("a minimal kubeconfig parses to the current context's server and token");
+    }
+
+    // The exact vectors from issue #306: the Java defaultPoolName MUST match the
+    // Python default_pool_name byte-for-byte, including applying the 40-char
+    // bound BEFORE stripping "-." (Python slug[:40].strip("-.")).
+    private static void testDefaultPoolNameVectors() {
+        assertEquals("mitos-default-python-3.12",
+                AgentRun.defaultPoolName("python:3.12"), "defaultPoolName python:3.12");
+        assertEquals("mitos-default-ghcr.io-acme-foo-bar-latest",
+                AgentRun.defaultPoolName("ghcr.io/Acme/Foo-Bar:latest"),
+                "defaultPoolName ghcr.io/Acme/Foo-Bar:latest");
+        assertEquals("mitos-default-busybox",
+                AgentRun.defaultPoolName("busybox"), "defaultPoolName busybox");
+        assertEquals("mitos-default-upper-case-tag",
+                AgentRun.defaultPoolName("UPPER/Case:TAG"), "defaultPoolName UPPER/Case:TAG");
+        assertEquals("mitos-default-" + "a".repeat(40),
+                AgentRun.defaultPoolName("a".repeat(60) + ":x"),
+                "defaultPoolName 60a:x bounds to 40 before stripping");
+        assertEquals("mitos-default-registry.io-x-sha256-abc",
+                AgentRun.defaultPoolName("registry.io/x@sha256:abc"),
+                "defaultPoolName registry.io/x@sha256:abc");
+        assertEquals("mitos-default-node-18",
+                AgentRun.defaultPoolName("node_18"), "defaultPoolName node_18");
+        ok("defaultPoolName matches the 7 Python vectors byte-for-byte");
+    }
+
+    // sandbox(image) with no pool get-or-creates the default pool: a 404 on GET
+    // sandboxpools/<name> leads to a POST sandboxpools with the inline template,
+    // then a POST sandboxes with the resolved poolRef.
+    private static void testSandboxGetOrCreatesDefaultPool() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        AtomicReference<String> poolBody = new AtomicReference<>();
+        AtomicReference<String> sandboxBody = new AtomicReference<>();
+        String pool = AgentRun.defaultPoolName("python:3.12");
+
+        // GET the pool: not found, so the lazy path must create it.
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxpools/" + pool,
+                ex -> SdkTest.json(ex, 404,
+                        "{\"kind\":\"Status\",\"reason\":\"NotFound\","
+                                + "\"message\":\"sandboxpools \\\"" + pool + "\\\" not found\",\"code\":404}"));
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxpools", ex -> {
+            poolBody.set(SdkTest.readBody(ex));
+            SdkTest.json(ex, 201, "{\"metadata\":{\"name\":\"" + pool + "\"}}");
+        });
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxes", ex -> {
+            sandboxBody.set(SdkTest.readBody(ex));
+            SdkTest.json(ex, 201, "{\"metadata\":{\"name\":\"sandbox-x\"}}");
+        });
+
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterSandbox sb = agent.sandbox("python:3.12");
+            assertTrue(sb.name() != null && sb.name().startsWith("sandbox-"),
+                    "created sandbox has a generated name: " + sb.name());
+            assertEquals(pool, sb.pool(), "sandbox pool is the default pool");
+
+            Map<String, Object> createdPool = Json.parseObject(poolBody.get());
+            assertEquals("SandboxPool", createdPool.get("kind"), "created object is a SandboxPool");
+            assertEquals("python:3.12",
+                    K8s.nestedString(createdPool, "spec", "template", "image"),
+                    "default pool carries the inline template image");
+            assertEquals(1, K8s.asInt(K8s.nested(createdPool, "spec", "replicas")),
+                    "default pool replicas is 1");
+            assertEquals(pool, K8s.nestedString(createdPool, "metadata", "name"),
+                    "default pool name is the slug");
+
+            Map<String, Object> createdSb = Json.parseObject(sandboxBody.get());
+            assertEquals(pool,
+                    K8s.nestedString(createdSb, "spec", "source", "poolRef", "name"),
+                    "sandbox spec.source.poolRef.name is the pool");
+        }
+        ok("sandbox(image) get-or-creates the default pool, then creates a Sandbox from it");
+    }
+
+    // sandbox(image) reuses a pre-existing default pool untouched when its inline
+    // image matches: only a GET (200) on the pool and a POST on the sandbox.
+    private static void testSandboxReusesExistingPool() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        String pool = AgentRun.defaultPoolName("busybox");
+        java.util.concurrent.atomic.AtomicInteger poolCreates = new java.util.concurrent.atomic.AtomicInteger();
+
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxpools/" + pool,
+                ex -> SdkTest.json(ex, 200,
+                        "{\"metadata\":{\"name\":\"" + pool + "\"},"
+                                + "\"spec\":{\"template\":{\"image\":\"busybox\"},\"replicas\":1}}"));
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxpools", ex -> {
+            poolCreates.incrementAndGet();
+            SdkTest.json(ex, 201, "{}");
+        });
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxes",
+                ex -> SdkTest.json(ex, 201, "{\"metadata\":{\"name\":\"sb-reuse\"}}"));
+
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterSandbox sb = agent.sandbox("busybox");
+            assertEquals(pool, sb.pool(), "reused pool name");
+            assertEquals(0, poolCreates.get(), "an existing matching pool is not re-created");
+        }
+        ok("sandbox(image) reuses a matching pre-existing default pool untouched");
+    }
+
+    // A 409 on the pool create (a concurrent creator won the race) is tolerated:
+    // the pool is reused and the sandbox is still created.
+    private static void testSandboxToleratesPoolConflict() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        String pool = AgentRun.defaultPoolName("alpine");
+
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxpools/" + pool,
+                ex -> SdkTest.json(ex, 404,
+                        "{\"reason\":\"NotFound\",\"message\":\"not found\",\"code\":404}"));
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxpools",
+                ex -> SdkTest.json(ex, 409,
+                        "{\"reason\":\"AlreadyExists\",\"message\":\"already exists\",\"code\":409}"));
+        java.util.concurrent.atomic.AtomicInteger sbCreates = new java.util.concurrent.atomic.AtomicInteger();
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxes", ex -> {
+            sbCreates.incrementAndGet();
+            SdkTest.json(ex, 201, "{\"metadata\":{\"name\":\"sb-409\"}}");
+        });
+
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterSandbox sb = agent.sandbox("alpine");
+            assertEquals(pool, sb.pool(), "pool reused after 409");
+            assertEquals(1, sbCreates.get(), "the sandbox is still created after a tolerated 409");
+        }
+        ok("a 409 on the default-pool create is tolerated and the pool is reused");
+    }
+
+    // create() with an explicit pool, env, secret, ttl, and workspace writes the
+    // expected Sandbox spec shape.
+    private static void testCreateWritesPoolRef() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        AtomicReference<String> body = new AtomicReference<>();
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/sandboxes", ex -> {
+            body.set(SdkTest.readBody(ex));
+            SdkTest.json(ex, 201, "{\"metadata\":{\"name\":\"worker-1\"}}");
+        });
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterSandbox sb = agent.create(SandboxParams.builder()
+                    .pool("my-pool")
+                    .name("worker-1")
+                    .env("MODE", "fast")
+                    .secret("API_KEY", "creds", "key")
+                    .ttl("30m")
+                    .workspace("ws-main")
+                    .build());
+            assertEquals("worker-1", sb.name(), "explicit sandbox name");
+            assertEquals("my-pool", sb.pool(), "explicit pool");
+
+            Map<String, Object> created = Json.parseObject(body.get());
+            assertEquals("Sandbox", created.get("kind"), "kind is Sandbox");
+            assertEquals("my-pool",
+                    K8s.nestedString(created, "spec", "source", "poolRef", "name"),
+                    "spec.source.poolRef.name");
+            assertEquals("30m", K8s.nestedString(created, "spec", "lifetime", "ttl"),
+                    "spec.lifetime.ttl");
+            assertEquals("ws-main", K8s.nestedString(created, "spec", "workspaceRef", "name"),
+                    "spec.workspaceRef.name");
+            List<Object> env = K8s.asList(K8s.nested(created, "spec", "env"));
+            assertEquals(1, env.size(), "one env entry");
+            assertEquals("MODE", K8s.nestedString(K8s.asMap(env.get(0)), "name"), "env name");
+            assertEquals("fast", K8s.nestedString(K8s.asMap(env.get(0)), "value"), "env value");
+            List<Object> secrets = K8s.asList(K8s.nested(created, "spec", "secrets"));
+            assertEquals(1, secrets.size(), "one secret entry");
+            assertEquals("creds",
+                    K8s.nestedString(K8s.asMap(secrets.get(0)), "secretRef", "name"),
+                    "secret references the secret name");
+            assertEquals("key",
+                    K8s.nestedString(K8s.asMap(secrets.get(0)), "secretRef", "key"),
+                    "secret references the secret key");
+        }
+        ok("create() writes spec.source.poolRef plus env/secrets/ttl/workspace");
+    }
+
+    // get(name) reads spec.source.poolRef and status.phase.
+    private static void testGetReadsPoolRefAndPhase() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxes/sb-get",
+                ex -> SdkTest.json(ex, 200,
+                        "{\"metadata\":{\"name\":\"sb-get\"},"
+                                + "\"spec\":{\"source\":{\"poolRef\":{\"name\":\"pool-a\"}}},"
+                                + "\"status\":{\"phase\":\"Pending\",\"endpoint\":\"\"}}"));
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterSandbox sb = agent.get("sb-get");
+            assertEquals("sb-get", sb.name(), "get name");
+            assertEquals("pool-a", sb.pool(), "get reads spec.source.poolRef.name");
+            assertEquals(SandboxPhase.PENDING, sb.phase(), "get reads status.phase");
+
+            // fromName is an alias for get.
+            ClusterSandbox same = agent.fromName("sb-get");
+            assertEquals("pool-a", same.pool(), "fromName aliases get");
+        }
+        ok("get/fromName read spec.source.poolRef and status.phase");
+    }
+
+    // list(pool) returns only the sandboxes whose poolRef matches the filter.
+    private static void testListFiltersByPool() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxes",
+                ex -> SdkTest.json(ex, 200,
+                        "{\"items\":["
+                                + "{\"metadata\":{\"name\":\"a\"},\"spec\":{\"source\":{\"poolRef\":{\"name\":\"p1\"}}},"
+                                + "\"status\":{\"phase\":\"Ready\",\"endpoint\":\"10.0.0.1:9091\"}},"
+                                + "{\"metadata\":{\"name\":\"b\"},\"spec\":{\"source\":{\"poolRef\":{\"name\":\"p2\"}}},"
+                                + "\"status\":{\"phase\":\"Pending\"}}"
+                                + "]}"));
+        // 'a' is Ready, so list() loads its token Secret; serve an empty 404 so
+        // the tokenless path is exercised without leaking anything.
+        stub.handle("GET", "/api/v1/namespaces/default/secrets/a-sandbox-token",
+                ex -> SdkTest.json(ex, 404, "{\"reason\":\"NotFound\",\"code\":404}"));
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            List<ClusterSandbox> all = agent.list(null);
+            assertEquals(2, all.size(), "list(null) returns every sandbox");
+            List<ClusterSandbox> filtered = agent.list("p2");
+            assertEquals(1, filtered.size(), "list(pool) filters by pool");
+            assertEquals("b", filtered.get(0).name(), "filtered sandbox is the p2 one");
+        }
+        ok("list(pool) filters by spec.source.poolRef.name");
+    }
+
+    // poolStatus reads status.readySnapshots, spec.replicas, and
+    // status.nodeDistribution.
+    private static void testPoolStatusReadsStatus() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxpools/p-stat",
+                ex -> SdkTest.json(ex, 200,
+                        "{\"metadata\":{\"name\":\"p-stat\"},"
+                                + "\"spec\":{\"replicas\":3},"
+                                + "\"status\":{\"readySnapshots\":2,"
+                                + "\"nodeDistribution\":{\"node-a\":1,\"node-b\":1}}}"));
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            PoolStatus status = agent.poolStatus("p-stat");
+            assertEquals("p-stat", status.name(), "pool status name");
+            assertEquals(2, status.readySnapshots(), "pool status readySnapshots");
+            assertEquals(3, status.desired(), "pool status desired from spec.replicas");
+            assertEquals(2, status.nodeDistribution().size(), "node distribution size");
+            assertEquals(1, status.nodeDistribution().get("node-a"), "node-a count");
+        }
+        ok("poolStatus reads readySnapshots, replicas, and nodeDistribution");
+    }
+
+    // A Ready sandbox loads its per-sandbox token from <name>-sandbox-token, and
+    // the token value is reachable via token() but never appears in toString().
+    private static void testReadyTokenFromSecretNeverLogged() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        String secret = "tok-abc-123-never-logged";
+        String tokenB64 = java.util.Base64.getEncoder()
+                .encodeToString(secret.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/sandboxes/sb-ready",
+                ex -> SdkTest.json(ex, 200,
+                        "{\"metadata\":{\"name\":\"sb-ready\"},"
+                                + "\"spec\":{\"source\":{\"poolRef\":{\"name\":\"p\"}}},"
+                                + "\"status\":{\"phase\":\"Ready\",\"endpoint\":\"10.0.0.9:9091\"}}"));
+        stub.handle("GET", "/api/v1/namespaces/default/secrets/sb-ready-sandbox-token",
+                ex -> SdkTest.json(ex, 200,
+                        "{\"data\":{\"token\":\"" + tokenB64 + "\"}}"));
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterSandbox sb = agent.get("sb-ready");
+            assertEquals(SandboxPhase.READY, sb.phase(), "sandbox is Ready");
+            assertEquals(secret, sb.token(), "token is decoded from the Secret");
+            assertTrue(!sb.toString().contains(secret),
+                    "the token value never appears in toString(): " + sb.toString());
+        }
+        ok("a Ready sandbox loads its token Secret; the token never appears in toString()");
+    }
+
+    // createWorkspace POSTs a Workspace; getWorkspace on an absent name raises a
+    // typed workspace_not_found.
+    private static void testWorkspaceCreateAndNotFound() throws Exception {
+        SdkTest.Stub stub = new SdkTest.Stub();
+        AtomicReference<String> body = new AtomicReference<>();
+        stub.handle("POST", "/apis/mitos.run/v1/namespaces/default/workspaces", ex -> {
+            body.set(SdkTest.readBody(ex));
+            SdkTest.json(ex, 201, "{\"metadata\":{\"name\":\"ws1\"}}");
+        });
+        stub.handle("GET", "/apis/mitos.run/v1/namespaces/default/workspaces/missing",
+                ex -> SdkTest.json(ex, 404,
+                        "{\"reason\":\"NotFound\",\"message\":\"not found\",\"code\":404}"));
+        try (stub) {
+            AgentRun agent = agentFor(stub);
+            ClusterWorkspace ws = agent.createWorkspace("ws1");
+            assertEquals("ws1", ws.name(), "created workspace name");
+            Map<String, Object> created = Json.parseObject(body.get());
+            assertEquals("Workspace", created.get("kind"), "kind is Workspace");
+
+            MitosException thrown = null;
+            try {
+                agent.getWorkspace("missing");
+            } catch (MitosException e) {
+                thrown = e;
+            }
+            assertTrue(thrown != null, "getWorkspace on an absent name throws");
+            assertEquals("workspace_not_found", thrown.getCode(), "typed workspace_not_found code");
+            assertEquals(404, thrown.getStatus(), "workspace_not_found carries status 404");
+        }
+        ok("createWorkspace POSTs a Workspace; getWorkspace raises workspace_not_found");
+    }
+
+    // agentFor wires an AgentRun at the in-process stub via the K8s.of seam,
+    // tokenless, in the default namespace, with the default-pool path enabled.
+    private static AgentRun agentFor(SdkTest.Stub stub) {
+        K8s k8s = K8s.of(stub.url(), null, HttpClient.newHttpClient());
+        return AgentRun.of(k8s, "default", true);
+    }
+}

--- a/sdk/java/src/test/java/run/mitos/sdk/SdkTest.java
+++ b/sdk/java/src/test/java/run/mitos/sdk/SdkTest.java
@@ -42,6 +42,11 @@ public final class SdkTest {
         testErrorEnvelopeParsed();
         testTokenNeverInExceptionMessage();
 
+        // Cluster mode (AgentRun) tests run against the same in-process HttpServer
+        // stub, reproducing the Kubernetes custom-resource REST wire shapes. They
+        // share the assert helpers and Stub harness below via package-private hooks.
+        ClusterTest.run();
+
         System.out.println();
         System.out.println("RESULT: " + passed + " passed, " + failed + " failed");
         if (failed > 0) {
@@ -283,17 +288,17 @@ public final class SdkTest {
 
     // ---- tiny assert + stub harness ----
 
-    private static void ok(String name) {
+    static void ok(String name) {
         passed++;
         System.out.println("PASS: " + name);
     }
 
-    private static void fail(String name) {
+    static void fail(String name) {
         failed++;
         System.out.println("FAIL: " + name);
     }
 
-    private static void assertTrue(boolean cond, String name) {
+    static void assertTrue(boolean cond, String name) {
         if (cond) {
             return;
         }
@@ -301,7 +306,7 @@ public final class SdkTest {
         throw new AssertionError(name);
     }
 
-    private static void assertEquals(Object expected, Object actual, String name) {
+    static void assertEquals(Object expected, Object actual, String name) {
         if (expected == null ? actual == null : expected.equals(actual)) {
             return;
         }
@@ -377,7 +382,7 @@ public final class SdkTest {
         }
     }
 
-    private static void json(HttpExchange ex, int status, String body) throws IOException {
+    static void json(HttpExchange ex, int status, String body) throws IOException {
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         ex.getResponseHeaders().add("Content-Type", "application/json");
         ex.sendResponseHeaders(status, bytes.length);
@@ -386,7 +391,7 @@ public final class SdkTest {
         }
     }
 
-    private static String readBody(HttpExchange ex) throws IOException {
+    static String readBody(HttpExchange ex) throws IOException {
         return new String(ex.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
     }
 


### PR DESCRIPTION
## What

Ports the Python `AgentRun` cluster surface to the Java SDK, bringing it to parity with the Python and TypeScript SDKs. The new `AgentRun` drives the `mitos.run/v1` CRDs (`SandboxPool`, `Sandbox`, `Workspace`) directly: the lazy `sandbox(image)` default-pool path, `create` with env/secrets/ttl/workspace, `get`/`fromName`/`list`, `poolStatus`, `waitUntilReady`/`info`/`terminate`, and the workspace verbs (`createWorkspace`/`workspace`/`getWorkspace`/`listWorkspaces`, `head`/`resumable`/`log`).

## Dependency-free, no-maven-buildable (hard constraint, preserved)

Cluster mode is built on the JDK standard library alone:

- `java.net.http.HttpClient` for the Kubernetes REST API.
- `javax.net.ssl` / `SSLContext` for the cluster CA trust and client-certificate mutual TLS (kind, minikube).
- `java.util.Base64` for the service-account and Secret payloads.
- The existing hand-rolled `Json` helper is reused for every request and response body (no JSON dependency added).
- A new minimal kubeconfig YAML reader (`Yaml.java`) so no YAML library is pulled in.

It does NOT use fabric8 or the official Kubernetes client. Direct mode (`SandboxServer`) is entirely untouched and pulls in none of this. CI still compiles with plain `javac --release 17` and runs `java -cp out run.mitos.sdk.SdkTest`.

## Correctness

- `defaultPoolName` matches the Python slug byte-for-byte, including applying the 40-char bound BEFORE stripping `-.` (Python `slug[:40].strip("-.")`). All 7 vectors from the issue are asserted.
- In-cluster auth (service-account token + mounted CA) is fully supported; kubeconfig parses a common subset (current context server, CA inline or file, bearer token or inline client cert/key). Exec credential plugins and auth-provider blocks are out of scope and documented.
- The per-sandbox token is read from the `<name>-sandbox-token` Secret, held in memory only, and never logged (never appears in `toString`).

## Tests

`ClusterTest` extends the existing main-based `SdkTest` runner (`SdkTest.main` calls `ClusterTest.run()`), so the same CI flow runs it. It asserts the 7 `defaultPoolName` vectors and exercises the CRD ops against a mock Kubernetes API server built on the JDK `com.sun.net.httpserver.HttpServer`: `sandbox()` get-or-creates the pool (body + path), `create()` writes the `poolRef` plus env/secrets/ttl/workspace, `get`/`fromName`/`list` read `spec.source.poolRef`, a 409 on the pool create is tolerated, `poolStatus` reads status, the token Secret decodes and never leaks, and a minimal kubeconfig parses. The direct-mode assertions are unchanged.

Result of the exact CI commands:

```
javac --release 17 -d out @sources.txt   # clean
java -cp out run.mitos.sdk.SdkTest        # RESULT: 22 passed, 0 failed / ALL GREEN
```

## Docs

`README.md` gains a world-class cluster-mode section (AgentRun usage, the in-cluster and kubeconfig auth modes table, a runnable example, default-pool naming) and the SDK-family table now lists Java as direct + cluster. The "Python/TS only" wording is removed from the pom description and the README scope.

Closes #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)