### PR TITLE
feat(console): Phase B3c data-retention policies and legal hold

### DIFF
--- a/docs/superpowers/plans/2026-06-25-console-b3c-retention.md
+++ b/docs/superpowers/plans/2026-06-25-console-b3c-retention.md
@@ -1,0 +1,172 @@
+# Console B3c: data-retention policies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Do NOT invoke finishing-a-development-branch; implement, test, commit, report.
+
+**Goal:** A per-org data-retention policy for terminated-sandbox metadata, sandbox logs, and usage records, plus a legal-hold toggle, surfaced in a "Data and retention" view. The console stores and exposes the policy; the controller GC (#163) enforces it.
+
+**Architecture:** Go BFF gains a `DataRetentionStore` seam (per-org policy) + `GET/PUT /console/retention`. The SPA gains a "Data and retention" view. B3b's audit-specific retention (`/console/audit/retention`) is untouched and stays on the Audit page; this view covers the other resources + legal hold. No GC is implemented here (it is the controller's job, #163); the console persists the policy and a "what gets deleted when" preview.
+
+**Tech Stack:** Go (`internal/saas/console`), React+Vite+TS, TanStack Query, Vitest + vitest-axe.
+
+**Scope note:** B3c of the B3 split. B3d (custom roles + per-project RBAC) follows; B3e (SAML) + B3f (SCIM) are auth-critical (threat-model deltas + named-human review).
+
+## Global Constraints
+
+- **Punctuation (strict):** no em/en dashes anywhere. Only `.` `,` `;` `:`; ASCII `-`. Verify each commit.
+- **Commits:** conventional + DCO (`git commit -s`). **Staging:** explicit paths only.
+- **Org-scoped isolation:** the retention endpoint reads org from request context only; per-org; cross-org never leaks; added to the auth-gate table; isolation tested.
+- **Honesty:** the view states plainly that the GC enforces the policy (the console stores it); a legal hold pauses deletion. No fabricated "deleted N records" claim.
+- **Go style:** `fmt.Errorf("...: %w", err)`; gofmt clean; BOTH golangci-lint invocations clean.
+- **Responsive + accessible (spec 4.6):** the view is responsive + labelled; axe zero violations.
+- **TypeScript strict** clean; SPA suite exits 0; `go test ./internal/saas/...` green.
+
+## File Structure
+
+- `internal/saas/console/retention.go` (create) - `DataRetentionPolicy`, `DataRetentionStore` seam + fake, handlers.
+- `internal/saas/console/console.go` (modify) - routes + dep default.
+- Go tests alongside.
+- `web/app/src/api.ts`, `web/app/src/data/retention.ts` (create), `web/app/src/views/Retention.tsx` (create), `web/app/src/nav/routes.tsx` (route).
+- `web/packages/brand/src/base.css` (modify).
+- Tests alongside.
+
+---
+
+### Task 1: Data-retention store + endpoint (Go)
+
+**Files:**
+- Create: `internal/saas/console/retention.go`
+- Modify: `internal/saas/console/console.go`
+- Test: `internal/saas/console/retention_test.go`
+
+Read `internal/saas/console/audit_export.go` (the B3b `RetentionStore` pattern), `forktree.go`/`projects.go` (seam + nil-default), `console.go` (Deps, New, routes, caller, decodeBody, writeJSON, apierr), and `console_test.go` (the auth-gate table) first.
+
+**Interfaces:**
+- `DataRetentionPolicy = { SandboxMetadataDays, LogsDays, UsageDays int; LegalHold bool }` (JSON tags `sandbox_metadata_days`, `logs_days`, `usage_days`, `legal_hold`).
+- `DataRetentionStore` seam: `Get(ctx, orgID) (DataRetentionPolicy, error)`, `Set(ctx, orgID, DataRetentionPolicy) error`. `NewMemDataRetentionStore()` fake (per-org; defaults to a zero policy = keep forever). `Deps.DataRetention` nil-defaults to the fake.
+- `GET /console/retention` -> the org's policy; `PUT /console/retention` body the policy.
+
+- [ ] **Step 1: Write the failing test `internal/saas/console/retention_test.go`**
+
+```go
+package console
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDataRetentionRoundTripOrgScoped(t *testing.T) {
+	c := New(Deps{DataRetention: NewMemDataRetentionStore()})
+	put := httptest.NewRequest("PUT", "/console/retention", strings.NewReader(`{"sandbox_metadata_days":30,"logs_days":14,"usage_days":365,"legal_hold":true}`)).WithContext(WithCaller(context.Background(), "acct", "orgA"))
+	rr := httptest.NewRecorder()
+	c.ServeHTTP(rr, put)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("put status %d", rr.Code)
+	}
+	// orgB sees the zero/default policy, not orgA's.
+	getB := httptest.NewRequest("GET", "/console/retention", nil).WithContext(WithCaller(context.Background(), "acct", "orgB"))
+	rrB := httptest.NewRecorder()
+	c.ServeHTTP(rrB, getB)
+	if strings.Contains(rrB.Body.String(), "365") {
+		t.Fatalf("orgA policy leaked into orgB: %s", rrB.Body.String())
+	}
+	// orgA reads back its policy.
+	getA := httptest.NewRequest("GET", "/console/retention", nil).WithContext(WithCaller(context.Background(), "acct", "orgA"))
+	rrA := httptest.NewRecorder()
+	c.ServeHTTP(rrA, getA)
+	if !strings.Contains(rrA.Body.String(), "365") || !strings.Contains(rrA.Body.String(), "true") {
+		t.Fatalf("orgA policy not persisted: %s", rrA.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `go test ./internal/saas/console/ -run TestDataRetention`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `internal/saas/console/retention.go`** (the policy + store + fake + `handleGetDataRetention`/`handleSetDataRetention`). Wire `Deps.DataRetention` nil-default + the 2 routes in `console.go`. Add both routes to the auth-gate table. A code comment notes the GC (#163) enforces the policy and that a legal hold pauses deletion.
+
+- [ ] **Step 4: Run; full package; gofmt; both lint**
+
+Run: `go test ./internal/saas/console/` ; `gofmt -l internal/saas/console/retention.go internal/saas/console/console.go`
+Run: `golangci-lint run --timeout=5m ./internal/saas/... && GOOS=linux golangci-lint run --timeout=5m ./internal/saas/...`
+Expected: green/clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/saas/console/retention.go internal/saas/console/console.go internal/saas/console/retention_test.go
+git commit -s -m "feat(console): per-org data-retention policy store and endpoint"
+```
+
+---
+
+### Task 2: Data-and-retention view (frontend)
+
+**Files:**
+- Modify: `web/app/src/api.ts`, `web/app/src/nav/routes.tsx`
+- Create: `web/app/src/data/retention.ts`, `web/app/src/views/Retention.tsx`
+- Test: `web/app/src/views/Retention.test.tsx`
+
+**Interfaces:**
+- `DataRetentionPolicy` type (TS, snake_case to match Go); `api.dataRetention()`, `api.setDataRetention(policy)`.
+- Hooks `useDataRetention`, `useSetDataRetention`.
+- `Retention` view: a form with number inputs for sandbox-metadata, logs, usage retention (days; 0 = keep forever, labelled), a legal-hold toggle, a Save button, and a short honest "what gets deleted when" preview (e.g. "Terminated sandbox metadata older than N days is removed by the garbage collector. A legal hold pauses all deletion."). Route `/retention` in the Govern group, label "Data and retention".
+
+- [ ] **Step 1: Write the failing test `web/app/src/views/Retention.test.tsx`** (render `/retention`, mock capabilities + retention `{sandbox_metadata_days:30, logs_days:14, usage_days:365, legal_hold:false}`; assert the inputs show the values and the legal-hold control renders; toggling legal hold and saving calls the PUT).
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `pnpm -C web/app test src/views/Retention.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement api.ts additions, `data/retention.ts`, `Retention.tsx`, and route `/retention`.** Labelled inputs; a legal-hold checkbox; Save -> toast; the honest GC-enforcement note.
+
+- [ ] **Step 4: Run the test, full suite, typecheck**
+
+Run: `pnpm -C web/app test src/views/Retention.test.tsx && pnpm -C web/app test && pnpm -C web/app typecheck`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/src/api.ts web/app/src/data/retention.ts web/app/src/views/Retention.tsx web/app/src/nav/routes.tsx web/app/src/views/Retention.test.tsx
+git commit -s -m "feat(console): Data and retention view with per-resource policy and legal hold"
+```
+
+---
+
+### Task 3: Styles, a11y, final verification
+
+**Files:**
+- Modify: `web/packages/brand/src/base.css`
+- Create: `web/app/src/views/Retention.a11y.test.tsx`
+
+- [ ] **Step 1: Append token-driven styles** for any new classes the view uses (reuse `.settings-section`/`.form-row`/input styles). No raw hex. Mobile rule.
+- [ ] **Step 2: Write the axe a11y test** for `/retention` (inputs + legal-hold toggle labelled; zero violations). Fix any real violation.
+- [ ] **Step 3: Final verification**
+
+Run: `pnpm -C web/app test` (exit 0) ; `pnpm -C web/app typecheck` (clean) ; `pnpm -C web/app build` (succeeds)
+Run: `go test ./internal/saas/...` (green) ; both golangci-lint invocations clean
+Run: `grep -rnP '\xe2\x80\x94|\xe2\x80\x93' web/app/src/views/Retention.tsx internal/saas/console/retention.go web/packages/brand/src/base.css` (empty)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/packages/brand/src/base.css web/app/src/views/Retention.a11y.test.tsx
+git commit -s -m "feat(console): retention view styles and B3c accessibility checks"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (section 5.3):** per-org data-retention for terminated-sandbox metadata, logs, and usage (Task 1, 2), a legal-hold toggle (Task 1, 2), and the "Data and retention" view with a delete-when preview (Task 2). Covered. GC enforcement is #163's job (noted honestly; the console stores + exposes the policy).
+
+**Org isolation:** the retention endpoint is per-org, context-sourced, isolation-tested (Task 1), auth-gate added.
+
+**Type consistency:** Go `DataRetentionPolicy` JSON tags match the TS type (Task 2); the endpoint (Task 1) backs the hooks (Task 2). No drift.

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -58,6 +58,13 @@ type Deps struct {
 	// enforces the policy runs in the controller (issue #163). Defaults to the
 	// in-memory fake so the BFF is safe to instantiate without a real store.
 	Retention RetentionStore
+	// DataRetention is the per-org data-retention policy seam. It stores and
+	// exposes the multi-dimensional retention policy (sandbox metadata, logs,
+	// usage) and a legal-hold flag for each org. The GC sweep that enforces the
+	// policy runs in the controller (issue #163); a legal hold pauses all
+	// automated deletion. Defaults to the in-memory fake so the BFF is safe to
+	// instantiate without a real store.
+	DataRetention DataRetentionStore
 	// Sessions is the account-scoped session-listing seam. It is used by the
 	// account-session endpoints (list, revoke one, revoke all) and defaults to a
 	// no-op in-memory implementation so the BFF is safe to instantiate without a
@@ -114,6 +121,9 @@ func New(deps Deps) *Console {
 	}
 	if deps.Retention == nil {
 		deps.Retention = NewMemRetentionStore()
+	}
+	if deps.DataRetention == nil {
+		deps.DataRetention = NewMemDataRetentionStore()
 	}
 	if deps.Sessions == nil {
 		deps.Sessions = noopSessionLister{}
@@ -191,6 +201,8 @@ func (c *Console) routes() {
 	mux.HandleFunc("GET /console/account/sessions", c.handleListSessions)
 	mux.HandleFunc("DELETE /console/account/sessions/{id}", c.handleRevokeSession)
 	mux.HandleFunc("DELETE /console/account/sessions", c.handleRevokeAllSessions)
+	mux.HandleFunc("GET /console/retention", c.handleGetDataRetention)
+	mux.HandleFunc("PUT /console/retention", c.handleSetDataRetention)
 	c.mux = mux
 }
 

--- a/internal/saas/console/console_test.go
+++ b/internal/saas/console/console_test.go
@@ -506,6 +506,8 @@ func TestEveryEndpointRefusesMissingOrgContext(t *testing.T) {
 		{"GET", "/console/account/sessions"},
 		{"DELETE", "/console/account/sessions/x"},
 		{"DELETE", "/console/account/sessions"},
+		{"GET", "/console/retention"},
+		{"PUT", "/console/retention"},
 	}
 	for _, ep := range endpoints {
 		// No WithCaller: the request carries no org context.

--- a/internal/saas/console/retention.go
+++ b/internal/saas/console/retention.go
@@ -1,0 +1,103 @@
+package console
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"mitos.run/mitos/internal/apierr"
+)
+
+// DataRetentionPolicy is the per-org data retention configuration. Zero values
+// mean no limit is set (keep forever). LegalHold pauses all automated deletion
+// for the org regardless of the individual day limits.
+//
+// The GC sweep that enforces these limits runs in the controller (issue #163).
+// A legal hold pauses deletion: no sandbox metadata, logs, or usage data is
+// deleted while LegalHold is true, even if the day limits have elapsed.
+type DataRetentionPolicy struct {
+	SandboxMetadataDays int  `json:"sandbox_metadata_days"`
+	LogsDays            int  `json:"logs_days"`
+	UsageDays           int  `json:"usage_days"`
+	LegalHold           bool `json:"legal_hold"`
+}
+
+// DataRetentionStore is the per-org data-retention policy seam. Get returns the
+// current policy for an org (zero value = keep forever). Set stores a new
+// policy. Both methods MUST be scoped to the supplied orgID: a Set for orgA
+// must never affect orgB's policy, and a Get for orgA must never return orgB's
+// value.
+type DataRetentionStore interface {
+	Get(ctx context.Context, orgID string) (DataRetentionPolicy, error)
+	Set(ctx context.Context, orgID string, p DataRetentionPolicy) error
+}
+
+// MemDataRetentionStore is the in-memory tested default for DataRetentionStore.
+// It is safe for concurrent use and never leaks one org's policy to another.
+// An org with no stored policy returns the zero value (keep forever).
+type MemDataRetentionStore struct {
+	mu    sync.RWMutex
+	byOrg map[string]DataRetentionPolicy
+}
+
+// NewMemDataRetentionStore returns an empty in-memory data-retention store.
+func NewMemDataRetentionStore() *MemDataRetentionStore {
+	return &MemDataRetentionStore{byOrg: map[string]DataRetentionPolicy{}}
+}
+
+// Get returns the org's data retention policy. Returns the zero policy (keep
+// forever) if no policy has been set.
+func (m *MemDataRetentionStore) Get(_ context.Context, orgID string) (DataRetentionPolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.byOrg[orgID], nil
+}
+
+// Set stores the org's data retention policy.
+func (m *MemDataRetentionStore) Set(_ context.Context, orgID string, p DataRetentionPolicy) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byOrg[orgID] = p
+	return nil
+}
+
+// handleGetDataRetention returns the caller org's current data retention policy.
+// Returns the zero policy (keep forever) if no policy has been set.
+func (c *Console) handleGetDataRetention(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	p, err := c.deps.DataRetention.Get(r.Context(), orgID)
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the data retention policy could not be read"))
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+// handleSetDataRetention stores the caller org's data retention policy. The
+// body must be a DataRetentionPolicy object. The GC sweep that enforces the
+// policy runs in the controller (issue #163); this endpoint stores and exposes
+// the policy only. A legal hold pauses all automated deletion for the org.
+func (c *Console) handleSetDataRetention(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.caller(r)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	var body DataRetentionPolicy
+	if err := decodeBody(r, &body); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the retention body is not valid JSON"))
+		return
+	}
+	if err := c.deps.DataRetention.Set(r.Context(), orgID, body); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the data retention policy could not be stored"))
+		return
+	}
+	writeJSON(w, http.StatusOK, body)
+}

--- a/internal/saas/console/retention_test.go
+++ b/internal/saas/console/retention_test.go
@@ -1,0 +1,33 @@
+package console
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDataRetentionRoundTripOrgScoped(t *testing.T) {
+	c := New(Deps{DataRetention: NewMemDataRetentionStore()})
+	put := httptest.NewRequest("PUT", "/console/retention", strings.NewReader(`{"sandbox_metadata_days":30,"logs_days":14,"usage_days":365,"legal_hold":true}`)).WithContext(WithCaller(context.Background(), "acct", "orgA"))
+	rr := httptest.NewRecorder()
+	c.ServeHTTP(rr, put)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("put status %d", rr.Code)
+	}
+	// orgB sees the zero/default policy, not orgA's.
+	getB := httptest.NewRequest("GET", "/console/retention", nil).WithContext(WithCaller(context.Background(), "acct", "orgB"))
+	rrB := httptest.NewRecorder()
+	c.ServeHTTP(rrB, getB)
+	if strings.Contains(rrB.Body.String(), "365") {
+		t.Fatalf("orgA policy leaked into orgB: %s", rrB.Body.String())
+	}
+	// orgA reads back its policy.
+	getA := httptest.NewRequest("GET", "/console/retention", nil).WithContext(WithCaller(context.Background(), "acct", "orgA"))
+	rrA := httptest.NewRecorder()
+	c.ServeHTTP(rrA, getA)
+	if !strings.Contains(rrA.Body.String(), "365") || !strings.Contains(rrA.Body.String(), "true") {
+		t.Fatalf("orgA policy not persisted: %s", rrA.Body.String())
+	}
+}

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -66,6 +66,13 @@ export type ProjectView = { id: string; org_id: string; name: string; descriptio
 export type SinkType = 'webhook' | 's3' | 'splunk' | 'datadog'
 export type SinkView = { id: string; org_id: string; type: SinkType; endpoint: string; enabled: boolean; created_at: string }
 
+export type DataRetentionPolicy = {
+  sandbox_metadata_days: number
+  logs_days: number
+  usage_days: number
+  legal_hold: boolean
+}
+
 export type AccountView = {
   account_id: string
   email: string
@@ -218,6 +225,17 @@ export const api = {
     if (!r.ok && r.status !== 204) throw new Error(`delete sink: ${r.status}`)
   },
   auditExportUrl: () => '/console/audit/export',
+  dataRetention: () => get<DataRetentionPolicy>('/console/retention'),
+  setDataRetention: async (policy: DataRetentionPolicy) => {
+    const r = await fetch('/console/retention', {
+      method: 'PUT',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(policy),
+    })
+    if (!r.ok) throw new Error(`set retention policy: ${r.status}`)
+    return (await r.json()) as DataRetentionPolicy
+  },
 }
 
 export function fmtBytes(n: number): string {

--- a/web/app/src/data/retention.ts
+++ b/web/app/src/data/retention.ts
@@ -1,0 +1,16 @@
+// Data hooks for the per-org data and retention policy.
+// GC enforcement lives in the controller (issue #163); this only stores/exposes the policy.
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api, type DataRetentionPolicy } from '../api'
+
+export function useDataRetention() {
+  return useQuery<DataRetentionPolicy>({ queryKey: ['data-retention'], queryFn: () => api.dataRetention() })
+}
+
+export function useSetDataRetention() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (policy: DataRetentionPolicy) => api.setDataRetention(policy),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['data-retention'] }),
+  })
+}

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -18,6 +18,7 @@ import { Members } from '../views/Members'
 import { Projects } from '../views/Projects'
 import { Settings } from '../views/Settings'
 import { Trust } from '../views/Trust'
+import { Retention } from '../views/Retention'
 
 export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Settings'
 export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Settings']
@@ -44,6 +45,7 @@ export const ROUTES: RouteDef[] = [
   { path: '/projects', label: 'Projects', group: 'Govern', element: () => <Projects />, when: (c) => c.teams },
   { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Audit /> },
   { path: '/trust', label: 'Trust', group: 'Govern', element: () => <Trust /> },
+  { path: '/retention', label: 'Data and retention', group: 'Govern', element: () => <Retention /> },
   { path: '/usage', label: 'Usage', group: 'Govern', element: () => <Usage /> },
   { path: '/billing', label: 'Billing', group: 'Govern', element: () => <Billing />, when: (c) => c.billing },
   { path: '/settings', label: 'Settings', group: 'Settings', element: () => <Settings /> },

--- a/web/app/src/views/Retention.a11y.test.tsx
+++ b/web/app/src/views/Retention.a11y.test.tsx
@@ -1,0 +1,49 @@
+// Axe accessibility audit for the Retention view: no violations with inputs labelled,
+// legal-hold checkbox labelled, and the form fully loaded.
+// Uses vitest-axe (^0.1.0) which wraps axe-core and provides Vitest-compatible
+// matchers. Import path: 'vitest-axe' for axe(), 'vitest-axe/matchers' for the
+// custom expect matcher.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import * as matchers from 'vitest-axe/matchers'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+expect.extend(matchers)
+
+const caps: Capabilities = {
+  edition: 'community', billing: false, signup: false, teams: false, idp: 'oidc',
+  orgSwitcher: false, secrets: { providers: ['kube'] }, proof: false, ownership: 'self-hosted',
+}
+
+const retentionPayload = {
+  sandbox_metadata_days: 30,
+  logs_days: 14,
+  usage_days: 365,
+  legal_hold: false,
+}
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = String(input).split('?')[0]
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/retention')) {
+      return Promise.resolve(new Response(JSON.stringify(retentionPayload), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+})
+
+describe('Retention view accessibility', () => {
+  it('has no axe violations on /retention', async () => {
+    const { container } = await renderAt('/retention', caps)
+    // Wait for the form to load: the sandbox-metadata input is a reliable sentinel.
+    await waitFor(() => expect(screen.getByLabelText(/sandbox.?metadata/i)).toBeInTheDocument())
+    // Confirm the legal-hold checkbox is labelled too.
+    expect(screen.getByRole('checkbox', { name: /legal.?hold/i })).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/web/app/src/views/Retention.test.tsx
+++ b/web/app/src/views/Retention.test.tsx
@@ -126,11 +126,16 @@ describe('Retention view', () => {
     const saveButton = screen.getByRole('button', { name: /save/i })
     fireEvent.click(saveButton)
 
-    // The PUT should be called with legal_hold: true
+    // The PUT should be called with the full body including all four fields.
     await waitFor(() => expect(calls.length).toBeGreaterThanOrEqual(1))
     const lastCall = calls[calls.length - 1]
     expect(lastCall.url).toContain('/console/retention')
-    expect((lastCall.body as { legal_hold: boolean }).legal_hold).toBe(true)
+    expect(lastCall.body).toEqual({
+      sandbox_metadata_days: retentionPayload.sandbox_metadata_days,
+      logs_days: retentionPayload.logs_days,
+      usage_days: retentionPayload.usage_days,
+      legal_hold: true,
+    })
   })
 
   it('shows a "0 = keep forever" hint on one of the number inputs', async () => {

--- a/web/app/src/views/Retention.test.tsx
+++ b/web/app/src/views/Retention.test.tsx
@@ -1,0 +1,148 @@
+// Behavior tests for the Retention view: number inputs for sandbox-metadata,
+// logs, and usage retention days; a legal-hold checkbox; Save -> toast; the
+// honest GC-enforcement note.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, waitFor, screen } from '@testing-library/react'
+import { renderAt } from '../test/utils'
+import type { Capabilities } from '../api'
+
+const caps: Capabilities = {
+  edition: 'community',
+  billing: false,
+  signup: false,
+  teams: false,
+  idp: 'oidc',
+  orgSwitcher: false,
+  secrets: { providers: ['kube'] },
+  proof: false,
+  ownership: 'self-hosted',
+}
+
+const retentionPayload = {
+  sandbox_metadata_days: 30,
+  logs_days: 14,
+  usage_days: 365,
+  legal_hold: false,
+}
+
+function mockFetch(putResponse?: object) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input).split('?')[0]
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(
+        new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    }
+    if (url.endsWith('/console/retention') && method === 'GET') {
+      return Promise.resolve(
+        new Response(JSON.stringify(retentionPayload), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    }
+    if (url.endsWith('/console/retention') && method === 'PUT') {
+      return Promise.resolve(
+        new Response(JSON.stringify(putResponse ?? retentionPayload), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }),
+    )
+  })
+}
+
+beforeEach(() => {
+  mockFetch()
+})
+
+describe('Retention view', () => {
+  it('renders the sandbox-metadata days input with the fetched value', async () => {
+    await renderAt('/retention', caps)
+    const input = await waitFor(() => screen.getByLabelText(/sandbox.?metadata/i))
+    expect(input.tagName).toBe('INPUT')
+    expect((input as HTMLInputElement).value).toBe('30')
+  })
+
+  it('renders the logs days input with the fetched value', async () => {
+    await renderAt('/retention', caps)
+    const input = await waitFor(() => screen.getByLabelText(/logs/i))
+    expect(input.tagName).toBe('INPUT')
+    expect((input as HTMLInputElement).value).toBe('14')
+  })
+
+  it('renders the usage days input with the fetched value', async () => {
+    await renderAt('/retention', caps)
+    const input = await waitFor(() => screen.getByLabelText(/usage/i))
+    expect(input.tagName).toBe('INPUT')
+    expect((input as HTMLInputElement).value).toBe('365')
+  })
+
+  it('renders the legal-hold checkbox unchecked when legal_hold is false', async () => {
+    await renderAt('/retention', caps)
+    const checkbox = await waitFor(() => screen.getByRole('checkbox', { name: /legal.?hold/i }))
+    expect((checkbox as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('toggling legal hold and saving calls PUT /console/retention with updated value', async () => {
+    const calls: { url: string; body: object }[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input).split('?')[0]
+      const method = (init?.method ?? 'GET').toUpperCase()
+
+      if (url.endsWith('/console/capabilities')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }),
+        )
+      }
+      if (url.endsWith('/console/retention') && method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify(retentionPayload), { status: 200, headers: { 'content-type': 'application/json' } }),
+        )
+      }
+      if (url.endsWith('/console/retention') && method === 'PUT') {
+        const body = JSON.parse((init?.body as string) ?? '{}') as object
+        calls.push({ url, body })
+        const echoed = { ...retentionPayload, ...body }
+        return Promise.resolve(
+          new Response(JSON.stringify(echoed), { status: 200, headers: { 'content-type': 'application/json' } }),
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }),
+      )
+    })
+
+    await renderAt('/retention', caps)
+
+    // Wait for the form to load
+    await waitFor(() => screen.getByRole('checkbox', { name: /legal.?hold/i }))
+
+    // Toggle legal hold on
+    const checkbox = screen.getByRole('checkbox', { name: /legal.?hold/i })
+    fireEvent.click(checkbox)
+    expect((checkbox as HTMLInputElement).checked).toBe(true)
+
+    // Click Save
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    fireEvent.click(saveButton)
+
+    // The PUT should be called with legal_hold: true
+    await waitFor(() => expect(calls.length).toBeGreaterThanOrEqual(1))
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall.url).toContain('/console/retention')
+    expect((lastCall.body as { legal_hold: boolean }).legal_hold).toBe(true)
+  })
+
+  it('shows a "0 = keep forever" hint on one of the number inputs', async () => {
+    await renderAt('/retention', caps)
+    await waitFor(() => screen.getByLabelText(/sandbox.?metadata/i))
+    expect(screen.getByText(/0.{0,10}keep forever/i)).toBeInTheDocument()
+  })
+
+  it('shows an honest note about GC enforcement', async () => {
+    await renderAt('/retention', caps)
+    await waitFor(() => screen.getByLabelText(/sandbox.?metadata/i))
+    const gcNodes = screen.getAllByText(/garbage collector/i)
+    expect(gcNodes.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/web/app/src/views/Retention.tsx
+++ b/web/app/src/views/Retention.tsx
@@ -58,6 +58,11 @@ export function Retention() {
   if (isLoading) return <Skeleton rows={5} />
   if (isError) return <p className="t-dim">Failed to load retention policy. Please refresh.</p>
 
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    void handleSave()
+  }
+
   return (
     <div>
       <h2>Data and retention</h2>
@@ -67,118 +72,115 @@ export function Retention() {
         A legal hold pauses all automated deletion regardless of the configured windows.
       </p>
 
-      <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
-        <h3 style={{ marginBottom: 'var(--space-4)' }}>Retention windows</h3>
-        <p className="t-dim" style={{ fontSize: 'var(--step--2)', marginBottom: 'var(--space-4)' }}>
-          0 = keep forever. Values are in days.
-        </p>
+      <form onSubmit={onSubmit}>
+        <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
+          <h3 style={{ marginBottom: 'var(--space-4)' }}>Retention windows</h3>
+          <p className="t-dim" style={{ fontSize: 'var(--step--2)', marginBottom: 'var(--space-4)' }}>
+            0 = keep forever. Values are in days.
+          </p>
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 480 }}>
-          <div>
-            <label htmlFor="sandbox-metadata-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
-              Sandbox metadata (days)
-            </label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 480 }}>
+            <div>
+              <label htmlFor="sandbox-metadata-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+                Sandbox metadata (days)
+              </label>
+              <input
+                id="sandbox-metadata-days"
+                type="number"
+                min={0}
+                value={sandboxMetadataDays}
+                onChange={(e) => setSandboxMetadataDays(e.target.value === '' ? '' : Number(e.target.value))}
+                style={{ width: '120px' }}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="logs-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+                Logs (days)
+              </label>
+              <input
+                id="logs-days"
+                type="number"
+                min={0}
+                value={logsDays}
+                onChange={(e) => setLogsDays(e.target.value === '' ? '' : Number(e.target.value))}
+                style={{ width: '120px' }}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="usage-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+                Usage (days)
+              </label>
+              <input
+                id="usage-days"
+                type="number"
+                min={0}
+                value={usageDays}
+                onChange={(e) => setUsageDays(e.target.value === '' ? '' : Number(e.target.value))}
+                style={{ width: '120px' }}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
+          <h3 style={{ marginBottom: 'var(--space-3)' }}>Legal hold</h3>
+          <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
+            Enabling legal hold pauses all automated deletion driven by the retention windows above.
+            No data is removed while a legal hold is active, regardless of the configured periods.
+          </p>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
             <input
-              id="sandbox-metadata-days"
-              aria-label="Sandbox metadata days"
-              type="number"
-              min={0}
-              value={sandboxMetadataDays}
-              onChange={(e) => setSandboxMetadataDays(e.target.value === '' ? '' : Number(e.target.value))}
-              style={{ width: '120px' }}
+              id="legal-hold"
+              type="checkbox"
+              checked={legalHold}
+              onChange={(e) => setLegalHold(e.target.checked)}
             />
-          </div>
-
-          <div>
-            <label htmlFor="logs-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
-              Logs (days)
+            <label htmlFor="legal-hold">
+              Legal hold active
             </label>
-            <input
-              id="logs-days"
-              aria-label="Logs days"
-              type="number"
-              min={0}
-              value={logsDays}
-              onChange={(e) => setLogsDays(e.target.value === '' ? '' : Number(e.target.value))}
-              style={{ width: '120px' }}
-            />
           </div>
+        </section>
 
-          <div>
-            <label htmlFor="usage-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
-              Usage (days)
-            </label>
-            <input
-              id="usage-days"
-              aria-label="Usage days"
-              type="number"
-              min={0}
-              value={usageDays}
-              onChange={(e) => setUsageDays(e.target.value === '' ? '' : Number(e.target.value))}
-              style={{ width: '120px' }}
-            />
+        <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
+          <h3 style={{ marginBottom: 'var(--space-3)' }}>What gets deleted when</h3>
+          <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
+            The garbage collector runs on a schedule in the controller. It applies the configured retention
+            windows to each resource class. A legal hold prevents any deletion until it is lifted.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', fontSize: 'var(--step--1)' }}>
+            <div>
+              <strong>Sandbox metadata:</strong>{' '}
+              <span className="t-dim">
+                {retentionLabel(currentSandboxMetadataDays)}
+                {legalHold ? ' (legal hold active, deletion paused)' : ''}
+              </span>
+            </div>
+            <div>
+              <strong>Logs:</strong>{' '}
+              <span className="t-dim">
+                {retentionLabel(currentLogsDays)}
+                {legalHold ? ' (legal hold active, deletion paused)' : ''}
+              </span>
+            </div>
+            <div>
+              <strong>Usage records:</strong>{' '}
+              <span className="t-dim">
+                {retentionLabel(currentUsageDays)}
+                {legalHold ? ' (legal hold active, deletion paused)' : ''}
+              </span>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
-        <h3 style={{ marginBottom: 'var(--space-3)' }}>Legal hold</h3>
-        <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
-          Enabling legal hold pauses all automated deletion driven by the retention windows above.
-          No data is removed while a legal hold is active, regardless of the configured periods.
-        </p>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
-          <input
-            id="legal-hold"
-            type="checkbox"
-            checked={legalHold}
-            onChange={(e) => setLegalHold(e.target.checked)}
-            aria-label="Legal hold"
-          />
-          <label htmlFor="legal-hold">
-            Legal hold active
-          </label>
-        </div>
-      </section>
-
-      <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
-        <h3 style={{ marginBottom: 'var(--space-3)' }}>What gets deleted when</h3>
-        <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
-          The garbage collector runs on a schedule in the controller. It applies the configured retention
-          windows to each resource class. A legal hold prevents any deletion until it is lifted.
-        </p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', fontSize: 'var(--step--1)' }}>
-          <div>
-            <strong>Sandbox metadata:</strong>{' '}
-            <span className="t-dim">
-              {retentionLabel(currentSandboxMetadataDays)}
-              {legalHold ? ' (legal hold active, deletion paused)' : ''}
-            </span>
-          </div>
-          <div>
-            <strong>Logs:</strong>{' '}
-            <span className="t-dim">
-              {retentionLabel(currentLogsDays)}
-              {legalHold ? ' (legal hold active, deletion paused)' : ''}
-            </span>
-          </div>
-          <div>
-            <strong>Usage records:</strong>{' '}
-            <span className="t-dim">
-              {retentionLabel(currentUsageDays)}
-              {legalHold ? ' (legal hold active, deletion paused)' : ''}
-            </span>
-          </div>
-        </div>
-      </section>
-
-      <button
-        onClick={handleSave}
-        disabled={setPolicy.isPending}
-        aria-label="Save retention policy"
-      >
-        {setPolicy.isPending ? 'Saving...' : 'Save'}
-      </button>
+        <button
+          type="submit"
+          disabled={setPolicy.isPending}
+        >
+          {setPolicy.isPending ? 'Saving...' : 'Save'}
+        </button>
+      </form>
     </div>
   )
 }

--- a/web/app/src/views/Retention.tsx
+++ b/web/app/src/views/Retention.tsx
@@ -1,0 +1,184 @@
+// Data and retention policy view. Lets org admins configure per-resource retention
+// windows and a legal hold. Policy is stored by the BFF; enforcement is done by
+// the garbage collector in the controller (issue #163). This view does NOT report
+// deletion counts; it only stores and displays the policy.
+import { useState, useEffect } from 'react'
+import { useDataRetention, useSetDataRetention } from '../data/retention'
+import { Skeleton } from '../ui/Skeleton'
+import { useToast } from '../ui/Toast'
+import type { DataRetentionPolicy } from '../api'
+
+function retentionLabel(days: number): string {
+  if (days === 0) return 'Kept indefinitely'
+  if (days === 1) return 'Removed after 1 day'
+  return `Removed after ${days} days`
+}
+
+export function Retention() {
+  const { data: policy, isLoading, isError } = useDataRetention()
+  const setPolicy = useSetDataRetention()
+  const { notify } = useToast()
+
+  const [sandboxMetadataDays, setSandboxMetadataDays] = useState<number | ''>('')
+  const [logsDays, setLogsDays] = useState<number | ''>('')
+  const [usageDays, setUsageDays] = useState<number | ''>('')
+  const [legalHold, setLegalHold] = useState<boolean>(false)
+  const [initialized, setInitialized] = useState(false)
+
+  // Sync form state from server once the policy loads (only the first time).
+  useEffect(() => {
+    if (policy && !initialized) {
+      setSandboxMetadataDays(policy.sandbox_metadata_days)
+      setLogsDays(policy.logs_days)
+      setUsageDays(policy.usage_days)
+      setLegalHold(policy.legal_hold)
+      setInitialized(true)
+    }
+  }, [policy, initialized])
+
+  const currentSandboxMetadataDays = sandboxMetadataDays === '' ? 0 : sandboxMetadataDays
+  const currentLogsDays = logsDays === '' ? 0 : logsDays
+  const currentUsageDays = usageDays === '' ? 0 : usageDays
+
+  const handleSave = async () => {
+    const updated: DataRetentionPolicy = {
+      sandbox_metadata_days: currentSandboxMetadataDays,
+      logs_days: currentLogsDays,
+      usage_days: currentUsageDays,
+      legal_hold: legalHold,
+    }
+    try {
+      await setPolicy.mutateAsync(updated)
+      notify('Retention policy saved')
+    } catch {
+      notify('Failed to save retention policy', 'error')
+    }
+  }
+
+  if (isLoading) return <Skeleton rows={5} />
+  if (isError) return <p className="t-dim">Failed to load retention policy. Please refresh.</p>
+
+  return (
+    <div>
+      <h2>Data and retention</h2>
+      <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-5)' }}>
+        Configure per-resource retention windows for this org. The garbage collector in the controller
+        enforces these settings on a scheduled basis. Setting a value to 0 means the data is kept forever.
+        A legal hold pauses all automated deletion regardless of the configured windows.
+      </p>
+
+      <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
+        <h3 style={{ marginBottom: 'var(--space-4)' }}>Retention windows</h3>
+        <p className="t-dim" style={{ fontSize: 'var(--step--2)', marginBottom: 'var(--space-4)' }}>
+          0 = keep forever. Values are in days.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 480 }}>
+          <div>
+            <label htmlFor="sandbox-metadata-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+              Sandbox metadata (days)
+            </label>
+            <input
+              id="sandbox-metadata-days"
+              aria-label="Sandbox metadata days"
+              type="number"
+              min={0}
+              value={sandboxMetadataDays}
+              onChange={(e) => setSandboxMetadataDays(e.target.value === '' ? '' : Number(e.target.value))}
+              style={{ width: '120px' }}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="logs-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+              Logs (days)
+            </label>
+            <input
+              id="logs-days"
+              aria-label="Logs days"
+              type="number"
+              min={0}
+              value={logsDays}
+              onChange={(e) => setLogsDays(e.target.value === '' ? '' : Number(e.target.value))}
+              style={{ width: '120px' }}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="usage-days" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+              Usage (days)
+            </label>
+            <input
+              id="usage-days"
+              aria-label="Usage days"
+              type="number"
+              min={0}
+              value={usageDays}
+              onChange={(e) => setUsageDays(e.target.value === '' ? '' : Number(e.target.value))}
+              style={{ width: '120px' }}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
+        <h3 style={{ marginBottom: 'var(--space-3)' }}>Legal hold</h3>
+        <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
+          Enabling legal hold pauses all automated deletion driven by the retention windows above.
+          No data is removed while a legal hold is active, regardless of the configured periods.
+        </p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+          <input
+            id="legal-hold"
+            type="checkbox"
+            checked={legalHold}
+            onChange={(e) => setLegalHold(e.target.checked)}
+            aria-label="Legal hold"
+          />
+          <label htmlFor="legal-hold">
+            Legal hold active
+          </label>
+        </div>
+      </section>
+
+      <section className="card" style={{ marginBottom: 'var(--space-6)' }}>
+        <h3 style={{ marginBottom: 'var(--space-3)' }}>What gets deleted when</h3>
+        <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
+          The garbage collector runs on a schedule in the controller. It applies the configured retention
+          windows to each resource class. A legal hold prevents any deletion until it is lifted.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', fontSize: 'var(--step--1)' }}>
+          <div>
+            <strong>Sandbox metadata:</strong>{' '}
+            <span className="t-dim">
+              {retentionLabel(currentSandboxMetadataDays)}
+              {legalHold ? ' (legal hold active, deletion paused)' : ''}
+            </span>
+          </div>
+          <div>
+            <strong>Logs:</strong>{' '}
+            <span className="t-dim">
+              {retentionLabel(currentLogsDays)}
+              {legalHold ? ' (legal hold active, deletion paused)' : ''}
+            </span>
+          </div>
+          <div>
+            <strong>Usage records:</strong>{' '}
+            <span className="t-dim">
+              {retentionLabel(currentUsageDays)}
+              {legalHold ? ' (legal hold active, deletion paused)' : ''}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <button
+        onClick={handleSave}
+        disabled={setPolicy.isPending}
+        aria-label="Save retention policy"
+      >
+        {setPolicy.isPending ? 'Saving...' : 'Save'}
+      </button>
+    </div>
+  )
+}

--- a/web/app/src/views/Retention.tsx
+++ b/web/app/src/views/Retention.tsx
@@ -176,6 +176,7 @@ export function Retention() {
 
         <button
           type="submit"
+          className="btn btn-primary"
           disabled={setPolicy.isPending}
         >
           {setPolicy.isPending ? 'Saving...' : 'Save'}


### PR DESCRIPTION
## Summary

Phase B3c of the console enterprise surface: a per-org data-retention policy for terminated-sandbox metadata, sandbox logs, and usage records, plus a legal-hold toggle, surfaced in a new "Data and retention" view.

The console stores and exposes the policy; the controller garbage collector (#163) enforces it. A legal hold pauses all automated deletion. The view is honest about this split: it never claims a deletion count, only what the GC will remove and when.

## What landed

- **BFF:** a per-org `DataRetentionStore` seam (in-memory default) plus `GET` and `PUT /console/retention`. Org is sourced from request context only; one org's policy never leaks to another. Both routes are in the auth-gate table.
- **SPA:** a "Data and retention" view in the Govern group: per-resource retention-window inputs (0 = keep forever), a legal-hold toggle, and a "what gets deleted when" preview. The Save action uses the brand primary button.
- **a11y:** axe audit on the view, zero violations; labelled inputs and toggle.

## Verification

- `go test ./internal/saas/...` green
- gofmt clean; both golangci-lint invocations (darwin and `GOOS=linux`) exit 0
- web suite 108/108; typecheck clean; build succeeds
- no em or en dashes in changed files

## Scope notes

- GC enforcement is the controller's job (#163); this PR persists and exposes the policy only.
- B3b's audit-specific retention (`/console/audit/retention`) is untouched and stays on the Audit page.
- Deferred Minor items (server-side input clamping, empty-body PUT semantics) belong with the GC work in #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)