### PR TITLE
docs: all six SDKs have cluster mode (AgentRun parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ sb.terminate()
 
 ### Languages and modes
 
-Every SDK speaks the same sandbox-server REST API in **direct mode** (standalone or hosted). **Cluster mode** (drive the CRDs) is in Python and TypeScript today; the others are tracked.
+Every SDK speaks the same sandbox-server REST API in **direct mode** (standalone or hosted), and every SDK now also has **cluster mode** (an `AgentRun` that drives the `mitos.run/v1` CRDs through the Kubernetes API). The default-pool naming is byte-for-byte identical across all six.
 
 | Language | Install | Direct mode | Cluster mode | SDK docs |
 |---|---|---|---|---|
 | Python | `pip install mitos-run` | yes (sync + async) | yes (`AgentRun`) | [sdk/python](sdk/python) |
 | TypeScript | `npm i @mitos/sdk` | yes | yes (`AgentRun`) | [sdk/typescript](sdk/typescript/README.md) |
-| Go | `go get github.com/mitos-run/mitos/sdk/go` | yes (typed, `errors.Is`-friendly) | planned | [sdk/go](sdk/go/README.md) |
-| Ruby | gem (stdlib only) | yes | planned | [sdk/ruby](sdk/ruby/README.md) |
-| Rust | crate (blocking) | yes | planned | [sdk/rust](sdk/rust/README.md) |
-| Java | JDK 17 (stdlib only) | yes | planned | [sdk/java](sdk/java/README.md) |
+| Go | `go get github.com/mitos-run/mitos/sdk/go` | yes (typed, `errors.Is`-friendly) | yes (`AgentRun`) | [sdk/go](sdk/go/README.md) |
+| Ruby | gem (stdlib only) | yes | yes (`AgentRun`) | [sdk/ruby](sdk/ruby/README.md) |
+| Rust | crate (blocking) | yes | yes (`AgentRun`) | [sdk/rust](sdk/rust/README.md) |
+| Java | JDK 17 (stdlib only) | yes | yes (`AgentRun`) | [sdk/java](sdk/java/README.md) |
 
 The Go SDK ships in its own nested module (`github.com/mitos-run/mitos/sdk/go`), so importing it never pulls the controller into your build.
 

--- a/docs/open-core.md
+++ b/docs/open-core.md
@@ -8,8 +8,8 @@ what exists today.
 
 Everything in this repository is open source under the Apache License 2.0 (see
 the `LICENSE` file at the repository root). This includes the controller,
-forkd, the guest agent, sandbox-server, the Python and TypeScript SDKs, the
-CRDs, and all documentation. You can run, modify, and redistribute it under the
+forkd, the guest agent, sandbox-server, the SDKs (Python, TypeScript, Go, Ruby,
+Rust, Java), the CRDs, and all documentation. You can run, modify, and redistribute it under the
 terms of Apache 2.0.
 
 ## Open-core boundary


### PR DESCRIPTION
The Go, Ruby, Rust, and Java SDKs shipped Kubernetes cluster mode (AgentRun), reaching parity with Python and TypeScript. This updates the docs to match.

- README SDK matrix: Go, Ruby, Rust, Java cluster mode flipped from "planned" to "yes (AgentRun)", and the intro line now states all six SDKs have cluster mode with byte-for-byte identical default-pool naming.
- docs/open-core.md: the open-source component list now names all six SDKs.

Closes the doc-parity follow-up to #303, #304, #305, #306. Per-SDK READMEs already carry their cluster-mode sections (added in the implementation PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)