### PR TITLE
test(sdk/python): de-flake test_kill_before_wait_does_not_crash

### DIFF
--- a/sdk/python/tests/test_stream.py
+++ b/sdk/python/tests/test_stream.py
@@ -238,10 +238,15 @@ def test_kill_before_wait_does_not_crash(slow_server):
     while proc.running() and time.time() < deadline:
         time.sleep(0.02)
     assert not proc.running(), "drain thread should finish after kill()"
-    # The stream was torn down before its exit frame, so wait() surfaces an
-    # error (a truncation RuntimeError or a transport read error). Either is a
-    # clean, non-hanging outcome; the important thing is it does not crash the
-    # interpreter or close the shared client.
-    with pytest.raises(Exception):
+    # The stream was torn down before its exit frame, so wait() either surfaces
+    # an error (a truncation RuntimeError or a transport read error) OR returns
+    # cleanly when the kill drained the stream before wait() ran. Both are the
+    # documented clean, non-hanging outcome; requiring an exception was a race
+    # (a kill that drains cleanly returns without raising). The invariant is
+    # only that wait() does not hang or crash the interpreter and the shared
+    # client stays open.
+    try:
         proc.wait()
+    except Exception:
+        pass
     assert sb._http.is_closed is False


### PR DESCRIPTION
`tests/test_stream.py::test_kill_before_wait_does_not_crash` is flaky in CI (observed failing on unrelated PRs, e.g. the Go-only #379, twice). The test requires `proc.wait()` to **raise** after a kill-before-wait, but its own docstring says *"wait() should return or raise cleanly, never hang or crash."*

On a slower CI runner the kill sometimes drains the stream before `wait()` runs, so `wait()` returns without raising and `pytest.raises(Exception)` fails with `DID NOT RAISE`. This accepts either a clean return or an exception, matching the documented contract. The real invariants are unchanged: `wait()` does not hang or crash, the drain thread finishes (the 3s deadline loop), and the shared client stays open.

Ran the previously-flaky test 5x locally: 5/5 pass. Test-only change.