### PR TITLE
feat(kubectl-mitos): exec + guest vitals over Connect, retire /v1 (#358 Task 3.5)

### DIFF
--- a/cmd/kubectl-mitos/exec.go
+++ b/cmd/kubectl-mitos/exec.go
@@ -1,29 +1,31 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
+	connect "connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "mitos.run/mitos/api/v1"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// execResult is the decoded sandbox exec response: the exit code and the
-// captured streams. It mirrors the forkd /v1/exec response (vsock.ExecResponse).
+// execResult is the folded sandbox exec result: the exit code and the captured
+// streams. It is the same shape the caller expects; the runtime call now rides
+// the Connect sandbox.v1.Sandbox/ExecStream RPC.
 type execResult struct {
-	ExitCode int    `json:"exit_code"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
+	ExitCode int
+	Stdout   string
+	Stderr   string
 }
 
 // runExec resolves the sandbox's endpoint and per-sandbox bearer token, then
@@ -110,47 +112,68 @@ func orUnknownPhase(p v1.SandboxPhase) string {
 	return string(p)
 }
 
-// execSandbox POSTs the command to <endpoint>/v1/exec with the per-sandbox
-// bearer token (the SAME gate the SDK uses; auth is never bypassed) and decodes
-// the result. A 401 means the token was rejected; a non-2xx surfaces the
-// server's message; a transport error is wrapped. The token value never appears
-// in an error.
+// execSandbox runs command in the sandbox over the Connect
+// sandbox.v1.Sandbox/ExecStream RPC (the HTTP/1.1-reachable non-interactive exec,
+// the same RPC the Go SDK uses) and folds the streamed ExecResponse frames into a
+// single execResult: stdout chunks and stderr chunks are accumulated and the
+// terminal exit frame supplies the exit code. The per-sandbox bearer token and
+// sandbox id ride on the Authorization and X-Sandbox-Id headers (the SAME gate
+// the SDK uses; auth is never bypassed). A rejected token (Connect
+// unauthenticated) maps to the same 401 message as before; any other failure is
+// wrapped. The token value never appears in an error.
+//
+// httpc may be nil, in which case http.DefaultClient is used.
 func execSandbox(ctx context.Context, httpc *http.Client, endpoint, token, ref, command string) (execResult, error) {
-	body, err := json.Marshal(map[string]any{
-		"sandbox": ref,
-		"command": command,
-	})
-	if err != nil {
-		return execResult{}, fmt.Errorf("encode exec request: %w", err)
+	if httpc == nil {
+		httpc = http.DefaultClient
 	}
-	url := fmt.Sprintf("http://%s/v1/exec", endpoint)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return execResult{}, fmt.Errorf("build exec request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	cli := sandboxv1connect.NewSandboxClient(httpc, "http://"+endpoint)
 
-	resp, err := httpc.Do(req)
-	if err != nil {
-		return execResult{}, fmt.Errorf("reach sandbox API at %s: %w (is the sandbox running and the endpoint routable?)", endpoint, err)
-	}
-	defer resp.Body.Close()
+	req := connect.NewRequest(&sandboxv1.ExecStreamRequest{Command: command})
+	req.Header().Set("Authorization", "Bearer "+token)
+	req.Header().Set("X-Sandbox-Id", ref)
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return execResult{}, fmt.Errorf("sandbox API rejected the bearer token (401): the token Secret may be stale")
+	stream, err := cli.ExecStream(ctx, req)
+	if err != nil {
+		return execResult{}, execConnectError(endpoint, token, err)
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		// Redact any echo of the bearer token from the server's body before it
-		// reaches an error string a caller may log.
-		safe := strings.ReplaceAll(strings.TrimSpace(string(msg)), token, "[REDACTED]")
-		return execResult{}, fmt.Errorf("sandbox API returned %d: %s", resp.StatusCode, safe)
-	}
+	defer func() { _ = stream.Close() }()
 
 	var res execResult
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return execResult{}, fmt.Errorf("decode exec response: %w", err)
+	var stdout, stderr strings.Builder
+	for stream.Receive() {
+		msg := stream.Msg()
+		if out := msg.GetStdout(); len(out) > 0 {
+			stdout.Write(out)
+		}
+		if errOut := msg.GetStderr(); len(errOut) > 0 {
+			stderr.Write(errOut)
+		}
+		if exit := msg.GetExit(); exit != nil {
+			res.ExitCode = int(exit.GetExitCode())
+		}
 	}
+	if err := stream.Err(); err != nil {
+		return execResult{}, execConnectError(endpoint, token, err)
+	}
+
+	res.Stdout = stdout.String()
+	res.Stderr = stderr.String()
 	return res, nil
+}
+
+// execConnectError maps a Connect ExecStream failure to the user-facing message,
+// preserving the legacy behavior: an unauthenticated code becomes the 401
+// "rejected the bearer token" message, anything else is wrapped with the
+// endpoint. The token value is redacted from any wrapped cause so it never
+// reaches an error string a caller may log.
+func execConnectError(endpoint, token string, err error) error {
+	if connect.CodeOf(err) == connect.CodeUnauthenticated {
+		return fmt.Errorf("sandbox API rejected the bearer token (401): the token Secret may be stale")
+	}
+	safe := err
+	if token != "" {
+		safe = errors.New(strings.ReplaceAll(err.Error(), token, "[REDACTED]"))
+	}
+	return fmt.Errorf("reach sandbox API at %s: %w (is the sandbox running and the endpoint routable?)", endpoint, safe)
 }

--- a/cmd/kubectl-mitos/exec_test.go
+++ b/cmd/kubectl-mitos/exec_test.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"net/http"
+
+	connect "connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	v1 "mitos.run/mitos/api/v1"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -24,52 +27,160 @@ func execScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func TestExecSandboxSendsBearerTokenAndDecodes(t *testing.T) {
-	const token = "secret-bearer-xyz"
-	var gotAuth string
-	var gotBody map[string]any
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"exit_code":0,"stdout":"hi\n","stderr":""}`))
-	}))
-	defer srv.Close()
-	endpoint := strings.TrimPrefix(srv.URL, "http://")
+// fakeSandboxSvc is a Connect sandbox.v1.Sandbox handler used to exercise the
+// kubectl-mitos exec and vitals clients. It implements only the methods those
+// commands call (ExecStream, Vitals, Processes); everything else stays
+// unimplemented.
+type fakeSandboxSvc struct {
+	sandboxv1connect.UnimplementedSandboxHandler
 
-	res, err := execSandbox(context.Background(), srv.Client(), endpoint, token, "sbx-id", "echo hi")
+	// execChunks are emitted as ExecResponse stdout/stderr frames in order,
+	// followed by a terminal exit frame carrying execExit.
+	execChunks []*sandboxv1.ExecResponse
+	execExit   *sandboxv1.ExecExit
+	// execErr, when set, is returned instead of streaming (e.g. an Unauthenticated
+	// to model a rejected token).
+	execErr error
+
+	// gotCommand records the command the handler received.
+	gotCommand string
+	// gotAuth and gotSandboxID record the Authorization and X-Sandbox-Id headers
+	// seen by the ExecStream and Vitals handlers.
+	gotAuth      string
+	gotSandboxID string
+
+	// vitalsSamples are emitted as GuestVitals frames in order.
+	vitalsSamples []*sandboxv1.GuestVitals
+	vitalsErr     error
+
+	// procList is returned by the Processes RPC; procErr, when set, is returned
+	// instead. procAuth and procSandboxID record the headers the Processes handler
+	// saw (kept distinct from the Vitals headers so a test can assert BOTH calls
+	// authenticated).
+	procList      *sandboxv1.ProcessList
+	procErr       error
+	procAuth      string
+	procSandboxID string
+}
+
+func (f *fakeSandboxSvc) ExecStream(ctx context.Context, req *connect.Request[sandboxv1.ExecStreamRequest], stream *connect.ServerStream[sandboxv1.ExecResponse]) error {
+	f.gotAuth = req.Header().Get("Authorization")
+	f.gotSandboxID = req.Header().Get("X-Sandbox-Id")
+	f.gotCommand = req.Msg.GetCommand()
+	if f.execErr != nil {
+		return f.execErr
+	}
+	for _, c := range f.execChunks {
+		if err := stream.Send(c); err != nil {
+			return err
+		}
+	}
+	if f.execExit != nil {
+		if err := stream.Send(&sandboxv1.ExecResponse{
+			Msg: &sandboxv1.ExecResponse_Exit{Exit: f.execExit},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeSandboxSvc) Vitals(ctx context.Context, req *connect.Request[sandboxv1.VitalsRequest], stream *connect.ServerStream[sandboxv1.GuestVitals]) error {
+	f.gotAuth = req.Header().Get("Authorization")
+	f.gotSandboxID = req.Header().Get("X-Sandbox-Id")
+	if f.vitalsErr != nil {
+		return f.vitalsErr
+	}
+	for _, s := range f.vitalsSamples {
+		if err := stream.Send(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeSandboxSvc) Processes(ctx context.Context, req *connect.Request[sandboxv1.ProcessesRequest]) (*connect.Response[sandboxv1.ProcessList], error) {
+	f.procAuth = req.Header().Get("Authorization")
+	f.procSandboxID = req.Header().Get("X-Sandbox-Id")
+	if f.procErr != nil {
+		return nil, f.procErr
+	}
+	pl := f.procList
+	if pl == nil {
+		pl = &sandboxv1.ProcessList{}
+	}
+	return connect.NewResponse(pl), nil
+}
+
+// newFakeSandboxServer stands up the fake Connect Sandbox service on an
+// httptest server and returns the host:port endpoint (no scheme) plus the svc so
+// the test can assert what the handler saw. Server-streaming RPCs (ExecStream,
+// Vitals) work over HTTP/1.1 chunked transfer, so a plain httptest server is
+// sufficient.
+func newFakeSandboxServer(t *testing.T, svc *fakeSandboxSvc) string {
+	t.Helper()
+	path, h := sandboxv1connect.NewSandboxHandler(svc)
+	mux := http.NewServeMux()
+	mux.Handle(path, h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+func TestExecSandboxStreamsAndFoldsResult(t *testing.T) {
+	const token = "secret-bearer-xyz"
+	svc := &fakeSandboxSvc{
+		execChunks: []*sandboxv1.ExecResponse{
+			{Msg: &sandboxv1.ExecResponse_Stdout{Stdout: []byte("hi")}},
+			{Msg: &sandboxv1.ExecResponse_Stdout{Stdout: []byte("\n")}},
+			{Msg: &sandboxv1.ExecResponse_Stderr{Stderr: []byte("warn\n")}},
+		},
+		execExit: &sandboxv1.ExecExit{ExitCode: 3},
+	}
+	endpoint := newFakeSandboxServer(t, svc)
+
+	res, err := execSandbox(context.Background(), nil, endpoint, token, "sbx-id", "echo hi")
 	if err != nil {
 		t.Fatalf("execSandbox: %v", err)
 	}
-	if gotAuth != "Bearer "+token {
-		t.Errorf("Authorization header = %q, want bearer token", gotAuth)
+	if svc.gotAuth != "Bearer "+token {
+		t.Errorf("Authorization header = %q, want bearer token", svc.gotAuth)
 	}
-	if gotBody["sandbox"] != "sbx-id" || gotBody["command"] != "echo hi" {
-		t.Errorf("exec body = %v, want sandbox/command set", gotBody)
+	if svc.gotSandboxID != "sbx-id" {
+		t.Errorf("X-Sandbox-Id header = %q, want sbx-id", svc.gotSandboxID)
 	}
-	if res.ExitCode != 0 || res.Stdout != "hi\n" {
-		t.Errorf("result = %+v, want exit 0 stdout hi", res)
+	if svc.gotCommand != "echo hi" {
+		t.Errorf("command = %q, want echo hi", svc.gotCommand)
+	}
+	if res.Stdout != "hi\n" {
+		t.Errorf("stdout = %q, want hi\\n", res.Stdout)
+	}
+	if res.Stderr != "warn\n" {
+		t.Errorf("stderr = %q, want warn\\n", res.Stderr)
+	}
+	if res.ExitCode != 3 {
+		t.Errorf("exit code = %d, want 3", res.ExitCode)
 	}
 }
 
-func TestExecSandboxRedactsTokenFromErrorBody(t *testing.T) {
+func TestExecSandboxUnauthorizedDoesNotLeakToken(t *testing.T) {
 	const token = "leaky-token-123"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte("boom token=" + token))
-	}))
-	defer srv.Close()
-	endpoint := strings.TrimPrefix(srv.URL, "http://")
+	svc := &fakeSandboxSvc{
+		// The server rejects with Unauthenticated; the message even echoes the
+		// token to prove the client never surfaces it.
+		execErr: connect.NewError(connect.CodeUnauthenticated, errInline("rejected token="+token)),
+	}
+	endpoint := newFakeSandboxServer(t, svc)
 
-	_, err := execSandbox(context.Background(), srv.Client(), endpoint, token, "sbx-id", "false")
+	_, err := execSandbox(context.Background(), nil, endpoint, token, "sbx-id", "false")
 	if err == nil {
-		t.Fatalf("want an error from the 500")
+		t.Fatalf("want an error from an unauthenticated server")
 	}
 	if strings.Contains(err.Error(), token) {
 		t.Fatalf("error leaked the token: %q", err.Error())
 	}
-	if !strings.Contains(err.Error(), "[REDACTED]") {
-		t.Fatalf("error should show the token redacted, got %q", err.Error())
+	if !strings.Contains(err.Error(), "token") || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("error should explain the bearer token was rejected, got %q", err.Error())
 	}
 }
 
@@ -147,3 +258,8 @@ func TestResolveSandboxAuthNotFound(t *testing.T) {
 		t.Errorf("missing sandbox should error with not found, got %v", err)
 	}
 }
+
+// errInline is a tiny error type for canned server-side error messages in tests.
+type errInline string
+
+func (e errInline) Error() string { return string(e) }

--- a/cmd/kubectl-mitos/ps_guest.go
+++ b/cmd/kubectl-mitos/ps_guest.go
@@ -1,90 +1,141 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	connect "connectrpc.com/connect"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 )
 
 // This file is the kubectl mitos ps consumer of the Layer 3 guest telemetry
-// bridge (issue #164): with --processes, ps fetches the REAL in-guest process
-// table from forkd's /v1/vitals endpoint (which asks the guest agent over vsock)
-// instead of listing fork Sandbox objects. When the guest is unreachable the
-// caller falls back to the object listing, so ps never renders a fabricated
-// table.
+// bridge (issue #164): with --processes, ps fetches the REAL in-guest vitals from
+// a sandbox's guest agent over the Connect sandbox.v1.Sandbox/Vitals and
+// /Processes RPCs instead of listing fork Sandbox objects. When the guest is
+// unreachable the caller falls back to the object listing, so ps never renders a
+// fabricated table.
 
-// guestProcess mirrors one row of the forkd vitals process table.
+// guestProcess mirrors one row of a guest vitals process table.
 type guestProcess struct {
-	PID        int    `json:"pid"`
-	Comm       string `json:"comm"`
-	State      string `json:"state"`
-	CPUJiffies uint64 `json:"cpu_jiffies"`
-	RSSKB      uint64 `json:"rss_kb"`
+	PID        int
+	Comm       string
+	State      string
+	CPUJiffies uint64
+	RSSKB      uint64
 }
 
-// guestVitals mirrors the forkd vitals snapshot the ps consumer reads.
+// guestVitals mirrors the guest vitals snapshot the ps consumer renders.
 type guestVitals struct {
-	StealFraction      float64        `json:"steal_fraction"`
-	MemTotalKB         uint64         `json:"mem_total_kb"`
-	MemUsedKB          uint64         `json:"mem_used_kb"`
-	BalloonReclaimedKB uint64         `json:"balloon_reclaimed_kb"`
-	Processes          []guestProcess `json:"processes"`
+	StealFraction      float64
+	MemTotalKB         uint64
+	MemUsedKB          uint64
+	BalloonReclaimedKB uint64
+	Processes          []guestProcess
 }
 
-// labeledVitals mirrors the forkd /v1/vitals LabeledVitals response: the guest
-// snapshot plus the host's claim/pool/workspace labels.
+// labeledVitals is the guest snapshot the ps consumer renders, plus the host's
+// claim/pool/workspace labels. The numeric sample (steal, memory vs balloon)
+// comes from the Connect Vitals RPC and the per-process table from the Connect
+// Processes RPC. The claim/pool/workspace labels are not carried by either RPC,
+// so they render empty until a future labeled RPC fills them.
 type labeledVitals struct {
-	Claim     string      `json:"claim"`
-	Pool      string      `json:"pool"`
-	Workspace string      `json:"workspace"`
-	Namespace string      `json:"namespace"`
-	Vitals    guestVitals `json:"vitals"`
+	Claim     string
+	Pool      string
+	Workspace string
+	Namespace string
+	Vitals    guestVitals
 }
 
-// fetchGuestVitals GETs the labeled guest telemetry snapshot from forkd's
-// /v1/vitals endpoint for one sandbox, sending the per-sandbox bearer token (the
-// same gate exec uses; auth is never bypassed). Any error (unreachable, non-2xx,
-// decode) is returned so the caller falls back to the object listing. The token
-// value never appears in a returned error.
+// fetchGuestVitals builds the guest snapshot from TWO Connect calls on one
+// client: the sandbox.v1.Sandbox/Vitals server-streaming RPC supplies the first
+// numeric GuestVitals sample (steal, memory vs balloon), and the Processes RPC
+// supplies the per-process table. Both carry the per-sandbox bearer token and
+// sandbox id on the Authorization and X-Sandbox-Id headers (the same gate exec
+// uses; auth is never bypassed). If EITHER call fails (unreachable, rejected
+// token, empty stream) an error is returned so the caller falls back to the
+// object listing rather than rendering a fabricated table. The token value never
+// appears in a returned error.
+//
+// httpc may be nil, in which case http.DefaultClient is used.
 func fetchGuestVitals(ctx context.Context, httpc *http.Client, endpoint, token, ref string) (labeledVitals, error) {
-	body, err := json.Marshal(map[string]any{"sandbox": ref})
-	if err != nil {
-		return labeledVitals{}, fmt.Errorf("encode vitals request: %w", err)
+	if httpc == nil {
+		httpc = http.DefaultClient
 	}
-	url := fmt.Sprintf("http://%s/v1/vitals", endpoint)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return labeledVitals{}, fmt.Errorf("build vitals request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	cli := sandboxv1connect.NewSandboxClient(httpc, "http://"+endpoint)
 
-	resp, err := httpc.Do(req)
+	// setAuth stamps the per-sandbox bearer token and sandbox id on a request so
+	// both Connect calls authenticate identically.
+	setAuth := func(h http.Header) {
+		h.Set("Authorization", "Bearer "+token)
+		h.Set("X-Sandbox-Id", ref)
+	}
+
+	vreq := connect.NewRequest(&sandboxv1.VitalsRequest{})
+	setAuth(vreq.Header())
+
+	stream, err := cli.Vitals(ctx, vreq)
 	if err != nil {
-		return labeledVitals{}, fmt.Errorf("reach sandbox API at %s: %w", endpoint, err)
+		return labeledVitals{}, vitalsConnectError(endpoint, token, err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		safe := strings.ReplaceAll(strings.TrimSpace(string(msg)), token, "[REDACTED]")
-		return labeledVitals{}, fmt.Errorf("sandbox API returned %d: %s", resp.StatusCode, safe)
+	defer func() { _ = stream.Close() }()
+
+	if !stream.Receive() {
+		if err := stream.Err(); err != nil {
+			return labeledVitals{}, vitalsConnectError(endpoint, token, err)
+		}
+		return labeledVitals{}, fmt.Errorf("guest vitals unavailable at %s: no sample", endpoint)
 	}
-	var v labeledVitals
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return labeledVitals{}, fmt.Errorf("decode vitals response: %w", err)
+
+	sample := stream.Msg()
+	var out labeledVitals
+	// CpuStealPercent is [0,100]; StealFraction is [0,1].
+	out.Vitals.StealFraction = sample.GetCpuStealPercent() / 100.0
+	out.Vitals.MemTotalKB = uint64(sample.GetMemTotalBytes()) / 1024
+	out.Vitals.MemUsedKB = uint64(sample.GetMemUsedBytes()) / 1024
+	out.Vitals.BalloonReclaimedKB = uint64(sample.GetMemBalloonBytes()) / 1024
+
+	// The per-process table comes from the unary Processes RPC. A failure here is
+	// fatal to the snapshot so the caller degrades to the object listing rather
+	// than rendering vitals with a silently empty table. CPUJiffies has no field
+	// on the Connect ProcessInfo (it was JSON-only on the legacy path), so it
+	// stays 0.
+	preq := connect.NewRequest(&sandboxv1.ProcessesRequest{})
+	setAuth(preq.Header())
+	pl, perr := cli.Processes(ctx, preq)
+	if perr != nil {
+		return labeledVitals{}, vitalsConnectError(endpoint, token, perr)
 	}
-	return v, nil
+	for _, p := range pl.Msg.GetProcesses() {
+		out.Vitals.Processes = append(out.Vitals.Processes, guestProcess{
+			PID:   int(p.GetPid()),
+			Comm:  p.GetCommand(),
+			State: p.GetState(),
+			RSSKB: uint64(p.GetRssBytes()) / 1024,
+		})
+	}
+	return out, nil
 }
 
-// runPsProcesses fetches and prints the REAL in-guest process table for one
-// sandbox via forkd's /v1/vitals endpoint. When the guest is unreachable (the
+// vitalsConnectError wraps a Connect Vitals or Processes failure with the
+// endpoint, redacting the token from any cause so it never reaches an error
+// string a caller may log.
+func vitalsConnectError(endpoint, token string, err error) error {
+	safe := err
+	if token != "" {
+		safe = errors.New(strings.ReplaceAll(err.Error(), token, "[REDACTED]"))
+	}
+	return fmt.Errorf("reach sandbox API at %s: %w", endpoint, safe)
+}
+
+// runPsProcesses fetches and prints the REAL in-guest vitals for one sandbox via
+// the Connect sandbox.v1.Sandbox/Vitals RPC. When the guest is unreachable (the
 // sandbox is not running, the endpoint is down, or KVM is absent so no guest is
 // behind it) it falls back to the fork sandbox listing for that sandbox, so the
 // command always shows something honest and never a fabricated table.

--- a/cmd/kubectl-mitos/ps_guest_test.go
+++ b/cmd/kubectl-mitos/ps_guest_test.go
@@ -3,50 +3,76 @@ package main
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	connect "connectrpc.com/connect"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
 )
 
-// TestFetchGuestVitals_RealProcesses verifies the ps --processes path consumes
-// the forkd /v1/vitals endpoint and surfaces REAL guest processes (not
-// SandboxFork objects). The endpoint is faked; the bearer token must be sent.
-func TestFetchGuestVitals_RealProcesses(t *testing.T) {
-	var sawAuth, sawSandbox string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sawAuth = r.Header.Get("Authorization")
-		body := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(body)
-		sawSandbox = string(body)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"claim":"claim-a","pool":"pool-x","workspace":"ws-1","namespace":"team-ns",
-			"vitals":{"steal_fraction":0.1,"mem_total_kb":2048000,"mem_used_kb":1024000,
-			"balloon_reclaimed_kb":512000,
-			"processes":[{"pid":1,"comm":"agent","state":"S","cpu_jiffies":42,"rss_kb":4096},
-			{"pid":99,"comm":"python","state":"R","cpu_jiffies":7,"rss_kb":65536}]}}`))
-	}))
-	defer srv.Close()
+// TestFetchGuestVitals_FirstSampleAndProcesses verifies the ps --processes path
+// builds the snapshot from TWO Connect calls: it takes the FIRST GuestVitals
+// sample (numeric fields) AND the Processes table, mapping both into the local
+// struct. The bearer token and sandbox id must ride on the headers of BOTH calls,
+// and the rendered table must show the real process rows over Connect.
+func TestFetchGuestVitals_FirstSampleAndProcesses(t *testing.T) {
+	svc := &fakeSandboxSvc{
+		vitalsSamples: []*sandboxv1.GuestVitals{
+			{
+				CpuStealPercent: 10, // percent; the local struct holds a [0,1] fraction
+				MemTotalBytes:   2048000 * 1024,
+				MemUsedBytes:    1024000 * 1024,
+				MemBalloonBytes: 512000 * 1024,
+				ProcessCount:    2,
+			},
+			// A second sample must be ignored: only the first is read.
+			{CpuStealPercent: 99},
+		},
+		procList: &sandboxv1.ProcessList{
+			Processes: []*sandboxv1.ProcessInfo{
+				{Pid: 1, Command: "agent", State: "S", RssBytes: 4096 * 1024},
+				{Pid: 99, Command: "python", State: "R", RssBytes: 65536 * 1024},
+			},
+		},
+	}
+	endpoint := newFakeSandboxServer(t, svc)
 
-	endpoint := strings.TrimPrefix(srv.URL, "http://")
-	v, err := fetchGuestVitals(context.Background(), srv.Client(), endpoint, "tok-123", "sb-1")
+	v, err := fetchGuestVitals(context.Background(), nil, endpoint, "tok-123", "sb-1")
 	if err != nil {
 		t.Fatalf("fetchGuestVitals: %v", err)
 	}
-	if sawAuth != "Bearer tok-123" {
-		t.Errorf("auth header = %q, want Bearer tok-123", sawAuth)
+	// Both the Vitals and the Processes call must carry the same auth headers.
+	if svc.gotAuth != "Bearer tok-123" || svc.gotSandboxID != "sb-1" {
+		t.Errorf("vitals headers = (%q,%q), want (Bearer tok-123, sb-1)", svc.gotAuth, svc.gotSandboxID)
 	}
-	if !strings.Contains(sawSandbox, "sb-1") {
-		t.Errorf("request body = %q, want sandbox sb-1", sawSandbox)
+	if svc.procAuth != "Bearer tok-123" || svc.procSandboxID != "sb-1" {
+		t.Errorf("processes headers = (%q,%q), want (Bearer tok-123, sb-1)", svc.procAuth, svc.procSandboxID)
 	}
-	if v.Claim != "claim-a" {
-		t.Errorf("claim = %q, want claim-a", v.Claim)
+	if v.Vitals.StealFraction != 0.1 {
+		t.Errorf("steal fraction = %v, want 0.1", v.Vitals.StealFraction)
 	}
-	if v.Namespace != "team-ns" {
-		t.Errorf("namespace = %q, want team-ns", v.Namespace)
+	if v.Vitals.MemTotalKB != 2048000 || v.Vitals.MemUsedKB != 1024000 {
+		t.Errorf("mem = %d/%d KB, want 1024000/2048000", v.Vitals.MemUsedKB, v.Vitals.MemTotalKB)
 	}
-	if len(v.Vitals.Processes) != 2 || v.Vitals.Processes[1].Comm != "python" {
-		t.Errorf("processes = %+v, want 2 incl python", v.Vitals.Processes)
+	if v.Vitals.BalloonReclaimedKB != 512000 {
+		t.Errorf("balloon = %d KB, want 512000", v.Vitals.BalloonReclaimedKB)
+	}
+	// The process table must be populated from the Processes RPC.
+	if len(v.Vitals.Processes) != 2 {
+		t.Fatalf("processes = %+v, want 2 rows", v.Vitals.Processes)
+	}
+	if v.Vitals.Processes[0].Comm != "agent" || v.Vitals.Processes[0].PID != 1 {
+		t.Errorf("row 0 = %+v, want agent pid 1", v.Vitals.Processes[0])
+	}
+	if v.Vitals.Processes[1].Comm != "python" || v.Vitals.Processes[1].State != "R" || v.Vitals.Processes[1].RSSKB != 65536 {
+		t.Errorf("row 1 = %+v, want python R 65536 KB", v.Vitals.Processes[1])
+	}
+	// The user-visible table must render the real rows over Connect.
+	out := renderGuestProcesses(v)
+	for _, want := range []string{"PID", "COMMAND", "STATE", "agent", "python", "99"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered table missing %q:\n%s", want, out)
+		}
 	}
 }
 
@@ -56,6 +82,23 @@ func TestFetchGuestVitals_Unreachable(t *testing.T) {
 	_, err := fetchGuestVitals(context.Background(), http.DefaultClient, "127.0.0.1:0", "tok", "sb-1")
 	if err == nil {
 		t.Error("expected error for unreachable endpoint")
+	}
+}
+
+// TestFetchGuestVitals_ProcessesFailureDegrades verifies that when the Vitals
+// call succeeds but the Processes call fails, the whole snapshot errors so the
+// caller falls back to the object listing instead of rendering vitals with an
+// empty table.
+func TestFetchGuestVitals_ProcessesFailureDegrades(t *testing.T) {
+	svc := &fakeSandboxSvc{
+		vitalsSamples: []*sandboxv1.GuestVitals{{CpuStealPercent: 1}},
+		procErr:       connect.NewError(connect.CodeUnavailable, errInline("guest table unavailable")),
+	}
+	endpoint := newFakeSandboxServer(t, svc)
+
+	_, err := fetchGuestVitals(context.Background(), nil, endpoint, "tok", "sb-1")
+	if err == nil {
+		t.Fatal("a Processes failure must error so ps degrades to the object listing")
 	}
 }
 


### PR DESCRIPTION
The `kubectl-mitos` plugin was the **last non-SDK caller** of the legacy `/v1` runtime routes (missed by the SDK-only gap analysis). This migrates it onto the Connect `sandbox.v1.Sandbox` protocol via the in-module generated connect-go client, unblocking removal of `/v1/exec` and `/v1/vitals`.

## What changes
- `exec.go`: `execSandbox` drives the server-streaming `ExecStream` RPC and folds stdout/stderr + the terminal exit into the same buffered `execResult`. Sets `Authorization: Bearer` + `X-Sandbox-Id`, maps connect `unauthenticated` to the same 401 message, never leaks the token.
- `ps_guest.go`: the guest snapshot is now two Connect calls, `Vitals` (numeric sample) + `Processes` (the per-process table for `ps --processes`), on one client. The unreachable-guest fallback to the object listing is preserved (either call failing degrades exactly as before).
- No `/v1/exec`/`/v1/vitals` literal remains; `/v1/vitals/node` and lifecycle routes untouched.

## Tests
A Connect test server (`sandboxv1connect.NewSandboxHandler` over a fake `ExecStream`/`Vitals`/`Processes`) backs the suite: asserts the exec fold + exit code, both auth headers on every call, the first-sample numeric mapping, the per-process rows render, and that a `Processes` failure degrades. `go test`/`build`/`vet`/`gofmt` clean.

After this, the final step (Task 4) removes the dead `/v1` runtime routes from the daemon + sandbox-server and closes #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)