### PR TITLE
feat(console): Phase B2b views (keys, secrets, usage, audit, templates, billing)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-console-b2b-views.md
+++ b/docs/superpowers/plans/2026-06-25-console-b2b-views.md
@@ -1,0 +1,508 @@
+# Console B2b: read/manage views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Do NOT invoke finishing-a-development-branch; just implement, test, commit, and report.
+
+**Goal:** Build the remaining over-existing-BFF views: API keys (create-once + revoke), Secrets (create write-only + delete), Usage & cost, Audit, Templates, and Billing (hosted). Replace their placeholders with real, polished, accessible views.
+
+**Architecture:** Frontend-only on the merged B0/B1/B2a console. Every endpoint exists: `GET/POST /console/keys`, `POST /console/keys/{id}/revoke`, `GET/POST /console/secrets`, `DELETE /console/secrets/{name}`, `GET /console/usage`, `GET /console/audit`, `GET /console/templates`, `GET /console/billing`, `GET /console/billing/portal`. Members (roles) is B2c; Workspaces has no BFF endpoint and stays an honest placeholder.
+
+**Tech Stack:** React 18 + Vite + TS strict, TanStack Router + Query (+ mutations), `@mitos/brand`, Vitest + Testing Library + vitest-axe.
+
+**Scope note:** B2b of the B2 split. B2c (roles + Projects + Members), B2d (profile), B3 (enterprise) follow.
+
+## Global Constraints
+
+- **Punctuation (strict):** no em (U+2014) or en (U+2013) dashes anywhere. Only `.` `,` `;` `:`; ASCII `-` for compounds. Verify each commit: `grep -rnP '\xe2\x80\x94|\xe2\x80\x93'` on changed files empty.
+- **Commits:** conventional + DCO sign-off (`git commit -s`).
+- **Staging:** explicit paths only; never `git add -A`.
+- **Secrets rule (load-bearing):** a raw API key value is shown EXACTLY ONCE on create (a `CopyOnce` affordance) and never again; the list shows only the masked prefix. A secret VALUE is never rendered or returned; the secret view shows only name/provider/version/fingerprint (write-only after create). No secret value in any log.
+- **Integrity:** views render only real BFF data; no fabricated numbers.
+- **Capability gating:** Billing mounts only when `caps.billing` (already gated in the routes config); keep it.
+- **Responsive + accessible (spec 4.6), every view:** tables reflow on mobile; forms are labelled; AA contrast (tokens); axe asserts zero violations.
+- **TypeScript strict** clean; SPA suite exits 0.
+
+## File Structure
+
+- `web/app/src/api.ts` (modify) - add typed shapes (`KeyView`, `UsageResponse`, `AuditEvent`, `TemplateView`, `BillingView`) + methods (`keys`, `createKey`, `revokeKey`, `usage`, `audit`, `templates`, `billing`, `billingPortal`).
+- `web/app/src/data/account.ts` (create) - hooks: `useKeys`, `useCreateKey`, `useRevokeKey`, `useUsage`, `useAudit`, `useTemplates`, `useBilling`.
+- `web/app/src/ui/CopyOnce.tsx` (create) - shows a one-time secret value with a copy button and a dismissable banner.
+- `web/app/src/views/Keys.tsx`, `Usage.tsx`, `Audit.tsx`, `Templates.tsx`, `Billing.tsx` (create); `web/app/src/views/Secrets.tsx` (modify, make real).
+- `web/app/src/nav/routes.tsx` (modify) - point `/keys`, `/usage`, `/audit`, `/templates`, `/billing`, `/secrets` at the real views.
+- `web/packages/brand/src/base.css` (modify) - form, badge, and ledger styles.
+- Tests alongside.
+
+---
+
+### Task 1: Data layer + CopyOnce primitive
+
+**Files:**
+- Modify: `web/app/src/api.ts`
+- Create: `web/app/src/data/account.ts`
+- Create: `web/app/src/ui/CopyOnce.tsx`
+- Test: `web/app/src/data/account.test.tsx`, `web/app/src/ui/CopyOnce.test.tsx`
+
+**Interfaces (match the Go BFF JSON exactly):**
+- `KeyView = { id, name, prefix, scopes: string[], created_at, expires_at?, revoked_at?, revoked: boolean }`.
+- `CreateKeyResult = { org_id, raw_key, key: KeyView }`.
+- `UsageResponse = { org_id, records: unknown[], totals: Record<string, number>, cost: Record<string, number> }` (render totals/cost; records can be summarized).
+- `AuditEvent = { org_id, actor_id, action, target, detail, at }`.
+- `TemplateView = { name, org_id, description, image, updated_at }`.
+- `BillingView = { org_id, status, balance_cents, spend_cents, soft_cap_cents, hard_cap_cents, ledger_entries: Array<{ ts?: string; cents?: number; reason?: string }> }`.
+- Hooks in `account.ts`: `useKeys()`, `useCreateKey()` (returns the raw key once; invalidates `['keys']`), `useRevokeKey()` (optimistic), `useUsage()`, `useAudit()`, `useTemplates()`, `useBilling()`.
+- `CopyOnce({ value, label })` - renders the value in a mono box with a Copy button and an explicit "shown once" warning.
+
+- [ ] **Step 1: Write the failing tests**
+
+`web/app/src/data/account.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useKeys } from './account'
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useKeys', () => {
+  it('lists api keys (masked)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ org_id: 'o', keys: [{ id: 'k1', name: 'ci', prefix: 'mitos_live_ab12', scopes: ['sandboxes'], created_at: '', revoked: false }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    const { result } = renderHook(() => useKeys(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.[0].prefix).toBe('mitos_live_ab12')
+  })
+})
+```
+
+`web/app/src/ui/CopyOnce.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CopyOnce } from './CopyOnce'
+
+describe('CopyOnce', () => {
+  it('shows the value once and copies it', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<CopyOnce value="mitos_live_secret123" label="API key" />)
+    expect(screen.getByText('mitos_live_secret123')).toBeInTheDocument()
+    expect(screen.getByText(/shown once/i)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /copy/i }))
+    expect(writeText).toHaveBeenCalledWith('mitos_live_secret123')
+  })
+})
+```
+
+- [ ] **Step 2: Run both, confirm they fail**
+
+Run: `pnpm -C web/app test src/data/account.test.tsx src/ui/CopyOnce.test.tsx`
+Expected: FAIL (modules not found).
+
+- [ ] **Step 3: Extend `web/app/src/api.ts`**
+
+Add the types above and the methods (use the existing `get<T>` helper for reads; raw fetch for the mutations). For example:
+
+```ts
+export type KeyView = { id: string; name: string; prefix: string; scopes: string[]; created_at: string; expires_at?: string; revoked_at?: string; revoked: boolean }
+export type CreateKeyResult = { org_id: string; raw_key: string; key: KeyView }
+export type AuditEvent = { org_id: string; actor_id: string; action: string; target: string; detail: string; at: string }
+export type TemplateView = { name: string; org_id: string; description: string; image: string; updated_at: string }
+export type UsageResponse = { org_id: string; records: unknown[]; totals: Record<string, number>; cost: Record<string, number> }
+export type BillingView = { org_id: string; status: string; balance_cents: number; spend_cents: number; soft_cap_cents: number; hard_cap_cents: number; ledger_entries: Array<{ ts?: string; cents?: number; reason?: string }> }
+```
+
+Add to `api`:
+
+```ts
+  keys: () => get<{ keys: KeyView[] }>('/console/keys').then((r) => r.keys ?? []),
+  createKey: async (name: string, scopes: string[], ttlSeconds: number) => {
+    const r = await fetch('/console/keys', { method: 'POST', credentials: 'same-origin', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name, scopes, ttl_seconds: ttlSeconds }) })
+    if (!r.ok) throw new Error(`create key: ${r.status}`)
+    return (await r.json()) as CreateKeyResult
+  },
+  revokeKey: async (id: string) => {
+    const r = await fetch(`/console/keys/${encodeURIComponent(id)}/revoke`, { method: 'POST', credentials: 'same-origin' })
+    if (!r.ok) throw new Error(`revoke: ${r.status}`)
+  },
+  usage: () => get<UsageResponse>('/console/usage?from=&to='),
+  audit: () => get<{ events: AuditEvent[] }>('/console/audit').then((r) => r.events ?? []),
+  templates: () => get<{ templates: TemplateView[] }>('/console/templates').then((r) => r.templates ?? []),
+  billing: () => get<BillingView>('/console/billing'),
+  billingPortal: () => get<{ url: string }>('/console/billing/portal').then((r) => r.url),
+```
+
+(Adjust the usage query string if the endpoint requires RFC3339 `from`/`to`; an empty range returns all per the BFF.)
+
+- [ ] **Step 4: Implement `web/app/src/data/account.ts`**
+
+```ts
+// Account-scoped data: api keys (with the create-once flow), usage, audit,
+// templates, and billing. Mutations invalidate their list; revoke is optimistic.
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api, type KeyView, type AuditEvent, type TemplateView, type UsageResponse, type BillingView } from '../api'
+
+export function useKeys() { return useQuery<KeyView[]>({ queryKey: ['keys'], queryFn: () => api.keys() }) }
+export function useUsage() { return useQuery<UsageResponse>({ queryKey: ['usage'], queryFn: () => api.usage() }) }
+export function useAudit() { return useQuery<AuditEvent[]>({ queryKey: ['audit'], queryFn: () => api.audit() }) }
+export function useTemplates() { return useQuery<TemplateView[]>({ queryKey: ['templates'], queryFn: () => api.templates() }) }
+export function useBilling() { return useQuery<BillingView>({ queryKey: ['billing'], queryFn: () => api.billing() }) }
+
+export function useCreateKey() {
+  const qc = useQueryClient()
+  return useMutation({ mutationFn: (v: { name: string; scopes: string[]; ttlSeconds: number }) => api.createKey(v.name, v.scopes, v.ttlSeconds), onSuccess: () => void qc.invalidateQueries({ queryKey: ['keys'] }) })
+}
+
+export function useRevokeKey() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => api.revokeKey(id),
+    onMutate: async (id: string) => {
+      await qc.cancelQueries({ queryKey: ['keys'] })
+      const prev = qc.getQueryData<KeyView[]>(['keys'])
+      qc.setQueryData<KeyView[]>(['keys'], (cur) => (cur ?? []).map((k) => (k.id === id ? { ...k, revoked: true } : k)))
+      return { prev }
+    },
+    onError: (_e, _id, ctx) => { if (ctx?.prev) qc.setQueryData(['keys'], ctx.prev) },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ['keys'] }),
+  })
+}
+```
+
+- [ ] **Step 5: Implement `web/app/src/ui/CopyOnce.tsx`**
+
+```tsx
+// One-time secret reveal: shows a value with a copy button and an explicit
+// "shown once" warning. Used for the raw API key on create. The caller is
+// responsible for never persisting the value.
+import { useState } from 'react'
+
+export function CopyOnce({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="card" style={{ borderColor: 'var(--amber)' }}>
+      <div className="t-dim" style={{ fontSize: 'var(--step--1)' }}>{label} (shown once, store it now)</div>
+      <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center', marginTop: 'var(--space-2)' }}>
+        <code className="mono" style={{ flex: 1, overflowX: 'auto' }}>{value}</code>
+        <button className="btn btn-ghost" onClick={() => { void navigator.clipboard.writeText(value); setCopied(true) }}>{copied ? 'Copied' : 'Copy'}</button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: Run the tests, confirm pass; typecheck**
+
+Run: `pnpm -C web/app test src/data/account.test.tsx src/ui/CopyOnce.test.tsx && pnpm -C web/app typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/app/src/api.ts web/app/src/data/account.ts web/app/src/ui/CopyOnce.tsx web/app/src/data/account.test.tsx web/app/src/ui/CopyOnce.test.tsx
+git commit -s -m "feat(console): account data layer (keys, usage, audit, templates, billing) and CopyOnce"
+```
+
+---
+
+### Task 2: API keys view
+
+**Files:**
+- Create: `web/app/src/views/Keys.tsx`
+- Modify: `web/app/src/nav/routes.tsx` (point `/keys` at `Keys`)
+- Test: `web/app/src/views/Keys.test.tsx`
+
+**Interfaces:**
+- Consumes: `useKeys`, `useCreateKey`, `useRevokeKey` (Task 1), `CopyOnce`, `useToast`, `Skeleton`/`EmptyState`.
+- Produces: `Keys` view: a create form (name, scopes checkboxes for `sandboxes`/`read`, TTL select), the raw key shown once via `CopyOnce` after create, a masked-prefix table with Revoke per row.
+
+- [ ] **Step 1: Write the failing test `web/app/src/views/Keys.test.tsx`**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = { edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc', orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted' }
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input)
+    if (url.endsWith('/console/capabilities')) return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/keys') && init?.method === 'POST') return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', raw_key: 'mitos_live_RAWSECRET', key: { id: 'k2', name: 'new', prefix: 'mitos_live_new1', scopes: ['read'], created_at: '', revoked: false } }), { status: 201, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/keys')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', keys: [{ id: 'k1', name: 'ci', prefix: 'mitos_live_ab12', scopes: ['sandboxes'], created_at: '', revoked: false }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('Keys view', () => {
+  it('lists masked keys and reveals a raw key once on create', async () => {
+    await renderAt('/keys', caps)
+    await waitFor(() => expect(screen.getByText('mitos_live_ab12')).toBeInTheDocument())
+    await userEvent.type(screen.getByLabelText(/name/i), 'new')
+    await userEvent.click(screen.getByRole('button', { name: /create key/i }))
+    await waitFor(() => expect(screen.getByText('mitos_live_RAWSECRET')).toBeInTheDocument())
+    expect(screen.getByText(/shown once/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `pnpm -C web/app test src/views/Keys.test.tsx`
+Expected: FAIL (placeholder renders, no create form).
+
+- [ ] **Step 3: Implement `web/app/src/views/Keys.tsx`**
+
+Render: a `<form>` with a name `<input aria-label="Key name">`, scope checkboxes (`sandboxes`, `read`), a TTL `<select>` (never / 30d / 90d), and a `Create key` submit; on success render `<CopyOnce value={result.raw_key} label="API key">`; a masked table (Name, Prefix, Scopes, Created, status) with a `Revoke` button per non-revoked key (optimistic via `useRevokeKey`, toast). Loading `Skeleton`, empty `EmptyState`. The raw key is held in component state only and cleared when dismissed; never refetched.
+
+(Implementer writes the full component; the test pins the list + create-once behavior.)
+
+- [ ] **Step 4: Point `/keys` at the view in `web/app/src/nav/routes.tsx`**
+
+Import `Keys`, change the `/keys` route element from the placeholder to `() => <Keys />`.
+
+- [ ] **Step 5: Run the test, full suite, typecheck**
+
+Run: `pnpm -C web/app test src/views/Keys.test.tsx && pnpm -C web/app test && pnpm -C web/app typecheck`
+Expected: all PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/app/src/views/Keys.tsx web/app/src/nav/routes.tsx web/app/src/views/Keys.test.tsx
+git commit -s -m "feat(console): API keys view with create-once reveal and revoke"
+```
+
+---
+
+### Task 3: Secrets view (real)
+
+**Files:**
+- Modify: `web/app/src/views/Secrets.tsx`
+- Modify: `web/app/src/nav/routes.tsx` (ensure `/secrets` points at the real view if not already)
+- Test: `web/app/src/views/Secrets.test.tsx`
+
+**Interfaces:**
+- Consumes: the existing `api.secrets`/`api.createSecret`/`api.deleteSecret` (already in `api.ts`); `useToast`; `Skeleton`/`EmptyState`.
+- Produces: `Secrets` view: a create form (name + value, write-only), a table (Name, Provider, Version, Fingerprint) with Delete per row; the value field is never echoed back after create.
+
+- [ ] **Step 1: Write the failing test `web/app/src/views/Secrets.test.tsx`**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = { edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc', orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted' }
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input)
+    if (url.endsWith('/console/capabilities')) return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/secrets')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', secrets: [{ name: 'OPENAI_API_KEY', org_id: 'o', provider: 'kube', mode: 'copy-in', version: 2, fingerprint: 'ab12cd34' }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('Secrets view', () => {
+  it('lists secrets without revealing values', async () => {
+    await renderAt('/secrets', caps)
+    await waitFor(() => expect(screen.getByText('OPENAI_API_KEY')).toBeInTheDocument())
+    expect(screen.getByText('kube')).toBeInTheDocument()
+    expect(screen.getByText('ab12cd34')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run it, confirm it fails (or that the old view does not match)**
+
+Run: `pnpm -C web/app test src/views/Secrets.test.tsx`
+Expected: FAIL until the view renders the table with provider + fingerprint columns.
+
+- [ ] **Step 3: Implement the real `web/app/src/views/Secrets.tsx`**
+
+Render: a create `<form>` (name `<input>`, value `<input type="password">`, Create button); on submit call `api.createSecret(name, value)` then clear the value field (never echo it); a table (Name, Provider, Mode, Version, Fingerprint) with Delete per row (toast on result). Loading `Skeleton`, empty `EmptyState` ("No secrets yet"). The value is write-only: after create only metadata shows.
+
+(Implementer writes it using the existing `api.secrets`/`createSecret`/`deleteSecret`; the test pins the no-value-reveal list.)
+
+- [ ] **Step 4: Ensure `/secrets` points at the view; run test, full suite, typecheck**
+
+Run: `pnpm -C web/app test src/views/Secrets.test.tsx && pnpm -C web/app test && pnpm -C web/app typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/src/views/Secrets.tsx web/app/src/nav/routes.tsx web/app/src/views/Secrets.test.tsx
+git commit -s -m "feat(console): real Secrets view (write-only create, delete, metadata table)"
+```
+
+---
+
+### Task 4: Usage, Audit, Templates, Billing views
+
+**Files:**
+- Create: `web/app/src/views/Usage.tsx`, `web/app/src/views/Audit.tsx`, `web/app/src/views/Templates.tsx`, `web/app/src/views/Billing.tsx`
+- Modify: `web/app/src/nav/routes.tsx` (point the four routes at the views)
+- Test: `web/app/src/views/ReadViews.test.tsx`
+
+**Interfaces:**
+- Consumes: `useUsage`, `useAudit`, `useTemplates`, `useBilling` (Task 1); `Skeleton`/`EmptyState`; `fmtBytes`.
+- Produces: four views: Usage (totals + cost summary tiles or table), Audit (filterable event table: actor, action, target, time), Templates (table: name, image, description, updated), Billing (status, balance, spend, caps, ledger table + a Manage billing portal link).
+
+- [ ] **Step 1: Write the failing test `web/app/src/views/ReadViews.test.tsx`**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = { edition: 'community', billing: true, signup: false, teams: true, idp: 'oidc', orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'hosted' }
+
+function mockFor(map: Record<string, unknown>) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input).split('?')[0]
+    const key = Object.keys(map).find((k) => url.endsWith(k))
+    return Promise.resolve(new Response(JSON.stringify(key ? map[key] : {}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+}
+
+beforeEach(() => {
+  mockFor({
+    '/console/capabilities': caps,
+    '/console/audit': { org_id: 'o', events: [{ org_id: 'o', actor_id: 'alice', action: 'key.create', target: 'k1', detail: 'created api key mitos_live_ab12', at: '2026-06-25T08:00:00Z' }] },
+    '/console/templates': { org_id: 'o', templates: [{ name: 'python-3.12', org_id: 'o', description: 'Python 3.12', image: 'ghcr.io/x/py:3.12', updated_at: '2026-06-01T00:00:00Z' }] },
+    '/console/billing': { org_id: 'o', status: 'active', balance_cents: 5000, spend_cents: 1234, soft_cap_cents: 0, hard_cap_cents: 0, ledger_entries: [] },
+    '/console/usage': { org_id: 'o', records: [], totals: { vcpu_seconds: 3600 }, cost: { total_cents: 1234 } },
+  })
+})
+
+describe('read views', () => {
+  it('audit shows an event', async () => {
+    await renderAt('/audit', caps)
+    await waitFor(() => expect(screen.getByText('key.create')).toBeInTheDocument())
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+  it('templates shows a template', async () => {
+    await renderAt('/templates', caps)
+    await waitFor(() => expect(screen.getByText('python-3.12')).toBeInTheDocument())
+  })
+  it('billing shows status when capability is on', async () => {
+    await renderAt('/billing', caps)
+    await waitFor(() => expect(screen.getByText(/active/i)).toBeInTheDocument())
+  })
+})
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `pnpm -C web/app test src/views/ReadViews.test.tsx`
+Expected: FAIL (placeholders render, not the data).
+
+- [ ] **Step 3: Implement the four views**
+
+- `Usage.tsx`: render the `totals` and `cost` maps as a small set of `StatTile`s or a definition list (e.g. vCPU-seconds, cost). Honest empty state when totals are all zero.
+- `Audit.tsx`: a filterable table (a text `<input aria-label="Filter audit">` filtering client-side over actor/action/target/detail) with columns Time, Actor, Action, Target, Detail. Empty state when no events.
+- `Templates.tsx`: a table (Name, Image, Description, Updated). Empty state.
+- `Billing.tsx`: status badge, balance and spend (cents to currency), cap info, a ledger table, and a `Manage billing` button that calls `api.billingPortal()` and opens the URL. Empty/loading states.
+
+(Implementer writes all four; the test pins audit/templates/billing rendering.)
+
+- [ ] **Step 4: Point the four routes at the views in `web/app/src/nav/routes.tsx`**
+
+Import and set `/usage`, `/audit`, `/templates`, `/billing` elements to the real views. Keep `/billing`'s `when: (c) => c.billing` gate.
+
+- [ ] **Step 5: Run the test, full suite, typecheck**
+
+Run: `pnpm -C web/app test src/views/ReadViews.test.tsx && pnpm -C web/app test && pnpm -C web/app typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/app/src/views/Usage.tsx web/app/src/views/Audit.tsx web/app/src/views/Templates.tsx web/app/src/views/Billing.tsx web/app/src/nav/routes.tsx web/app/src/views/ReadViews.test.tsx
+git commit -s -m "feat(console): Usage, Audit, Templates, and Billing views over the live BFF"
+```
+
+---
+
+### Task 5: Styles, a11y axe, final verification
+
+**Files:**
+- Modify: `web/packages/brand/src/base.css`
+- Create: `web/app/src/views/B2bViews.a11y.test.tsx`
+
+**Interfaces:**
+- Produces: token-driven form/badge/ledger styles; an axe test asserting zero violations on Keys and Secrets (the form-bearing views).
+
+- [ ] **Step 1: Append token-driven styles to `web/packages/brand/src/base.css`**
+
+Add `.form-row` (label + control vertical rhythm), `input`/`select`/`textarea` base styling (token bg `var(--field-1)`, hairline border, focus ring `var(--cyan)`, 44px min height), `.badge` (status pill: `.badge-ok` green, `.badge-warn` amber), and `.ledger` (reuse `.tbl`). Token-driven, no raw hex. Add a `@media (max-width: 768px)` rule so forms stack and tables scroll.
+
+- [ ] **Step 2: Write the axe a11y test `web/app/src/views/B2bViews.a11y.test.tsx`**
+
+Mirror the existing a11y test pattern (`vitest-axe` + matchers). Render `/keys` and `/secrets`, wait for content, assert `expect(await axe(container)).toHaveNoViolations()` for each. Fix any real violation (form labels, button names); do not suppress rules.
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import * as matchers from 'vitest-axe/matchers'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+expect.extend(matchers)
+const caps: Capabilities = { edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc', orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted' }
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input)
+    if (url.endsWith('/console/capabilities')) return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/keys')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', keys: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/secrets')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', secrets: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('B2b views accessibility', () => {
+  it('Keys has no axe violations', async () => {
+    const { container } = await renderAt('/keys', caps)
+    await waitFor(() => expect(screen.getByRole('button', { name: /create key/i })).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+```
+
+- [ ] **Step 3: Run the a11y test; fix violations; final verification**
+
+Run: `pnpm -C web/app test` (exit 0, all pass)
+Run: `pnpm -C web/app typecheck` (clean)
+Run: `pnpm -C web/app build` (succeeds)
+Run: `grep -rnP '\xe2\x80\x94|\xe2\x80\x93' web/app/src/views web/app/src/ui/CopyOnce.tsx web/packages/brand/src/base.css` (empty)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/packages/brand/src/base.css web/app/src/views/B2bViews.a11y.test.tsx
+git commit -s -m "feat(console): form and badge styles plus B2b accessibility checks"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (section 4.3 IA):** API keys (Task 2, scoped/expiring/revocable/masked + create-once), Secrets (Task 3, write-only), Usage & cost (Task 4), Audit (Task 4, filterable list), Templates (Task 4), Billing hosted (Task 4, portal link). Covered. Members (roles) is B2c; Workspaces stays a placeholder (no BFF endpoint). 
+
+**Secrets rule:** the raw key is shown once via `CopyOnce` (Task 1, used in Task 2) and never refetched; the masked prefix is all the list shows; secret values are write-only (Task 3). Enforced.
+
+**Placeholder scan:** the honest Workspaces placeholder is intentional; every code step shows complete code (the four read views in Task 4 and the form views in Tasks 2-3 are described with their exact data sources and pinned by tests).
+
+**Type consistency:** the api.ts shapes (Task 1) match the Go BFF JSON tags and are consumed by the hooks (Task 1) and views (Tasks 2-4); `CopyOnce` (Task 1) consumed by Task 2. No drift.

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -52,6 +52,13 @@ export type ForkNode = {
 
 export type ForkTree = { org_id: string; nodes: ForkNode[] }
 
+export type KeyView = { id: string; name: string; prefix: string; scopes: string[]; created_at: string; expires_at?: string; revoked_at?: string; revoked: boolean }
+export type CreateKeyResult = { org_id: string; raw_key: string; key: KeyView }
+export type AuditEvent = { org_id: string; actor_id: string; action: string; target: string; detail: string; at: string }
+export type TemplateView = { name: string; org_id: string; description: string; image: string; updated_at: string }
+export type UsageResponse = { org_id: string; records: unknown[]; totals: Record<string, number>; cost: Record<string, number> }
+export type BillingView = { org_id: string; status: string; balance_cents: number; spend_cents: number; soft_cap_cents: number; hard_cap_cents: number; ledger_entries: Array<{ ts?: string; cents?: number; reason?: string }> }
+
 async function get<T>(path: string): Promise<T> {
   const r = await fetch(path, { credentials: 'same-origin' })
   if (!r.ok) throw new Error(`${path}: ${r.status}`)
@@ -91,6 +98,21 @@ export const api = {
     return r.text()
   },
   forktree: () => get<ForkTree>('/console/forktree'),
+  keys: () => get<{ keys: KeyView[] }>('/console/keys').then((r) => r.keys ?? []),
+  createKey: async (name: string, scopes: string[], ttlSeconds: number) => {
+    const r = await fetch('/console/keys', { method: 'POST', credentials: 'same-origin', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name, scopes, ttl_seconds: ttlSeconds }) })
+    if (!r.ok) throw new Error(`create key: ${r.status}`)
+    return (await r.json()) as CreateKeyResult
+  },
+  revokeKey: async (id: string) => {
+    const r = await fetch(`/console/keys/${encodeURIComponent(id)}/revoke`, { method: 'POST', credentials: 'same-origin' })
+    if (!r.ok) throw new Error(`revoke: ${r.status}`)
+  },
+  usage: () => get<UsageResponse>('/console/usage?from=&to='),
+  audit: () => get<{ events: AuditEvent[] }>('/console/audit').then((r) => r.events ?? []),
+  templates: () => get<{ templates: TemplateView[] }>('/console/templates').then((r) => r.templates ?? []),
+  billing: () => get<BillingView>('/console/billing'),
+  billingPortal: () => get<{ url: string }>('/console/billing/portal').then((r) => r.url),
 }
 
 export function fmtBytes(n: number): string {

--- a/web/app/src/data/account.test.tsx
+++ b/web/app/src/data/account.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useKeys } from './account'
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useKeys', () => {
+  it('lists api keys (masked)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ org_id: 'o', keys: [{ id: 'k1', name: 'ci', prefix: 'mitos_live_ab12', scopes: ['sandboxes'], created_at: '', revoked: false }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    const { result } = renderHook(() => useKeys(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.[0].prefix).toBe('mitos_live_ab12')
+  })
+})

--- a/web/app/src/data/account.ts
+++ b/web/app/src/data/account.ts
@@ -1,0 +1,30 @@
+// Account-scoped data: api keys (with the create-once flow), usage, audit,
+// templates, and billing. Mutations invalidate their list; revoke is optimistic.
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api, type KeyView, type AuditEvent, type TemplateView, type UsageResponse, type BillingView } from '../api'
+
+export function useKeys() { return useQuery<KeyView[]>({ queryKey: ['keys'], queryFn: () => api.keys() }) }
+export function useUsage() { return useQuery<UsageResponse>({ queryKey: ['usage'], queryFn: () => api.usage() }) }
+export function useAudit() { return useQuery<AuditEvent[]>({ queryKey: ['audit'], queryFn: () => api.audit() }) }
+export function useTemplates() { return useQuery<TemplateView[]>({ queryKey: ['templates'], queryFn: () => api.templates() }) }
+export function useBilling() { return useQuery<BillingView>({ queryKey: ['billing'], queryFn: () => api.billing() }) }
+
+export function useCreateKey() {
+  const qc = useQueryClient()
+  return useMutation({ mutationFn: (v: { name: string; scopes: string[]; ttlSeconds: number }) => api.createKey(v.name, v.scopes, v.ttlSeconds), onSuccess: () => void qc.invalidateQueries({ queryKey: ['keys'] }) })
+}
+
+export function useRevokeKey() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => api.revokeKey(id),
+    onMutate: async (id: string) => {
+      await qc.cancelQueries({ queryKey: ['keys'] })
+      const prev = qc.getQueryData<KeyView[]>(['keys'])
+      qc.setQueryData<KeyView[]>(['keys'], (cur) => (cur ?? []).map((k) => (k.id === id ? { ...k, revoked: true } : k)))
+      return { prev }
+    },
+    onError: (_e, _id, ctx) => { if (ctx?.prev) qc.setQueryData(['keys'], ctx.prev) },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ['keys'] }),
+  })
+}

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -9,6 +9,7 @@ import { ForkTree } from '../views/forktree/ForkTree'
 import { Secrets } from '../views/Secrets'
 import { Placeholder } from '../views/Placeholder'
 import { SandboxDetail } from '../views/sandboxes/SandboxDetail'
+import { Keys } from '../views/Keys'
 
 export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Settings'
 export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Settings']
@@ -30,7 +31,7 @@ export const ROUTES: RouteDef[] = [
   { path: '/workspaces', label: 'Workspaces', group: 'Build', element: () => <Placeholder title="Workspaces" endpoint="/console/workspaces" phase="B2" /> },
   { path: '/templates', label: 'Templates', group: 'Build', element: () => <Placeholder title="Templates" endpoint="/console/templates" phase="B2" /> },
   { path: '/secrets', label: 'Secrets', group: 'Build', element: () => <Secrets /> },
-  { path: '/keys', label: 'API keys', group: 'Build', element: () => <Placeholder title="API keys" endpoint="/console/keys" phase="B2" /> },
+  { path: '/keys', label: 'API keys', group: 'Build', element: () => <Keys /> },
   { path: '/members', label: 'Members', group: 'Govern', element: () => <Placeholder title="Members & roles" endpoint="/console/members" phase="B2" />, when: (c) => c.teams },
   { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Placeholder title="Audit log" endpoint="/console/audit" phase="B2" /> },
   { path: '/usage', label: 'Usage', group: 'Govern', element: () => <Placeholder title="Usage & cost" endpoint="/console/usage" phase="B2" /> },

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -10,6 +10,10 @@ import { Secrets } from '../views/Secrets'
 import { Placeholder } from '../views/Placeholder'
 import { SandboxDetail } from '../views/sandboxes/SandboxDetail'
 import { Keys } from '../views/Keys'
+import { Usage } from '../views/Usage'
+import { Audit } from '../views/Audit'
+import { Templates } from '../views/Templates'
+import { Billing } from '../views/Billing'
 
 export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Settings'
 export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Settings']
@@ -29,13 +33,13 @@ export const ROUTES: RouteDef[] = [
   { path: '/sandboxes/$id', label: 'Sandbox', group: 'Run', element: () => <SandboxDetail />, hidden: true },
   { path: '/forks', label: 'Fork tree', group: 'Run', element: () => <ForkTree /> },
   { path: '/workspaces', label: 'Workspaces', group: 'Build', element: () => <Placeholder title="Workspaces" endpoint="/console/workspaces" phase="B2" /> },
-  { path: '/templates', label: 'Templates', group: 'Build', element: () => <Placeholder title="Templates" endpoint="/console/templates" phase="B2" /> },
+  { path: '/templates', label: 'Templates', group: 'Build', element: () => <Templates /> },
   { path: '/secrets', label: 'Secrets', group: 'Build', element: () => <Secrets /> },
   { path: '/keys', label: 'API keys', group: 'Build', element: () => <Keys /> },
   { path: '/members', label: 'Members', group: 'Govern', element: () => <Placeholder title="Members & roles" endpoint="/console/members" phase="B2" />, when: (c) => c.teams },
-  { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Placeholder title="Audit log" endpoint="/console/audit" phase="B2" /> },
-  { path: '/usage', label: 'Usage', group: 'Govern', element: () => <Placeholder title="Usage & cost" endpoint="/console/usage" phase="B2" /> },
-  { path: '/billing', label: 'Billing', group: 'Govern', element: () => <Placeholder title="Billing" endpoint="/console/billing" phase="B2" />, when: (c) => c.billing },
+  { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Audit /> },
+  { path: '/usage', label: 'Usage', group: 'Govern', element: () => <Usage /> },
+  { path: '/billing', label: 'Billing', group: 'Govern', element: () => <Billing />, when: (c) => c.billing },
   { path: '/settings', label: 'Settings', group: 'Settings', element: () => <Placeholder title="Settings" endpoint="/console/capabilities" phase="B2" /> },
 ]
 

--- a/web/app/src/ui/CopyOnce.test.tsx
+++ b/web/app/src/ui/CopyOnce.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CopyOnce } from './CopyOnce'
+
+describe('CopyOnce', () => {
+  it('shows the value once and copies it', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<CopyOnce value="mitos_live_secret123" label="API key" />)
+    expect(screen.getByText('mitos_live_secret123')).toBeInTheDocument()
+    expect(screen.getByText(/shown once/i)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /copy/i }))
+    expect(writeText).toHaveBeenCalledWith('mitos_live_secret123')
+  })
+})

--- a/web/app/src/ui/CopyOnce.tsx
+++ b/web/app/src/ui/CopyOnce.tsx
@@ -1,0 +1,17 @@
+// One-time secret reveal: shows a value with a copy button and an explicit
+// "shown once" warning. Used for the raw API key on create. The caller is
+// responsible for never persisting the value.
+import { useState } from 'react'
+
+export function CopyOnce({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="card" style={{ borderColor: 'var(--amber)' }}>
+      <div className="t-dim" style={{ fontSize: 'var(--step--1)' }}>{label} (shown once, store it now)</div>
+      <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center', marginTop: 'var(--space-2)' }}>
+        <code className="mono" style={{ flex: 1, overflowX: 'auto' }}>{value}</code>
+        <button className="btn btn-ghost" onClick={() => { void navigator.clipboard.writeText(value); setCopied(true) }}>{copied ? 'Copied' : 'Copy'}</button>
+      </div>
+    </div>
+  )
+}

--- a/web/app/src/views/Audit.tsx
+++ b/web/app/src/views/Audit.tsx
@@ -1,0 +1,81 @@
+// Audit view: client-side filterable event table. Columns: Time, Actor, Action,
+// Target, Detail. Filter input covers actor_id, action, target, and detail
+// fields (case-insensitive). Consumes the live BFF via useAudit().
+import { useState } from 'react'
+import { useAudit } from '../data/account'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+
+export function Audit() {
+  const { data: events = [], isLoading } = useAudit()
+  const [filter, setFilter] = useState('')
+
+  const filtered = filter
+    ? events.filter((e) => {
+        const q = filter.toLowerCase()
+        return (
+          e.actor_id.toLowerCase().includes(q) ||
+          e.action.toLowerCase().includes(q) ||
+          e.target.toLowerCase().includes(q) ||
+          e.detail.toLowerCase().includes(q)
+        )
+      })
+    : events
+
+  return (
+    <section>
+      <h2>Audit log</h2>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Immutable record of org-scoped actions. Filter by actor, action, target, or detail.
+      </p>
+
+      {isLoading ? (
+        <Skeleton rows={5} />
+      ) : (
+        <>
+          <div style={{ marginBottom: 'var(--space-4)' }}>
+            <input
+              aria-label="Filter audit"
+              placeholder="Filter by actor, action, target, or detail"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              style={{ width: '100%', maxWidth: '400px' }}
+            />
+          </div>
+
+          {filtered.length === 0 ? (
+            <EmptyState
+              title={events.length === 0 ? 'No audit events yet' : 'No matching events'}
+              body={events.length === 0 ? 'Actions taken in this org will appear here.' : 'Try a different filter term.'}
+            />
+          ) : (
+            <div style={{ overflowX: 'auto' }}>
+              <table className="tbl" aria-label="Audit log">
+                <thead>
+                  <tr>
+                    <th scope="col">Time</th>
+                    <th scope="col">Actor</th>
+                    <th scope="col">Action</th>
+                    <th scope="col">Target</th>
+                    <th scope="col">Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((e, i) => (
+                    <tr key={i}>
+                      <td className="t-dim">{new Date(e.at).toLocaleString()}</td>
+                      <td className="mono">{e.actor_id}</td>
+                      <td className="mono">{e.action}</td>
+                      <td className="mono">{e.target}</td>
+                      <td>{e.detail}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/web/app/src/views/B2bViews.a11y.test.tsx
+++ b/web/app/src/views/B2bViews.a11y.test.tsx
@@ -1,0 +1,47 @@
+// Axe accessibility audit for B2b views: no violations on Keys and Secrets.
+// Uses vitest-axe (^0.1.0) which wraps axe-core and provides Vitest-compatible
+// matchers. Import path: 'vitest-axe' for axe(), 'vitest-axe/matchers' for the
+// custom expect matcher.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import * as matchers from 'vitest-axe/matchers'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+expect.extend(matchers)
+
+const caps: Capabilities = {
+  edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc',
+  orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted',
+}
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input)
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/keys')) {
+      return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', keys: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/secrets')) {
+      return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', secrets: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('B2b views accessibility', () => {
+  it('Keys has no axe violations', async () => {
+    const { container } = await renderAt('/keys', caps)
+    await waitFor(() => expect(screen.getByRole('button', { name: /create key/i })).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('Secrets has no axe violations', async () => {
+    const { container } = await renderAt('/secrets', caps)
+    await waitFor(() => expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/web/app/src/views/Billing.tsx
+++ b/web/app/src/views/Billing.tsx
@@ -1,0 +1,95 @@
+// Billing view: status badge, balance and spend (cents to dollars), cap info,
+// a ledger table (Time, Amount, Reason), and a "Manage billing" button that
+// calls api.billingPortal() and opens the returned URL. Gated on c.billing.
+import { useBilling } from '../data/account'
+import { api } from '../api'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+import { StatTile } from '../ui/StatTile'
+
+function fmtDollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+export function Billing() {
+  const { data, isLoading } = useBilling()
+
+  async function onManageBilling() {
+    const url = await api.billingPortal()
+    window.open(url, '_blank')
+  }
+
+  return (
+    <section>
+      <h2>Billing</h2>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Balance, spend, and ledger for this org.
+      </p>
+
+      {isLoading ? (
+        <Skeleton rows={4} />
+      ) : !data ? (
+        <EmptyState
+          title="Billing unavailable"
+          body="Billing information could not be loaded."
+        />
+      ) : (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)', marginBottom: 'var(--space-5)', flexWrap: 'wrap' }}>
+            <span
+              className="mono"
+              style={{ padding: 'var(--space-1) var(--space-3)', borderRadius: 'var(--r-sm)', background: 'var(--field-1)', fontSize: 'var(--step--1)' }}
+            >
+              {data.status}
+            </span>
+            <button className="btn" onClick={() => void onManageBilling()}>
+              Manage billing
+            </button>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 'var(--space-4)', marginBottom: 'var(--space-6)' }}>
+            <StatTile label="Balance" value={fmtDollars(data.balance_cents)} />
+            <StatTile label="Spend" value={fmtDollars(data.spend_cents)} />
+            <StatTile
+              label="Soft cap"
+              value={data.soft_cap_cents > 0 ? fmtDollars(data.soft_cap_cents) : 'No cap'}
+            />
+            <StatTile
+              label="Hard cap"
+              value={data.hard_cap_cents > 0 ? fmtDollars(data.hard_cap_cents) : 'No cap'}
+            />
+          </div>
+
+          <h3 style={{ marginBottom: 'var(--space-3)' }}>Ledger</h3>
+          {data.ledger_entries.length === 0 ? (
+            <EmptyState
+              title="No ledger entries"
+              body="Charges and credits will appear here."
+            />
+          ) : (
+            <div style={{ overflowX: 'auto' }}>
+              <table className="tbl" aria-label="Ledger">
+                <thead>
+                  <tr>
+                    <th scope="col">Time</th>
+                    <th scope="col">Amount</th>
+                    <th scope="col">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.ledger_entries.map((entry, i) => (
+                    <tr key={i}>
+                      <td className="t-dim">{entry.ts ? new Date(entry.ts).toLocaleString() : '-'}</td>
+                      <td className="mono">{entry.cents != null ? fmtDollars(entry.cents) : '-'}</td>
+                      <td>{entry.reason ?? '-'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/web/app/src/views/Keys.test.tsx
+++ b/web/app/src/views/Keys.test.tsx
@@ -1,0 +1,140 @@
+// Behavior tests for the API keys view: create form, masked table, CopyOnce
+// reveal (shown once in component state, never refetched), and optimistic revoke.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ToastProvider } from '../ui/Toast'
+import { Keys } from './Keys'
+import type { KeyView, CreateKeyResult } from '../api'
+
+function wrap(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>{ui}</ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+const baseKey: KeyView = {
+  id: 'k1',
+  name: 'ci-bot',
+  prefix: 'mitos_live_ab12',
+  scopes: ['sandboxes'],
+  created_at: '2026-01-01T00:00:00Z',
+  revoked: false,
+}
+
+const revokedKey: KeyView = {
+  id: 'k2',
+  name: 'old-key',
+  prefix: 'mitos_live_zz99',
+  scopes: ['read'],
+  created_at: '2025-12-01T00:00:00Z',
+  revoked: true,
+  revoked_at: '2026-01-10T00:00:00Z',
+}
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input)
+    if (url.endsWith('/console/keys') && !url.includes('revoke')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ keys: [baseKey, revokedKey] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('Keys view', () => {
+  it('renders the create form with name input, scope checkboxes, TTL select, and submit button', async () => {
+    wrap(<Keys />)
+    await waitFor(() => expect(screen.getByLabelText(/name/i)).toBeInTheDocument())
+    expect(screen.getByRole('checkbox', { name: /sandboxes/i })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /read/i })).toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create key/i })).toBeInTheDocument()
+  })
+
+  it('renders the masked key table with accessible column headers', async () => {
+    wrap(<Keys />)
+    await waitFor(() => expect(screen.getByText('ci-bot')).toBeInTheDocument())
+    expect(screen.getByRole('columnheader', { name: /name/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /prefix/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /scopes/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /created/i })).toBeInTheDocument()
+    expect(screen.getByText('mitos_live_ab12')).toBeInTheDocument()
+    expect(screen.getByText('mitos_live_zz99')).toBeInTheDocument()
+  })
+
+  it('shows Revoke button only for non-revoked keys', async () => {
+    wrap(<Keys />)
+    await waitFor(() => expect(screen.getByText('ci-bot')).toBeInTheDocument())
+    const revokeButtons = screen.getAllByRole('button', { name: /revoke/i })
+    expect(revokeButtons.length).toBe(1)
+  })
+
+  it('shows CopyOnce after successful create and clears it on dismiss', async () => {
+    const newKey: KeyView = { id: 'k3', name: 'new-key', prefix: 'mitos_live_cc11', scopes: ['sandboxes'], created_at: '2026-06-01T00:00:00Z', revoked: false }
+    const createResult: CreateKeyResult = { org_id: 'o1', raw_key: 'mitos_live_secret_FULL_KEY', key: newKey }
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input)
+      if (url.endsWith('/console/keys') && init?.method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify(createResult), { status: 200, headers: { 'content-type': 'application/json' } }),
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ keys: [baseKey] }), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    })
+
+    wrap(<Keys />)
+    await waitFor(() => expect(screen.getByLabelText(/name/i)).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'new-key' } })
+    fireEvent.click(screen.getByRole('button', { name: /create key/i }))
+    await waitFor(() => expect(screen.getByText('mitos_live_secret_FULL_KEY')).toBeInTheDocument())
+    expect(screen.getByText(/shown once/i)).toBeInTheDocument()
+
+    // Dismiss (the CopyOnce area should have a dismiss button or we check that
+    // re-fetching the list does not bring the raw key back)
+    const dismissBtn = screen.getByRole('button', { name: /dismiss/i })
+    fireEvent.click(dismissBtn)
+    await waitFor(() => expect(screen.queryByText('mitos_live_secret_FULL_KEY')).not.toBeInTheDocument())
+  })
+
+  it('shows loading skeleton while keys are fetching', () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}))
+    wrap(<Keys />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no keys', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ keys: [] }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    )
+    wrap(<Keys />)
+    await waitFor(() => expect(screen.getByText(/no api keys/i)).toBeInTheDocument())
+  })
+
+  it('optimistically marks a key revoked and shows a toast on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input)
+      if (url.includes('/revoke') && init?.method === 'POST') {
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ keys: [baseKey] }), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    })
+    wrap(<Keys />)
+    await waitFor(() => expect(screen.getByText('ci-bot')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /revoke/i }))
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument())
+  })
+})

--- a/web/app/src/views/Keys.tsx
+++ b/web/app/src/views/Keys.tsx
@@ -1,0 +1,192 @@
+// API keys view: create form with scopes and TTL, masked table with one-time
+// raw key reveal (CopyOnce; never refetched), and optimistic revoke per row.
+import { useState } from 'react'
+import { useKeys, useCreateKey, useRevokeKey } from '../data/account'
+import { CopyOnce } from '../ui/CopyOnce'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+import { useToast } from '../ui/Toast'
+import type { CreateKeyResult } from '../api'
+
+const TTL_OPTIONS = [
+  { label: 'Never expires', value: 0 },
+  { label: '30 days', value: 2592000 },
+  { label: '90 days', value: 7776000 },
+] as const
+
+export function Keys() {
+  const { data: keys = [], isLoading } = useKeys()
+  const createKey = useCreateKey()
+  const revokeKey = useRevokeKey()
+  const { notify } = useToast()
+
+  const [name, setName] = useState('')
+  const [scopeSandboxes, setScopeSandboxes] = useState(true)
+  const [scopeRead, setScopeRead] = useState(false)
+  const [ttl, setTtl] = useState(0)
+  const [revealed, setRevealed] = useState<CreateKeyResult | null>(null)
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const scopes: string[] = []
+    if (scopeSandboxes) scopes.push('sandboxes')
+    if (scopeRead) scopes.push('read')
+    createKey.mutate(
+      { name, scopes, ttlSeconds: ttl },
+      {
+        onSuccess: (result) => {
+          setRevealed(result)
+          setName('')
+          setScopeSandboxes(true)
+          setScopeRead(false)
+          setTtl(0)
+        },
+        onError: () => notify('Failed to create key', 'error'),
+      },
+    )
+  }
+
+  function onRevoke(id: string) {
+    revokeKey.mutate(id, {
+      onSuccess: () => notify('Key revoked', 'ok'),
+      onError: () => notify('Failed to revoke key', 'error'),
+    })
+  }
+
+  return (
+    <section>
+      <h2>API keys</h2>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Keys authenticate requests to the Mitos API. The raw key is shown only once on creation; store it immediately.
+      </p>
+
+      {revealed && (
+        <div style={{ marginBottom: 'var(--space-5)' }}>
+          <CopyOnce value={revealed.raw_key} label="API key" />
+          <div style={{ marginTop: 'var(--space-2)' }}>
+            <button
+              className="btn btn-ghost"
+              onClick={() => setRevealed(null)}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={onSubmit} style={{ marginBottom: 'var(--space-6)' }}>
+        <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+          <div>
+            <label htmlFor="key-name" style={{ display: 'block', marginBottom: 'var(--space-1)', fontSize: 'var(--step--1)' }}>
+              Name
+            </label>
+            <input
+              id="key-name"
+              className="mono"
+              placeholder="e.g. ci-bot"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'center' }}>
+            <label style={{ display: 'flex', gap: 'var(--space-1)', alignItems: 'center', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={scopeSandboxes}
+                onChange={(e) => setScopeSandboxes(e.target.checked)}
+              />
+              sandboxes
+            </label>
+            <label style={{ display: 'flex', gap: 'var(--space-1)', alignItems: 'center', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={scopeRead}
+                onChange={(e) => setScopeRead(e.target.checked)}
+              />
+              read
+            </label>
+          </div>
+
+          <div>
+            <label htmlFor="key-ttl" style={{ display: 'block', marginBottom: 'var(--space-1)', fontSize: 'var(--step--1)' }}>
+              Expiry
+            </label>
+            <select
+              id="key-ttl"
+              value={ttl}
+              onChange={(e) => setTtl(Number(e.target.value))}
+            >
+              {TTL_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            type="submit"
+            className="btn"
+            disabled={!name || createKey.isPending}
+          >
+            Create key
+          </button>
+        </div>
+      </form>
+
+      {isLoading ? (
+        <Skeleton rows={3} />
+      ) : keys.length === 0 ? (
+        <EmptyState
+          title="No API keys"
+          body="Create your first key to authenticate API requests."
+        />
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="tbl" aria-label="API keys">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Prefix</th>
+                <th scope="col">Scopes</th>
+                <th scope="col">Created</th>
+                <th scope="col">Status</th>
+                <th scope="col"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.id}>
+                  <td>{k.name}</td>
+                  <td className="mono">{k.prefix}</td>
+                  <td>{k.scopes.join(', ')}</td>
+                  <td className="t-dim">{new Date(k.created_at).toLocaleDateString()}</td>
+                  <td>
+                    {k.revoked ? (
+                      <span className="t-dim">revoked</span>
+                    ) : (
+                      <span>active</span>
+                    )}
+                  </td>
+                  <td>
+                    {!k.revoked && (
+                      <button
+                        className="btn btn-ghost"
+                        onClick={() => onRevoke(k.id)}
+                        aria-label={`Revoke ${k.name}`}
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/app/src/views/ReadViews.test.tsx
+++ b/web/app/src/views/ReadViews.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = { edition: 'community', billing: true, signup: false, teams: true, idp: 'oidc', orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'hosted' }
+
+function mockFor(map: Record<string, unknown>) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input).split('?')[0]
+    const key = Object.keys(map).find((k) => url.endsWith(k))
+    return Promise.resolve(new Response(JSON.stringify(key ? map[key] : {}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+}
+
+beforeEach(() => {
+  mockFor({
+    '/console/capabilities': caps,
+    '/console/audit': { org_id: 'o', events: [{ org_id: 'o', actor_id: 'alice', action: 'key.create', target: 'k1', detail: 'created api key mitos_live_ab12', at: '2026-06-25T08:00:00Z' }] },
+    '/console/templates': { org_id: 'o', templates: [{ name: 'python-3.12', org_id: 'o', description: 'Python 3.12', image: 'ghcr.io/x/py:3.12', updated_at: '2026-06-01T00:00:00Z' }] },
+    '/console/billing': { org_id: 'o', status: 'active', balance_cents: 5000, spend_cents: 1234, soft_cap_cents: 0, hard_cap_cents: 0, ledger_entries: [] },
+    '/console/usage': { org_id: 'o', records: [], totals: { vcpu_seconds: 3600 }, cost: { total_cents: 1234 } },
+  })
+})
+
+describe('read views', () => {
+  it('audit shows an event', async () => {
+    await renderAt('/audit', caps)
+    await waitFor(() => expect(screen.getByText('key.create')).toBeInTheDocument())
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+  it('templates shows a template', async () => {
+    await renderAt('/templates', caps)
+    await waitFor(() => expect(screen.getByText('python-3.12')).toBeInTheDocument())
+  })
+  it('billing shows status when capability is on', async () => {
+    await renderAt('/billing', caps)
+    await waitFor(() => expect(screen.getByText(/active/i)).toBeInTheDocument())
+  })
+})

--- a/web/app/src/views/Secrets.test.tsx
+++ b/web/app/src/views/Secrets.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { waitFor, screen } from '@testing-library/react'
-import _userEvent from '@testing-library/user-event'
 import { renderAt } from '../test/utils'
 import type { Capabilities } from '../api'
 

--- a/web/app/src/views/Secrets.test.tsx
+++ b/web/app/src/views/Secrets.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import _userEvent from '@testing-library/user-event'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = { edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc', orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted' }
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input)
+    if (url.endsWith('/console/capabilities')) return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/secrets')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', secrets: [{ name: 'OPENAI_API_KEY', org_id: 'o', provider: 'kube', mode: 'copy-in', version: 2, fingerprint: 'ab12cd34' }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('Secrets view', () => {
+  it('lists secrets without revealing values', async () => {
+    await renderAt('/secrets', caps)
+    await waitFor(() => expect(screen.getByText('OPENAI_API_KEY')).toBeInTheDocument())
+    expect(screen.getByText('kube')).toBeInTheDocument()
+    expect(screen.getByText('ab12cd34')).toBeInTheDocument()
+  })
+})

--- a/web/app/src/views/Secrets.tsx
+++ b/web/app/src/views/Secrets.tsx
@@ -1,63 +1,155 @@
 // Org secrets (#275). Write-only: the value is sent on create and never shown
-// again — the list renders metadata + fingerprint only.
-import { useEffect, useState } from 'react'
-import { Button, Card } from '@mitos/brand'
+// again -- the list renders metadata plus fingerprint only. Values are
+// encrypted server-side and injected into sandboxes at fork time.
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api, type SecretView } from '../api'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+import { useToast } from '../ui/Toast'
+
+function useSecrets() {
+  return useQuery<SecretView[]>({ queryKey: ['secrets'], queryFn: () => api.secrets() })
+}
+
+function useCreateSecret() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (v: { name: string; value: string }) => api.createSecret(v.name, v.value),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['secrets'] }),
+  })
+}
+
+function useDeleteSecret() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) => api.deleteSecret(name),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['secrets'] }),
+  })
+}
 
 export function Secrets() {
-  const [rows, setRows] = useState<SecretView[]>([])
+  const { data: secrets = [], isLoading } = useSecrets()
+  const createSecret = useCreateSecret()
+  const deleteSecret = useDeleteSecret()
+  const { notify } = useToast()
+
   const [name, setName] = useState('')
   const [value, setValue] = useState('')
-  const [err, setErr] = useState<string>()
 
-  const reload = () => api.secrets().then(setRows).catch((e) => setErr(String(e)))
-  useEffect(() => {
-    reload()
-  }, [])
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    createSecret.mutate(
+      { name, value },
+      {
+        onSuccess: () => {
+          setName('')
+          setValue('')
+          notify('Secret stored', 'ok')
+        },
+        onError: () => notify('Failed to create secret', 'error'),
+      },
+    )
+  }
 
-  const create = async () => {
-    setErr(undefined)
-    try {
-      await api.createSecret(name, value)
-      setName('')
-      setValue('')
-      await reload()
-    } catch (e) {
-      setErr(String(e))
-    }
+  function onDelete(secretName: string) {
+    deleteSecret.mutate(secretName, {
+      onSuccess: () => notify('Secret deleted', 'ok'),
+      onError: () => notify('Failed to delete secret', 'error'),
+    })
   }
 
   return (
-    <div>
+    <section>
       <h2>Secrets</h2>
-      <p className="t-dim" style={{ fontSize: 'var(--step--1)' }}>
-        Write-only. Values are encrypted server-side and injected into sandboxes; they are never shown again — rotate, don't read.
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Write-only. Values are encrypted server-side and injected into sandboxes; they are never shown again. Rotate, do not read.
       </p>
-      <Card style={{ marginBottom: 'var(--space-5)' }}>
-        <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
-          <input className="mono" placeholder="NAME (e.g. OPENAI_API_KEY)" value={name} onChange={(e) => setName(e.target.value)} />
-          <input className="mono" type="password" placeholder="value" value={value} onChange={(e) => setValue(e.target.value)} />
-          <Button onClick={create} disabled={!name || !value}>Store</Button>
+
+      <form onSubmit={onSubmit} style={{ marginBottom: 'var(--space-6)' }}>
+        <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+          <div>
+            <label htmlFor="secret-name" style={{ display: 'block', marginBottom: 'var(--space-1)', fontSize: 'var(--step--1)' }}>
+              Name
+            </label>
+            <input
+              id="secret-name"
+              className="mono"
+              placeholder="e.g. OPENAI_API_KEY"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="secret-value" style={{ display: 'block', marginBottom: 'var(--space-1)', fontSize: 'var(--step--1)' }}>
+              Value
+            </label>
+            <input
+              id="secret-value"
+              type="password"
+              className="mono"
+              placeholder="secret value"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="btn"
+            disabled={!name || !value || createSecret.isPending}
+          >
+            Create
+          </button>
         </div>
-        {err && <div className="t-dim" style={{ marginTop: 'var(--space-2)' }}>{err}</div>}
-      </Card>
-      <table className="tbl">
-        <thead>
-          <tr><th>Name</th><th>Provider</th><th>Version</th><th>Fingerprint</th><th /></tr>
-        </thead>
-        <tbody>
-          {rows.map((s) => (
-            <tr key={s.name}>
-              <td className="mono">{s.name}</td>
-              <td>{s.provider}</td>
-              <td>{s.version}</td>
-              <td className="mono t-dim">{s.fingerprint}</td>
-              <td><Button variant="ghost" onClick={() => api.deleteSecret(s.name).then(reload)}>Delete</Button></td>
-            </tr>
-          ))}
-          {rows.length === 0 && <tr><td colSpan={5} className="t-dim">no secrets yet</td></tr>}
-        </tbody>
-      </table>
-    </div>
+      </form>
+
+      {isLoading ? (
+        <Skeleton rows={3} />
+      ) : secrets.length === 0 ? (
+        <EmptyState
+          title="No secrets yet"
+          body="Store your first secret to inject credentials into sandboxes at fork time."
+        />
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="tbl" aria-label="Secrets">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Provider</th>
+                <th scope="col">Mode</th>
+                <th scope="col">Version</th>
+                <th scope="col">Fingerprint</th>
+                <th scope="col"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {secrets.map((s) => (
+                <tr key={s.name}>
+                  <td className="mono">{s.name}</td>
+                  <td>{s.provider}</td>
+                  <td>{s.mode}</td>
+                  <td>{s.version}</td>
+                  <td className="mono t-dim">{s.fingerprint}</td>
+                  <td>
+                    <button
+                      className="btn btn-ghost"
+                      onClick={() => onDelete(s.name)}
+                      aria-label={`Delete ${s.name}`}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
   )
 }

--- a/web/app/src/views/Templates.tsx
+++ b/web/app/src/views/Templates.tsx
@@ -1,0 +1,51 @@
+// Templates view: table listing org templates with columns Name, Image,
+// Description, Updated. Empty state when none exist. Consumes the live BFF
+// via useTemplates().
+import { useTemplates } from '../data/account'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+
+export function Templates() {
+  const { data: templates = [], isLoading } = useTemplates()
+
+  return (
+    <section>
+      <h2>Templates</h2>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Preconfigured sandbox images available to this org.
+      </p>
+
+      {isLoading ? (
+        <Skeleton rows={3} />
+      ) : templates.length === 0 ? (
+        <EmptyState
+          title="No templates yet"
+          body="Templates registered in this org will appear here."
+        />
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="tbl" aria-label="Templates">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Image</th>
+                <th scope="col">Description</th>
+                <th scope="col">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {templates.map((t) => (
+                <tr key={t.name}>
+                  <td className="mono">{t.name}</td>
+                  <td className="mono t-dim">{t.image}</td>
+                  <td>{t.description}</td>
+                  <td className="t-dim">{new Date(t.updated_at).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/app/src/views/Usage.tsx
+++ b/web/app/src/views/Usage.tsx
@@ -1,0 +1,57 @@
+// Usage view: renders totals and cost maps as StatTiles. Shows an honest empty
+// state when all totals are zero. Consumes the live BFF via useUsage().
+import { useUsage } from '../data/account'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+import { StatTile } from '../ui/StatTile'
+
+function fmtLabel(key: string): string {
+  return key.replace(/_/g, ' ')
+}
+
+function fmtCents(n: number): string {
+  return `$${(n / 100).toFixed(2)}`
+}
+
+export function Usage() {
+  const { data, isLoading } = useUsage()
+
+  const totals = data?.totals ?? {}
+  const cost = data?.cost ?? {}
+  const hasData = Object.values(totals).some((v) => v > 0)
+
+  return (
+    <section>
+      <h2>Usage</h2>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Consumption metrics for the current billing period. All numbers come directly from the BFF.
+      </p>
+
+      {isLoading ? (
+        <Skeleton rows={3} />
+      ) : !hasData ? (
+        <EmptyState
+          title="No usage yet"
+          body="Metrics will appear here once sandboxes have been run."
+        />
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 'var(--space-4)' }}>
+          {Object.entries(totals).map(([key, value]) => (
+            <StatTile
+              key={key}
+              label={fmtLabel(key)}
+              value={String(value)}
+            />
+          ))}
+          {Object.entries(cost).map(([key, value]) => (
+            <StatTile
+              key={`cost-${key}`}
+              label={fmtLabel(key)}
+              value={fmtCents(value)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/packages/brand/src/base.css
+++ b/web/packages/brand/src/base.css
@@ -404,3 +404,102 @@ code, kbd, pre, .mono { font-family: var(--mono); }
     min-width: 600px;
   }
 }
+
+/* Form controls: field-1 background, hairline border, cyan focus ring, 44px
+   min-height to meet touch-target requirements. Radius matches .card tight. */
+input:not([type="checkbox"]):not([type="radio"]),
+select,
+textarea {
+  background: var(--field-1);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-sm);
+  color: var(--ink);
+  font: inherit;
+  min-height: 44px;
+  padding: var(--space-2) var(--space-3);
+  transition: border-color var(--dur) var(--ease), outline-color var(--dur) var(--ease);
+  width: 100%;
+}
+
+input:not([type="checkbox"]):not([type="radio"]):focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+  border-color: transparent;
+}
+
+input:not([type="checkbox"]):not([type="radio"])::placeholder,
+textarea::placeholder {
+  color: var(--ink-3);
+}
+
+/* Form row: label above control with consistent spacing. */
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.form-row label {
+  color: var(--ink-3);
+  font-size: var(--step--1);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Status badge pills: semantic color tokens only. */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--r-sm);
+  font-size: var(--step--1);
+  font-family: var(--mono);
+  border: 1px solid var(--hairline);
+  background: var(--field-1);
+  color: var(--ink-2);
+}
+
+.badge-ok {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.badge-warn {
+  border-color: var(--amber);
+  color: var(--amber);
+}
+
+/* Ledger: reuses .tbl conventions; alias for clarity in billing/usage views. */
+.ledger {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--step--1);
+}
+.ledger th, .ledger td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--hairline);
+}
+.ledger th {
+  color: var(--ink-3);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ledger a { color: var(--cyan); text-decoration: none; }
+.ledger a:hover { text-decoration: underline; }
+
+/* Mobile: forms stack naturally (already column); tables scroll horizontally. */
+@media (max-width: 768px) {
+  .form-row {
+    width: 100%;
+  }
+
+  .ledger {
+    min-width: 600px;
+  }
+}


### PR DESCRIPTION
## What

Phase B2b of the Mitos Console: the remaining over-existing-BFF management views, replacing their placeholders. Frontend-only.

- **API keys** (`/keys`): create (name, scopes, TTL) with the raw key revealed **exactly once** via a `CopyOnce` affordance (held in state only, never refetched or logged); masked-prefix table with optimistic revoke.
- **Secrets** (`/secrets`): write-only create (value is `type=password`, cleared on submit, never echoed), delete, and a metadata table (name, provider, mode, version, fingerprint). No secret value is ever rendered.
- **Usage & cost** (`/usage`), **Audit** (`/audit`, client-side filterable), **Templates** (`/templates`), **Billing** (`/billing`, hosted-gated: balance/spend/caps tiles + ledger + Manage-billing portal link).

Members (roles) is B2c; Workspaces stays an honest placeholder (no BFF endpoint yet).

Plan: `docs/superpowers/plans/2026-06-25-console-b2b-views.md`.

## Verification

- SPA: 64 passing (keys create-once + revoke, secrets write-only, the read views, CopyOnce clipboard, axe a11y on the form views), exit 0.
- TypeScript strict clean; build succeeds.
- **Visual QA via Playwright screenshots:** API keys, Billing (correct cents->currency, ledger, portal link), and Audit (filterable) all verified Linear-grade and consistent.
- Accessibility: labelled form inputs, named buttons, table headers (incl. sr-only Actions), axe zero violations, responsive.

## Security

The raw API key is shown once and never persisted/logged; secret values are write-only (never returned to the UI). The list views show only masked prefixes / fingerprints.

Refs #208 #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
