### PR TITLE
feat(console): Phase B2d account settings (profile, sessions, appearance)

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -57,6 +57,12 @@ func main() {
 	// so a provider event (payment failed / canceled) is reflected in the console.
 	statusStore := billing.NewMemStatusStore()
 	bill := setupBilling(logger, statusStore)
+
+	// sessionStore is created before console.New so it can be passed into
+	// Deps.Sessions in the production branch. In dev mode it is unused (the
+	// console's noopSessionLister default is fine for local smoke testing).
+	sessionStore := saas.NewSessionStore()
+
 	con := console.New(console.Deps{
 		Accounts: accounts,
 		Usage:    usage.NewMemUsageStore(),
@@ -78,7 +84,13 @@ func main() {
 		// Edition + feature flags from the server-controlled environment the chart
 		// sets; the SAME binary serves both editions.
 		Capabilities: caps,
-		Log:          logger,
+		// Wire the real session store so /console/account/sessions reflects live
+		// sessions. The adapter translates saas.Session to console.SessionRecord.
+		// Both dev and production share the same store; in dev the store is empty
+		// (no real session middleware issues tokens), which is fine for local
+		// smoke testing.
+		Sessions: sessionStoreAdapter{s: sessionStore},
+		Log:      logger,
 	})
 
 	mux := http.NewServeMux()
@@ -94,7 +106,6 @@ func main() {
 		// OIDC session cookie, and the embedded SPA is served at the root. ONE
 		// binary serves the BFF and the UI. The login flow and the middleware share
 		// ONE session store so a session issued at /auth/callback resolves here.
-		sessionStore := saas.NewSessionStore()
 		sessions := saas.NewSessionService(sessionStore, accounts)
 		mux.Handle("/console/", console.SessionMiddleware(sessions)(con))
 		mux.Handle("/", spa.Handler())
@@ -122,6 +133,31 @@ func main() {
 		log.Fatal(err)
 	}
 }
+
+// sessionStoreAdapter bridges *saas.SessionStore to the console.SessionLister
+// seam. It translates saas.Session to console.SessionRecord so the console
+// package does not import the production store directly.
+type sessionStoreAdapter struct{ s *saas.SessionStore }
+
+func (a sessionStoreAdapter) ListByAccount(accountID string) []console.SessionRecord {
+	recs := a.s.ListByAccount(accountID)
+	out := make([]console.SessionRecord, len(recs))
+	for i, r := range recs {
+		out[i] = console.SessionRecord{
+			ID:        r.ID,
+			AccountID: r.AccountID,
+			Label:     r.Label,
+			CreatedAt: r.CreatedAt,
+		}
+	}
+	return out
+}
+
+func (a sessionStoreAdapter) Revoke(accountID, sessionID string) error {
+	return a.s.Revoke(accountID, sessionID)
+}
+
+func (a sessionStoreAdapter) RevokeAll(accountID string) { a.s.RevokeAll(accountID) }
 
 // mountAuth discovers the OIDC issuer and mounts /auth/login, /auth/callback,
 // and /auth/logout. The LoginManager issues sessions into the SAME store the

--- a/docs/superpowers/plans/2026-06-25-console-b2d-profile.md
+++ b/docs/superpowers/plans/2026-06-25-console-b2d-profile.md
@@ -1,0 +1,288 @@
+# Console B2d: user profile + account settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Do NOT invoke finishing-a-development-branch; implement, test, commit, report.
+
+**Goal:** A best-practice account settings surface: an editable Profile (display name, timezone, locale; read-only email + org/role memberships), Security (active sessions list, revoke a session, sign out everywhere), and Appearance (reduced-motion and density preferences).
+
+**Architecture:** Go BFF gains profile fields on `Account` + `Get/UpdateProfile`, an auth-sensitive `SessionStore` extension (session records with ids + metadata, `ListByAccount`/`Revoke`/`RevokeAll`, with token `Resolve` unchanged so existing auth keeps working), and console endpoints (`GET/PATCH /console/account`, `GET /console/account/sessions`, `DELETE /console/account/sessions/{id}`, `DELETE /console/account/sessions`). The SPA gains an Account settings view. Appearance prefs are client-side (localStorage applied to `<html>` data attributes; honored by CSS).
+
+**Tech Stack:** Go (`internal/saas`), React+Vite+TS, TanStack Query, Vitest + vitest-axe.
+
+**Scope note:** B2d of the B2 split. Deferred to B3 / follow-up (each needs the auth work landing in B3): personal access tokens, notification preferences, 2FA/passkey enrollment, a light theme (a light variant conflicts with the additive-glow Fluorescence aesthetic and needs a dedicated design decision).
+
+**Security note:** the `SessionStore` change is an authentication-critical path. It must preserve the existing `Resolve(token)` contract exactly (revoked/unknown tokens are indistinguishable), and revoking a session must immediately invalidate that session's token. This task carries the security-sensitive-path discipline (CLAUDE.md): extra care + the cross-account isolation test (account A can never list or revoke account B's sessions).
+
+## Global Constraints
+
+- **Punctuation (strict):** no em (U+2014) or en (U+2013) dashes anywhere. Only `.` `,` `;` `:`; ASCII `-`. Verify each commit.
+- **Commits:** conventional + DCO (`git commit -s`). **Staging:** explicit paths only.
+- **Account isolation:** every account endpoint reads the caller's account id from request context (`CallerFromContext`) only; account A can never read or mutate account B's profile or sessions. Tested.
+- **Session security:** `Resolve` semantics unchanged; revoking a session invalidates its token; no token value or hash is ever logged or returned (only opaque session ids + non-secret metadata).
+- **Go style:** `fmt.Errorf("...: %w", err)`; gofmt clean; BOTH golangci-lint invocations clean; production code not errcheck-excluded.
+- **Responsive + accessible (spec 4.6):** the settings view is responsive; forms labelled; tabs/sections accessible; axe zero violations.
+- **TypeScript strict** clean; SPA suite exits 0; `go test ./internal/saas/...` green.
+
+## File Structure
+
+- `internal/saas/model.go` (modify) - add `DisplayName`, `Timezone`, `Locale` to `Account`.
+- `internal/saas/account.go` (modify) - `Profile(ctx, accountID)` and `UpdateProfile(ctx, accountID, ProfileUpdate)`.
+- `internal/saas/session.go` (modify) - session records + `ListByAccount`/`Revoke`/`RevokeAll`; `Resolve` unchanged.
+- `internal/saas/console/account.go` (create) - `AccountView`, the profile + sessions handlers.
+- `internal/saas/console/console.go` (modify) - register the account routes.
+- Go tests alongside.
+- `web/app/src/api.ts` (modify), `web/app/src/data/account-settings.ts` (create), `web/app/src/views/Settings.tsx` (create), `web/app/src/appearance.ts` (create) + applied in `App`/`main`.
+- `web/app/src/nav/routes.tsx` (modify) - point `/settings` at `Settings`.
+- `web/packages/brand/src/base.css` (modify) - settings + appearance styles + reduced-motion/density honoring.
+- Tests alongside.
+
+---
+
+### Task 1: Account profile (Go)
+
+**Files:**
+- Modify: `internal/saas/model.go`, `internal/saas/account.go`
+- Test: `internal/saas/account_test.go`
+
+**Interfaces:**
+- `Account` gains `DisplayName string`, `Timezone string`, `Locale string`.
+- `type ProfileUpdate struct { DisplayName, Timezone, Locale string }`.
+- `func (s *AccountService) Profile(ctx, accountID string) (Account, []Membership, error)` (the account + its memberships).
+- `func (s *AccountService) UpdateProfile(ctx, accountID string, u ProfileUpdate) (Account, error)` (loads the account, applies non-empty fields, `PutAccount`s it; `ErrNotFound` if absent).
+
+- [ ] **Step 1: Write the failing test (append to `internal/saas/account_test.go`)**
+
+```go
+func TestUpdateProfile(t *testing.T) {
+	svc, _, ownerID, _ := seedOrgWithOwnerAndMember(t)
+	if _, err := svc.UpdateProfile(context.Background(), ownerID, ProfileUpdate{DisplayName: "Alice A", Timezone: "Europe/Berlin", Locale: "en-GB"}); err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	acct, _, err := svc.Profile(context.Background(), ownerID)
+	if err != nil {
+		t.Fatalf("Profile: %v", err)
+	}
+	if acct.DisplayName != "Alice A" || acct.Timezone != "Europe/Berlin" || acct.Locale != "en-GB" {
+		t.Fatalf("profile not updated: %+v", acct)
+	}
+}
+```
+
+(Reuse the `seedOrgWithOwnerAndMember` helper from the B2c tests.)
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `go test ./internal/saas/ -run TestUpdateProfile`
+Expected: FAIL (undefined `UpdateProfile`/`Profile`/`ProfileUpdate`).
+
+- [ ] **Step 3: Implement the fields + methods**
+
+Add the three fields to `Account` in `model.go`. Add `ProfileUpdate`, `Profile`, `UpdateProfile` to `account.go` (read via `store.GetAccount`, apply non-empty fields, `store.PutAccount`; `Profile` also returns memberships via the existing membership listing). gofmt clean.
+
+- [ ] **Step 4: Run it, confirm pass; full package; gofmt**
+
+Run: `go test ./internal/saas/ -run TestUpdateProfile` then `go test ./internal/saas/`
+Run: `gofmt -l internal/saas/model.go internal/saas/account.go`
+Expected: PASS, gofmt clean, existing tests hold.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/saas/model.go internal/saas/account.go internal/saas/account_test.go
+git commit -s -m "feat(saas): account profile fields with Profile and UpdateProfile"
+```
+
+---
+
+### Task 2: Session records + management (Go, auth-sensitive)
+
+**Files:**
+- Modify: `internal/saas/session.go`
+- Test: `internal/saas/session_test.go`
+
+Read `internal/saas/session.go` fully first. The current `SessionStore` keeps `byHash map[string]string` (token hash -> account id). You will add a parallel session-record map WITHOUT changing the `Resolve(token)` contract.
+
+**Interfaces:**
+- `type Session struct { ID, AccountID string; CreatedAt time.Time; Label string }` (Label is a non-secret hint, e.g. "browser session"; NO token or hash).
+- `Issue` gains an id + record (keep the existing signature working: add an `IssueSession(accountID, token, label) string` that returns the session id, and keep `Issue` as a wrapper, OR extend `Issue` carefully without breaking callers; check all callers of `Issue` first).
+- `func (s *SessionStore) ListByAccount(accountID string) []Session` (most-recent-first; never another account's).
+- `func (s *SessionStore) Revoke(accountID, sessionID string) error` (removes the session AND its token hash so `Resolve` of that token now fails; `ErrNotFound` if the session is not that account's).
+- `func (s *SessionStore) RevokeAll(accountID string)` (all the account's sessions).
+- `Resolve(token)` unchanged in behavior.
+
+- [ ] **Step 1: Write the failing test `internal/saas/session_test.go` (extend)**
+
+```go
+func TestSessionListAndRevoke(t *testing.T) {
+	store := NewSessionStore()
+	id1 := store.IssueSession("acctA", "tokA1", "browser")
+	_ = store.IssueSession("acctA", "tokA2", "cli")
+	store.IssueSession("acctB", "tokB1", "browser")
+
+	a := store.ListByAccount("acctA")
+	if len(a) != 2 {
+		t.Fatalf("acctA sessions = %d, want 2", len(a))
+	}
+	// acctA never sees acctB.
+	for _, s := range a {
+		if s.AccountID != "acctA" {
+			t.Fatalf("leaked session for %s", s.AccountID)
+		}
+	}
+	// Revoking a session invalidates its token.
+	if err := store.Revoke("acctA", id1); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := store.Resolve("tokA1"); err == nil {
+		t.Fatalf("revoked token must not resolve")
+	}
+	// The other session still resolves.
+	if _, err := store.Resolve("tokA2"); err != nil {
+		t.Fatalf("tokA2 should still resolve: %v", err)
+	}
+	// acctA cannot revoke acctB's session.
+	bsel := store.ListByAccount("acctB")
+	if err := store.Revoke("acctA", bsel[0].ID); err == nil {
+		t.Fatalf("cross-account revoke must fail")
+	}
+}
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `go test ./internal/saas/ -run TestSessionListAndRevoke`
+Expected: FAIL (undefined `IssueSession`/`ListByAccount`/`Revoke`).
+
+- [ ] **Step 3: Implement the extension in `internal/saas/session.go`**
+
+Keep `byHash`. Add `records map[string]Session` (session id -> record) and `tokenByID map[string]string` (session id -> token hash) so `Revoke` can delete the hash from `byHash`. `IssueSession` generates an id (deterministic-safe; the store may use a counter under the lock, NOT `Math/rand`/clock in a way that breaks tests), stores the record + the byHash entry + tokenByID. `Resolve` unchanged. `ListByAccount` filters records by accountID. `Revoke` checks the record belongs to the account (else `ErrNotFound`), deletes the record, its byHash entry, and tokenByID. `RevokeAll` loops. All under the mutex. Find and update every caller of the old `Issue` (e.g. the login flow `LoginManager`) to use `IssueSession` or keep `Issue` as a label-defaulting wrapper.
+
+- [ ] **Step 4: Run it; full package; build; gofmt**
+
+Run: `go test ./internal/saas/ -run TestSession` then `go test ./internal/saas/`
+Run: `go build ./...` (catches broken `Issue` callers)
+Run: `gofmt -l internal/saas/session.go`
+Expected: PASS, build clean, gofmt clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/saas/session.go internal/saas/session_test.go
+git commit -s -m "feat(saas): session records with per-account list and revoke"
+```
+
+---
+
+### Task 3: Console account endpoints (Go)
+
+**Files:**
+- Create: `internal/saas/console/account.go`
+- Modify: `internal/saas/console/console.go`
+- Test: `internal/saas/console/account_test.go`
+
+Read the console seam/handler patterns first.
+
+**Interfaces:**
+- `AccountView = { account_id, email, display_name, timezone, locale, memberships: []MemberView }`; `SessionView = { id, label, created_at, current: bool }`.
+- Routes: `GET /console/account` (profile + memberships), `PATCH /console/account` (body `{display_name, timezone, locale}`), `GET /console/account/sessions`, `DELETE /console/account/sessions/{id}`, `DELETE /console/account/sessions`.
+- Handlers read the caller account id from `CallerFromContext`; the sessions endpoints call the `SessionStore` (a new `Deps.Sessions` seam, or reuse the account service if it exposes it). Keep it simple: add a narrow `SessionLister` seam to `Deps` (`ListByAccount`, `Revoke`, `RevokeAll`) defaulting to a no-op/in-memory in tests.
+
+- [ ] **Step 1: Write the failing test `internal/saas/console/account_test.go`**
+
+A test that `GET /console/account` returns the caller's profile, `PATCH` updates it, and `GET /console/account/sessions` lists only the caller's sessions (cross-account isolation). Model fixtures on the existing console tests; inject a fake `SessionLister` + the account service.
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `go test ./internal/saas/console/ -run TestAccount`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `account.go` + wire routes/deps in `console.go`**
+
+Add `AccountView`/`SessionView`, the `SessionLister` seam + `Deps.Sessions` (nil-default to an in-memory fake), register the five routes, implement the handlers (account from `CallerFromContext`; PATCH via `AccountService.UpdateProfile`; sessions via the seam; mark the caller's current session id if available, else `current:false`). Audit profile changes and session revokes via `c.audit`. Add the new routes to the auth-gate table in `console_test.go`.
+
+- [ ] **Step 4: Run tests; full package; both lint; gofmt**
+
+Run: `go test ./internal/saas/console/` ; `go build ./...`
+Run: `gofmt -l internal/saas/console/account.go internal/saas/console/console.go`
+Run: `golangci-lint run --timeout=5m ./internal/saas/... && GOOS=linux golangci-lint run --timeout=5m ./internal/saas/...`
+Expected: all green/clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/saas/console/account.go internal/saas/console/console.go internal/saas/console/account_test.go
+git commit -s -m "feat(console): account profile + session management endpoints"
+```
+
+---
+
+### Task 4: Settings view + appearance (frontend)
+
+**Files:**
+- Modify: `web/app/src/api.ts`, `web/app/src/nav/routes.tsx`, `web/app/src/main.tsx`
+- Create: `web/app/src/data/account-settings.ts`, `web/app/src/views/Settings.tsx`, `web/app/src/appearance.ts`
+- Test: `web/app/src/views/Settings.test.tsx`, `web/app/src/appearance.test.ts`
+
+**Interfaces:**
+- `AccountView`, `SessionView` types; `api.account()`, `api.updateAccount(patch)`, `api.sessions()`, `api.revokeSession(id)`, `api.revokeAllSessions()`.
+- Hooks: `useAccount`, `useUpdateAccount`, `useSessions`, `useRevokeSession`, `useRevokeAllSessions`.
+- `appearance.ts`: `getAppearance()/setAppearance({reducedMotion, density})` persisting to localStorage and applying `document.documentElement.dataset` (`reduceMotion`, `density`); `applyAppearanceOnLoad()` called from `main.tsx`.
+- `Settings` view: a `Tabs`-based view (Profile, Security, Appearance). Profile: editable display name / timezone / locale form + read-only email + memberships (with role badges). Security: the sessions table (label, created, current) with Revoke per row + a Sign out everywhere button. Appearance: reduced-motion toggle + density select, applied immediately.
+
+- [ ] **Step 1: Write the failing tests**
+
+`Settings.test.tsx`: render `/settings`, assert the Profile shows the email and an editable display-name input; switch to Security and see a session row; switch to Appearance and toggle reduced motion (assert `document.documentElement.dataset.reduceMotion` becomes set). `appearance.test.ts`: `setAppearance({reducedMotion:true,density:'compact'})` then `getAppearance()` round-trips and the dataset is applied.
+
+- [ ] **Step 2: Run them, confirm they fail**
+
+Run: `pnpm -C web/app test src/views/Settings.test.tsx src/appearance.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement api.ts additions, `appearance.ts`, `data/account-settings.ts`, `Settings.tsx`, route `/settings`, and `applyAppearanceOnLoad()` in `main.tsx`.**
+
+- [ ] **Step 4: Run tests, full suite, typecheck**
+
+Run: `pnpm -C web/app test src/views/Settings.test.tsx src/appearance.test.ts && pnpm -C web/app test && pnpm -C web/app typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/src/api.ts web/app/src/data/account-settings.ts web/app/src/views/Settings.tsx web/app/src/appearance.ts web/app/src/nav/routes.tsx web/app/src/main.tsx web/app/src/views/Settings.test.tsx web/app/src/appearance.test.ts
+git commit -s -m "feat(console): account settings view (profile, security sessions, appearance)"
+```
+
+---
+
+### Task 5: Styles, a11y, final verification
+
+**Files:**
+- Modify: `web/packages/brand/src/base.css`
+- Create: `web/app/src/views/Settings.a11y.test.tsx`
+
+- [ ] **Step 1: Append token-driven settings styles** (`.settings-section`, `.kv` reuse, a density rule honoring `html[data-density="compact"]` tightening table/row padding, and a `html[data-reduce-motion="true"] *` rule disabling transitions/animations - complementing the existing `prefers-reduced-motion` block). No raw hex. Mobile rule.
+
+- [ ] **Step 2: Write the axe a11y test `Settings.a11y.test.tsx`** (render `/settings`, assert zero violations on the Profile and Security tabs; tab controls and form inputs labelled). Fix any real violation.
+
+- [ ] **Step 3: Final verification**
+
+Run: `pnpm -C web/app test` (exit 0) ; `pnpm -C web/app typecheck` (clean) ; `pnpm -C web/app build` (succeeds)
+Run: `go test ./internal/saas/...` (green)
+Run: `golangci-lint run --timeout=5m ./internal/saas/... && GOOS=linux golangci-lint run --timeout=5m ./internal/saas/...` (clean)
+Run: `grep -rnP '\xe2\x80\x94|\xe2\x80\x93' web/app/src internal/saas/console/account.go internal/saas/session.go web/packages/brand/src/base.css` (empty)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/packages/brand/src/base.css web/app/src/views/Settings.a11y.test.tsx
+git commit -s -m "feat(console): settings styles and B2d accessibility checks"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (section 5.5):** editable profile (Task 1, 4: display name, timezone, locale; read-only email + memberships); security sessions (Task 2, 3, 4: list, revoke, sign-out-everywhere); appearance (Task 4: reduced-motion + density). Covered. Deferred (noted): personal access tokens, notifications, 2FA/passkeys, light theme (each needs the B3 auth work or a dedicated design decision).
+
+**Security:** the session-store change preserves `Resolve`, invalidates revoked tokens, and is cross-account isolated (Task 2 test). Account endpoints read the caller from context only and are isolation-tested (Task 3). The session store is a security-sensitive path: full review + named-human review before merge per CLAUDE.md.
+
+**Type consistency:** Go `AccountView`/`SessionView` JSON tags match the TS types (Task 4); `Profile`/`UpdateProfile` (Task 1) and the session methods (Task 2) back the endpoints (Task 3) consumed by the hooks (Task 4). No drift.

--- a/internal/saas/account.go
+++ b/internal/saas/account.go
@@ -195,6 +195,53 @@ func (s *AccountService) ListMembers(ctx context.Context, accountID, orgID strin
 	return members, nil
 }
 
+// ProfileUpdate carries the fields a caller may change on an account. Only
+// non-empty fields are applied; an empty field leaves the stored value
+// unchanged.
+type ProfileUpdate struct {
+	DisplayName string
+	Timezone    string
+	Locale      string
+}
+
+// Profile returns the account and its memberships for accountID. It is the
+// read side of the profile surface: the console profile page calls this to
+// populate the form.
+func (s *AccountService) Profile(ctx context.Context, accountID string) (Account, []Membership, error) {
+	acct, err := s.store.GetAccount(ctx, accountID)
+	if err != nil {
+		return Account{}, nil, fmt.Errorf("profile: %w", err)
+	}
+	mems, err := s.store.ListMemberships(ctx, accountID)
+	if err != nil {
+		return Account{}, nil, fmt.Errorf("profile: list memberships: %w", err)
+	}
+	return acct, mems, nil
+}
+
+// UpdateProfile applies non-empty fields from u to the account identified by
+// accountID, persists the result, and returns the updated account. If the
+// account does not exist, ErrNotFound is returned.
+func (s *AccountService) UpdateProfile(ctx context.Context, accountID string, u ProfileUpdate) (Account, error) {
+	acct, err := s.store.GetAccount(ctx, accountID)
+	if err != nil {
+		return Account{}, fmt.Errorf("update profile: %w", err)
+	}
+	if u.DisplayName != "" {
+		acct.DisplayName = u.DisplayName
+	}
+	if u.Timezone != "" {
+		acct.Timezone = u.Timezone
+	}
+	if u.Locale != "" {
+		acct.Locale = u.Locale
+	}
+	if err := s.store.PutAccount(ctx, acct); err != nil {
+		return Account{}, fmt.Errorf("update profile: store account: %w", err)
+	}
+	return acct, nil
+}
+
 // RevokeKey revokes a key by id on behalf of accountID, enforcing that the key
 // belongs to an org the account is a member of. This prevents an account from
 // revoking another org's key even if it learns the key id.

--- a/internal/saas/account_test.go
+++ b/internal/saas/account_test.go
@@ -218,6 +218,22 @@ func TestSetMemberRoleAuthorization(t *testing.T) {
 	}
 }
 
+// TestUpdateProfile asserts UpdateProfile persists display name, timezone, and
+// locale, and that Profile returns the updated values alongside memberships.
+func TestUpdateProfile(t *testing.T) {
+	svc, _, ownerID, _ := seedOrgWithOwnerAndMember(t)
+	if _, err := svc.UpdateProfile(context.Background(), ownerID, ProfileUpdate{DisplayName: "Alice A", Timezone: "Europe/Berlin", Locale: "en-GB"}); err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	acct, _, err := svc.Profile(context.Background(), ownerID)
+	if err != nil {
+		t.Fatalf("Profile: %v", err)
+	}
+	if acct.DisplayName != "Alice A" || acct.Timezone != "Europe/Berlin" || acct.Locale != "en-GB" {
+		t.Fatalf("profile not updated: %+v", acct)
+	}
+}
+
 // TestListMembersReturnsOrgMembers asserts a member can list its org's members
 // and that another org's members are never included.
 func TestListMembersReturnsOrgMembers(t *testing.T) {

--- a/internal/saas/console/account.go
+++ b/internal/saas/console/account.go
@@ -1,0 +1,306 @@
+package console
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// SessionRecord is the console-local shape of one session record. It mirrors the
+// fields the BFF needs from saas.Session but lives in this package so the seam
+// interface (SessionLister) does not import the production SessionStore directly.
+type SessionRecord struct {
+	ID        string
+	AccountID string
+	Label     string
+	CreatedAt time.Time
+}
+
+// SessionLister is the narrow seam the account-sessions endpoints read. It is
+// satisfied by *saas.SessionStore (via a thin adapter in cmd/console) and by
+// MemSessionLister in tests. Every method MUST be account-scoped: ListByAccount
+// returns only the named account's sessions; Revoke refuses a session that
+// belongs to a different account.
+type SessionLister interface {
+	// ListByAccount returns all sessions for accountID, account-scoped: sessions
+	// belonging to any other account are never returned.
+	ListByAccount(accountID string) []SessionRecord
+	// Revoke removes the session identified by sessionID from accountID's session
+	// set. Returns ErrNotFound (the saas package error) if the session does not
+	// exist or belongs to a different account.
+	Revoke(accountID, sessionID string) error
+	// RevokeAll removes every session belonging to accountID. Sessions belonging
+	// to other accounts are not affected.
+	RevokeAll(accountID string)
+}
+
+// MemSessionLister is the in-memory tested default for SessionLister. It stores
+// sessions per account and enforces account isolation on every access.
+type MemSessionLister struct {
+	mu   sync.Mutex
+	recs map[string]SessionRecord // session id -> record
+}
+
+// NewMemSessionLister returns an empty in-memory session lister.
+func NewMemSessionLister() *MemSessionLister {
+	return &MemSessionLister{recs: map[string]SessionRecord{}}
+}
+
+// Add stores a session record and returns its ID (convenience for test setup).
+func (m *MemSessionLister) Add(r SessionRecord) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recs[r.ID] = r
+	return r.ID
+}
+
+// ListByAccount returns all sessions for accountID. The list is never empty but
+// may contain zero elements; sessions for other accounts are never included.
+func (m *MemSessionLister) ListByAccount(accountID string) []SessionRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []SessionRecord
+	for _, r := range m.recs {
+		if r.AccountID == accountID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Revoke removes the session if it exists and belongs to accountID. Returns
+// saas.ErrNotFound if the session is absent or belongs to a different account.
+func (m *MemSessionLister) Revoke(accountID, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.recs[sessionID]
+	if !ok || r.AccountID != accountID {
+		return saas.ErrNotFound
+	}
+	delete(m.recs, sessionID)
+	return nil
+}
+
+// RevokeAll removes all sessions belonging to accountID and leaves every other
+// account's sessions intact.
+func (m *MemSessionLister) RevokeAll(accountID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, r := range m.recs {
+		if r.AccountID == accountID {
+			delete(m.recs, id)
+		}
+	}
+}
+
+// AccountView is the console-safe shape of an account's profile. It carries no
+// secret and no hash; it is safe to return to the account owner.
+type AccountView struct {
+	AccountID   string       `json:"account_id"`
+	Email       string       `json:"email"`
+	DisplayName string       `json:"display_name"`
+	Timezone    string       `json:"timezone"`
+	Locale      string       `json:"locale"`
+	Memberships []MemberView `json:"memberships"`
+}
+
+// SessionView is the console-safe shape of one session. Current is true when
+// the session is the one the caller is currently authenticated through; because
+// the console BFF does not (yet) surface the active session id, it always
+// defaults to false in this slice. The flag is reserved for the follow-up that
+// threads the session id through the auth middleware.
+type SessionView struct {
+	ID        string    `json:"id"`
+	Label     string    `json:"label"`
+	CreatedAt time.Time `json:"created_at"`
+	Current   bool      `json:"current"`
+}
+
+// accountView builds an AccountView from a saas.Account and its memberships.
+func accountView(acct saas.Account, mems []saas.Membership) AccountView {
+	mv := make([]MemberView, 0, len(mems))
+	for _, m := range mems {
+		mv = append(mv, MemberView{
+			AccountID: m.AccountID,
+			OrgID:     m.OrgID,
+			Role:      m.Role,
+			CreatedAt: m.CreatedAt,
+		})
+	}
+	return AccountView{
+		AccountID:   acct.ID,
+		Email:       acct.Email,
+		DisplayName: acct.DisplayName,
+		Timezone:    acct.Timezone,
+		Locale:      acct.Locale,
+		Memberships: mv,
+	}
+}
+
+// handleGetAccount returns the caller's profile and memberships. The account id
+// is always taken from the request context; it is never read from the path,
+// query, or body, which is the account-isolation guarantee.
+func (c *Console) handleGetAccount(w http.ResponseWriter, r *http.Request) {
+	accountID, _, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	acct, mems, err := c.deps.Accounts.Profile(r.Context(), accountID)
+	if err != nil {
+		c.failAccount(w, err, "the account profile could not be read")
+		return
+	}
+	writeJSON(w, http.StatusOK, accountView(acct, mems))
+}
+
+// updateProfileRequest is the PATCH /console/account body. Only non-empty fields
+// are applied; an empty field leaves the stored value unchanged.
+type updateProfileRequest struct {
+	DisplayName string `json:"display_name"`
+	Timezone    string `json:"timezone"`
+	Locale      string `json:"locale"`
+}
+
+// handlePatchAccount applies a partial update to the caller's own profile and
+// returns the updated view. The account id is always from context.
+func (c *Console) handlePatchAccount(w http.ResponseWriter, r *http.Request) {
+	accountID, orgID, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	var req updateProfileRequest
+	if err := decodeBody(r, &req); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the profile-update body is not valid JSON"))
+		return
+	}
+	updated, err := c.deps.Accounts.UpdateProfile(r.Context(), accountID, saas.ProfileUpdate{
+		DisplayName: req.DisplayName,
+		Timezone:    req.Timezone,
+		Locale:      req.Locale,
+	})
+	if err != nil {
+		c.failAccount(w, err, "the account profile could not be updated")
+		return
+	}
+	// Re-read memberships so the returned view is complete.
+	_, mems, err := c.deps.Accounts.Profile(r.Context(), accountID)
+	if err != nil {
+		c.failAccount(w, err, "the account profile could not be read after update")
+		return
+	}
+	c.audit(r.Context(), AuditEvent{
+		OrgID:   orgID,
+		ActorID: accountID,
+		Action:  "profile.update",
+		Target:  accountID,
+		Detail:  "updated account profile",
+		At:      c.deps.Now(),
+	})
+	writeJSON(w, http.StatusOK, accountView(updated, mems))
+}
+
+// handleListSessions returns the caller's sessions. The account id is from
+// context only; sessions belonging to other accounts are never included.
+func (c *Console) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	accountID, _, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	recs := c.deps.Sessions.ListByAccount(accountID)
+	out := make([]SessionView, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, SessionView{
+			ID:        rec.ID,
+			Label:     rec.Label,
+			CreatedAt: rec.CreatedAt,
+			Current:   false,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sessions": out})
+}
+
+// handleRevokeSession revokes a single session belonging to the caller. The
+// account id is from context only; an attempt to revoke another account's
+// session returns 404 (the session is indistinguishable from not found).
+func (c *Console) handleRevokeSession(w http.ResponseWriter, r *http.Request) {
+	accountID, orgID, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	sessionID := r.PathValue("id")
+	if err := c.deps.Sessions.Revoke(accountID, sessionID); err != nil {
+		if errors.Is(err, saas.ErrNotFound) {
+			apierr.Encode(w, apierr.Get(apierr.CodeNotFound).
+				WithCause("the session does not exist or does not belong to this account"))
+			return
+		}
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the session could not be revoked"))
+		return
+	}
+	c.audit(r.Context(), AuditEvent{
+		OrgID:   orgID,
+		ActorID: accountID,
+		Action:  "session.revoke",
+		Target:  sessionID,
+		Detail:  "revoked session " + sessionID,
+		At:      c.deps.Now(),
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"revoked": sessionID})
+}
+
+// handleRevokeAllSessions revokes every session belonging to the caller. It
+// never touches sessions that belong to other accounts.
+func (c *Console) handleRevokeAllSessions(w http.ResponseWriter, r *http.Request) {
+	accountID, orgID, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	c.deps.Sessions.RevokeAll(accountID)
+	c.audit(r.Context(), AuditEvent{
+		OrgID:   orgID,
+		ActorID: accountID,
+		Action:  "session.revoke_all",
+		Target:  accountID,
+		Detail:  "revoked all sessions",
+		At:      c.deps.Now(),
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"revoked_all": true})
+}
+
+// noopSessionLister is the zero-value SessionLister: returns no sessions, and
+// Revoke always returns ErrNotFound. It is the fallback when Deps.Sessions is
+// nil so the BFF is safe to instantiate without a real session store.
+type noopSessionLister struct{}
+
+func (noopSessionLister) ListByAccount(_ string) []SessionRecord { return nil }
+func (noopSessionLister) Revoke(_, _ string) error               { return saas.ErrNotFound }
+func (noopSessionLister) RevokeAll(_ string)                     {}
+
+// Compile-time interface checks.
+var _ SessionLister = (*MemSessionLister)(nil)
+var _ SessionLister = noopSessionLister{}
+
+// currentSessionKey is an unexported context key for threading the active
+// session id through the auth middleware so the sessions list can mark it
+// current. The gateway sets this alongside WithCaller; the follow-up that wires
+// the real session id can use WithCurrentSession below.
+type currentSessionKey struct{}
+
+// WithCurrentSession returns a context carrying the active session id. This is
+// called by the session middleware (the follow-up wiring) so the sessions list
+// handler can mark the caller's current session.
+func WithCurrentSession(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, currentSessionKey{}, sessionID)
+}

--- a/internal/saas/console/account_test.go
+++ b/internal/saas/console/account_test.go
@@ -1,0 +1,273 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/saas"
+)
+
+// accountFixture wires a console with two accounts (alice and bob), each with
+// their own personal org. A fake SessionLister seeds sessions for both so the
+// cross-account isolation tests can assert that session list calls never return
+// the other account's sessions.
+type accountFixture struct {
+	con         *Console
+	sessions    *MemSessionLister
+	aliceAcct   string
+	aliceOrg    string
+	bobAcct     string
+	bobOrg      string
+	aliceSessID string
+	bobSessID   string
+}
+
+func newAccountFixture(t *testing.T) *accountFixture {
+	t.Helper()
+	store := saas.NewMemStore()
+	keys := saas.NewKeyService(store)
+	accounts := saas.NewAccountService(store, keys)
+	ctx := context.Background()
+
+	alice, aliceOrg, err := accounts.SignUp(ctx, "alice@account-test.example")
+	if err != nil {
+		t.Fatalf("SignUp alice: %v", err)
+	}
+	bob, bobOrg, err := accounts.SignUp(ctx, "bob@account-test.example")
+	if err != nil {
+		t.Fatalf("SignUp bob: %v", err)
+	}
+
+	sessions := NewMemSessionLister()
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	aliceSessID := sessions.Add(SessionRecord{
+		ID:        "sess-alice-1",
+		AccountID: alice.ID,
+		Label:     "browser",
+		CreatedAt: now,
+	})
+	bobSessID := sessions.Add(SessionRecord{
+		ID:        "sess-bob-1",
+		AccountID: bob.ID,
+		Label:     "cli",
+		CreatedAt: now,
+	})
+
+	con := New(Deps{
+		Accounts: accounts,
+		Sessions: sessions,
+		Audit:    NewMemAuditLog(),
+		Now:      func() time.Time { return now },
+	})
+	return &accountFixture{
+		con:         con,
+		sessions:    sessions,
+		aliceAcct:   alice.ID,
+		aliceOrg:    aliceOrg.ID,
+		bobAcct:     bob.ID,
+		bobOrg:      bobOrg.ID,
+		aliceSessID: aliceSessID,
+		bobSessID:   bobSessID,
+	}
+}
+
+func (f *accountFixture) req(t *testing.T, method, target, body, acct, org string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, target, nil)
+	} else {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	}
+	r = r.WithContext(WithCaller(r.Context(), acct, org))
+	w := httptest.NewRecorder()
+	f.con.ServeHTTP(w, r)
+	return w
+}
+
+// --- Profile GET ---
+
+func TestAccountProfileReturnsCallerProfile(t *testing.T) {
+	f := newAccountFixture(t)
+	w := f.req(t, "GET", "/console/account", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AccountView
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%s", err, w.Body.String())
+	}
+	if resp.AccountID != f.aliceAcct {
+		t.Errorf("account_id = %q, want alice", resp.AccountID)
+	}
+	if resp.Email != "alice@account-test.example" {
+		t.Errorf("email = %q, want alice@account-test.example", resp.Email)
+	}
+}
+
+func TestAccountProfileNeverReturnsOtherAccount(t *testing.T) {
+	f := newAccountFixture(t)
+	// Alice authenticated but we ensure her profile contains her account_id only.
+	w := f.req(t, "GET", "/console/account", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), f.bobAcct) {
+		t.Errorf("alice profile response leaked bob account id: %s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "bob@") {
+		t.Errorf("alice profile response leaked bob email: %s", w.Body.String())
+	}
+}
+
+// --- Profile PATCH ---
+
+func TestAccountProfilePatchUpdatesCallerOnly(t *testing.T) {
+	f := newAccountFixture(t)
+	body := `{"display_name":"Alice A","timezone":"Europe/Berlin","locale":"de-DE"}`
+	w := f.req(t, "PATCH", "/console/account", body, f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AccountView
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DisplayName != "Alice A" {
+		t.Errorf("display_name = %q, want Alice A", resp.DisplayName)
+	}
+	if resp.Timezone != "Europe/Berlin" {
+		t.Errorf("timezone = %q, want Europe/Berlin", resp.Timezone)
+	}
+	if resp.Locale != "de-DE" {
+		t.Errorf("locale = %q, want de-DE", resp.Locale)
+	}
+	// Bob's profile must be unchanged.
+	bw := f.req(t, "GET", "/console/account", "", f.bobAcct, f.bobOrg)
+	var bobResp AccountView
+	if err := json.Unmarshal(bw.Body.Bytes(), &bobResp); err != nil {
+		t.Fatalf("decode bob: %v", err)
+	}
+	if bobResp.DisplayName == "Alice A" || bobResp.Timezone == "Europe/Berlin" {
+		t.Errorf("patch leaked into bob profile: %+v", bobResp)
+	}
+}
+
+func TestAccountProfilePatchAudits(t *testing.T) {
+	f := newAccountFixture(t)
+	f.req(t, "PATCH", "/console/account", `{"display_name":"New Name"}`, f.aliceAcct, f.aliceOrg)
+	// Verify the audit event was recorded by checking that the audit log records the profile update.
+	// We cannot query audit directly from the fixture here, but we can call /console/audit
+	// as alice and look for the profile.update action.
+	w := f.req(t, "GET", "/console/audit", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("audit status = %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "profile.update") {
+		t.Errorf("profile.update not in audit log: %s", w.Body.String())
+	}
+}
+
+// --- Sessions GET ---
+
+func TestAccountSessionsListOnlyCallerSessions(t *testing.T) {
+	f := newAccountFixture(t)
+	w := f.req(t, "GET", "/console/account/sessions", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Sessions []SessionView `json:"sessions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%s", err, w.Body.String())
+	}
+	// Must have alice's session only; never bob's.
+	if len(resp.Sessions) != 1 {
+		t.Fatalf("sessions count = %d, want 1 (alice only); got %+v", len(resp.Sessions), resp.Sessions)
+	}
+	if resp.Sessions[0].ID != f.aliceSessID {
+		t.Errorf("session id = %q, want alice sess id %q", resp.Sessions[0].ID, f.aliceSessID)
+	}
+	if strings.Contains(w.Body.String(), f.bobSessID) {
+		t.Errorf("alice sessions response leaked bob session: %s", w.Body.String())
+	}
+}
+
+func TestAccountSessionsNoCrossAccountLeak(t *testing.T) {
+	f := newAccountFixture(t)
+	// Request as bob; alice's session must not appear.
+	w := f.req(t, "GET", "/console/account/sessions", "", f.bobAcct, f.bobOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), f.aliceSessID) {
+		t.Errorf("bob sessions response leaked alice session: %s", w.Body.String())
+	}
+}
+
+// --- Session DELETE one ---
+
+func TestAccountSessionRevokeOwn(t *testing.T) {
+	f := newAccountFixture(t)
+	w := f.req(t, "DELETE", "/console/account/sessions/"+f.aliceSessID, "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	// After revoke, the session should no longer appear in the list.
+	lw := f.req(t, "GET", "/console/account/sessions", "", f.aliceAcct, f.aliceOrg)
+	if strings.Contains(lw.Body.String(), f.aliceSessID) {
+		t.Errorf("revoked session still appears in list: %s", lw.Body.String())
+	}
+}
+
+func TestAccountSessionRevokeRefusesCrossAccount(t *testing.T) {
+	f := newAccountFixture(t)
+	// Alice tries to revoke bob's session: must return 404 (indistinguishable from not found).
+	w := f.req(t, "DELETE", "/console/account/sessions/"+f.bobSessID, "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-account revoke = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+	// Bob's session must still be there.
+	bw := f.req(t, "GET", "/console/account/sessions", "", f.bobAcct, f.bobOrg)
+	if !strings.Contains(bw.Body.String(), f.bobSessID) {
+		t.Errorf("bob session disappeared after alice's failed revoke: %s", bw.Body.String())
+	}
+}
+
+// --- Sessions DELETE all ---
+
+func TestAccountSessionsRevokeAll(t *testing.T) {
+	f := newAccountFixture(t)
+	// Seed a second session for alice.
+	f.sessions.Add(SessionRecord{
+		ID:        "sess-alice-2",
+		AccountID: f.aliceAcct,
+		Label:     "cli",
+		CreatedAt: time.Now(),
+	})
+	w := f.req(t, "DELETE", "/console/account/sessions", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	lw := f.req(t, "GET", "/console/account/sessions", "", f.aliceAcct, f.aliceOrg)
+	var resp struct {
+		Sessions []SessionView `json:"sessions"`
+	}
+	if err := json.Unmarshal(lw.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Sessions) != 0 {
+		t.Errorf("expected 0 sessions after RevokeAll, got %d: %+v", len(resp.Sessions), resp.Sessions)
+	}
+	// Bob's sessions must survive.
+	bw := f.req(t, "GET", "/console/account/sessions", "", f.bobAcct, f.bobOrg)
+	if !strings.Contains(bw.Body.String(), f.bobSessID) {
+		t.Errorf("bob session was removed by alice's RevokeAll: %s", bw.Body.String())
+	}
+}

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -52,6 +52,11 @@ type Deps struct {
 	ForkTree    ForkTreeSource
 	Projects    ProjectStore
 	Portal      PortalLinker
+	// Sessions is the account-scoped session-listing seam. It is used by the
+	// account-session endpoints (list, revoke one, revoke all) and defaults to a
+	// no-op in-memory implementation so the BFF is safe to instantiate without a
+	// real session store.
+	Sessions SessionLister
 	// Capabilities is the deployment edition + feature flags the console
 	// advertises at GET /console/capabilities. Left zero, it defaults to the
 	// self-hosted community edition.
@@ -95,6 +100,9 @@ func New(deps Deps) *Console {
 	}
 	if deps.Portal == nil {
 		deps.Portal = noPortal{}
+	}
+	if deps.Sessions == nil {
+		deps.Sessions = noopSessionLister{}
 	}
 	if deps.Logs == nil {
 		// Default to an authorizing streamer over the (already-defaulted)
@@ -150,6 +158,11 @@ func (c *Console) routes() {
 	mux.HandleFunc("GET /console/projects", c.handleListProjects)
 	mux.HandleFunc("POST /console/projects", c.handleCreateProject)
 	mux.HandleFunc("POST /console/members/{accountID}/role", c.handleSetMemberRole)
+	mux.HandleFunc("GET /console/account", c.handleGetAccount)
+	mux.HandleFunc("PATCH /console/account", c.handlePatchAccount)
+	mux.HandleFunc("GET /console/account/sessions", c.handleListSessions)
+	mux.HandleFunc("DELETE /console/account/sessions/{id}", c.handleRevokeSession)
+	mux.HandleFunc("DELETE /console/account/sessions", c.handleRevokeAllSessions)
 	c.mux = mux
 }
 

--- a/internal/saas/console/console_test.go
+++ b/internal/saas/console/console_test.go
@@ -498,6 +498,11 @@ func TestEveryEndpointRefusesMissingOrgContext(t *testing.T) {
 		{"GET", "/console/projects"},
 		{"POST", "/console/projects"},
 		{"POST", "/console/members/someacct/role"},
+		{"GET", "/console/account"},
+		{"PATCH", "/console/account"},
+		{"GET", "/console/account/sessions"},
+		{"DELETE", "/console/account/sessions/x"},
+		{"DELETE", "/console/account/sessions"},
 	}
 	for _, ep := range endpoints {
 		// No WithCaller: the request carries no org context.

--- a/internal/saas/model.go
+++ b/internal/saas/model.go
@@ -33,6 +33,16 @@ type Account struct {
 	CreatedAt time.Time
 	// PersonalOrgID is the id of the org created alongside the account.
 	PersonalOrgID string
+	// DisplayName is the human-readable name shown in the console. Optional.
+	DisplayName string
+	// Timezone is the IANA timezone string preferred by the account holder (for
+	// example "Europe/Berlin"). Optional; empty means the console falls back to
+	// browser-local time.
+	Timezone string
+	// Locale is the BCP 47 language tag for the account holder (for example
+	// "en-GB"). Optional; empty means the console falls back to the browser
+	// locale.
+	Locale string
 }
 
 // Organization is the unit of ownership, billing, and quota. Every sandbox,

--- a/internal/saas/session.go
+++ b/internal/saas/session.go
@@ -6,40 +6,78 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"sort"
 	"sync"
+	"time"
 )
 
 // ErrSessionInvalid is returned when a session token does not resolve to an
 // account. It never reveals whether the token was malformed or simply unknown.
 var ErrSessionInvalid = errors.New("saas: session token is invalid")
 
+// Session is the non-secret record the store keeps per issued session. It
+// carries no token value and no token hash; it is safe to return to the
+// session owner.
+type Session struct {
+	ID        string
+	AccountID string
+	CreatedAt time.Time
+	Label     string
+}
+
 // SessionStore maps an opaque session token to the account behind it. Like API
 // keys, session tokens are stored hashed, never in the clear, and resolved in
 // constant time. This is the seam the browser OAuth login flow (a documented
-// follow-up) plugs into; the token-based CLI login in this slice issues a session
-// token directly. The in-memory implementation is the tested default.
+// follow-up) plugs into; the token-based CLI login in this slice issues a
+// session token directly. The in-memory implementation is the tested default.
 type SessionStore struct {
-	mu     sync.RWMutex
-	byHash map[string]string // session-token hash -> account id
+	mu       sync.RWMutex
+	byHash   map[string]string  // session-token hash -> account id
+	records  map[string]Session // session id -> Session record
+	hashByID map[string]string  // session id -> token hash
+	nextID   uint64             // counter for deterministic, test-safe session ids
 }
 
 // NewSessionStore returns an empty in-memory session store.
 func NewSessionStore() *SessionStore {
-	return &SessionStore{byHash: map[string]string{}}
+	return &SessionStore{
+		byHash:   map[string]string{},
+		records:  map[string]Session{},
+		hashByID: map[string]string{},
+	}
 }
 
-// Issue records that token authenticates accountID. The raw token is hashed; the
-// store never holds it in the clear. The caller is responsible for delivering the
-// raw token to the user over a secure channel exactly once.
-func (s *SessionStore) Issue(accountID, token string) {
+// IssueSession records that token authenticates accountID and attaches a
+// human-readable label (e.g. "browser", "cli"). The raw token is hashed; the
+// store never holds it in the clear. Returns the opaque session id.
+func (s *SessionStore) IssueSession(accountID, token, label string) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.byHash[hashSession(token)] = accountID
+	s.nextID++
+	id := fmt.Sprintf("sess-%d", s.nextID)
+	h := hashSession(token)
+	s.byHash[h] = accountID
+	s.records[id] = Session{
+		ID:        id,
+		AccountID: accountID,
+		CreatedAt: time.Now(),
+		Label:     label,
+	}
+	s.hashByID[id] = h
+	return id
 }
 
-// Resolve returns the account id for a session token, or ErrSessionInvalid. The
-// lookup is by exact hash, so a forged token simply fails to resolve; the
-// constant-time compare guards the hash equality.
+// Issue records that token authenticates accountID. This is a backward-
+// compatible wrapper around IssueSession with a default label so existing
+// callers (e.g. oidc.go LoginManager) compile unchanged.
+func (s *SessionStore) Issue(accountID, token string) {
+	s.IssueSession(accountID, token, "session")
+}
+
+// Resolve returns the account id for a session token, or ErrSessionInvalid.
+// The lookup is by exact hash, so a forged or revoked token simply fails to
+// resolve; the constant-time compare guards the hash equality.
 func (s *SessionStore) Resolve(token string) (string, error) {
 	h := hashSession(token)
 	s.mu.RLock()
@@ -56,6 +94,57 @@ func (s *SessionStore) Resolve(token string) (string, error) {
 	return id, nil
 }
 
+// ListByAccount returns all sessions for accountID, most-recent-first. It
+// never returns sessions belonging to any other account.
+func (s *SessionStore) ListByAccount(accountID string) []Session {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []Session
+	for _, rec := range s.records {
+		if rec.AccountID == accountID {
+			out = append(out, rec)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out
+}
+
+// Revoke removes the session identified by sessionID from accountID's session
+// set and deletes its token hash so Resolve of that token now returns
+// ErrSessionInvalid. If sessionID does not exist or belongs to a different
+// account, ErrNotFound is returned; in that case no state is modified.
+func (s *SessionStore) Revoke(accountID, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[sessionID]
+	if !ok || rec.AccountID != accountID {
+		return ErrNotFound
+	}
+	h := s.hashByID[sessionID]
+	delete(s.byHash, h)
+	delete(s.hashByID, sessionID)
+	delete(s.records, sessionID)
+	return nil
+}
+
+// RevokeAll removes every session belonging to accountID and invalidates their
+// tokens. Sessions belonging to other accounts are not affected.
+func (s *SessionStore) RevokeAll(accountID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, rec := range s.records {
+		if rec.AccountID != accountID {
+			continue
+		}
+		h := s.hashByID[id]
+		delete(s.byHash, h)
+		delete(s.hashByID, id)
+		delete(s.records, id)
+	}
+}
+
 // hashSession hashes a session token for at-rest storage. Sessions are not
 // salted with the key pepper because they are short-lived and store-local; the
 // sha256 is sufficient to avoid holding the raw token.
@@ -64,10 +153,10 @@ func hashSession(token string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// SessionService ties a SessionStore to an AccountService so a session token can
-// be resolved to its account and that account's organizations. It is the object
-// the CLI bridge (cmd/mitos) and the future web console (issue #214) use to back
-// the token-based auth surface.
+// SessionService ties a SessionStore to an AccountService so a session token
+// can be resolved to its account and that account's organizations. It is the
+// object the CLI bridge (cmd/mitos) and the future web console (issue #214)
+// use to back the token-based auth surface.
 type SessionService struct {
 	sessions *SessionStore
 	accounts *AccountService

--- a/internal/saas/session_test.go
+++ b/internal/saas/session_test.go
@@ -52,3 +52,39 @@ func TestSessionStoresTokenHashedNotInClear(t *testing.T) {
 		}
 	}
 }
+
+// TestSessionListAndRevoke verifies per-account session listing and revocation,
+// including cross-account isolation and token invalidation on revoke.
+func TestSessionListAndRevoke(t *testing.T) {
+	store := NewSessionStore()
+	id1 := store.IssueSession("acctA", "tokA1", "browser")
+	_ = store.IssueSession("acctA", "tokA2", "cli")
+	store.IssueSession("acctB", "tokB1", "browser")
+
+	a := store.ListByAccount("acctA")
+	if len(a) != 2 {
+		t.Fatalf("acctA sessions = %d, want 2", len(a))
+	}
+	// acctA never sees acctB.
+	for _, s := range a {
+		if s.AccountID != "acctA" {
+			t.Fatalf("leaked session for %s", s.AccountID)
+		}
+	}
+	// Revoking a session invalidates its token.
+	if err := store.Revoke("acctA", id1); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := store.Resolve("tokA1"); err == nil {
+		t.Fatalf("revoked token must not resolve")
+	}
+	// The other session still resolves.
+	if _, err := store.Resolve("tokA2"); err != nil {
+		t.Fatalf("tokA2 should still resolve: %v", err)
+	}
+	// acctA cannot revoke acctB's session.
+	bsel := store.ListByAccount("acctB")
+	if err := store.Revoke("acctA", bsel[0].ID); err == nil {
+		t.Fatalf("cross-account revoke must fail")
+	}
+}

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -63,6 +63,28 @@ export type Role = 'owner' | 'admin' | 'billing' | 'member' | 'viewer'
 export type MemberView = { account_id: string; org_id: string; role: Role; created_at: string }
 export type ProjectView = { id: string; org_id: string; name: string; description: string; created_at: string }
 
+export type AccountView = {
+  account_id: string
+  email: string
+  display_name: string
+  timezone: string
+  locale: string
+  memberships: MemberView[]
+}
+
+export type AccountPatch = {
+  display_name?: string
+  timezone?: string
+  locale?: string
+}
+
+export type SessionView = {
+  id: string
+  label: string
+  created_at: string
+  current: boolean
+}
+
 async function get<T>(path: string): Promise<T> {
   const r = await fetch(path, { credentials: 'same-origin' })
   if (!r.ok) throw new Error(`${path}: ${r.status}`)
@@ -137,6 +159,32 @@ export const api = {
     })
     if (!r.ok) throw new Error(`create project: ${r.status}`)
     return (await r.json()) as ProjectView
+  },
+  account: () => get<AccountView>('/console/account'),
+  updateAccount: async (patch: AccountPatch) => {
+    const r = await fetch('/console/account', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(patch),
+    })
+    if (!r.ok) throw new Error(`update account: ${r.status}`)
+    return (await r.json()) as AccountView
+  },
+  sessions: () => get<{ sessions: SessionView[] }>('/console/account/sessions').then((r) => r.sessions ?? []),
+  revokeSession: async (id: string) => {
+    const r = await fetch(`/console/account/sessions/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+    if (!r.ok && r.status !== 204) throw new Error(`revoke session: ${r.status}`)
+  },
+  revokeAllSessions: async () => {
+    const r = await fetch('/console/account/sessions', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+    if (!r.ok && r.status !== 204) throw new Error(`revoke all sessions: ${r.status}`)
   },
 }
 

--- a/web/app/src/appearance.test.ts
+++ b/web/app/src/appearance.test.ts
@@ -1,0 +1,41 @@
+// Behavior tests for the appearance module: round-trip localStorage persistence
+// and document.documentElement.dataset side-effects.
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getAppearance, setAppearance } from './appearance'
+
+beforeEach(() => {
+  localStorage.clear()
+  delete document.documentElement.dataset['reduceMotion']
+  delete document.documentElement.dataset['density']
+})
+
+describe('appearance', () => {
+  it('round-trips setAppearance -> getAppearance for reducedMotion:true, density:compact', () => {
+    setAppearance({ reducedMotion: true, density: 'compact' })
+    const got = getAppearance()
+    expect(got.reducedMotion).toBe(true)
+    expect(got.density).toBe('compact')
+  })
+
+  it('applies dataset.reduceMotion when reducedMotion is true', () => {
+    setAppearance({ reducedMotion: true, density: 'comfortable' })
+    expect(document.documentElement.dataset['reduceMotion']).toBe('1')
+  })
+
+  it('removes dataset.reduceMotion when reducedMotion is false', () => {
+    document.documentElement.dataset['reduceMotion'] = '1'
+    setAppearance({ reducedMotion: false, density: 'comfortable' })
+    expect(document.documentElement.dataset['reduceMotion']).toBeUndefined()
+  })
+
+  it('applies dataset.density', () => {
+    setAppearance({ reducedMotion: false, density: 'compact' })
+    expect(document.documentElement.dataset['density']).toBe('compact')
+  })
+
+  it('returns defaults when nothing is stored', () => {
+    const got = getAppearance()
+    expect(got.reducedMotion).toBe(false)
+    expect(got.density).toBe('comfortable')
+  })
+})

--- a/web/app/src/appearance.ts
+++ b/web/app/src/appearance.ts
@@ -1,0 +1,55 @@
+// Appearance preferences: reduced-motion toggle + layout density.
+// Persisted to localStorage; applied immediately to document.documentElement.dataset
+// so that CSS can react without a React re-render cycle.
+// Guard every localStorage call with try/catch for SSR or restricted contexts.
+
+export type Density = 'comfortable' | 'compact'
+
+export type Appearance = {
+  reducedMotion: boolean
+  density: Density
+}
+
+const STORAGE_KEY = 'mitos-appearance'
+
+const DEFAULTS: Appearance = { reducedMotion: false, density: 'comfortable' }
+
+export function getAppearance(): Appearance {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { ...DEFAULTS }
+    const parsed = JSON.parse(raw) as Partial<Appearance>
+    return {
+      reducedMotion: typeof parsed.reducedMotion === 'boolean' ? parsed.reducedMotion : DEFAULTS.reducedMotion,
+      density: parsed.density === 'compact' || parsed.density === 'comfortable' ? parsed.density : DEFAULTS.density,
+    }
+  } catch {
+    return { ...DEFAULTS }
+  }
+}
+
+function applyToDocument(a: Appearance): void {
+  try {
+    if (a.reducedMotion) {
+      document.documentElement.dataset['reduceMotion'] = '1'
+    } else {
+      delete document.documentElement.dataset['reduceMotion']
+    }
+    document.documentElement.dataset['density'] = a.density
+  } catch {
+    // Non-browser context: no-op
+  }
+}
+
+export function setAppearance(a: Appearance): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(a))
+  } catch {
+    // Storage unavailable: still apply to document
+  }
+  applyToDocument(a)
+}
+
+export function applyAppearanceOnLoad(): void {
+  applyToDocument(getAppearance())
+}

--- a/web/app/src/data/account-settings.ts
+++ b/web/app/src/data/account-settings.ts
@@ -1,0 +1,46 @@
+// Account-settings hooks: profile fetch/update, session list, and session revocation.
+// useRevokeSession is optimistic: it removes the row from the cache before the
+// server responds and rolls back on error.
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api, type AccountView, type AccountPatch, type SessionView } from '../api'
+
+export function useAccount() {
+  return useQuery<AccountView>({ queryKey: ['account'], queryFn: () => api.account() })
+}
+
+export function useUpdateAccount() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (patch: AccountPatch) => api.updateAccount(patch),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['account'] }),
+  })
+}
+
+export function useSessions() {
+  return useQuery<SessionView[]>({ queryKey: ['sessions'], queryFn: () => api.sessions() })
+}
+
+export function useRevokeSession() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => api.revokeSession(id),
+    onMutate: async (id: string) => {
+      await qc.cancelQueries({ queryKey: ['sessions'] })
+      const prev = qc.getQueryData<SessionView[]>(['sessions'])
+      qc.setQueryData<SessionView[]>(['sessions'], (cur) => (cur ?? []).filter((s) => s.id !== id))
+      return { prev }
+    },
+    onError: (_e, _id, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['sessions'], ctx.prev)
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ['sessions'] }),
+  })
+}
+
+export function useRevokeAllSessions() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => api.revokeAllSessions(),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['sessions'] }),
+  })
+}

--- a/web/app/src/main.tsx
+++ b/web/app/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import '@mitos/brand/base.css'
 import { App } from './App'
+import { applyAppearanceOnLoad } from './appearance'
+
+applyAppearanceOnLoad()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -16,6 +16,7 @@ import { Templates } from '../views/Templates'
 import { Billing } from '../views/Billing'
 import { Members } from '../views/Members'
 import { Projects } from '../views/Projects'
+import { Settings } from '../views/Settings'
 
 export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Settings'
 export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Settings']
@@ -43,7 +44,7 @@ export const ROUTES: RouteDef[] = [
   { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Audit /> },
   { path: '/usage', label: 'Usage', group: 'Govern', element: () => <Usage /> },
   { path: '/billing', label: 'Billing', group: 'Govern', element: () => <Billing />, when: (c) => c.billing },
-  { path: '/settings', label: 'Settings', group: 'Settings', element: () => <Placeholder title="Settings" endpoint="/console/capabilities" phase="B2" /> },
+  { path: '/settings', label: 'Settings', group: 'Settings', element: () => <Settings /> },
 ]
 
 export function visibleRoutes(caps: Capabilities): RouteDef[] {

--- a/web/app/src/views/Settings.a11y.test.tsx
+++ b/web/app/src/views/Settings.a11y.test.tsx
@@ -1,0 +1,76 @@
+// Axe accessibility audit for the Settings view: no violations on Profile and Security tabs.
+// Uses vitest-axe (^0.1.0) which wraps axe-core and provides Vitest-compatible
+// matchers. Import path: 'vitest-axe' for axe(), 'vitest-axe/matchers' for the
+// custom expect matcher.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+import * as matchers from 'vitest-axe/matchers'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+import type { AccountView, SessionView } from '../api'
+
+expect.extend(matchers)
+
+const caps: Capabilities = {
+  edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc',
+  orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted',
+}
+
+const account: AccountView = {
+  account_id: 'acc-1',
+  email: 'test@example.com',
+  display_name: 'Test User',
+  timezone: 'UTC',
+  locale: 'en',
+  memberships: [{
+    account_id: 'acc-1',
+    org_id: 'org-1',
+    role: 'admin',
+    created_at: '2024-01-01T00:00:00Z',
+  }],
+}
+
+const sessions: SessionView[] = [{
+  id: 'sess-1',
+  label: 'Web browser',
+  created_at: '2024-01-01T00:00:00Z',
+  current: true,
+}]
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input)
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/account/sessions')) {
+      return Promise.resolve(new Response(JSON.stringify({ sessions }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/account')) {
+      return Promise.resolve(new Response(JSON.stringify(account), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('Settings accessibility', () => {
+  it('has no axe violations on the Profile tab', async () => {
+    const { container } = await renderAt('/settings', caps)
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument())
+    // Wait for profile data to load (display name input should be visible).
+    await waitFor(() => expect(screen.getByLabelText('Display name')).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations on the Security tab', async () => {
+    const user = userEvent.setup()
+    const { container } = await renderAt('/settings', caps)
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument())
+    await user.click(screen.getByRole('tab', { name: 'Security' }))
+    // Wait for sessions table to render.
+    await waitFor(() => expect(screen.getByRole('table', { name: 'Sessions' })).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/web/app/src/views/Settings.test.tsx
+++ b/web/app/src/views/Settings.test.tsx
@@ -1,0 +1,125 @@
+// Behavior tests for the Settings view: Profile (email, editable display name),
+// Security (session rows), and Appearance (reduced-motion toggle).
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, waitFor, screen } from '@testing-library/react'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = {
+  edition: 'community',
+  billing: false,
+  signup: false,
+  teams: false,
+  idp: 'oidc',
+  orgSwitcher: false,
+  secrets: { providers: ['kube'] },
+  proof: false,
+  ownership: 'self-hosted',
+}
+
+const accountPayload = {
+  account_id: 'acc-1',
+  email: 'alice@example.com',
+  display_name: 'Alice',
+  timezone: 'UTC',
+  locale: 'en',
+  memberships: [{ account_id: 'acc-1', org_id: 'org-1', role: 'owner', created_at: '2026-01-01T00:00:00Z' }],
+}
+
+const sessionsPayload = {
+  sessions: [
+    { id: 's1', label: 'Chrome on Linux', created_at: '2026-06-01T00:00:00Z', current: true },
+    { id: 's2', label: 'Firefox on macOS', created_at: '2026-06-10T00:00:00Z', current: false },
+  ],
+}
+
+function mockFetch() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input).split('?')[0]
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/account') && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify(accountPayload), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/account') && method === 'PATCH') {
+      return Promise.resolve(new Response(JSON.stringify(accountPayload), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/account/sessions') && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify(sessionsPayload), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/account\/sessions\/[^/]+/) && method === 'DELETE') {
+      return Promise.resolve(new Response(null, { status: 204 }))
+    }
+    if (url.endsWith('/console/account/sessions') && method === 'DELETE') {
+      return Promise.resolve(new Response(null, { status: 204 }))
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+}
+
+beforeEach(() => {
+  mockFetch()
+  localStorage.clear()
+  delete document.documentElement.dataset['reduceMotion']
+  delete document.documentElement.dataset['density']
+})
+
+describe('Settings view', () => {
+  it('renders the Profile tab with read-only email and editable display-name input', async () => {
+    await renderAt('/settings', caps)
+    await waitFor(() => expect(screen.getByText('alice@example.com')).toBeInTheDocument())
+    expect(screen.getByLabelText(/display.?name/i)).toBeInTheDocument()
+    const input = screen.getByLabelText(/display.?name/i)
+    expect(input.tagName).toBe('INPUT')
+  })
+
+  it('shows membership rows with role badges in the Profile tab', async () => {
+    await renderAt('/settings', caps)
+    await waitFor(() => expect(screen.getByText('alice@example.com')).toBeInTheDocument())
+    expect(screen.getByText('org-1')).toBeInTheDocument()
+    // Role badge is present
+    const badge = document.querySelector('.role-badge')
+    expect(badge).not.toBeNull()
+  })
+
+  it('switches to Security and shows session rows with Revoke buttons', async () => {
+    await renderAt('/settings', caps)
+    // Switch to Security tab
+    const securityTab = await waitFor(() => screen.getByRole('tab', { name: /security/i }))
+    fireEvent.click(securityTab)
+    await waitFor(() => expect(screen.getByText('Chrome on Linux')).toBeInTheDocument())
+    expect(screen.getByText('Firefox on macOS')).toBeInTheDocument()
+    const revokeButtons = screen.getAllByRole('button', { name: /revoke/i })
+    expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows a Sign out everywhere button in the Security tab', async () => {
+    await renderAt('/settings', caps)
+    const securityTab = await waitFor(() => screen.getByRole('tab', { name: /security/i }))
+    fireEvent.click(securityTab)
+    await waitFor(() => expect(screen.getByRole('button', { name: /sign out everywhere/i })).toBeInTheDocument())
+  })
+
+  it('switches to Appearance and toggling reduced-motion sets dataset.reduceMotion', async () => {
+    await renderAt('/settings', caps)
+    const appearanceTab = await waitFor(() => screen.getByRole('tab', { name: /appearance/i }))
+    fireEvent.click(appearanceTab)
+    const checkbox = await waitFor(() => screen.getByRole('checkbox', { name: /reduced.?motion/i }))
+    expect(checkbox).toBeInTheDocument()
+    // Toggle it on
+    fireEvent.click(checkbox)
+    expect(document.documentElement.dataset['reduceMotion']).toBe('1')
+  })
+
+  it('density select in Appearance applies dataset.density immediately', async () => {
+    await renderAt('/settings', caps)
+    const appearanceTab = await waitFor(() => screen.getByRole('tab', { name: /appearance/i }))
+    fireEvent.click(appearanceTab)
+    const densitySelect = await waitFor(() => screen.getByRole('combobox', { name: /density/i }))
+    fireEvent.change(densitySelect, { target: { value: 'compact' } })
+    expect(document.documentElement.dataset['density']).toBe('compact')
+  })
+})

--- a/web/app/src/views/Settings.tsx
+++ b/web/app/src/views/Settings.tsx
@@ -184,7 +184,7 @@ function SecurityTab() {
                 <th scope="col">Label</th>
                 <th scope="col">Created</th>
                 <th scope="col">Status</th>
-                <th scope="col"></th>
+                <th scope="col"><span className="sr-only">Actions</span></th>
               </tr>
             </thead>
             <tbody>
@@ -274,7 +274,12 @@ export function Settings() {
     <div>
       <h2>Settings</h2>
       <Tabs tabs={TABS} active={activeTab} onChange={setActiveTab} ariaLabel="Settings" />
-      <div style={{ marginTop: 'var(--space-6)' }}>
+      <div
+        id={`panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`tab-${activeTab}`}
+        style={{ marginTop: 'var(--space-6)' }}
+      >
         {activeTab === 'profile' && <ProfileTab />}
         {activeTab === 'security' && <SecurityTab />}
         {activeTab === 'appearance' && <AppearanceTab />}

--- a/web/app/src/views/Settings.tsx
+++ b/web/app/src/views/Settings.tsx
@@ -1,0 +1,284 @@
+// Account settings view: Profile, Security (sessions), and Appearance tabs.
+// Profile: editable display name / timezone / locale form + read-only email + memberships.
+// Security: sessions table with per-row revoke and a sign-out-everywhere button.
+// Appearance: reduced-motion toggle and density select applied immediately to the document.
+import { useState } from 'react'
+import { Tabs, type TabDef } from '../ui/Tabs'
+import { Skeleton } from '../ui/Skeleton'
+import { EmptyState } from '../ui/EmptyState'
+import { useToast } from '../ui/Toast'
+import { useAccount, useUpdateAccount, useSessions, useRevokeSession, useRevokeAllSessions } from '../data/account-settings'
+import { getAppearance, setAppearance } from '../appearance'
+
+const TABS: TabDef[] = [
+  { key: 'profile', label: 'Profile' },
+  { key: 'security', label: 'Security' },
+  { key: 'appearance', label: 'Appearance' },
+]
+
+// --- Profile tab ---
+
+function ProfileTab() {
+  const { data: account, isLoading, isError } = useAccount()
+  const updateAccount = useUpdateAccount()
+  const { notify } = useToast()
+
+  const [displayName, setDisplayName] = useState<string | undefined>(undefined)
+  const [timezone, setTimezone] = useState<string | undefined>(undefined)
+  const [locale, setLocale] = useState<string | undefined>(undefined)
+
+  // Use local state overrides if the user has started editing; fall back to fetched values.
+  const currentDisplayName = displayName ?? account?.display_name ?? ''
+  const currentTimezone = timezone ?? account?.timezone ?? ''
+  const currentLocale = locale ?? account?.locale ?? ''
+
+  function onSave(e: React.FormEvent) {
+    e.preventDefault()
+    updateAccount.mutate(
+      { display_name: currentDisplayName, timezone: currentTimezone, locale: currentLocale },
+      {
+        onSuccess: () => {
+          notify('Profile saved', 'ok')
+          // Clear local overrides so we reflect the server response.
+          setDisplayName(undefined)
+          setTimezone(undefined)
+          setLocale(undefined)
+        },
+        onError: () => notify('Failed to save profile', 'error'),
+      },
+    )
+  }
+
+  if (isLoading) return <Skeleton rows={4} />
+  if (isError) return <p className="t-dim">Failed to load account. Please refresh.</p>
+  if (!account) return null
+
+  return (
+    <section>
+      <h3>Profile</h3>
+
+      <div style={{ marginBottom: 'var(--space-5)' }}>
+        <p className="t-dim" style={{ fontSize: 'var(--step--1)' }}>
+          <strong>Email:</strong> {account.email}
+        </p>
+      </div>
+
+      <form onSubmit={onSave} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 480 }}>
+        <div>
+          <label htmlFor="display-name" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+            Display name
+          </label>
+          <input
+            id="display-name"
+            type="text"
+            value={currentDisplayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="input"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="timezone" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+            Timezone
+          </label>
+          <input
+            id="timezone"
+            type="text"
+            value={currentTimezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            className="input"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="locale" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+            Locale
+          </label>
+          <input
+            id="locale"
+            type="text"
+            value={currentLocale}
+            onChange={(e) => setLocale(e.target.value)}
+            className="input"
+          />
+        </div>
+
+        <div>
+          <button type="submit" disabled={updateAccount.isPending}>
+            {updateAccount.isPending ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </form>
+
+      {account.memberships.length > 0 && (
+        <div style={{ marginTop: 'var(--space-7)' }}>
+          <h4 style={{ marginBottom: 'var(--space-4)' }}>Memberships</h4>
+          <div style={{ overflowX: 'auto' }}>
+            <table className="tbl" aria-label="Memberships">
+              <thead>
+                <tr>
+                  <th scope="col">Org</th>
+                  <th scope="col">Role</th>
+                  <th scope="col">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {account.memberships.map((m) => (
+                  <tr key={`${m.account_id}-${m.org_id}`}>
+                    <td>{m.org_id}</td>
+                    <td>
+                      <span className={`role-badge role-${m.role}`}>{m.role}</span>
+                    </td>
+                    <td className="t-dim">{new Date(m.created_at).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+// --- Security tab ---
+
+function SecurityTab() {
+  const { data: sessions = [], isLoading, isError } = useSessions()
+  const revokeSession = useRevokeSession()
+  const revokeAll = useRevokeAllSessions()
+  const { notify } = useToast()
+
+  function onRevoke(id: string) {
+    revokeSession.mutate(id, {
+      onSuccess: () => notify('Session revoked', 'ok'),
+      onError: () => notify('Failed to revoke session', 'error'),
+    })
+  }
+
+  function onSignOutEverywhere() {
+    revokeAll.mutate(undefined, {
+      onSuccess: () => notify('Signed out everywhere', 'ok'),
+      onError: () => notify('Failed to sign out everywhere', 'error'),
+    })
+  }
+
+  return (
+    <section>
+      <h3>Security</h3>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Active sessions for your account. Revoke any session you do not recognise.
+      </p>
+
+      {isLoading ? (
+        <Skeleton rows={2} />
+      ) : isError ? (
+        <p className="t-dim">Failed to load sessions. Please refresh.</p>
+      ) : sessions.length === 0 ? (
+        <EmptyState title="No sessions" body="No active sessions found." />
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="tbl" aria-label="Sessions">
+            <thead>
+              <tr>
+                <th scope="col">Label</th>
+                <th scope="col">Created</th>
+                <th scope="col">Status</th>
+                <th scope="col"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((s) => (
+                <tr key={s.id}>
+                  <td>{s.label}</td>
+                  <td className="t-dim">{new Date(s.created_at).toLocaleDateString()}</td>
+                  <td>{s.current ? <span className="t-dim">Current</span> : null}</td>
+                  <td>
+                    {!s.current && (
+                      <button onClick={() => onRevoke(s.id)} disabled={revokeSession.isPending}>
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div style={{ marginTop: 'var(--space-6)' }}>
+        <button onClick={onSignOutEverywhere} disabled={revokeAll.isPending}>
+          Sign out everywhere
+        </button>
+      </div>
+    </section>
+  )
+}
+
+// --- Appearance tab ---
+
+function AppearanceTab() {
+  const [prefs, setPrefs] = useState(() => getAppearance())
+
+  function onReducedMotionChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const next = { ...prefs, reducedMotion: e.target.checked }
+    setPrefs(next)
+    setAppearance(next)
+  }
+
+  function onDensityChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const next = { ...prefs, density: e.target.value as 'comfortable' | 'compact' }
+    setPrefs(next)
+    setAppearance(next)
+  }
+
+  return (
+    <section>
+      <h3>Appearance</h3>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Changes apply immediately and persist across sessions.
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 400 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+          <input
+            id="reduced-motion"
+            type="checkbox"
+            checked={prefs.reducedMotion}
+            onChange={onReducedMotionChange}
+          />
+          <label htmlFor="reduced-motion">Reduced motion</label>
+        </div>
+
+        <div>
+          <label htmlFor="density" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+            Density
+          </label>
+          <select id="density" value={prefs.density} onChange={onDensityChange} aria-label="Density">
+            <option value="comfortable">Comfortable</option>
+            <option value="compact">Compact</option>
+          </select>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// --- Main Settings view ---
+
+export function Settings() {
+  const [activeTab, setActiveTab] = useState('profile')
+
+  return (
+    <div>
+      <h2>Settings</h2>
+      <Tabs tabs={TABS} active={activeTab} onChange={setActiveTab} ariaLabel="Settings" />
+      <div style={{ marginTop: 'var(--space-6)' }}>
+        {activeTab === 'profile' && <ProfileTab />}
+        {activeTab === 'security' && <SecurityTab />}
+        {activeTab === 'appearance' && <AppearanceTab />}
+      </div>
+    </div>
+  )
+}

--- a/web/packages/brand/src/base.css
+++ b/web/packages/brand/src/base.css
@@ -545,3 +545,31 @@ textarea::placeholder {
     overflow-x: auto;
   }
 }
+
+/* Settings layout: vertical rhythm for settings sections. */
+.settings-section {
+  margin-bottom: var(--space-7);
+}
+
+.settings-section h3 {
+  margin-bottom: var(--space-4);
+}
+
+/* Density override: compact tightens table cell padding. */
+html[data-density="compact"] .tbl th,
+html[data-density="compact"] .tbl td {
+  padding: var(--space-1) var(--space-2);
+}
+
+/* Reduced-motion override: JS-controlled complement to prefers-reduced-motion. */
+html[data-reduce-motion="1"] * {
+  transition: none !important;
+  animation: none !important;
+}
+
+/* Mobile: settings form fills viewport width. */
+@media (max-width: 768px) {
+  .settings-section form {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## What

Phase B2d of the Mitos Console: a best-practice account settings surface.

**Backend (`internal/saas`):**
- **Account profile** fields (display name, timezone, locale) + `Profile`/`UpdateProfile` (applies non-empty fields only).
- **Session records** (auth-sensitive): the `SessionStore` gains per-account session records with `ListByAccount` / `Revoke` / `RevokeAll`, while `Resolve(token)` is byte-for-byte unchanged. Revoking a session deletes its token hash (the token stops resolving); other sessions survive; cross-account list/revoke is impossible (returns not-found). No token value or hash is ever returned or logged.
- **Console endpoints**: `GET/PATCH /console/account`, `GET /console/account/sessions`, `DELETE /console/account/sessions/{id}`, `DELETE /console/account/sessions` (sign out everywhere), all account-isolated (account id read from request context only). Added to the auth-gate table. The real `SessionStore` is wired into the console binary via a thin adapter.

**Frontend:** an Account Settings view (Profile editable + memberships with role badges; Security: sessions list + revoke + sign-out-everywhere; Appearance: reduced-motion + density prefs persisted to localStorage and applied to the document).

Deferred to B3 (they belong with the SSO/auth work): personal access tokens, notification preferences, 2FA/passkeys. A light theme is deferred as a dedicated design decision (a light variant conflicts with the additive-glow Fluorescence aesthetic).

Plan: `docs/superpowers/plans/2026-06-25-console-b2d-profile.md`.

## SECURITY REVIEW REQUESTED

This PR modifies the **session / token store** (`internal/saas/session.go`), an authentication-critical path. Per CLAUDE.md, security-sensitive token code requires a named human reviewer before merge. Key invariants to confirm in review:
- `Resolve(token)` semantics unchanged (unknown/revoked tokens are indistinguishable).
- Revoking a session invalidates exactly that token; siblings survive.
- Cross-account isolation on list/revoke; no token/hash leaves the package.

## Verification

- Go: `go test ./internal/saas/... ./cmd/console/...` green (session list/revoke + cross-account isolation, account endpoints isolation, auth-gate table); gofmt clean; BOTH golangci-lint invocations clean.
- SPA: 89 passing (settings view, appearance round-trip, axe a11y), exit 0; typecheck + build clean.
- **Visual QA via Playwright screenshots:** the Settings view (Profile/Security/Appearance tabs, profile form, membership role badge) verified Linear-grade.
- No em/en dashes.

Refs #208 #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
