### PR TITLE
SDK: migrate Ruby, Java, Rust exec to the Connect runtime protocol (#358)

### DIFF
--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -178,8 +178,8 @@ result is prefixed with `mitos-default-`. For example `python:3.12` maps to
 | `fork(template, id)` | `POST /v1/fork` | `Sandbox` |
 | `fork(template, id, idempotencyKey)` | `POST /v1/fork` | `Sandbox` |
 | `listSandboxes()` | `GET /v1/sandboxes` | `List<ServerSandbox>` |
-| `Sandbox.exec(command)` | `POST /v1/exec` | `ExecResult` |
-| `Sandbox.exec(command, timeoutSeconds)` | `POST /v1/exec` | `ExecResult` |
+| `Sandbox.exec(command)` | `POST /sandbox.v1.Sandbox/ExecStream` | `ExecResult` |
+| `Sandbox.exec(command, timeoutSeconds)` | `POST /sandbox.v1.Sandbox/ExecStream` | `ExecResult` |
 | `Sandbox.terminate()` | `DELETE /v1/sandboxes/{id}` | `void` |
 
 Either constructor argument may be `null` to fall through the precedence below.

--- a/sdk/java/src/main/java/run/mitos/sdk/ConnectClient.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/ConnectClient.java
@@ -1,0 +1,341 @@
+// ConnectClient speaks the Connect sandbox.v1.Sandbox runtime protocol (issue
+// #358/#24) directly over the SDK's existing java.net.http.HttpClient, so the
+// Java SDK gains streaming exec WITHOUT a gRPC runtime or a codegen step: it
+// stays dependency-free (JDK stdlib only, the SDK's Json helper, java.util.Base64).
+// It mirrors the Go sdk/go/connect.go and the Python sdk/python/mitos/_connect.py
+// references; the proto-JSON message shapes come straight from
+// proto/sandbox/v1/sandbox.proto (camelCase field names; bytes fields are base64
+// strings).
+//
+// Only the server-streaming shape is implemented here (ExecStream): the SDK
+// sends ONE opening enveloped frame (the request message) and then reads a
+// stream of response frames. A frame is a 5-byte prefix (1 flag byte + 4-byte
+// big-endian length) then the JSON payload. The terminal server frame sets the
+// end-stream flag (0x02); its payload carries trailers and, on failure, an
+// {"error":{code,message}} object.
+//
+// The bearer token rides on Authorization and is never logged; it is redacted
+// from any error cause via the shared transport redactor.
+package run.mitos.sdk;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** A dependency-free client for the Connect sandbox.v1.Sandbox runtime service. */
+final class ConnectClient {
+
+    static final String SERVICE_NAME = "sandbox.v1.Sandbox";
+    static final String STREAM_CONTENT_TYPE = "application/connect+json";
+    static final String SANDBOX_ID_HEADER = "X-Sandbox-Id";
+
+    /** The end-stream flag (bit 1). The terminal server frame sets it; its
+     * payload carries trailers and an optional error object. */
+    static final int FLAG_END_STREAM = 0x02;
+    /** The compressed flag (bit 0). The SDK negotiates identity encoding and
+     * never sends or accepts a compressed frame, so this is only used to refuse
+     * an unexpected one. */
+    static final int FLAG_COMPRESSED = 0x01;
+
+    /** Guards the frame-length prefix so a malformed or hostile length cannot
+     * make the SDK allocate unbounded memory. */
+    static final long MAX_FRAME_BYTES = 64L << 20; // 64 MiB
+
+    // Maps the Connect textual error codes to the HTTP-ish status the SDK's
+    // typed-error layer keys remediation on. An unmapped code falls back to 500.
+    // Mirrors the Go and Python maps.
+    private static final Map<String, Integer> CONNECT_CODE_STATUS = Map.ofEntries(
+            Map.entry("canceled", 499),
+            Map.entry("unknown", 500),
+            Map.entry("invalid_argument", 400),
+            Map.entry("deadline_exceeded", 504),
+            Map.entry("not_found", 404),
+            Map.entry("already_exists", 409),
+            Map.entry("permission_denied", 403),
+            Map.entry("resource_exhausted", 429),
+            Map.entry("failed_precondition", 400),
+            Map.entry("aborted", 409),
+            Map.entry("out_of_range", 400),
+            Map.entry("unimplemented", 501),
+            Map.entry("internal", 500),
+            Map.entry("unavailable", 503),
+            Map.entry("data_loss", 500),
+            Map.entry("unauthenticated", 401));
+
+    private final HttpClient client;
+    private final String baseUrl;
+    private final String token;
+    private final HttpTransport transport;
+
+    ConnectClient(HttpTransport transport) {
+        this.transport = transport;
+        // Reuse the SDK's one HttpClient (and its connection pool); the request is
+        // pinned to HTTP/1.1 below.
+        this.client = transport.client();
+        this.baseUrl = transport.baseUrl();
+        this.token = transport.token();
+    }
+
+    /** The Connect RPC path for a Sandbox method name (e.g. "ExecStream"). */
+    private static String path(String method) {
+        return "/" + SERVICE_NAME + "/" + method;
+    }
+
+    /**
+     * Opens a server-streaming Connect call: sends {@code message} as the single
+     * opening enveloped frame and returns the list of response message payloads
+     * (each a parsed JSON object), draining the stream. The terminal end-stream
+     * frame is consumed here: a clean end ends the list, an error end throws a
+     * typed {@link MitosException}.
+     *
+     * @param method    the Sandbox method name (e.g. "ExecStream")
+     * @param sandboxId the sandbox id, sent as the X-Sandbox-Id header
+     * @param message   the proto-JSON request message (Map tree)
+     */
+    List<Map<String, Object>> serverStream(String method, String sandboxId, Map<String, Object> message) {
+        byte[] body = encodeFrame(Json.encode(message).getBytes(StandardCharsets.UTF_8), false);
+
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path(method)))
+                // Pin HTTP/1.1: the Connect server-stream is delivered as a plain
+                // chunked body that the SDK reads frame by frame, so we read it as
+                // a 1.1 stream rather than attempt an HTTP/2 upgrade.
+                .version(HttpClient.Version.HTTP_1_1)
+                .header("Content-Type", STREAM_CONTENT_TYPE)
+                .header("Connect-Protocol-Version", "1")
+                .header(SANDBOX_ID_HEADER, sandboxId)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body));
+        if (token != null) {
+            b.header("Authorization", "Bearer " + token);
+        }
+
+        HttpResponse<InputStream> resp;
+        try {
+            resp = client.send(b.build(), HttpResponse.BodyHandlers.ofInputStream());
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new MitosException(
+                    "sandbox RPC request failed: " + transport.redact(e.getMessage()),
+                    "transport_error",
+                    transport.redact(String.valueOf(e)),
+                    "Check the base URL is reachable and the network allows the request.",
+                    0);
+        }
+
+        int status = resp.statusCode();
+        if (status < 200 || status >= 300) {
+            // A streaming RPC that fails before the first frame returns a normal
+            // HTTP error body (the Connect error envelope), not an end-stream frame.
+            byte[] errBody = drain(resp.body());
+            throw connectErrorFromBody(status, new String(errBody, StandardCharsets.UTF_8));
+        }
+
+        List<Map<String, Object>> messages = new ArrayList<>();
+        try (InputStream in = resp.body()) {
+            FrameReader reader = new FrameReader(in);
+            Frame frame;
+            while ((frame = reader.next()) != null) {
+                if ((frame.flag & FLAG_COMPRESSED) != 0) {
+                    throw new MitosException(
+                            "sandbox RPC returned a compressed frame the SDK did not negotiate",
+                            "internal_error",
+                            "unexpected compressed Connect frame",
+                            "Report this; the SDK negotiates identity encoding.",
+                            500);
+                }
+                if ((frame.flag & FLAG_END_STREAM) != 0) {
+                    handleEndStream(frame.payload);
+                    return messages;
+                }
+                if (frame.payload.length == 0) {
+                    continue;
+                }
+                messages.add(SandboxServer.asObject(
+                        Json.parse(new String(frame.payload, StandardCharsets.UTF_8))));
+            }
+        } catch (IOException e) {
+            throw new MitosException(
+                    "sandbox RPC stream read failed: " + transport.redact(e.getMessage()),
+                    "transport_error",
+                    transport.redact(String.valueOf(e)),
+                    "Retry the request; if it persists, inspect the sandbox-server logs.",
+                    0);
+        }
+        // A clean transport EOF without an explicit end-stream frame ends the stream.
+        return messages;
+    }
+
+    // ---- frame parsing ----
+
+    /** Wraps one message payload in the Connect 5-byte envelope prefix: a flag
+     * byte, a 4-byte big-endian length, then the payload. */
+    static byte[] encodeFrame(byte[] payload, boolean endStream) {
+        byte flag = (byte) (endStream ? FLAG_END_STREAM : 0);
+        int n = payload.length;
+        byte[] out = new byte[5 + n];
+        out[0] = flag;
+        out[1] = (byte) ((n >>> 24) & 0xff);
+        out[2] = (byte) ((n >>> 16) & 0xff);
+        out[3] = (byte) ((n >>> 8) & 0xff);
+        out[4] = (byte) (n & 0xff);
+        System.arraycopy(payload, 0, out, 5, n);
+        return out;
+    }
+
+    /** One decoded Connect frame: the flag byte and the JSON payload bytes. */
+    private static final class Frame {
+        final int flag;
+        final byte[] payload;
+
+        Frame(int flag, byte[] payload) {
+            this.flag = flag;
+            this.payload = payload;
+        }
+    }
+
+    /** Reads Connect enveloped frames off an InputStream, reassembling each frame
+     * across read boundaries. {@link #next()} returns the next frame or null at a
+     * clean end of stream. */
+    private static final class FrameReader {
+        private final InputStream in;
+
+        FrameReader(InputStream in) {
+            this.in = in;
+        }
+
+        Frame next() throws IOException {
+            byte[] header = readN(5, true);
+            if (header == null) {
+                // A clean EOF at a frame boundary is the end of the stream.
+                return null;
+            }
+            int flag = header[0] & 0xff;
+            long len = ((long) (header[1] & 0xff) << 24)
+                    | ((long) (header[2] & 0xff) << 16)
+                    | ((long) (header[3] & 0xff) << 8)
+                    | (header[4] & 0xff);
+            if (len > MAX_FRAME_BYTES) {
+                throw new IOException("connect: response frame too large (" + len + " bytes)");
+            }
+            byte[] payload = readN((int) len, false);
+            if (payload == null) {
+                // Header read but payload truncated: a short frame is a hard error.
+                throw new IOException("connect: short frame payload");
+            }
+            return new Frame(flag, payload);
+        }
+
+        // readN reads exactly n bytes, looping until filled or EOF. When
+        // eofAtStartOk is true a clean EOF before the first byte returns null
+        // (the stream ended at a frame boundary); a truncated read still throws.
+        private byte[] readN(int n, boolean eofAtStartOk) throws IOException {
+            byte[] buf = new byte[n];
+            int off = 0;
+            while (off < n) {
+                int r = in.read(buf, off, n - off);
+                if (r < 0) {
+                    if (off == 0 && eofAtStartOk) {
+                        return null;
+                    }
+                    if (off == 0) {
+                        return null;
+                    }
+                    throw new IOException("connect: unexpected EOF mid-frame");
+                }
+                off += r;
+            }
+            return buf;
+        }
+    }
+
+    private static byte[] drain(InputStream in) {
+        try (in) {
+            return in.readAllBytes();
+        } catch (IOException e) {
+            return new byte[0];
+        }
+    }
+
+    // ---- error handling ----
+
+    /** Processes the terminal end-stream frame. A payload carrying an
+     * {"error":{code,message}} object throws a typed MitosException; a clean end
+     * (empty, trailers only, or non-JSON) returns normally. */
+    private void handleEndStream(byte[] payload) {
+        if (payload.length == 0) {
+            return;
+        }
+        Object parsed;
+        try {
+            parsed = Json.parse(new String(payload, StandardCharsets.UTF_8));
+        } catch (RuntimeException e) {
+            // Malformed trailer: treat as a clean end.
+            return;
+        }
+        if (!(parsed instanceof Map<?, ?> map)) {
+            return;
+        }
+        Object err = map.get("error");
+        if (err instanceof Map<?, ?> e) {
+            String code = SandboxServer.asString(e.get("code"));
+            String message = SandboxServer.asString(e.get("message"));
+            throw connectError(code, message, statusForCode(code));
+        }
+    }
+
+    /** Turns a non-2xx Connect response body into a typed MitosException. Prefers
+     * the Connect error envelope {code,message}; falls back to the raw redacted
+     * body and the HTTP status when the body is not the envelope. */
+    private MitosException connectErrorFromBody(int status, String rawBody) {
+        String body = rawBody == null ? "" : rawBody;
+        try {
+            Object parsed = Json.parse(body);
+            if (parsed instanceof Map<?, ?> map) {
+                String code = SandboxServer.asString(map.get("code"));
+                String message = SandboxServer.asString(map.get("message"));
+                if (code != null && !code.isEmpty()) {
+                    return connectError(code, message, status);
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Not the envelope: fall through to the raw body.
+        }
+        return new MitosException(
+                "sandbox RPC failed: HTTP " + status,
+                "http_error",
+                transport.redact(body.trim()),
+                "Inspect the request against the sandbox.v1.Sandbox contract.",
+                status);
+    }
+
+    /** Builds a typed MitosException from a Connect error code and message. The
+     * Connect textual code is the stable code; the message is redacted of any
+     * token before it becomes the cause. */
+    private MitosException connectError(String code, String message, int status) {
+        String stable = (code == null || code.isEmpty()) ? "internal" : code;
+        String cause = transport.redact(message == null ? "" : message);
+        if (cause.isEmpty()) {
+            cause = "connect error " + stable;
+        }
+        return new MitosException(
+                "sandbox RPC failed: " + stable,
+                stable,
+                cause,
+                "Inspect the request against the sandbox.v1.Sandbox contract.",
+                status);
+    }
+
+    private static int statusForCode(String code) {
+        Integer s = CONNECT_CODE_STATUS.get(code);
+        return s == null ? 500 : s;
+    }
+}

--- a/sdk/java/src/main/java/run/mitos/sdk/ExecResult.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/ExecResult.java
@@ -1,5 +1,6 @@
 // The result of a Sandbox.exec call. Mirrors the Python ExecResult and the
-// sandbox-server /v1/exec response {exit_code, stdout, stderr, exec_time_ms}.
+// Connect sandbox.v1.Sandbox ExecStream response (stdout/stderr frames plus the
+// terminal exit frame {exitCode, execTimeMs}), reassembled into one record.
 package run.mitos.sdk;
 
 /**

--- a/sdk/java/src/main/java/run/mitos/sdk/HttpTransport.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/HttpTransport.java
@@ -33,6 +33,18 @@ final class HttpTransport {
         return token;
     }
 
+    /** The resolved base URL (trailing slashes stripped). Package-private so the
+     * Connect runtime client targets the same server as the REST transport. */
+    String baseUrl() {
+        return baseUrl;
+    }
+
+    /** The shared HttpClient. Package-private so the Connect runtime client
+     * reuses one client (and its connection pool) for the whole SDK. */
+    HttpClient client() {
+        return client;
+    }
+
     /** GETs path and returns the parsed JSON tree (Map / List / scalar), or null
      * on an empty body. Throws MitosException on a non-2xx status. */
     Object get(String path) {

--- a/sdk/java/src/main/java/run/mitos/sdk/Sandbox.java
+++ b/sdk/java/src/main/java/run/mitos/sdk/Sandbox.java
@@ -1,11 +1,15 @@
-// A sandbox handle returned by SandboxServer.fork. exec round-trips through the
-// server URL (POST /v1/exec) and terminate issues DELETE /v1/sandboxes/{id}.
-// The handle holds the SandboxServer it was forked from so requests carry the
-// same base URL and optional bearer header. Mirrors the Ruby Mitos::Sandbox and
-// the Python DirectSandbox exec / terminate surface.
+// A sandbox handle returned by SandboxServer.fork. exec runs over the Connect
+// sandbox.v1.Sandbox runtime protocol (the ExecStream server-streaming RPC,
+// issue #358/#24) and terminate issues DELETE /v1/sandboxes/{id}. The handle
+// holds the SandboxServer it was forked from so requests carry the same base URL
+// and optional bearer header. Mirrors the Ruby Mitos::Sandbox and the Python
+// DirectSandbox exec / terminate surface.
 package run.mitos.sdk;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /** A running sandbox in direct (sandbox-server) mode. */
@@ -44,21 +48,51 @@ public final class Sandbox {
      * Requires a Ready sandbox: the sandbox-server routes exec through the guest
      * agent over vsock, so a sandbox that is not yet up returns a typed error.
      *
+     * <p>The call uses the Connect {@code sandbox.v1.Sandbox/ExecStream}
+     * server-streaming RPC: it sends one request message and drains the response
+     * stream of stdout, stderr, and the terminal exit frame, returning the same
+     * {@link ExecResult} shape the legacy path did.
+     *
      * @param command        the shell command to run
      * @param timeoutSeconds the per-command timeout in seconds
      */
     public ExecResult exec(String command, int timeoutSeconds) {
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("sandbox", id);
-        body.put("command", command);
-        body.put("timeout", timeoutSeconds);
-        Object data = server.transport().post("/v1/exec", body, null);
-        Map<String, Object> m = SandboxServer.asObject(data);
-        return new ExecResult(
-                SandboxServer.asInt(m.get("exit_code")),
-                SandboxServer.asString(m.get("stdout")),
-                SandboxServer.asString(m.get("stderr")),
-                SandboxServer.asDouble(m.get("exec_time_ms")));
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("command", command);
+        // Proto-JSON omits the field entirely when there is no timeout; a positive
+        // value rides as camelCase timeoutSeconds.
+        if (timeoutSeconds > 0) {
+            request.put("timeoutSeconds", timeoutSeconds);
+        }
+
+        ConnectClient connect = new ConnectClient(server.transport());
+        List<Map<String, Object>> messages = connect.serverStream("ExecStream", id, request);
+
+        StringBuilder stdout = new StringBuilder();
+        StringBuilder stderr = new StringBuilder();
+        int exitCode = 0;
+        double execTimeMs = 0.0;
+        for (Map<String, Object> m : messages) {
+            if (m.containsKey("stdout")) {
+                stdout.append(decodeBase64(SandboxServer.asString(m.get("stdout"))));
+            } else if (m.containsKey("stderr")) {
+                stderr.append(decodeBase64(SandboxServer.asString(m.get("stderr"))));
+            } else if (m.get("exit") instanceof Map<?, ?>) {
+                Map<String, Object> exit = SandboxServer.asObject(m.get("exit"));
+                exitCode = SandboxServer.asInt(exit.get("exitCode"));
+                execTimeMs = SandboxServer.asDouble(exit.get("execTimeMs"));
+            }
+        }
+        return new ExecResult(exitCode, stdout.toString(), stderr.toString(), execTimeMs);
+    }
+
+    /** Decodes a base64 proto-JSON bytes field to a UTF-8 string. An empty or
+     * null value decodes to the empty string. */
+    private static String decodeBase64(String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
     }
 
     /** Terminates the sandbox via DELETE /v1/sandboxes/{id}. */

--- a/sdk/java/src/test/java/run/mitos/sdk/SdkTest.java
+++ b/sdk/java/src/test/java/run/mitos/sdk/SdkTest.java
@@ -36,6 +36,8 @@ public final class SdkTest {
         testForkGeneratesId();
         testInvalidIdThrowsBeforeRequest();
         testExecRoundTrip();
+        testExecSendsSandboxIdAndBearer();
+        testExecErrorEndStream();
         testTerminateIssuesDelete();
         testDefaultBaseUrl();
         testBearerPrecedenceCredentialFile();
@@ -151,13 +153,21 @@ public final class SdkTest {
         stub.handle("POST", "/v1/fork", ex -> json(ex, 200,
                 "{\"id\":\"sb1\",\"template_id\":\"python\","
                         + "\"endpoint\":\"http://x\",\"fork_time_ms\":1.0}"));
-        stub.handle("POST", "/v1/exec", ex -> {
-            String body = readBody(ex);
-            Map<String, Object> m = Json.parseObject(body);
-            assertEquals("sb1", String.valueOf(m.get("sandbox")), "exec body sandbox id");
-            assertEquals("echo hi", String.valueOf(m.get("command")), "exec body command");
-            json(ex, 200, "{\"exit_code\":0,\"stdout\":\"hi\\n\","
-                    + "\"stderr\":\"\",\"exec_time_ms\":2.0}");
+        // The Connect ExecStream RPC: the server replies with a stream of
+        // enveloped frames (a stdout frame, an exit frame, then a clean
+        // end-stream frame). stdout/stderr are base64 in proto-JSON.
+        stub.handle("POST", "/sandbox.v1.Sandbox/ExecStream", ex -> {
+            // The request rides as ONE opening enveloped frame; the payload is the
+            // proto-JSON ExecStreamRequest. (Read the body exactly once.)
+            Map<String, Object> req = Json.parseObject(firstFramePayload(ex));
+            assertEquals("echo hi", String.valueOf(req.get("command")), "exec command");
+            String b64Hi = java.util.Base64.getEncoder()
+                    .encodeToString("hi\n".getBytes(StandardCharsets.UTF_8));
+            byte[] frames = concat(
+                    frame(0x00, "{\"stdout\":\"" + b64Hi + "\"}"),
+                    frame(0x00, "{\"exit\":{\"exitCode\":0,\"execTimeMs\":2.0}}"),
+                    frame(0x02, "{}"));
+            connectStream(ex, frames);
         });
         try (stub) {
             SandboxServer server = new SandboxServer(stub.url(), null);
@@ -165,9 +175,66 @@ public final class SdkTest {
             ExecResult r = sb.exec("echo hi");
             assertEquals(0, r.exitCode(), "exec exit_code");
             assertEquals("hi\n", r.stdout(), "exec stdout");
+            assertEquals(2.0, r.execTimeMs(), "exec exec_time_ms");
             assertTrue(r.success(), "exec success()");
         }
-        ok("exec round-trips stdout and exit_code");
+        ok("exec round-trips stdout and exit_code over Connect ExecStream");
+    }
+
+    private static void testExecSendsSandboxIdAndBearer() throws Exception {
+        String token = "sk-exec-token-abc";
+        Stub stub = new Stub();
+        stub.handle("POST", "/v1/fork", ex -> json(ex, 200,
+                "{\"id\":\"sb-hdr\",\"template_id\":\"python\","
+                        + "\"endpoint\":\"http://x\",\"fork_time_ms\":1.0}"));
+        stub.handle("POST", "/sandbox.v1.Sandbox/ExecStream", ex -> {
+            byte[] frames = concat(
+                    frame(0x00, "{\"exit\":{\"exitCode\":0,\"execTimeMs\":1.0}}"),
+                    frame(0x02, "{}"));
+            connectStream(ex, frames);
+        });
+        try (stub) {
+            SandboxServer server = new SandboxServer(stub.url(), token);
+            Sandbox sb = server.fork("python", "sb-hdr");
+            sb.exec("true");
+            String sid = stub.lastHeader("/sandbox.v1.Sandbox/ExecStream", "X-Sandbox-Id");
+            assertEquals("sb-hdr", sid, "exec sent X-Sandbox-Id header");
+            String auth = stub.lastHeader("/sandbox.v1.Sandbox/ExecStream", "Authorization");
+            assertEquals("Bearer " + token, auth, "exec sent the bearer header when a token is set");
+            String proto = stub.lastHeader("/sandbox.v1.Sandbox/ExecStream", "Connect-Protocol-Version");
+            assertEquals("1", proto, "exec sent Connect-Protocol-Version: 1");
+        }
+        ok("exec carries X-Sandbox-Id and the bearer header");
+    }
+
+    private static void testExecErrorEndStream() throws Exception {
+        Stub stub = new Stub();
+        stub.handle("POST", "/v1/fork", ex -> json(ex, 200,
+                "{\"id\":\"sb-err\",\"template_id\":\"python\","
+                        + "\"endpoint\":\"http://x\",\"fork_time_ms\":1.0}"));
+        // The terminal end-stream frame carries an error object: the SDK must turn
+        // it into a typed MitosException with the mapped code and status.
+        stub.handle("POST", "/sandbox.v1.Sandbox/ExecStream", ex -> {
+            byte[] frames = frame(0x02,
+                    "{\"error\":{\"code\":\"not_found\",\"message\":\"no such sandbox\"}}");
+            connectStream(ex, frames);
+        });
+        try (stub) {
+            SandboxServer server = new SandboxServer(stub.url(), null);
+            Sandbox sb = server.fork("python", "sb-err");
+            MitosException thrown = null;
+            try {
+                sb.exec("true");
+            } catch (MitosException e) {
+                thrown = e;
+            }
+            assertTrue(thrown != null, "error end-stream throws MitosException");
+            assertEquals("not_found", thrown.getCode(), "error end-stream code");
+            assertEquals(404, thrown.getStatus(), "error end-stream status (mapped from code)");
+            assertTrue(thrown.getMessage().contains("no such sandbox"),
+                    "error end-stream message: " + thrown.getMessage());
+        }
+        ok("an error end-stream frame throws a typed MitosException");
     }
 
     private static void testTerminateIssuesDelete() throws Exception {
@@ -393,6 +460,59 @@ public final class SdkTest {
 
     static String readBody(HttpExchange ex) throws IOException {
         return new String(ex.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    // ---- Connect enveloped-frame helpers (mirror the wire the server speaks) ----
+
+    /** Encodes one Connect enveloped frame: a flag byte, a 4-byte big-endian
+     * length, then the JSON payload. */
+    static byte[] frame(int flag, String json) {
+        byte[] payload = json.getBytes(StandardCharsets.UTF_8);
+        int n = payload.length;
+        byte[] out = new byte[5 + n];
+        out[0] = (byte) flag;
+        out[1] = (byte) ((n >>> 24) & 0xff);
+        out[2] = (byte) ((n >>> 16) & 0xff);
+        out[3] = (byte) ((n >>> 8) & 0xff);
+        out[4] = (byte) (n & 0xff);
+        System.arraycopy(payload, 0, out, 5, n);
+        return out;
+    }
+
+    static byte[] concat(byte[]... parts) {
+        int total = 0;
+        for (byte[] p : parts) {
+            total += p.length;
+        }
+        byte[] out = new byte[total];
+        int off = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, off, p.length);
+            off += p.length;
+        }
+        return out;
+    }
+
+    /** Writes a Connect server-stream response (HTTP 200, the connect+json
+     * content type, then the enveloped frame bytes). */
+    static void connectStream(HttpExchange ex, byte[] frames) throws IOException {
+        ex.getResponseHeaders().add("Content-Type", "application/connect+json");
+        ex.sendResponseHeaders(200, frames.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(frames);
+        }
+    }
+
+    /** Reads the request body (one or more enveloped frames) and returns the JSON
+     * payload of the FIRST frame as a string. */
+    static String firstFramePayload(HttpExchange ex) throws IOException {
+        byte[] body = ex.getRequestBody().readAllBytes();
+        if (body.length < 5) {
+            return "";
+        }
+        int n = ((body[1] & 0xff) << 24) | ((body[2] & 0xff) << 16)
+                | ((body[3] & 0xff) << 8) | (body[4] & 0xff);
+        return new String(body, 5, n, StandardCharsets.UTF_8);
     }
 
     // runChild launches a fresh JVM running mainClass with MITOS_CONFIG_DIR set to

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -70,7 +70,7 @@ server = Mitos.server(url: "http://localhost:8080")
 | `SandboxServer#list_templates` | `GET /v1/templates` | `Array<Template>` |
 | `SandboxServer#fork(template, id:, idempotency_key:)` | `POST /v1/fork` | `Sandbox` |
 | `SandboxServer#list_sandboxes` | `GET /v1/sandboxes` | `Array<ServerSandbox>` |
-| `Sandbox#exec(command, timeout:)` | `POST /v1/exec` | `ExecResult` |
+| `Sandbox#exec(command, timeout:)` | `POST /sandbox.v1.Sandbox/ExecStream` (Connect) | `ExecResult` |
 | `Sandbox#terminate` | `DELETE /v1/sandboxes/{id}` | `nil` |
 
 Creating calls (`create_template`, `fork`) send a fresh `Idempotency-Key`, so a
@@ -83,9 +83,11 @@ Value objects:
 - `ExecResult`: `exit_code`, `stdout`, `stderr`, `exec_time_ms` (`success?`).
 - `Sandbox`: `id`, `endpoint`.
 
-`exec` requires a Ready sandbox: the sandbox-server routes exec through the guest
-agent over vsock, so calling exec on a sandbox that is not yet up returns a typed
-`not_found` error.
+`exec` runs over the Connect `sandbox.v1.Sandbox` runtime protocol (the
+`ExecStream` RPC): the server streams stdout and stderr frames followed by an
+exit frame, which the SDK drains into the `ExecResult`. It requires a Ready
+sandbox: the sandbox-server routes exec through the guest agent over vsock, so
+calling exec on a sandbox that is not yet up returns a typed `not_found` error.
 
 ## Cluster mode (Kubernetes)
 

--- a/sdk/ruby/lib/mitos/connect.rb
+++ b/sdk/ruby/lib/mitos/connect.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+require "mitos/errors"
+
+module Mitos
+  # A dependency-free client for the Connect "sandbox.v1.Sandbox" runtime
+  # protocol (issue #24), spoken over the Ruby standard library (net/http, json).
+  # It mirrors the Go SDK's connect.go and the Python SDK's _connect.py: the
+  # proto-JSON message shapes come straight from proto/sandbox/v1/sandbox.proto
+  # (camelCase field names; bytes fields are base64 strings).
+  #
+  # Only the server-streaming shape used by ExecStream is implemented here: the
+  # client sends ONE request message as a single enveloped frame, then reads a
+  # stream of enveloped response frames.
+  #
+  # An enveloped frame is a 5-byte prefix (1 flag byte + 4-byte big-endian
+  # uint32 length) followed by that many JSON payload bytes:
+  #
+  #   - flag & 0x01 (compressed): refused. The SDK negotiates identity encoding
+  #     and never expects a compressed frame.
+  #   - flag & 0x02 (end-stream): the terminal frame. Its JSON payload carries
+  #     trailers and, on failure, an {"error":{code,message}} object that becomes
+  #     a typed MitosError. A clean payload ends the stream.
+  #   - else (data frame, flag 0x00): the JSON payload is a proto-JSON response
+  #     message yielded to the caller.
+  #
+  # The bearer token rides on Authorization and is never logged; it is redacted
+  # from any error cause before it surfaces.
+  class ConnectClient
+    SERVICE_NAME = "sandbox.v1.Sandbox"
+    STREAM_CONTENT_TYPE = "application/connect+json"
+    SANDBOX_ID_HEADER = "X-Sandbox-Id"
+
+    # The end-stream flag (bit 1). The final server frame sets it; its payload
+    # carries trailers and an optional error object.
+    FLAG_END_STREAM = 0x02
+    # The compressed flag (bit 0). The SDK negotiates identity encoding and
+    # rejects a compressed response frame, so this is only used to refuse one.
+    FLAG_COMPRESSED = 0x01
+
+    # Guard the frame-length prefix so a malformed or hostile length cannot make
+    # the SDK allocate unbounded memory.
+    MAX_FRAME_BYTES = 64 * 1024 * 1024 # 64 MiB
+
+    # Map the Connect textual error codes to the HTTP-ish status the SDK's
+    # typed-error layer keys remediation on. An unmapped code falls back to 500.
+    # Mirrors the Go and Python maps.
+    CODE_STATUS = {
+      "canceled" => 499,
+      "unknown" => 500,
+      "invalid_argument" => 400,
+      "deadline_exceeded" => 504,
+      "not_found" => 404,
+      "already_exists" => 409,
+      "permission_denied" => 403,
+      "resource_exhausted" => 429,
+      "failed_precondition" => 400,
+      "aborted" => 409,
+      "out_of_range" => 400,
+      "unimplemented" => 501,
+      "internal" => 500,
+      "unavailable" => 503,
+      "data_loss" => 500,
+      "unauthenticated" => 401
+    }.freeze
+
+    # base_url is the server origin (no trailing slash needed); sandbox_id rides
+    # on X-Sandbox-Id; token, when present, rides on Authorization: Bearer.
+    def initialize(base_url:, sandbox_id:, token: nil)
+      @base_url = base_url.sub(%r{/+\z}, "")
+      @sandbox_id = sandbox_id
+      @token = token
+    end
+
+    # Opens a server-streaming Connect call to +method+ (e.g. "ExecStream"),
+    # sending +message+ (a proto-JSON Hash) as the single opening frame. Yields
+    # each response message (a parsed Hash) the instant its frame arrives. The
+    # terminal end-stream frame is consumed here: a clean end ends the stream; an
+    # error end raises a typed MitosError. A non-2xx status on open raises a
+    # typed MitosError from the Connect unary error envelope.
+    def server_stream(method, message)
+      uri = URI.join(@base_url + "/", path(method).sub(%r{\A/}, ""))
+      req = Net::HTTP::Post.new(uri)
+      req["Content-Type"] = STREAM_CONTENT_TYPE
+      req["Connect-Protocol-Version"] = "1"
+      req[SANDBOX_ID_HEADER] = @sandbox_id
+      req["Authorization"] = "Bearer #{@token}" if @token && !@token.empty?
+      req.body = encode_frame(JSON.generate(message))
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+
+      http.request(req) do |resp|
+        status = resp.code.to_i
+        unless status >= 200 && status < 300
+          raise error_from_body(status, resp.body.to_s)
+        end
+
+        buffer = +"".b
+        ended = false
+        resp.read_body do |chunk|
+          next if chunk.nil? || chunk.empty?
+
+          buffer << chunk.b
+          loop do
+            break if buffer.bytesize < 5
+
+            length = buffer.byteslice(1, 4).unpack1("N")
+            if length > MAX_FRAME_BYTES
+              raise MitosError.new(
+                "connect: response frame too large",
+                code: "internal_error",
+                cause: "frame length #{length} exceeds #{MAX_FRAME_BYTES} bytes",
+                remediation: "Report this; the SDK negotiates identity encoding and bounded frames.",
+                status: 500
+              )
+            end
+            break if buffer.bytesize < 5 + length
+
+            flag = buffer.getbyte(0)
+            payload = buffer.byteslice(5, length)
+            buffer = buffer.byteslice(5 + length, buffer.bytesize - (5 + length)) || +"".b
+
+            if (flag & FLAG_COMPRESSED) != 0
+              raise MitosError.new(
+                "connect: unexpected compressed response frame",
+                code: "internal_error",
+                cause: "the SDK negotiates identity encoding and does not accept compressed frames",
+                remediation: "Report this; the server should not compress when identity is negotiated.",
+                status: 500
+              )
+            end
+
+            if (flag & FLAG_END_STREAM) != 0
+              handle_end_stream(payload)
+              ended = true
+              break
+            end
+
+            next if payload.empty?
+
+            yield JSON.parse(payload)
+          end
+          break if ended
+        end
+      end
+    end
+
+    private
+
+    def path(method)
+      "/#{SERVICE_NAME}/#{method}"
+    end
+
+    # Wraps one payload in the Connect 5-byte envelope prefix (flag 0x00 + a
+    # 4-byte big-endian length).
+    def encode_frame(payload)
+      bytes = payload.b
+      [0].pack("C") + [bytes.bytesize].pack("N") + bytes
+    end
+
+    # Inspects the terminal end-stream frame. A payload carrying an
+    # {"error":{code,message}} object raises a typed MitosError; a clean payload
+    # (empty, trailers only, or non-JSON) returns normally.
+    def handle_end_stream(payload)
+      return if payload.nil? || payload.empty?
+
+      end_msg = begin
+        JSON.parse(payload)
+      rescue JSON::ParserError
+        return
+      end
+      return unless end_msg.is_a?(Hash)
+
+      err = end_msg["error"]
+      return unless err.is_a?(Hash)
+
+      raise connect_error(err["code"].to_s, err["message"].to_s, nil)
+    end
+
+    # Builds a typed MitosError from a non-2xx Connect response. Prefers the
+    # Connect unary error envelope {"code","message"}; falls back to the raw
+    # (redacted) body and HTTP status when the body is not that shape.
+    def error_from_body(status, raw_body)
+      parsed = begin
+        JSON.parse(raw_body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      if parsed.is_a?(Hash) && parsed["code"] && !parsed["code"].to_s.empty?
+        return connect_error(parsed["code"].to_s, parsed["message"].to_s, status)
+      end
+
+      MitosError.new(
+        "sandbox RPC failed: HTTP #{status}",
+        code: "http_error",
+        cause: redact(raw_body.strip.empty? ? "HTTP #{status}" : raw_body.strip),
+        remediation: "Inspect the request against the sandbox.v1.Sandbox contract.",
+        status: status
+      )
+    end
+
+    # Builds a typed MitosError from a Connect error code and message. The
+    # Connect textual code is the stable code; the status is mapped (or the HTTP
+    # status from a non-2xx open is used when given); the message is redacted of
+    # any token.
+    def connect_error(code, message, http_status)
+      stable = code.empty? ? "internal" : code
+      status = http_status || CODE_STATUS[code] || 500
+      MitosError.new(
+        "sandbox RPC failed: #{stable}",
+        code: stable,
+        cause: redact(message.empty? ? "connect error #{stable}" : message),
+        remediation: "Inspect the request against the sandbox.v1.Sandbox contract.",
+        status: status
+      )
+    end
+
+    def redact(text)
+      return text if @token.nil? || @token.empty?
+
+      text.to_s.gsub(@token, "[REDACTED]")
+    end
+  end
+end

--- a/sdk/ruby/lib/mitos/sandbox.rb
+++ b/sdk/ruby/lib/mitos/sandbox.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require "net/http"
+require "base64"
 
 module Mitos
-  # The result of a Sandbox#exec call. Mirrors the Python ExecResult and the
-  # sandbox-server /v1/exec response {exit_code, stdout, stderr, exec_time_ms}.
+  # The result of a Sandbox#exec call. Mirrors the Python ExecResult: it carries
+  # {exit_code, stdout, stderr, exec_time_ms} drained from the Connect ExecStream
+  # response (stdout / stderr / exit frames).
   ExecResult = Struct.new(:exit_code, :stdout, :stderr, :exec_time_ms, keyword_init: true) do
     def success?
       exit_code.zero?
@@ -12,9 +13,10 @@ module Mitos
   end
 
   # A sandbox handle returned by SandboxServer#fork. exec round-trips through the
-  # server URL (POST /v1/exec) and terminate issues DELETE /v1/sandboxes/{id}.
-  # The handle holds the SandboxServer it was forked from so requests carry the
-  # same base URL and optional bearer header.
+  # Connect sandbox.v1.Sandbox runtime protocol (the ExecStream RPC) and
+  # terminate issues DELETE /v1/sandboxes/{id}. The handle holds the
+  # SandboxServer it was forked from so requests carry the same base URL and
+  # optional bearer header.
   class Sandbox
     attr_reader :id, :endpoint
 
@@ -24,17 +26,38 @@ module Mitos
       @server = server
     end
 
-    # Runs +command+ in the sandbox and returns an ExecResult. Requires a Ready
-    # sandbox: the sandbox-server routes exec through the guest agent over vsock,
-    # so a sandbox that is not yet up returns a typed error.
+    # Runs +command+ in the sandbox over the Connect ExecStream RPC and returns
+    # an ExecResult. The server streams stdout and stderr frames followed by an
+    # exit frame; this drains them into the result. Requires a Ready sandbox: the
+    # sandbox-server routes exec through the guest agent over vsock, so a sandbox
+    # that is not yet up returns a typed error.
     def exec(command, timeout: 30)
-      body = { "sandbox" => @id, "command" => command, "timeout" => timeout }
-      data = @server.request_json(Net::HTTP::Post, "/v1/exec", body, {})
+      message = { "command" => command }
+      message["timeoutSeconds"] = timeout if timeout && timeout > 0
+
+      stdout = +"".b
+      stderr = +"".b
+      exit_code = 0
+      exec_time_ms = 0
+
+      client = @server.connect_client(@id)
+      client.server_stream("ExecStream", message) do |response|
+        if response.key?("stdout")
+          stdout << Base64.decode64(response["stdout"].to_s)
+        elsif response.key?("stderr")
+          stderr << Base64.decode64(response["stderr"].to_s)
+        elsif response.key?("exit")
+          exit_info = response["exit"] || {}
+          exit_code = exit_info["exitCode"] || 0
+          exec_time_ms = exit_info["execTimeMs"] || 0
+        end
+      end
+
       ExecResult.new(
-        exit_code: data["exit_code"],
-        stdout: data["stdout"] || "",
-        stderr: data["stderr"] || "",
-        exec_time_ms: data["exec_time_ms"] || 0
+        exit_code: exit_code,
+        stdout: stdout.force_encoding(Encoding::UTF_8),
+        stderr: stderr.force_encoding(Encoding::UTF_8),
+        exec_time_ms: exec_time_ms
       )
     end
 

--- a/sdk/ruby/lib/mitos/sandbox_server.rb
+++ b/sdk/ruby/lib/mitos/sandbox_server.rb
@@ -5,6 +5,7 @@ require "net/http"
 require "securerandom"
 require "uri"
 
+require "mitos/connect"
 require "mitos/errors"
 require "mitos/sandbox"
 
@@ -98,10 +99,18 @@ module Mitos
       nil
     end
 
-    # Sends a request through the sandbox-server. Exposed for Sandbox#exec, which
-    # posts to /v1/exec on the same server URL.
+    # Sends a request through the sandbox-server. Exposed for the SDK's REST
+    # calls that ride this transport.
     def request_json(method_class, path, body, extra_headers = {})
       request(method_class, path, body, extra_headers)
+    end
+
+    # Builds a ConnectClient for +sandbox_id+ bound to this server's base URL and
+    # bearer token. Used by Sandbox#exec to run over the Connect
+    # sandbox.v1.Sandbox runtime protocol. The token VALUE stays encapsulated
+    # here and is never logged.
+    def connect_client(sandbox_id)
+      ConnectClient.new(base_url: @url, sandbox_id: sandbox_id, token: @api_key)
     end
 
     def valid_sandbox_id?(id)

--- a/sdk/ruby/test/sandbox_server_test.rb
+++ b/sdk/ruby/test/sandbox_server_test.rb
@@ -3,6 +3,7 @@
 require "minitest/autorun"
 require "webrick"
 require "json"
+require "base64"
 require "socket"
 require "stringio"
 
@@ -129,22 +130,59 @@ class StubServer
       end
     end
 
-    mount_any("/v1/exec") do |req, res|
-      body = record(req)
-      if @sandbox_ids.include?(body["sandbox"])
-        json(res, { "exit_code" => 0, "stdout" => "2\n", "stderr" => "", "exec_time_ms" => 5 })
+    # The Connect ExecStream RPC. The request is ONE enveloped frame whose JSON
+    # payload is the proto-JSON ExecStreamRequest ({command, timeoutSeconds?}).
+    # The id rides on the X-Sandbox-Id header, not the body. A known sandbox gets
+    # a stdout data frame, an exit data frame, then a clean end-stream frame; an
+    # unknown sandbox gets an end-stream frame carrying a Connect error object.
+    mount_any("/sandbox.v1.Sandbox/ExecStream") do |req, res|
+      record_connect(req)
+      sandbox_id = req["X-Sandbox-Id"]
+      res.status = 200
+      res["Content-Type"] = "application/connect+json"
+      if @sandbox_ids.include?(sandbox_id)
+        out = +""
+        out << connect_frame({ "stdout" => Base64.strict_encode64("2\n") })
+        out << connect_frame({ "exit" => { "exitCode" => 0, "execTimeMs" => 5 } })
+        out << connect_frame({}, end_stream: true)
+        res.body = out
       else
-        json(res, {
-               "error" => {
-                 "code" => "not_found",
-                 "message" => "sandbox not found",
-                 "cause" => "no sandbox registered",
-                 "remediation" => "Confirm the sandbox id exists and is Ready before calling."
-               }
-             }, 404)
+        res.body = connect_frame(
+          {
+            "error" => {
+              "code" => "not_found",
+              "message" => "sandbox not found"
+            }
+          },
+          end_stream: true
+        )
       end
     end
 
+  end
+
+  # connect_frame wraps a proto-JSON message in the Connect 5-byte envelope
+  # (1 flag byte + 4-byte big-endian length + JSON payload). end_stream sets the
+  # 0x02 flag on the terminal frame.
+  def connect_frame(message, end_stream: false)
+    payload = JSON.generate(message).b
+    flag = end_stream ? 0x02 : 0x00
+    [flag].pack("C") + [payload.bytesize].pack("N") + payload
+  end
+
+  # record_connect records an ExecStream call: it unwraps the single request
+  # frame to capture the proto-JSON ExecStreamRequest as the body, and records
+  # the headers (so tests can assert X-Sandbox-Id and Authorization).
+  def record_connect(req)
+    raw = (req.body || "").b
+    body = nil
+    if raw.bytesize >= 5
+      length = raw.byteslice(1, 4).unpack1("N")
+      body = JSON.parse(raw.byteslice(5, length)) if raw.bytesize >= 5 + length
+    end
+    headers = {}
+    req.each { |k, v| headers[k.downcase] = v }
+    @recorded << Recorded.new(method: req.request_method, path: req.path, body: body, headers: headers)
   end
 end
 
@@ -214,11 +252,30 @@ class SandboxServerTest < Minitest::Test
     result = sandbox.exec("print(1 + 1)")
     assert_equal 0, result.exit_code
     assert_equal "2\n", result.stdout
+    assert_equal 5, result.exec_time_ms
     assert result.success?
 
-    call = @stub.recorded.find { |r| r.path == "/v1/exec" }
-    assert_equal "sbx-exec", call.body["sandbox"]
+    call = @stub.recorded.find { |r| r.path == "/sandbox.v1.Sandbox/ExecStream" }
+    refute_nil call
+    # The id rides on the X-Sandbox-Id header, the command on the proto-JSON body.
+    assert_equal "sbx-exec", call.headers["x-sandbox-id"]
     assert_equal "print(1 + 1)", call.body["command"]
+    assert_equal 30, call.body["timeoutSeconds"]
+  end
+
+  def test_exec_passes_explicit_timeout_seconds
+    sandbox = server.fork("python", id: "sbx-timeout")
+    sandbox.exec("sleep 1", timeout: 7)
+    call = @stub.recorded.find { |r| r.path == "/sandbox.v1.Sandbox/ExecStream" }
+    assert_equal 7, call.body["timeoutSeconds"]
+  end
+
+  def test_exec_sends_bearer_header_when_api_key_present
+    keyed = server(api_key: "sk-exec-secret")
+    sandbox = keyed.fork("python", id: "sbx-auth")
+    sandbox.exec("echo hi")
+    call = @stub.recorded.find { |r| r.path == "/sandbox.v1.Sandbox/ExecStream" }
+    assert_equal "Bearer sk-exec-secret", call.headers["authorization"]
   end
 
   def test_exec_on_unknown_sandbox_raises_typed_error
@@ -280,14 +337,17 @@ class SandboxServerTest < Minitest::Test
     end
   end
 
-  def test_non_2xx_envelope_raises_mitos_error_with_parsed_code
-    # Forking an unknown template id path is not modeled by the stub; instead
-    # drive a 404 through exec on a never-forked sandbox via a hand-built handle.
+  def test_error_end_stream_frame_raises_typed_mitos_error
+    # An unknown sandbox makes the stub emit an end-stream frame carrying a
+    # Connect {"error":{code,message}} object; the SDK maps it to a typed error.
     sandbox = Mitos::Sandbox.new(id: "never-forked", endpoint: @stub.base_url, server: server)
     err = assert_raises(Mitos::MitosError) { sandbox.exec("echo hi") }
     assert_equal "not_found", err.code
     assert_equal 404, err.status
-    assert_match(/Ready/, err.remediation)
+    assert_match(/sandbox\.v1\.Sandbox/, err.remediation)
+    # The token is never echoed: there is no token here, but the cause carries
+    # only the server message, not any secret.
+    assert_equal "sandbox not found", err.cause_detail
   end
 
   def test_bearer_header_sent_when_api_key_present

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -85,13 +85,16 @@ let server = SandboxServer::builder()
 | `SandboxServer::fork_as(template, id)` | `POST /v1/fork` | `Sandbox` |
 | `SandboxServer::fork_opts(template, id, idempotency_key)` | `POST /v1/fork` | `Sandbox` |
 | `SandboxServer::list_sandboxes()` | `GET /v1/sandboxes` | `Vec<ServerSandbox>` |
-| `Sandbox::exec(command)` | `POST /v1/exec` | `ExecResult` |
-| `Sandbox::exec_with_timeout(command, timeout)` | `POST /v1/exec` | `ExecResult` |
+| `Sandbox::exec(command)` | `POST /sandbox.v1.Sandbox/ExecStream` | `ExecResult` |
+| `Sandbox::exec_with_timeout(command, timeout)` | `POST /sandbox.v1.Sandbox/ExecStream` | `ExecResult` |
 | `Sandbox::terminate()` | `DELETE /v1/sandboxes/{id}` | `()` |
 
 `fork` defaults `init_wait_seconds` to 5 and generates a `sandbox-<hex>` id; both
 creating calls send a fresh `Idempotency-Key` so a retry is de-duplicated by the
-server. `exec` defaults to a 30 second timeout and needs a Ready sandbox.
+server. `exec` defaults to a 30 second timeout and needs a Ready sandbox; it runs
+over the Connect `sandbox.v1.Sandbox/ExecStream` runtime protocol (the sandbox id
+rides the `X-Sandbox-Id` header) and drains the streamed stdout, stderr, and exit
+frames into an `ExecResult`.
 
 Value types:
 

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use serde_json::json;
 
+use crate::connect::ConnectClient;
 use crate::error::MitosError;
 use crate::types::{ExecResult, ForkWire, ServerSandbox, Template};
 
@@ -320,12 +321,15 @@ impl SandboxServer {
         Ok(())
     }
 
-    /// Runs `command` in the sandbox via `POST /v1/exec`. Used by
-    /// [`Sandbox::exec`].
+    /// Runs `command` in the sandbox over the Connect `sandbox.v1.Sandbox`
+    /// runtime protocol (`POST /sandbox.v1.Sandbox/ExecStream`, issue #358/#24).
+    /// Used by [`Sandbox::exec`]. The server-streaming response is drained into
+    /// an [`ExecResult`] (stdout, stderr, then the exit frame). The sandbox id
+    /// rides the `X-Sandbox-Id` header; the optional bearer token rides
+    /// `Authorization` and is never logged.
     fn exec(&self, id: &str, command: &str, timeout: u32) -> Result<ExecResult, MitosError> {
-        let body = json!({ "sandbox": id, "command": command, "timeout": timeout });
-        let value = self.post("/v1/exec", &body, None)?;
-        serde_json::from_value(value).map_err(decode_err)
+        ConnectClient::new(&self.agent, &self.url, self.token.as_deref())
+            .exec_stream(id, command, timeout)
     }
 
     /// Attaches `Authorization: Bearer <token>` when a token is configured. The
@@ -446,7 +450,8 @@ fn redact_transport(text: &str, token: Option<&str>) -> String {
 }
 
 /// A running sandbox handle returned by [`SandboxServer::fork`]. `exec`
-/// round-trips through the server URL (`POST /v1/exec`) and `terminate` issues
+/// round-trips through the server URL over the Connect runtime protocol
+/// (`POST /sandbox.v1.Sandbox/ExecStream`) and `terminate` issues
 /// `DELETE /v1/sandboxes/{id}`. Holds the [`SandboxServer`] it was forked from
 /// so requests carry the same base URL and optional bearer header.
 pub struct Sandbox {

--- a/sdk/rust/src/connect.rs
+++ b/sdk/rust/src/connect.rs
@@ -1,0 +1,557 @@
+//! A dependency-free Connect protocol codec over the SDK's existing `ureq`
+//! transport.
+//!
+//! The native direct-mode runtime calls (today: `exec`) speak the Connect
+//! `sandbox.v1.Sandbox` service (issue #24/#358) instead of the legacy JSON
+//! `/v1/exec` route. Rather than add a generated-stub plus codegen dependency to
+//! this thin SDK, this module implements the Connect wire directly over the same
+//! blocking `ureq::Agent` `client.rs` already uses for `/v1/*`. The proto-JSON
+//! message shapes come straight from `proto/sandbox/v1/sandbox.proto` (camelCase
+//! field names, `bytes` fields as base64 strings). It mirrors the Go SDK's
+//! `sdk/go/connect.go` and the Python SDK's `sdk/python/mitos/_connect.py`.
+//!
+//! Only the server-streaming shape is needed here:
+//!
+//!   - `POST /sandbox.v1.Sandbox/<Method>` with `Content-Type:
+//!     application/connect+json`. Each message is an ENVELOPED frame: a 5-byte
+//!     prefix (1 flag byte + 4-byte big-endian length) then the JSON payload.
+//!     The client sends its single request message as a plain (flag `0x00`)
+//!     enveloped frame; the server replies with a stream of frames whose final
+//!     frame sets the end-stream flag (`0x02`), carrying trailers and, on
+//!     failure, an `{"error":{...}}` object.
+//!
+//! The direct-mode `exec` only sends the opening message (no live stdin), so the
+//! call is half-duplex: the full request body (one enveloped frame) is buffered
+//! and sent, then the response frames are read. `exec` output is bounded, so the
+//! buffered response body is parsed frame-by-frame after the read completes,
+//! reassembling correctly across the byte stream.
+//!
+//! The bearer token rides on `Authorization` and is never logged; it is redacted
+//! from any error cause via the same redactor the rest of the SDK uses.
+
+use std::io::Read;
+
+use crate::error::MitosError;
+use crate::types::ExecResult;
+
+/// The Connect service name; the RPC path is `/<service>/<Method>`.
+const SERVICE_NAME: &str = "sandbox.v1.Sandbox";
+/// The streaming content type. Each message is an enveloped JSON frame.
+const STREAM_CONTENT_TYPE: &str = "application/connect+json";
+/// The per-sandbox routing header the server keys on (both the tokenless
+/// standalone case and the hosted/forkd bearer case).
+const SANDBOX_ID_HEADER: &str = "X-Sandbox-Id";
+
+/// The end-stream flag (bit 1) on a Connect enveloped frame. The final server
+/// frame sets it; its payload carries trailers and an optional error object.
+const FLAG_END_STREAM: u8 = 0b0000_0010;
+/// The compressed flag (bit 0). The SDK negotiates identity encoding and never
+/// sends or accepts a compressed frame, so this is only used to refuse an
+/// unexpected one.
+const FLAG_COMPRESSED: u8 = 0b0000_0001;
+
+/// Guards the frame-length prefix so a malformed or hostile length cannot make
+/// the SDK allocate unbounded memory. 64 MiB matches the Go SDK's cap.
+const MAX_FRAME_BYTES: u32 = 64 << 20;
+
+/// Speaks the Connect `sandbox.v1.Sandbox` protocol over a borrowed
+/// `ureq::Agent`. Constructed per call with the server base URL, the per-sandbox
+/// id, and the optional bearer token. The token value is never logged.
+pub(crate) struct ConnectClient<'a> {
+    agent: &'a ureq::Agent,
+    base_url: &'a str,
+    token: Option<&'a str>,
+}
+
+impl<'a> ConnectClient<'a> {
+    pub(crate) fn new(agent: &'a ureq::Agent, base_url: &'a str, token: Option<&'a str>) -> Self {
+        ConnectClient {
+            agent,
+            base_url,
+            token,
+        }
+    }
+
+    /// Runs `command` in `sandbox_id` over `ExecStream`, draining the stdout,
+    /// stderr, and exit frames into an [`ExecResult`]. `timeout_seconds` is sent
+    /// only when greater than zero (proto-JSON omits a zero default).
+    pub(crate) fn exec_stream(
+        &self,
+        sandbox_id: &str,
+        command: &str,
+        timeout_seconds: u32,
+    ) -> Result<ExecResult, MitosError> {
+        // Build the proto-JSON ExecStreamRequest by hand so a zero timeout is
+        // omitted (proto-JSON drops zero-valued scalars), matching the Go and
+        // Python clients.
+        let request = if timeout_seconds > 0 {
+            serde_json::json!({ "command": command, "timeoutSeconds": timeout_seconds })
+        } else {
+            serde_json::json!({ "command": command })
+        };
+        let payload = serde_json::to_vec(&request).map_err(|e| {
+            MitosError::client(
+                "encode_error",
+                "failed to encode the ExecStream request",
+                e.to_string(),
+                "This is an SDK bug; report it with the command that triggered it.",
+            )
+        })?;
+        let body = encode_frame(&payload, false);
+
+        let url = format!("{}/{}/ExecStream", self.base_url, SERVICE_NAME);
+        let mut req = self
+            .agent
+            .post(&url)
+            .set("Content-Type", STREAM_CONTENT_TYPE)
+            .set("Connect-Protocol-Version", "1")
+            .set(SANDBOX_ID_HEADER, sandbox_id);
+        if let Some(t) = self.token {
+            if !t.is_empty() {
+                req = req.set("Authorization", &format!("Bearer {t}"));
+            }
+        }
+
+        let resp = match req.send_bytes(&body) {
+            Ok(resp) => resp,
+            Err(ureq::Error::Status(status, resp)) => {
+                // A streaming RPC that fails before the first frame returns a
+                // normal HTTP error body (the Connect error envelope), not an
+                // end-stream frame. Read it and raise the typed error.
+                let text = resp.into_string().unwrap_or_default();
+                return Err(self.error_from_body(status, text.as_bytes()));
+            }
+            Err(ureq::Error::Transport(t)) => {
+                return Err(MitosError::client(
+                    "transport_error",
+                    "sandbox runtime request failed to reach the server",
+                    self.redact(&t.to_string()),
+                    "Check the base URL is reachable and the server is running.",
+                ));
+            }
+        };
+
+        // The response is a 200 stream of enveloped frames. exec output is
+        // bounded, so the whole body is read and parsed frame-by-frame. A frame
+        // can straddle any read boundary, which is why the body is buffered fully
+        // before parsing.
+        let mut raw = Vec::new();
+        resp.into_reader()
+            .take((MAX_FRAME_BYTES as u64) * 2)
+            .read_to_end(&mut raw)
+            .map_err(|e| {
+                MitosError::client(
+                    "response_read_error",
+                    "failed to read the ExecStream response body",
+                    e.to_string(),
+                    "Retry the request; if it persists, inspect the sandbox-server logs.",
+                )
+            })?;
+
+        self.drain(&raw)
+    }
+
+    /// Walks the buffered response frames, accumulating stdout/stderr and the
+    /// exit frame into an [`ExecResult`]. A compressed frame is refused; an
+    /// end-stream frame with an `error` object becomes a typed error; a clean
+    /// end-stream (or a clean transport EOF) ends the drain.
+    fn drain(&self, raw: &[u8]) -> Result<ExecResult, MitosError> {
+        let mut result = ExecResult {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            exec_time_ms: 0.0,
+        };
+        let mut saw_exit = false;
+        let mut offset = 0usize;
+
+        while offset < raw.len() {
+            let (flag, payload, next) = match parse_frame(raw, offset)? {
+                Some(frame) => frame,
+                // A trailing partial frame (a clean transport EOF mid-header)
+                // ends the stream; the bounded exec output is already drained.
+                None => break,
+            };
+            offset = next;
+
+            if flag & FLAG_COMPRESSED != 0 {
+                return Err(MitosError::client(
+                    "internal_error",
+                    "sandbox runtime returned a compressed frame the SDK did not negotiate",
+                    "unexpected compressed Connect frame",
+                    "Report this; the SDK negotiates identity encoding.",
+                ));
+            }
+
+            if flag & FLAG_END_STREAM != 0 {
+                if let Some(err) = self.error_from_end_stream(payload) {
+                    return Err(err);
+                }
+                break;
+            }
+
+            if payload.is_empty() {
+                continue;
+            }
+            self.apply_response(payload, &mut result, &mut saw_exit)?;
+        }
+
+        Ok(result)
+    }
+
+    /// Applies one non-terminal ExecResponse frame. Exactly one of `stdout`,
+    /// `stderr`, or `exit` is set per the contract; an unrecognized message is
+    /// tolerated (forward compatibility), an undecodable base64 is an error.
+    fn apply_response(
+        &self,
+        payload: &[u8],
+        result: &mut ExecResult,
+        saw_exit: &mut bool,
+    ) -> Result<(), MitosError> {
+        let msg: serde_json::Value = serde_json::from_slice(payload).map_err(|e| {
+            MitosError::client(
+                "decode_error",
+                "failed to decode an ExecStream response frame",
+                e.to_string(),
+                "The server returned a frame that does not match the ExecResponse schema; check server and SDK versions.",
+            )
+        })?;
+
+        if let Some(b64) = msg.get("stdout").and_then(|v| v.as_str()) {
+            result.stdout.push_str(&decode_b64_utf8(b64, "stdout")?);
+        } else if let Some(b64) = msg.get("stderr").and_then(|v| v.as_str()) {
+            result.stderr.push_str(&decode_b64_utf8(b64, "stderr")?);
+        } else if let Some(exit) = msg.get("exit") {
+            *saw_exit = true;
+            if let Some(code) = exit.get("exitCode").and_then(|v| v.as_i64()) {
+                result.exit_code = code as i32;
+            }
+            if let Some(ms) = exit.get("execTimeMs").and_then(|v| v.as_f64()) {
+                result.exec_time_ms = ms;
+            }
+            // The exit frame may carry a non-fatal "error" string (for example a
+            // command that could not be spawned). It is surfaced through stderr
+            // so the caller still gets the exit code; the typed-error path is
+            // reserved for the Connect end-stream error object.
+            if let Some(err) = exit.get("error").and_then(|v| v.as_str()) {
+                if !err.is_empty() {
+                    if !result.stderr.is_empty() && !result.stderr.ends_with('\n') {
+                        result.stderr.push('\n');
+                    }
+                    result.stderr.push_str(err);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Inspects the terminal end-stream frame. A payload carrying an
+    /// `{"error":{...}}` object yields a typed error; a clean payload (trailers
+    /// only, empty, or non-JSON) yields `None`.
+    fn error_from_end_stream(&self, payload: &[u8]) -> Option<MitosError> {
+        if payload.is_empty() {
+            return None;
+        }
+        let end: serde_json::Value = serde_json::from_slice(payload).ok()?;
+        let err = end.get("error")?;
+        let code = err.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        let message = err.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        Some(self.connect_error(code, message, connect_code_status(code)))
+    }
+
+    /// Turns a non-2xx Connect response into a typed error. Prefers the Connect
+    /// error envelope `{"code","message"}`; falls back to the raw redacted body
+    /// and the HTTP status when the body is not the envelope (a proxy 502, a
+    /// transport error).
+    fn error_from_body(&self, status: u16, body: &[u8]) -> MitosError {
+        if let Ok(env) = serde_json::from_slice::<serde_json::Value>(body) {
+            let code = env.get("code").and_then(|v| v.as_str()).unwrap_or("");
+            if !code.is_empty() {
+                let message = env.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                let mut e = self.connect_error(code, message, status);
+                e.status = status;
+                return e;
+            }
+        }
+        let text = String::from_utf8_lossy(body);
+        MitosError::client_with_status(
+            status_code(status),
+            format!("sandbox runtime request failed: HTTP {status}"),
+            self.redact(text.trim()),
+            status_remediation(status),
+            status,
+        )
+    }
+
+    /// Builds a typed error from a Connect error code and message. The Connect
+    /// textual code is the stable `code`; `status` is mapped so the typed layer
+    /// picks the right remediation, and the message is redacted of any token.
+    fn connect_error(&self, code: &str, message: &str, status: u16) -> MitosError {
+        let stable = if code.is_empty() { "internal" } else { code };
+        let cause = {
+            let redacted = self.redact(message);
+            if redacted.is_empty() {
+                format!("connect error {stable}")
+            } else {
+                redacted
+            }
+        };
+        MitosError::client_with_status(
+            stable,
+            format!("sandbox RPC failed: {stable}"),
+            cause,
+            "Inspect the request against the sandbox.v1.Sandbox contract.",
+            status,
+        )
+    }
+
+    /// Redacts the bearer token from a string in the unlikely event a body or
+    /// transport message carries it.
+    fn redact(&self, text: &str) -> String {
+        match self.token {
+            Some(t) if !t.is_empty() => text.replace(t, "[REDACTED]"),
+            _ => text.to_string(),
+        }
+    }
+}
+
+/// Wraps one message payload in the Connect 5-byte envelope prefix (1 flag byte
+/// + 4-byte big-endian length + payload).
+fn encode_frame(payload: &[u8], end_stream: bool) -> Vec<u8> {
+    let flag = if end_stream { FLAG_END_STREAM } else { 0 };
+    let len = payload.len() as u32;
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(flag);
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// One parsed enveloped frame: its flag byte, its payload slice, and the offset
+/// just past it in the buffer.
+type ParsedFrame<'a> = (u8, &'a [u8], usize);
+
+/// Parses one enveloped frame starting at `offset` in `buf`. Returns
+/// `Some((flag, payload, next_offset))` for a complete frame, or `None` when the
+/// remaining bytes are a partial frame (a clean truncation at the end of the
+/// buffered body). Refuses a compressed flag-length only at the caller; here it
+/// guards the declared length against the size cap and against a short payload.
+fn parse_frame(buf: &[u8], offset: usize) -> Result<Option<ParsedFrame<'_>>, MitosError> {
+    // Need at least the 5-byte header.
+    if offset + 5 > buf.len() {
+        return Ok(None);
+    }
+    let flag = buf[offset];
+    let len = u32::from_be_bytes([
+        buf[offset + 1],
+        buf[offset + 2],
+        buf[offset + 3],
+        buf[offset + 4],
+    ]);
+    if len > MAX_FRAME_BYTES {
+        return Err(MitosError::client(
+            "internal_error",
+            "sandbox runtime returned an oversized response frame",
+            format!("connect response frame too large ({len} bytes)"),
+            "Report this; the server should not emit frames over the SDK cap.",
+        ));
+    }
+    let start = offset + 5;
+    let end = start + len as usize;
+    if end > buf.len() {
+        // A truncated payload: treat as a clean end of the buffered stream.
+        return Ok(None);
+    }
+    Ok(Some((flag, &buf[start..end], end)))
+}
+
+/// Decodes standard base64 (RFC 4648, with optional `=` padding) into a UTF-8
+/// String. exec stdout/stderr are text; invalid base64 or invalid UTF-8 is a
+/// typed decode error rather than a panic. Implemented inline to avoid adding a
+/// base64 crate.
+fn decode_b64_utf8(input: &str, field: &str) -> Result<String, MitosError> {
+    let bytes = decode_b64(input).ok_or_else(|| {
+        MitosError::client(
+            "decode_error",
+            format!("failed to base64-decode the ExecStream {field}"),
+            "the server returned a non-base64 value for a bytes field",
+            "Check the server and SDK versions; the runtime contract sends base64 bytes.",
+        )
+    })?;
+    String::from_utf8(bytes).map_err(|e| {
+        MitosError::client(
+            "decode_error",
+            format!("the ExecStream {field} was not valid UTF-8"),
+            e.to_string(),
+            "The captured output was not UTF-8; this SDK surfaces exec output as text.",
+        )
+    })
+}
+
+/// Decodes standard base64 (alphabet `A-Za-z0-9+/`, `=` padding). Returns `None`
+/// on any invalid character or malformed length. Whitespace is ignored so a
+/// pretty-printed value still decodes.
+fn decode_b64(input: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    // Collect the significant (non-whitespace, non-padding) sextets.
+    let mut sextets: Vec<u8> = Vec::with_capacity(input.len());
+    let mut padding = 0usize;
+    let mut seen_padding = false;
+    for &c in input.as_bytes() {
+        match c {
+            b'\r' | b'\n' | b' ' | b'\t' => continue,
+            b'=' => {
+                seen_padding = true;
+                padding += 1;
+                if padding > 2 {
+                    return None;
+                }
+            }
+            _ => {
+                // A data character after padding is malformed.
+                if seen_padding {
+                    return None;
+                }
+                sextets.push(val(c)?);
+            }
+        }
+    }
+
+    // 4 sextets -> 3 bytes. The remainder (after removing padding) must be 0, 2,
+    // or 3 sextets; a remainder of 1 is impossible in valid base64.
+    let mut out = Vec::with_capacity(sextets.len() / 4 * 3 + 2);
+    let mut chunks = sextets.chunks_exact(4);
+    for chunk in &mut chunks {
+        let n = (u32::from(chunk[0]) << 18)
+            | (u32::from(chunk[1]) << 12)
+            | (u32::from(chunk[2]) << 6)
+            | u32::from(chunk[3]);
+        out.push((n >> 16) as u8);
+        out.push((n >> 8) as u8);
+        out.push(n as u8);
+    }
+    let rem = chunks.remainder();
+    match rem.len() {
+        0 => {}
+        2 => {
+            let n = (u32::from(rem[0]) << 18) | (u32::from(rem[1]) << 12);
+            out.push((n >> 16) as u8);
+        }
+        3 => {
+            let n =
+                (u32::from(rem[0]) << 18) | (u32::from(rem[1]) << 12) | (u32::from(rem[2]) << 6);
+            out.push((n >> 16) as u8);
+            out.push((n >> 8) as u8);
+        }
+        _ => return None,
+    }
+    Some(out)
+}
+
+/// Maps a Connect textual error code to the HTTP-ish status the typed-error
+/// layer keys remediation on. An unmapped code falls back to 500. Mirrors the Go
+/// and Python maps.
+fn connect_code_status(code: &str) -> u16 {
+    match code {
+        "canceled" => 499,
+        "unknown" => 500,
+        "invalid_argument" => 400,
+        "deadline_exceeded" => 504,
+        "not_found" => 404,
+        "already_exists" => 409,
+        "permission_denied" => 403,
+        "resource_exhausted" => 429,
+        "failed_precondition" => 400,
+        "aborted" => 409,
+        "out_of_range" => 400,
+        "unimplemented" => 501,
+        "internal" => 500,
+        "unavailable" => 503,
+        "data_loss" => 500,
+        "unauthenticated" => 401,
+        _ => 500,
+    }
+}
+
+/// The default machine code for an HTTP status when a streaming open fails with
+/// a body that is not the Connect error envelope. Mirrors `error.rs`.
+fn status_code(status: u16) -> &'static str {
+    match status {
+        400 => "bad_request",
+        401 => "unauthorized",
+        403 => "forbidden",
+        404 => "not_found",
+        409 => "conflict",
+        413 => "request_too_large",
+        429 => "rate_limited",
+        500 => "internal_error",
+        503 => "unavailable",
+        s if s >= 500 => "server_error",
+        _ => "request_failed",
+    }
+}
+
+/// The default remediation hint for an HTTP status. Mirrors `error.rs`.
+fn status_remediation(status: u16) -> &'static str {
+    match status {
+        401 | 403 => "Check the API key is set and authorizes this request.",
+        404 => "Confirm the sandbox id exists and is Ready before calling.",
+        413 => "Reduce the request payload size.",
+        429 => "Back off and retry the request after a short delay.",
+        s if s >= 500 => "Retry the request; if it persists, inspect the sandbox-server logs.",
+        _ => "Inspect the request fields against the sandbox API contract.",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_round_trip_known_vectors() {
+        assert_eq!(decode_b64("").unwrap(), b"");
+        assert_eq!(decode_b64("aGVsbG8=").unwrap(), b"hello");
+        assert_eq!(decode_b64("aGVsbG8gd29ybGQ=").unwrap(), b"hello world");
+        assert_eq!(decode_b64("Zm9v").unwrap(), b"foo");
+        assert_eq!(decode_b64("Zm8=").unwrap(), b"fo");
+        assert_eq!(decode_b64("Zg==").unwrap(), b"f");
+        // Whitespace is ignored.
+        assert_eq!(decode_b64("aGVs\nbG8=").unwrap(), b"hello");
+    }
+
+    #[test]
+    fn base64_rejects_invalid() {
+        assert!(decode_b64("a").is_none()); // length-1 remainder is impossible
+        assert!(decode_b64("****").is_none());
+        assert!(decode_b64("ab=c").is_none()); // data after padding
+    }
+
+    #[test]
+    fn frame_round_trips() {
+        let payload = br#"{"command":"echo hi"}"#;
+        let framed = encode_frame(payload, false);
+        let (flag, body, next) = parse_frame(&framed, 0).unwrap().unwrap();
+        assert_eq!(flag, 0);
+        assert_eq!(body, payload);
+        assert_eq!(next, framed.len());
+    }
+
+    #[test]
+    fn frame_partial_returns_none() {
+        let framed = encode_frame(b"abc", false);
+        // Truncate mid-payload.
+        assert!(parse_frame(&framed[..6], 0).unwrap().is_none());
+        // Truncate mid-header.
+        assert!(parse_frame(&framed[..3], 0).unwrap().is_none());
+    }
+}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -49,6 +49,26 @@ impl MitosError {
         }
     }
 
+    /// Builds a client-side error carrying an explicit HTTP `status`. Used by
+    /// the Connect codec, whose typed errors map a Connect code onto a status
+    /// the remediation layer keys on even though no legacy REST envelope was
+    /// returned.
+    pub(crate) fn client_with_status(
+        code: &str,
+        message: impl Into<String>,
+        cause: impl Into<String>,
+        remediation: impl Into<String>,
+        status: u16,
+    ) -> Self {
+        MitosError {
+            code: code.to_string(),
+            message: message.into(),
+            cause: cause.into(),
+            remediation: remediation.into(),
+            status,
+        }
+    }
+
     /// Builds a [`MitosError`] from a non-2xx response body. Prefers the
     /// structured server envelope `{error:{code, message, cause, remediation}}`
     /// and falls back to status-derived defaults for an older or non-Mitos

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -69,6 +69,7 @@
 
 mod client;
 mod cluster;
+mod connect;
 mod error;
 mod k8s;
 mod types;

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -41,8 +41,10 @@ pub struct ServerSandbox {
     pub fork_time_ms: f64,
 }
 
-/// The result of [`crate::Sandbox::exec`], mirroring the `/v1/exec` response
-/// `{exit_code, stdout, stderr, exec_time_ms}`.
+/// The result of [`crate::Sandbox::exec`]: `{exit_code, stdout, stderr,
+/// exec_time_ms}`. The fields are drained from the Connect
+/// `sandbox.v1.Sandbox/ExecStream` response: the stdout and stderr frames plus
+/// the terminal exit frame.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct ExecResult {
     /// The command exit code.

--- a/sdk/rust/tests/connect_test.rs
+++ b/sdk/rust/tests/connect_test.rs
@@ -1,0 +1,379 @@
+//! Integration tests for the direct-mode `Sandbox::exec`, which speaks the
+//! Connect `sandbox.v1.Sandbox/ExecStream` runtime protocol (issue #358/#24)
+//! over the SDK's existing `ureq` transport.
+//!
+//! Each stub is a hand-rolled HTTP/1.1 listener that serves a queue of canned
+//! responses (raw bytes, arbitrary content type) and records every request. A
+//! test forks first (the stub answers the fork POST with a JSON reply), then
+//! calls exec (the stub answers with an `application/connect+json` body of
+//! ENVELOPED frames: a stdout frame, an exit frame, an end-stream frame). The
+//! test asserts the SDK hit the ExecStream path with the right headers and an
+//! enveloped request body, and that an error end-stream surfaces as a typed
+//! `MitosError`. No network access is needed.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use mitos::SandboxServer;
+
+/// A captured request as seen by the stub.
+#[derive(Debug, Clone)]
+struct CapturedRequest {
+    method: String,
+    path: String,
+    headers: Vec<(String, String)>,
+    /// The raw request body bytes (for exec, the enveloped ExecStream request).
+    body: Vec<u8>,
+}
+
+impl CapturedRequest {
+    fn header(&self, name: &str) -> Option<&str> {
+        let lname = name.to_ascii_lowercase();
+        self.headers
+            .iter()
+            .find(|(k, _)| k.to_ascii_lowercase() == lname)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// A canned response: a status, a content type, and a raw body written verbatim.
+#[derive(Clone)]
+struct StubResponse {
+    status: u16,
+    reason: String,
+    content_type: String,
+    body: Vec<u8>,
+}
+
+impl StubResponse {
+    /// A JSON fork reply for `id`, used as the first queued response so a test
+    /// can mint a `Sandbox` bound to this stub before driving exec.
+    fn fork_reply(id: &str) -> Self {
+        StubResponse {
+            status: 200,
+            reason: "OK".to_string(),
+            content_type: "application/json".to_string(),
+            body: format!(
+                r#"{{"id":"{id}","template_id":"python","endpoint":"e","fork_time_ms":1.0}}"#
+            )
+            .into_bytes(),
+        }
+    }
+
+    /// A Connect streaming reply (`application/connect+json`) carrying `body`.
+    fn connect_stream(body: Vec<u8>) -> Self {
+        StubResponse {
+            status: 200,
+            reason: "OK".to_string(),
+            content_type: "application/connect+json".to_string(),
+            body,
+        }
+    }
+
+    /// A non-2xx Connect error envelope returned before any frame.
+    fn connect_error(status: u16, reason: &str, body: &str) -> Self {
+        StubResponse {
+            status,
+            reason: reason.to_string(),
+            content_type: "application/json".to_string(),
+            body: body.as_bytes().to_vec(),
+        }
+    }
+}
+
+const FLAG_DATA: u8 = 0x00;
+const FLAG_END_STREAM: u8 = 0x02;
+
+/// Wraps one payload in the Connect 5-byte envelope prefix (1 flag byte + 4-byte
+/// big-endian length + payload).
+fn frame(flag: u8, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(flag);
+    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// A successful ExecStream response: a stdout frame, an exit frame, then a clean
+/// end-stream frame. `stdout_b64` is the base64 of the stdout bytes.
+fn exec_ok_body(stdout_b64: &str, exit_code: i64, exec_time_ms: f64) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&frame(
+        FLAG_DATA,
+        format!(r#"{{"stdout":"{stdout_b64}"}}"#).as_bytes(),
+    ));
+    body.extend_from_slice(&frame(
+        FLAG_DATA,
+        format!(r#"{{"exit":{{"exitCode":{exit_code},"execTimeMs":{exec_time_ms}}}}}"#).as_bytes(),
+    ));
+    // A clean end-stream frame: empty trailers object.
+    body.extend_from_slice(&frame(FLAG_END_STREAM, b"{}"));
+    body
+}
+
+/// An in-process HTTP/1.1 stub serving a queue of canned responses in order and
+/// recording each request.
+struct ConnectStub {
+    base_url: String,
+    captured: Receiver<CapturedRequest>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl ConnectStub {
+    fn start(responses: Vec<StubResponse>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let base_url = format!("http://{addr}");
+
+        let (tx, rx) = mpsc::channel();
+        let queue = Arc::new(Mutex::new(responses.into_iter()));
+
+        let handle = thread::spawn(move || {
+            for stream in listener.incoming() {
+                let stream = match stream {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let next = queue.lock().unwrap().next();
+                let resp = match next {
+                    Some(r) => r,
+                    None => break,
+                };
+                if let Some(req) = handle_connection(stream, &resp) {
+                    let _ = tx.send(req);
+                }
+            }
+        });
+
+        ConnectStub {
+            base_url,
+            captured: rx,
+            handle: Some(handle),
+        }
+    }
+
+    fn next_request(&self) -> CapturedRequest {
+        self.captured
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("a request should have reached the stub")
+    }
+}
+
+impl Drop for ConnectStub {
+    fn drop(&mut self) {
+        let _ = TcpStream::connect(self.base_url.trim_start_matches("http://"));
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Reads one HTTP/1.1 request (with a Content-Length body of raw bytes), writes
+/// the canned response, and returns the captured request.
+fn handle_connection(stream: TcpStream, resp: &StubResponse) -> Option<CapturedRequest> {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).ok()? == 0 {
+        return None;
+    }
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next()?.to_string();
+    let path = parts.next()?.to_string();
+
+    let mut headers = Vec::new();
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            break;
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((k, v)) = trimmed.split_once(':') {
+            let k = k.trim().to_string();
+            let v = v.trim().to_string();
+            if k.eq_ignore_ascii_case("content-length") {
+                content_length = v.parse().unwrap_or(0);
+            }
+            headers.push((k, v));
+        }
+    }
+
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        reader.read_exact(&mut body).ok()?;
+    }
+
+    let mut out = stream;
+    let header = format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        resp.status,
+        resp.reason,
+        resp.content_type,
+        resp.body.len(),
+    );
+    let _ = out.write_all(header.as_bytes());
+    let _ = out.write_all(&resp.body);
+    let _ = out.flush();
+
+    Some(CapturedRequest {
+        method,
+        path,
+        headers,
+        body,
+    })
+}
+
+/// Builds a client pointed at the stub with no token.
+fn client_for(base_url: &str) -> SandboxServer {
+    SandboxServer::builder().base_url(base_url).build()
+}
+
+/// Parses the captured enveloped request body into (flag, json-payload-string).
+fn parse_one_frame(body: &[u8]) -> (u8, String) {
+    assert!(body.len() >= 5, "request body is too short for a frame");
+    let flag = body[0];
+    let len = u32::from_be_bytes([body[1], body[2], body[3], body[4]]) as usize;
+    assert_eq!(body.len(), 5 + len, "request body length mismatch");
+    (flag, String::from_utf8_lossy(&body[5..]).to_string())
+}
+
+#[test]
+fn exec_round_trips_stdout_and_exit_code_over_connect() {
+    // "hello\n" base64 == "aGVsbG8K".
+    let stub = ConnectStub::start(vec![
+        StubResponse::fork_reply("box"),
+        StubResponse::connect_stream(exec_ok_body("aGVsbG8K", 0, 4.2)),
+    ]);
+    let server = client_for(&stub.base_url);
+
+    let sandbox = server.fork_as("python", "box").expect("fork");
+    let _fork_req = stub.next_request();
+
+    let result = sandbox.exec("echo hello").expect("exec");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "hello\n");
+    assert_eq!(result.exec_time_ms, 4.2);
+    assert!(result.success());
+
+    let req = stub.next_request();
+    assert_eq!(req.method, "POST");
+    assert_eq!(req.path, "/sandbox.v1.Sandbox/ExecStream");
+    assert_eq!(req.header("Content-Type"), Some("application/connect+json"));
+    assert_eq!(req.header("Connect-Protocol-Version"), Some("1"));
+    assert_eq!(req.header("X-Sandbox-Id"), Some("box"));
+    // Tokenless client: no Authorization header.
+    assert!(req.header("Authorization").is_none());
+
+    let (flag, payload) = parse_one_frame(&req.body);
+    assert_eq!(flag, FLAG_DATA, "request frame must be a plain data frame");
+    assert!(
+        payload.contains("\"command\":\"echo hello\""),
+        "payload was {payload}"
+    );
+    // The default 30s timeout is sent as proto-JSON timeoutSeconds.
+    assert!(
+        payload.contains("\"timeoutSeconds\":30"),
+        "payload was {payload}"
+    );
+}
+
+#[test]
+fn exec_captures_stderr_and_nonzero_exit() {
+    // stdout "" , stderr "boom\n" base64 == "Ym9vbQo=", exit 2.
+    let mut body = Vec::new();
+    body.extend_from_slice(&frame(FLAG_DATA, br#"{"stderr":"Ym9vbQo="}"#));
+    body.extend_from_slice(&frame(
+        FLAG_DATA,
+        br#"{"exit":{"exitCode":2,"execTimeMs":7.0}}"#,
+    ));
+    body.extend_from_slice(&frame(FLAG_END_STREAM, b"{}"));
+
+    let stub = ConnectStub::start(vec![
+        StubResponse::fork_reply("box"),
+        StubResponse::connect_stream(body),
+    ]);
+    let server = client_for(&stub.base_url);
+    let sandbox = server.fork_as("python", "box").expect("fork");
+    let _ = stub.next_request();
+
+    let result = sandbox.exec("false").expect("exec");
+    assert_eq!(result.exit_code, 2);
+    assert_eq!(result.stderr, "boom\n");
+    assert!(!result.success());
+    let _ = stub.next_request();
+}
+
+#[test]
+fn exec_error_end_stream_yields_typed_error() {
+    let mut body = Vec::new();
+    // A stdout frame before the error proves partial output does not mask the
+    // terminal error.
+    body.extend_from_slice(&frame(FLAG_DATA, br#"{"stdout":"cGFydGlhbA=="}"#));
+    body.extend_from_slice(&frame(
+        FLAG_END_STREAM,
+        br#"{"error":{"code":"not_found","message":"sandbox not ready"}}"#,
+    ));
+    let stub = ConnectStub::start(vec![
+        StubResponse::fork_reply("box"),
+        StubResponse::connect_stream(body),
+    ]);
+    let server = client_for(&stub.base_url);
+    let sandbox = server.fork_as("python", "box").expect("fork");
+    let _ = stub.next_request();
+
+    let err = sandbox
+        .exec("echo hi")
+        .expect_err("error end-stream must fail");
+    assert_eq!(err.code, "not_found");
+    assert_eq!(err.status, 404);
+    let _ = stub.next_request();
+}
+
+#[test]
+fn exec_non_2xx_connect_envelope_yields_typed_error() {
+    // A streaming RPC that fails before the first frame returns a normal HTTP
+    // error body (the Connect error envelope), not an end-stream frame.
+    let stub = ConnectStub::start(vec![
+        StubResponse::fork_reply("box"),
+        StubResponse::connect_error(
+            429,
+            "Too Many Requests",
+            r#"{"code":"resource_exhausted","message":"too many concurrent streams"}"#,
+        ),
+    ]);
+    let server = client_for(&stub.base_url);
+    let sandbox = server.fork_as("python", "box").expect("fork");
+    let _ = stub.next_request();
+
+    let err = sandbox.exec("echo hi").expect_err("429 must fail");
+    assert_eq!(err.code, "resource_exhausted");
+    assert_eq!(err.status, 429);
+    let _ = stub.next_request();
+}
+
+#[test]
+fn exec_sends_authorization_when_token_set() {
+    let stub = ConnectStub::start(vec![
+        StubResponse::fork_reply("box"),
+        StubResponse::connect_stream(exec_ok_body("", 0, 1.0)),
+    ]);
+    let server = SandboxServer::builder()
+        .base_url(&stub.base_url)
+        .api_key("sk-secret")
+        .build();
+    let sandbox = server.fork_as("python", "box").expect("fork");
+    let _ = stub.next_request();
+
+    let _ = sandbox.exec("true").expect("exec");
+    let req = stub.next_request();
+    assert_eq!(req.header("Authorization"), Some("Bearer sk-secret"));
+    // The token value must never leak into the recorded path or any header key.
+    assert_eq!(req.path, "/sandbox.v1.Sandbox/ExecStream");
+}

--- a/sdk/rust/tests/server_test.rs
+++ b/sdk/rust/tests/server_test.rs
@@ -308,31 +308,11 @@ fn fork_rejects_path_traversal_id() {
     drop(stub);
 }
 
-#[test]
-fn exec_round_trips_stdout_and_exit_code() {
-    let stub = StubServer::start(vec![
-        StubResponse::ok(
-            r#"{"id":"box","template_id":"python","endpoint":"e","fork_time_ms":1.0}"#,
-        ),
-        StubResponse::ok(r#"{"exit_code":0,"stdout":"hello\n","stderr":"","exec_time_ms":4.2}"#),
-    ]);
-    let server = client_for(&stub.base_url);
-
-    let sandbox = server.fork_as("python", "box").expect("fork");
-    let _fork_req = stub.next_request();
-
-    let result = sandbox.exec("echo hello").expect("exec");
-    assert_eq!(result.exit_code, 0);
-    assert_eq!(result.stdout, "hello\n");
-    assert!(result.success());
-
-    let req = stub.next_request();
-    assert_eq!(req.method, "POST");
-    assert_eq!(req.path, "/v1/exec");
-    assert!(req.body.contains("\"sandbox\":\"box\""));
-    assert!(req.body.contains("\"command\":\"echo hello\""));
-    assert!(req.body.contains("\"timeout\":30"));
-}
+// `exec` now speaks the Connect `sandbox.v1.Sandbox/ExecStream` runtime
+// protocol rather than the legacy `POST /v1/exec` JSON route. Its wire (enveloped
+// streaming frames, an `application/connect+json` response) needs a stub that
+// emits raw framed bytes, which the JSON-only `StubServer` above cannot do, so the
+// exec coverage lives in `tests/connect_test.rs` against a Connect stub.
 
 #[test]
 fn terminate_issues_delete() {


### PR DESCRIPTION
Migrates the three thin SDKs' runtime `exec` off the legacy REST `/v1/exec` onto the Connect `sandbox.v1.Sandbox/ExecStream` RPC (#24/#358), each dependency-free, mirroring the proven Go (`sdk/go/connect.go`) and Python (`sdk/python/mitos/_connect.py`) wire.

Each SDK gains a small Connect-over-HTTP client (unary `application/json`; server-stream `application/connect+json` with 5-byte enveloped frames, end-stream flag `0x02`, `Connect-Protocol-Version: 1`, `X-Sandbox-Id`, bearer). Public `exec` signatures and `ExecResult` shapes are unchanged — only the transport moved.

- **Ruby** (`net/http`): new `lib/mitos/connect.rb`. Tests **37 runs / 0 failures**.
- **Java** (`java.net.http`): new `ConnectClient.java`, reuses the SDK `Json` helper. Tests **24 passed / 0 failed**.
- **Rust** (existing `ureq` + `serde_json`, inline base64 decoder, **no new crates**): new `src/connect.rs`. `cargo test`/`clippy`/`fmt` clean.

Each keeps a unit test driving a fake Connect server (stdout/exit/end-stream frames + an error-end-stream typed-error case) asserting the request hits `/sandbox.v1.Sandbox/ExecStream` with the routing + bearer headers (run in `sdk-tests.yaml`). I re-ran all three suites locally and reviewed each codec against the proven Go wire (framing, flags, headers, base64) — verified faithful.

With Python/TypeScript/Go already on Connect, only the Python async/files/PTY/run_code surface remains before the legacy `/v1` runtime routes can be deleted (the next steps of this cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)