### PR TITLE
Deprecate the legacy /v1 runtime endpoints in favor of Connect (#24)

### DIFF
--- a/docs/api/runtime-protocol.md
+++ b/docs/api/runtime-protocol.md
@@ -74,6 +74,15 @@ Every current runtime endpoint maps onto one `sandbox.v1.Sandbox` RPC. This tabl
 is the migration's normative correspondence; each row is a unit the follow-up
 slices port.
 
+The runtime routes below (exec, exec/stream, run_code/stream, files/*, pty,
+vitals) are DEPRECATED in favor of the Connect protocol: each response carries an
+RFC 8594 `Deprecation: true` header and a `Link: </sandbox.v1.Sandbox>;
+rel="successor-version"` header (`deprecatedRuntimeNote`, `internal/daemon/sandbox_api.go`).
+They stay active (deprecated-but-working) so existing SDK callers are not broken,
+and are removed once every SDK execs over Connect (#358). The lifecycle routes
+(`set_timeout`, `pause`, `resume`) have no Connect runtime successor and are NOT
+deprecated.
+
 ### HTTP sandbox API (forkd :9091)
 
 | Current endpoint | v2 RPC | Notes |

--- a/internal/daemon/deprecation_test.go
+++ b/internal/daemon/deprecation_test.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestLegacyRuntimeRoutesCarryDeprecationHeader asserts the legacy JSON /v1
+// runtime endpoints (those with a live Connect successor) carry the RFC 8594
+// Deprecation header and a Link to the successor protocol, so a caller is told
+// the JSON runtime shape is deprecated in favor of the Connect sandbox.v1.Sandbox
+// protocol (issue #24, "the old HTTP shape is removed or shimmed with a
+// deprecation note"). The header is set regardless of the response status, so a
+// caller learns of the deprecation even on an error.
+func TestLegacyRuntimeRoutesCarryDeprecationHeader(t *testing.T) {
+	api := NewSandboxAPI(t.TempDir())
+	if err := api.RegisterSandbox("sb-1", "/nonexistent.sock"); err != nil {
+		t.Fatalf("RegisterSandbox: %v", err)
+	}
+	api.AllowTokenless() // so requireBearer lets the request reach the handler
+	ts := httptest.NewServer(api.Handler())
+	defer ts.Close()
+
+	runtimeRoutes := []string{
+		"/v1/exec",
+		"/v1/exec/stream",
+		"/v1/run_code/stream",
+		"/v1/files/read",
+		"/v1/files/write",
+		"/v1/files/list",
+		"/v1/files/mkdir",
+		"/v1/files/remove",
+		"/v1/vitals",
+	}
+	for _, route := range runtimeRoutes {
+		t.Run(route, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, ts.URL+route, bytes.NewReader([]byte(`{"sandbox":"sb-1"}`)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request %s: %v", route, err)
+			}
+			defer resp.Body.Close()
+			if got := resp.Header.Get("Deprecation"); got != "true" {
+				t.Errorf("%s: Deprecation header = %q, want \"true\"", route, got)
+			}
+			if link := resp.Header.Get("Link"); !bytes.Contains([]byte(link), []byte("successor-version")) {
+				t.Errorf("%s: Link header = %q, want it to name the successor-version", route, link)
+			}
+		})
+	}
+}
+
+// TestLifecycleRoutesAreNotDeprecated asserts the lifecycle/management JSON
+// routes that have NO Connect runtime successor (set_timeout, pause, resume) do
+// NOT carry the Deprecation header: only the runtime exec/files surface that
+// Connect replaces is deprecated, not the whole /v1 API.
+func TestLifecycleRoutesAreNotDeprecated(t *testing.T) {
+	api := NewSandboxAPI(t.TempDir())
+	if err := api.RegisterSandbox("sb-1", "/nonexistent.sock"); err != nil {
+		t.Fatalf("RegisterSandbox: %v", err)
+	}
+	api.AllowTokenless()
+	ts := httptest.NewServer(api.Handler())
+	defer ts.Close()
+
+	for _, route := range []string{"/v1/set_timeout", "/v1/pause", "/v1/resume"} {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+route, bytes.NewReader([]byte(`{"sandbox":"sb-1"}`)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request %s: %v", route, err)
+		}
+		resp.Body.Close()
+		if got := resp.Header.Get("Deprecation"); got != "" {
+			t.Errorf("%s: lifecycle route must NOT be deprecated, got Deprecation=%q", route, got)
+		}
+	}
+}

--- a/internal/daemon/sandbox_api.go
+++ b/internal/daemon/sandbox_api.go
@@ -528,18 +528,25 @@ func (api *SandboxAPI) checkSandboxRegistered(sandboxID string) error {
 // callers are not broken.
 func (api *SandboxAPI) Handler() http.Handler {
 	jsonMux := http.NewServeMux()
-	jsonMux.HandleFunc("POST /v1/exec", api.handleExec)
-	jsonMux.HandleFunc("POST /v1/exec/stream", api.handleExecStream)
-	jsonMux.HandleFunc("POST /v1/run_code/stream", api.handleRunCodeStream)
-	jsonMux.HandleFunc("POST /v1/files/read", api.handleReadFile)
-	jsonMux.HandleFunc("POST /v1/files/write", api.handleWriteFile)
-	jsonMux.HandleFunc("POST /v1/files/list", api.handleListDir)
-	jsonMux.HandleFunc("POST /v1/files/mkdir", api.handleMkdir)
-	jsonMux.HandleFunc("POST /v1/files/remove", api.handleRemove)
+	// Runtime exec/files/run_code/vitals routes are SUPERSEDED by the Connect
+	// sandbox.v1.Sandbox protocol (issue #24); they carry a Deprecation note
+	// (deprecatedRuntimeNote) so callers learn the JSON runtime shape is the
+	// legacy path. They stay active (deprecated-but-working) until every SDK is on
+	// Connect (#358), then they are removed.
+	jsonMux.HandleFunc("POST /v1/exec", deprecatedRuntimeNote(api.handleExec))
+	jsonMux.HandleFunc("POST /v1/exec/stream", deprecatedRuntimeNote(api.handleExecStream))
+	jsonMux.HandleFunc("POST /v1/run_code/stream", deprecatedRuntimeNote(api.handleRunCodeStream))
+	jsonMux.HandleFunc("POST /v1/files/read", deprecatedRuntimeNote(api.handleReadFile))
+	jsonMux.HandleFunc("POST /v1/files/write", deprecatedRuntimeNote(api.handleWriteFile))
+	jsonMux.HandleFunc("POST /v1/files/list", deprecatedRuntimeNote(api.handleListDir))
+	jsonMux.HandleFunc("POST /v1/files/mkdir", deprecatedRuntimeNote(api.handleMkdir))
+	jsonMux.HandleFunc("POST /v1/files/remove", deprecatedRuntimeNote(api.handleRemove))
+	jsonMux.HandleFunc("POST /v1/vitals", deprecatedRuntimeNote(api.handleVitals))
+	// Lifecycle/management routes have NO Connect runtime successor and are NOT
+	// deprecated: they keep working unchanged.
 	jsonMux.HandleFunc("POST /v1/set_timeout", api.handleSetTimeout)
 	jsonMux.HandleFunc("POST /v1/pause", api.handlePause)
 	jsonMux.HandleFunc("POST /v1/resume", api.handleResume)
-	jsonMux.HandleFunc("POST /v1/vitals", api.handleVitals)
 
 	// Connect Sandbox service (issue #24, Task 3.2). The BearerInterceptor
 	// enforces the same per-sandbox bearer-token security as requireBearer, but
@@ -582,10 +589,28 @@ func (api *SandboxAPI) Handler() http.Handler {
 	// outer combines all three auth surfaces. The order of Handle calls matters:
 	// more specific prefixes (Connect, PTY) take precedence over the catch-all "/".
 	outer := http.NewServeMux()
-	outer.HandleFunc("GET /v1/pty", api.handlePty)
+	// The legacy PTY WebSocket is superseded by Connect Exec with PtyOptions
+	// (issue #24), so it carries the same Deprecation note as the other runtime
+	// routes (set on the upgrade handshake response).
+	outer.HandleFunc("GET /v1/pty", deprecatedRuntimeNote(api.handlePty))
 	outer.Handle(connectPath, connectHandler)
 	outer.Handle("/", api.requireBearer(jsonMux))
 	return outer
+}
+
+// deprecatedRuntimeNote wraps a legacy JSON /v1 runtime handler so its responses
+// carry the RFC 8594 Deprecation header and a Link to the Connect successor (the
+// sandbox.v1.Sandbox protocol, issue #24). The runtime exec/files/run_code/pty/
+// vitals surface is superseded by the Connect protocol; lifecycle routes
+// (set_timeout, pause, resume) have no Connect successor and are NOT wrapped. The
+// headers are set BEFORE delegating, so a caller is told of the deprecation
+// regardless of the handler's status code (including auth failures and errors).
+func deprecatedRuntimeNote(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.Header().Set("Link", `</sandbox.v1.Sandbox>; rel="successor-version"; title="Connect runtime protocol (issue #24)"`)
+		next(w, r)
+	}
 }
 
 // connectLookupToken is the token lookup function passed to BearerInterceptor


### PR DESCRIPTION
Marks the legacy JSON `/v1` runtime surface (exec, exec/stream, run_code/stream, files/*, pty, vitals) DEPRECATED in favor of the Connect `sandbox.v1.Sandbox` protocol (#24/#326) — the *"old HTTP shape ... shimmed with a deprecation note"* half of #24's acceptance criterion.

Each of those responses now carries an RFC 8594 `Deprecation: true` header plus `Link: </sandbox.v1.Sandbox>; rel="successor-version"` (`deprecatedRuntimeNote`), set before delegating so the note is present regardless of status. Routes stay active (deprecated-but-working) so existing SDK callers are not broken; they are removed once every SDK execs over Connect (#358, with the Go SDK now migrated in #367). Lifecycle routes (set_timeout, pause, resume) have no Connect successor and are deliberately not deprecated. Tested in `internal/daemon/deprecation_test.go`.

## Note on #328 (re-gating the KVM gRPC proof)
This PR originally also removed `continue-on-error` from the `kvm-test.yaml` "gRPC runtime protocol proof" phase. I dropped that change: the re-gate run revealed the phase is **intermittently flaky at guest gRPC-server bring-up** (green for 5 consecutive main runs, then red on this PR, which touches neither the guest nor the transport; the smoke driver already retries the dial for 30s). The transport itself (the #328 broken-pipe) is healthy, but gating a flaky phase would cause spurious CI failures. Details and a recommendation are on #328; the re-gate should follow a guest-bring-up flake fix reproduced on the KVM runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)