### PR TITLE
feat(sdk/python): PTY over the Connect WebSocket transport (#358 Task 2)

### DIFF
--- a/sdk/python/mitos/aio.py
+++ b/sdk/python/mitos/aio.py
@@ -212,10 +212,13 @@ class AsyncSandbox:
             return {"Authorization": f"Bearer {self._token}"}
         return {}
 
-    def pty_url(self, cols: int = 80, rows: int = 24) -> str:
-        base = self._base_url  # http(s)://<endpoint>/v1
-        ws_base = base.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
-        return f"{ws_base}/pty?sandbox={self.id}&cols={cols}&rows={rows}"
+    def pty_url(self) -> str:
+        # The Connect ``sandbox.v1.Sandbox.Exec`` bidi route over a WebSocket,
+        # mounted at the endpoint root (no /v1 suffix). The window size rides the
+        # open ExecRequest frame, not the query.
+        root = self._connect_base  # http(s)://<endpoint>
+        ws_base = root.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
+        return f"{ws_base}/sandbox.v1.Sandbox/Exec?sandbox={self.id}"
 
     async def create_pty(self, on_data, cols: int = 80, rows: int = 24):
         """Open an interactive PTY over a WebSocket and return an
@@ -224,9 +227,11 @@ class AsyncSandbox:
         from mitos.pty import AsyncPtyHandle
 
         return await AsyncPtyHandle.connect(
-            url=self.pty_url(cols, rows),
+            url=self.pty_url(),
             token=self._token,
             on_data=on_data,
+            cols=cols,
+            rows=rows,
         )
 
     async def set_timeout(self, timeout_seconds: int) -> int:
@@ -644,9 +649,12 @@ class AsyncDirectSandbox:
             on_result,
         )
 
-    def pty_url(self, cols: int = 80, rows: int = 24) -> str:
+    def pty_url(self) -> str:
+        # The Connect ``sandbox.v1.Sandbox.Exec`` bidi route over a WebSocket,
+        # mounted at the server root. The window size rides the open ExecRequest
+        # frame, not the query.
         ws_base = self._server_url.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
-        return f"{ws_base}/v1/pty?sandbox={self.id}&cols={cols}&rows={rows}"
+        return f"{ws_base}/sandbox.v1.Sandbox/Exec?sandbox={self.id}"
 
     async def create_pty(self, on_data, cols: int = 80, rows: int = 24):
         """Open an interactive PTY over a WebSocket and return an
@@ -655,7 +663,11 @@ class AsyncDirectSandbox:
         from mitos.pty import AsyncPtyHandle
 
         return await AsyncPtyHandle.connect(
-            url=self.pty_url(cols, rows), token=self._api_key, on_data=on_data
+            url=self.pty_url(),
+            token=self._api_key,
+            on_data=on_data,
+            cols=cols,
+            rows=rows,
         )
 
     async def fork(self, n: int = 1, id: Optional[str] = None) -> list["AsyncDirectSandbox"]:

--- a/sdk/python/mitos/direct.py
+++ b/sdk/python/mitos/direct.py
@@ -359,14 +359,16 @@ class DirectSandbox:
             on_result,
         )
 
-    def pty_url(self, cols: int = 80, rows: int = 24) -> str:
-        """The WebSocket URL for an interactive PTY in this sandbox. The bearer
-        key (when set) is sent in the Authorization header on connect, never on
-        the URL."""
+    def pty_url(self) -> str:
+        """The WebSocket URL for an interactive PTY in this sandbox: the Connect
+        ``sandbox.v1.Sandbox.Exec`` bidi route carried over a WebSocket. The
+        bearer key (when set) is sent in the Authorization header on connect,
+        never on the URL; the window size rides the open ExecRequest frame, not
+        the query."""
         ws_base = self._server_url.replace("http://", "ws://", 1).replace(
             "https://", "wss://", 1
         )
-        return f"{ws_base}/v1/pty?sandbox={self.id}&cols={cols}&rows={rows}"
+        return f"{ws_base}/sandbox.v1.Sandbox/Exec?sandbox={self.id}"
 
     def pty(self, on_data: Callable[[bytes], None], cols: int = 80, rows: int = 24):
         """Open an interactive PTY (a shell) in the sandbox over a WebSocket.
@@ -377,7 +379,13 @@ class DirectSandbox:
         header, never logged."""
         from mitos.pty import PtyHandle
 
-        return PtyHandle(url=self.pty_url(cols, rows), token=self._api_key, on_data=on_data)
+        return PtyHandle(
+            url=self.pty_url(),
+            token=self._api_key,
+            on_data=on_data,
+            cols=cols,
+            rows=rows,
+        )
 
     def set_timeout(self, timeout_seconds: int) -> int:
         """Adjust this RUNNING sandbox's TTL to now + timeout_seconds (issue

--- a/sdk/python/mitos/pty.py
+++ b/sdk/python/mitos/pty.py
@@ -6,12 +6,49 @@ import json
 import threading
 from typing import Callable, Optional
 
-from websocket import WebSocketApp  # from the websocket-client package
+import websocket  # the websocket-client package
+from websocket import WebSocketApp
+
+from mitos._connect import _FLAG_END_STREAM, _FrameDecoder, _encode_frame
 
 # NOTE: the async 'websockets' package is an OPTIONAL extra (mitos[async]); it is
 # imported lazily inside AsyncPtyHandle.connect so that importing this module (and
 # therefore mitos.sandbox) never fails when only the synchronous path is used and
 # the extra is not installed.
+
+# The ws subprotocol the host advertises for the Connect-over-WebSocket bidi
+# Exec transport. The legacy JSON PTY route used "mitos.pty.v1"; the Connect
+# transport negotiates this instead.
+_EXEC_WS_SUBPROTOCOL = "connect.sandbox.v1"
+
+
+def _open_request(cols: int, rows: int) -> bytes:
+    """The first enveloped ExecRequest frame: open an interactive pty with the
+    initial window size. The host reads cols/rows from this open, not from the
+    URL query."""
+    msg = {"open": {"pty": {"size": {"cols": int(cols), "rows": int(rows)}}}}
+    return _encode_frame(json.dumps(msg).encode())
+
+
+def _stdin_request(data: bytes) -> bytes:
+    """An enveloped ExecRequest{stdin} frame carrying raw keystroke bytes
+    (base64-encoded per the proto-JSON bytes encoding)."""
+    msg = {"stdin": base64.b64encode(data).decode("ascii")}
+    return _encode_frame(json.dumps(msg).encode())
+
+
+def _resize_request(cols: int, rows: int) -> bytes:
+    """An enveloped ExecRequest{resize} frame."""
+    msg = {"resize": {"cols": int(cols), "rows": int(rows)}}
+    return _encode_frame(json.dumps(msg).encode())
+
+
+def _exit_code_from(exit_obj: dict) -> int:
+    """Read the exit code from an ExecResponse exit object. The proto-JSON field
+    is camelCase ``exitCode``; ``exit_code`` is accepted defensively."""
+    if "exitCode" in exit_obj:
+        return int(exit_obj.get("exitCode") or 0)
+    return int(exit_obj.get("exit_code", 0) or 0)
 
 
 class PtyHandle:
@@ -20,9 +57,13 @@ class PtyHandle:
     reader thread; send_input/resize write frames to the guest, kill() force
     closes, and wait() blocks for the exit code.
 
-    The transport is a WebSocket to forkd's GET /v1/pty (subprotocol
-    mitos.pty.v1), gated by the per-sandbox bearer token. The token is sent in
-    the Authorization header and is never logged.
+    The transport is a WebSocket carrying the Connect ``sandbox.v1.Sandbox.Exec``
+    bidi schema: each binary ws message is one Connect-enveloped frame (a 5-byte
+    header then the protojson payload). The client sends ExecRequest frames (the
+    open first, then stdin/resize); the server sends ExecResponse frames
+    (stdout/stderr/exit). The connection negotiates the ``connect.sandbox.v1``
+    subprotocol and is gated by the per-sandbox bearer token, sent in the
+    Authorization header and never logged.
     """
 
     def __init__(
@@ -30,20 +71,28 @@ class PtyHandle:
         url: str,
         token: Optional[str],
         on_data: Callable[[bytes], None],
+        cols: int = 80,
+        rows: int = 24,
     ):
         self._on_data = on_data
+        self._cols = cols
+        self._rows = rows
         self._exit_code: Optional[int] = None
         self._done = threading.Event()
         self._open = threading.Event()
         self._lock = threading.Lock()
+        # The host sends one enveloped frame per binary ws message, but decode
+        # through the shared incremental decoder so a frame split across reads is
+        # still reassembled correctly.
+        self._decoder = _FrameDecoder()
 
         header = [f"Authorization: Bearer {token}"] if token else []
         self._ws = WebSocketApp(
             url,
             header=header,
-            subprotocols=["mitos.pty.v1"],
+            subprotocols=[_EXEC_WS_SUBPROTOCOL],
             on_open=self._handle_open,
-            on_message=self._handle_message,
+            on_data=self._handle_data,
             on_close=self._handle_close,
             on_error=self._handle_error,
         )
@@ -53,17 +102,31 @@ class PtyHandle:
         self._open.wait(timeout=10)
 
     def _handle_open(self, ws) -> None:  # noqa: ANN001
+        # Send the open ExecRequest FIRST, before any input, so the host can
+        # build the guest Exec stream with the requested window size.
+        ws.send(_open_request(self._cols, self._rows), opcode=websocket.ABNF.OPCODE_BINARY)
         self._open.set()
 
-    def _handle_message(self, ws, message) -> None:  # noqa: ANN001
-        frame = json.loads(message)
-        kind = frame.get("kind")
-        if kind == "output":
-            data = frame.get("data")
-            decoded = base64.b64decode(data) if data else b""
-            self._on_data(decoded)
-        elif kind == "exit":
-            self._exit_code = int(frame.get("exit_code", 0))
+    def _handle_data(self, ws, message, data_type, cont) -> None:  # noqa: ANN001
+        # on_data fires for both text and binary frames; the transport is binary
+        # only, so coerce a str frame (should not happen) to bytes.
+        if isinstance(message, str):
+            message = message.encode()
+        for flag, payload in self._decoder.feed(message):
+            self._consume(ws, flag, payload)
+
+    def _consume(self, ws, flag: int, payload: bytes) -> None:  # noqa: ANN001
+        if payload:
+            resp = json.loads(payload)
+            if "stdout" in resp and resp["stdout"]:
+                self._on_data(base64.b64decode(resp["stdout"]))
+            elif "stderr" in resp and resp["stderr"]:
+                self._on_data(base64.b64decode(resp["stderr"]))
+            elif "exit" in resp:
+                self._exit_code = _exit_code_from(resp["exit"] or {})
+        if flag & _FLAG_END_STREAM:
+            if self._exit_code is None:
+                self._exit_code = 0
             self._done.set()
             ws.close()
 
@@ -78,17 +141,17 @@ class PtyHandle:
             self._exit_code = -1
         self._done.set()
 
-    def _send(self, frame: dict) -> None:
+    def _send(self, frame: bytes) -> None:
         with self._lock:
-            self._ws.send(json.dumps(frame))
+            self._ws.send(frame, opcode=websocket.ABNF.OPCODE_BINARY)
 
     def send_input(self, data: bytes) -> None:
         """Send raw keystroke bytes to the shell."""
-        self._send({"kind": "input", "data": base64.b64encode(data).decode("ascii")})
+        self._send(_stdin_request(data))
 
     def resize(self, cols: int, rows: int) -> None:
         """Resize the terminal window (TIOCSWINSZ in the guest, then SIGWINCH)."""
-        self._send({"kind": "resize", "cols": cols, "rows": rows})
+        self._send(_resize_request(cols, rows))
 
     def kill(self) -> None:
         """Force-close the terminal. The guest kills the shell process group
@@ -108,13 +171,18 @@ class PtyHandle:
 class AsyncPtyHandle:
     """Async counterpart to PtyHandle. Output is delivered to on_data from a
     background asyncio task; send_input/resize are coroutines, wait() awaits the
-    exit code. Transport is a WebSocket to /v1/pty gated by the bearer token."""
+    exit code.
+
+    Transport is a WebSocket carrying the Connect ``sandbox.v1.Sandbox.Exec``
+    bidi schema (one enveloped frame per binary ws message), negotiating the
+    ``connect.sandbox.v1`` subprotocol and gated by the bearer token."""
 
     def __init__(self, ws, on_data: Callable[[bytes], None]):
         self._ws = ws
         self._on_data = on_data
         self._exit_code: Optional[int] = None
         self._done = asyncio.Event()
+        self._decoder = _FrameDecoder()
         self._reader = asyncio.create_task(self._read_loop())
 
     @classmethod
@@ -123,6 +191,8 @@ class AsyncPtyHandle:
         url: str,
         token: Optional[str],
         on_data: Callable[[bytes], None],
+        cols: int = 80,
+        rows: int = 24,
     ) -> "AsyncPtyHandle":
         headers = [("Authorization", f"Bearer {token}")] if token else []
         try:
@@ -135,21 +205,31 @@ class AsyncPtyHandle:
         ws = await websockets.connect(
             url,
             additional_headers=headers,
-            subprotocols=["mitos.pty.v1"],
+            subprotocols=[_EXEC_WS_SUBPROTOCOL],
         )
+        # Send the open ExecRequest FIRST so the host builds the guest Exec
+        # stream with the requested window size before any input arrives.
+        await ws.send(_open_request(cols, rows))
         return cls(ws, on_data)
 
     async def _read_loop(self) -> None:
         try:
             async for raw in self._ws:
-                frame = json.loads(raw)
-                kind = frame.get("kind")
-                if kind == "output":
-                    data = frame.get("data")
-                    self._on_data(base64.b64decode(data) if data else b"")
-                elif kind == "exit":
-                    self._exit_code = int(frame.get("exit_code", 0))
-                    break
+                if isinstance(raw, str):
+                    raw = raw.encode()
+                for flag, payload in self._decoder.feed(raw):
+                    if payload:
+                        resp = json.loads(payload)
+                        if "stdout" in resp and resp["stdout"]:
+                            self._on_data(base64.b64decode(resp["stdout"]))
+                        elif "stderr" in resp and resp["stderr"]:
+                            self._on_data(base64.b64decode(resp["stderr"]))
+                        elif "exit" in resp:
+                            self._exit_code = _exit_code_from(resp["exit"] or {})
+                    if flag & _FLAG_END_STREAM:
+                        if self._exit_code is None:
+                            self._exit_code = 0
+                        return
         finally:
             if self._exit_code is None:
                 self._exit_code = -1
@@ -157,12 +237,10 @@ class AsyncPtyHandle:
             await self._ws.close()
 
     async def send_input(self, data: bytes) -> None:
-        await self._ws.send(
-            json.dumps({"kind": "input", "data": base64.b64encode(data).decode("ascii")})
-        )
+        await self._ws.send(_stdin_request(data))
 
     async def resize(self, cols: int, rows: int) -> None:
-        await self._ws.send(json.dumps({"kind": "resize", "cols": cols, "rows": rows}))
+        await self._ws.send(_resize_request(cols, rows))
 
     async def kill(self) -> None:
         await self._ws.close()

--- a/sdk/python/mitos/sandbox.py
+++ b/sdk/python/mitos/sandbox.py
@@ -217,14 +217,23 @@ class SandboxPty:
         delivered to on_data on a background thread. Returns a PtyHandle with
         send_input(bytes), resize(cols, rows), kill(), and wait() -> exit_code.
 
-        The transport is a WebSocket to the sandbox API's /v1/pty, gated by the
-        per-sandbox bearer token (sent in the Authorization header, never
-        logged)."""
-        base = self._sandbox._base_url  # http://<endpoint>/v1
-        ws_base = base.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
+        The transport is a WebSocket carrying the Connect
+        ``sandbox.v1.Sandbox.Exec`` bidi schema, gated by the per-sandbox bearer
+        token (sent in the Authorization header, never logged). The window size
+        rides the open ExecRequest frame, not the URL query."""
+        # The Connect service is mounted at the endpoint root (no /v1 suffix),
+        # the same base the runtime RPC client uses.
+        root = self._sandbox._connect_base  # http://<endpoint>
+        ws_base = root.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
         ref = self._sandbox._sandbox_ref
-        url = f"{ws_base}/pty?sandbox={ref}&cols={cols}&rows={rows}"
-        return PtyHandle(url=url, token=self._sandbox._token, on_data=on_data)
+        url = f"{ws_base}/sandbox.v1.Sandbox/Exec?sandbox={ref}"
+        return PtyHandle(
+            url=url,
+            token=self._sandbox._token,
+            on_data=on_data,
+            cols=cols,
+            rows=rows,
+        )
 
 
 class Sandbox:

--- a/sdk/python/tests/test_flat_create.py
+++ b/sdk/python/tests/test_flat_create.py
@@ -444,6 +444,11 @@ def test_pty_url_carries_no_key(fake_server):
     pu = sb.pty_url()
     assert pu.startswith("ws://")
     assert "sk-secret" not in pu
+    # PTY now rides the Connect Exec route over a WebSocket; the window size
+    # rides the open frame, not the query, and /v1/pty is gone.
+    assert "/sandbox.v1.Sandbox/Exec" in pu
+    assert "/v1/pty" not in pu
+    assert "cols=" not in pu and "rows=" not in pu
     sb.terminate()
 
 

--- a/sdk/python/tests/test_pty.py
+++ b/sdk/python/tests/test_pty.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import struct
 import threading
 import time
 
@@ -10,10 +11,23 @@ from mitos.pty import PtyHandle
 
 websockets = pytest.importorskip("websockets")
 
+_FLAG_END_STREAM = 0b00000010
+
+
+def _encode_frame(payload: bytes, end_stream: bool = False) -> bytes:
+    flag = _FLAG_END_STREAM if end_stream else 0
+    return bytes([flag]) + struct.pack(">I", len(payload)) + payload
+
+
+def _decode_frame(message: bytes):
+    length = struct.unpack(">I", message[1:5])[0]
+    return message[0], message[5 : 5 + length]
+
 
 class _EchoServer:
-    """A local WS server that echoes input frames as output frames and exits on
-    input 'exit\\n', mimicking the forkd /v1/pty protocol."""
+    """A local ws server speaking the Connect-enveloped Exec protocol: it echoes
+    a stdin frame's bytes back as a stdout ExecResponse and exits on stdin
+    'exit\\n' with a terminal exit frame, mimicking forkd's ws Exec transport."""
 
     def __init__(self):
         self.port = None
@@ -30,21 +44,35 @@ class _EchoServer:
             self._stop = self._loop.create_future()
 
             async def handler(ws):
+                first = True
                 async for raw in ws:
-                    frame = json.loads(raw)
-                    if frame.get("kind") == "input":
-                        data = frame.get("data", "")
+                    _flag, payload = _decode_frame(bytes(raw))
+                    req = json.loads(payload)
+                    if first:
+                        # The first frame is always the open.
+                        assert "open" in req
+                        first = False
+                        continue
+                    if "stdin" in req:
+                        data = req["stdin"]
                         decoded = base64.b64decode(data) if data else b""
                         if decoded == b"exit\n":
-                            await ws.send(json.dumps({"kind": "exit", "exit_code": 0}))
+                            await ws.send(
+                                _encode_frame(
+                                    json.dumps({"exit": {"exitCode": 0}}).encode(),
+                                    end_stream=True,
+                                )
+                            )
                             return
-                        await ws.send(json.dumps({"kind": "output", "data": data}))
+                        await ws.send(
+                            _encode_frame(json.dumps({"stdout": data}).encode())
+                        )
 
             async def main():
-                # Negotiate the same subprotocol forkd's /v1/pty advertises so
-                # the websocket-client handshake matches the real server.
+                # Negotiate the same subprotocol the ws Exec transport advertises
+                # so the websocket-client handshake matches the real server.
                 server = await websockets.serve(
-                    handler, "127.0.0.1", 0, subprotocols=["mitos.pty.v1"]
+                    handler, "127.0.0.1", 0, subprotocols=["connect.sandbox.v1"]
                 )
                 self.port = server.sockets[0].getsockname()[1]
                 ready.set()
@@ -60,15 +88,20 @@ class _EchoServer:
         if self._loop and self._stop and not self._stop.done():
             self._loop.call_soon_threadsafe(self._stop.set_result, None)
 
+    def url(self):
+        return f"ws://127.0.0.1:{self.port}/sandbox.v1.Sandbox/Exec?sandbox=sb1"
+
 
 def test_pty_echo_and_exit():
     srv = _EchoServer()
     srv.start()
     received = []
     handle = PtyHandle(
-        url=f"ws://127.0.0.1:{srv.port}/v1/pty?sandbox=sb1&cols=80&rows=24",
+        url=srv.url(),
         token=None,
         on_data=lambda b: received.append(b),
+        cols=80,
+        rows=24,
     )
     handle.send_input(b"hi-from-test\n")
     deadline = time.time() + 3
@@ -85,9 +118,11 @@ def test_pty_resize_sends_frame():
     srv = _EchoServer()
     srv.start()
     handle = PtyHandle(
-        url=f"ws://127.0.0.1:{srv.port}/v1/pty?sandbox=sb1",
+        url=srv.url(),
         token=None,
         on_data=lambda b: None,
+        cols=80,
+        rows=24,
     )
     # Resize should not raise; the echo server ignores it.
     handle.resize(120, 40)
@@ -104,9 +139,11 @@ async def test_async_pty_echo_and_exit():
     srv.start()
     received = []
     handle = await AsyncPtyHandle.connect(
-        url=f"ws://127.0.0.1:{srv.port}/v1/pty?sandbox=sb1",
+        url=srv.url(),
         token=None,
         on_data=lambda b: received.append(b),
+        cols=80,
+        rows=24,
     )
     await handle.send_input(b"async-hi\n")
     for _ in range(150):

--- a/sdk/python/tests/test_pty_connect.py
+++ b/sdk/python/tests/test_pty_connect.py
@@ -1,0 +1,205 @@
+"""Tests for the interactive PTY carried over the Connect ws transport.
+
+The PTY no longer rides the legacy /v1/pty JSON WebSocket; it speaks the
+sandbox.v1.Sandbox.Exec bidi schema over a WebSocket, where every binary ws
+message is exactly one Connect-enveloped frame (a 5-byte header then the
+protojson payload). The client sends ExecRequest frames (open first, then
+stdin/resize), the server sends ExecResponse frames (stdout/stderr/exit).
+
+These tests stand up an in-process fake ws server that speaks the enveloped
+protocol and drive both PtyHandle (sync) and AsyncPtyHandle (async) against it.
+"""
+import asyncio
+import base64
+import json
+import struct
+import threading
+import time
+
+import pytest
+
+from mitos.pty import PtyHandle
+
+websockets = pytest.importorskip("websockets")
+
+_FLAG_END_STREAM = 0b00000010
+
+
+def _encode_frame(payload: bytes, end_stream: bool = False) -> bytes:
+    flag = _FLAG_END_STREAM if end_stream else 0
+    return bytes([flag]) + struct.pack(">I", len(payload)) + payload
+
+
+def _decode_frame(message: bytes):
+    """Split one binary ws message (exactly one enveloped frame) into
+    (flag, payload). The host sends one frame per message, so no reassembly is
+    needed here."""
+    flag = message[0]
+    length = struct.unpack(">I", message[1:5])[0]
+    payload = message[5 : 5 + length]
+    return flag, payload
+
+
+class _ConnectExecServer:
+    """A local ws server that speaks the enveloped ExecRequest/ExecResponse
+    protocol: it asserts the first frame is open{pty{size}}, echoes a stdin
+    frame's bytes back as a stdout ExecResponse, and on stdin == b"exit\\n"
+    sends a terminal exit ExecResponse with the end-stream flag.
+
+    It records every decoded client request so a test can assert the stdin
+    frame arrived as a proper enveloped ExecRequest{stdin}."""
+
+    def __init__(self):
+        self.port = None
+        self._thread = None
+        self._loop = None
+        self._stop = None
+        self.requests = []  # decoded client ExecRequest dicts
+        self.open_seen = threading.Event()
+        self.subprotocol = None
+
+    def start(self):
+        ready = threading.Event()
+
+        def run():
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+            self._stop = self._loop.create_future()
+
+            async def handler(ws):
+                self.subprotocol = ws.subprotocol
+                first = True
+                async for raw in ws:
+                    # Every client message is binary; reject str defensively.
+                    assert isinstance(raw, (bytes, bytearray)), "expected binary frame"
+                    _flag, payload = _decode_frame(bytes(raw))
+                    req = json.loads(payload)
+                    self.requests.append(req)
+                    if first:
+                        assert "open" in req, "first frame must be the open"
+                        assert req["open"]["pty"]["size"]["cols"] >= 1
+                        assert req["open"]["pty"]["size"]["rows"] >= 1
+                        self.open_seen.set()
+                        first = False
+                        continue
+                    if "stdin" in req:
+                        decoded = base64.b64decode(req["stdin"])
+                        if decoded == b"exit\n":
+                            exit_msg = {"exit": {"exitCode": 0}}
+                            await ws.send(
+                                _encode_frame(
+                                    json.dumps(exit_msg).encode(), end_stream=True
+                                )
+                            )
+                            return
+                        out = {"stdout": req["stdin"]}
+                        await ws.send(_encode_frame(json.dumps(out).encode()))
+
+            async def main():
+                server = await websockets.serve(
+                    handler,
+                    "127.0.0.1",
+                    0,
+                    subprotocols=["connect.sandbox.v1"],
+                )
+                self.port = server.sockets[0].getsockname()[1]
+                ready.set()
+                await self._stop
+
+            self._loop.run_until_complete(main())
+
+        self._thread = threading.Thread(target=run, daemon=True)
+        self._thread.start()
+        ready.wait(5)
+
+    def stop(self):
+        if self._loop and self._stop and not self._stop.done():
+            self._loop.call_soon_threadsafe(self._stop.set_result, None)
+
+    def url(self, sandbox="sb1"):
+        return f"ws://127.0.0.1:{self.port}/sandbox.v1.Sandbox/Exec?sandbox={sandbox}"
+
+
+def test_pty_connect_echo_and_exit():
+    srv = _ConnectExecServer()
+    srv.start()
+    received = []
+    handle = PtyHandle(
+        url=srv.url(),
+        token=None,
+        on_data=lambda b: received.append(b),
+        cols=80,
+        rows=24,
+    )
+    # The open frame must reach the server before any input.
+    assert srv.open_seen.wait(3), "server never saw the open frame"
+
+    handle.send_input(b"hi-from-test\n")
+    deadline = time.time() + 3
+    while time.time() < deadline and b"".join(received) != b"hi-from-test\n":
+        time.sleep(0.02)
+    assert b"".join(received) == b"hi-from-test\n"
+
+    handle.send_input(b"exit\n")
+    assert handle.wait(timeout=3) == 0
+
+    # The open frame carried open.pty.size; the stdin frame carried stdin.
+    assert "open" in srv.requests[0]
+    assert srv.requests[0]["open"]["pty"]["size"] == {"cols": 80, "rows": 24}
+    stdin_reqs = [r for r in srv.requests if "stdin" in r]
+    assert any(base64.b64decode(r["stdin"]) == b"hi-from-test\n" for r in stdin_reqs)
+    assert srv.subprotocol == "connect.sandbox.v1"
+    srv.stop()
+
+
+def test_pty_connect_resize_sends_frame():
+    srv = _ConnectExecServer()
+    srv.start()
+    handle = PtyHandle(
+        url=srv.url(),
+        token=None,
+        on_data=lambda b: None,
+        cols=80,
+        rows=24,
+    )
+    assert srv.open_seen.wait(3)
+    handle.resize(120, 40)
+    # Give the resize frame a moment to arrive before exit.
+    deadline = time.time() + 2
+    while time.time() < deadline and not any("resize" in r for r in srv.requests):
+        time.sleep(0.02)
+    handle.send_input(b"exit\n")
+    assert handle.wait(timeout=3) == 0
+    resize_reqs = [r for r in srv.requests if "resize" in r]
+    assert resize_reqs and resize_reqs[0]["resize"] == {"cols": 120, "rows": 40}
+    srv.stop()
+
+
+@pytest.mark.asyncio
+async def test_async_pty_connect_echo_and_exit():
+    from mitos.pty import AsyncPtyHandle
+
+    srv = _ConnectExecServer()
+    srv.start()
+    received = []
+    handle = await AsyncPtyHandle.connect(
+        url=srv.url(),
+        token=None,
+        on_data=lambda b: received.append(b),
+        cols=100,
+        rows=30,
+    )
+    assert srv.open_seen.wait(3)
+    await handle.send_input(b"async-hi\n")
+    for _ in range(150):
+        if b"".join(received) == b"async-hi\n":
+            break
+        await asyncio.sleep(0.02)
+    assert b"".join(received) == b"async-hi\n"
+    await handle.send_input(b"exit\n")
+    assert await handle.wait() == 0
+
+    assert srv.requests[0]["open"]["pty"]["size"] == {"cols": 100, "rows": 30}
+    stdin_reqs = [r for r in srv.requests if "stdin" in r]
+    assert any(base64.b64decode(r["stdin"]) == b"async-hi\n" for r in stdin_reqs)
+    srv.stop()


### PR DESCRIPTION
Task 2 of #358. Moves the Python SDK's interactive PTY off the legacy `/v1/pty` JSON WebSocket onto the `sandbox.v1.Sandbox.Exec` schema carried over the new WebSocket transport (host side: #379).

## What changes
- `pty.py`: both `PtyHandle` (sync, `websocket-client`) and `AsyncPtyHandle` (async, `websockets`) now speak the Connect enveloped wire, reusing `_encode_frame`/`_FrameDecoder`/`_FLAG_END_STREAM` from `_connect.py`. The client sends the `open` ExecRequest first (pty size), then `stdin`/`resize` as binary enveloped frames; decodes `ExecResponse` `stdout`/`stderr`/`exit`, honoring the end-stream flag. Subprotocol `connect.sandbox.v1`; bearer token stays in the `Authorization` header, never logged.
- `direct.py`/`sandbox.py`/`aio.py`: the pty entry points build `/sandbox.v1.Sandbox/Exec?sandbox=...` and thread `cols`/`rows` into the handle (for the open frame) instead of the URL query. No `/v1/pty` literal remains in `sdk/python/mitos`.

## Public API
Unchanged: `send_input`, `resize`, `kill`, `wait`, the `on_data` callback, and the `pty()`/`create_pty()` signatures.

## Tests
- New `test_pty_connect.py`: a fake enveloped-protocol ws server drives both handles (asserts the open carries `pty.size`, stdin echoes to stdout via `on_data`, exit code parsed, resize delivered).
- Existing pty tests rewritten to the new wire; `test_flat_create` strengthened to assert the new path and the absence of `/v1/pty` and `cols=`/`rows=`.
- Full suite: **250 passed, 1 skipped** (baseline 247+1; +3 new).

Independent of #379 merging (the test mocks the server). PTY is the last `/v1` runtime call; after the TS client (Task 3) lands, Task 4 removes the dead `/v1` routes and closes #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)