### PR TITLE
feat(console): shell part 2 (nav regroup, operational Overview home)

### DIFF
--- a/web/app/src/nav/routes.test.tsx
+++ b/web/app/src/nav/routes.test.tsx
@@ -50,4 +50,18 @@ describe('routes config', () => {
     const visible = visibleRoutes({ ...base, proof: false })
     expect(visible.find((r) => r.path === '/')).toBeUndefined()
   })
+
+  it('groups Usage and Billing under a Billing group, not Govern', () => {
+    expect(GROUP_ORDER).toContain('Billing')
+    expect(ROUTES.find((r) => r.path === '/usage')?.group).toBe('Billing')
+    expect(ROUTES.find((r) => r.path === '/billing')?.group).toBe('Billing')
+  })
+
+  it('keeps Settings reachable but out of the sidebar nav (moved to the account menu)', () => {
+    // Account Settings lives in the top-bar account menu now, not a nav group.
+    expect(GROUP_ORDER).not.toContain('Settings')
+    expect(ROUTES.find((r) => r.path === '/settings')?.hidden).toBe(true)
+    expect(navRoutes(base).find((r) => r.path === '/settings')).toBeUndefined()
+    expect(visibleRoutes(base).find((r) => r.path === '/settings')).toBeDefined()
+  })
 })

--- a/web/app/src/nav/routes.test.tsx
+++ b/web/app/src/nav/routes.test.tsx
@@ -46,9 +46,13 @@ describe('routes config', () => {
     expect(visible.find((r) => r.path === '/billing')).toBeDefined()
   })
 
-  it('hides the overview home when proof is false', () => {
+  it('always shows the overview home regardless of the proof capability', () => {
+    // Overview is a real operational home (not just a proof screen), so it must
+    // always be reachable even when proof is false.
     const visible = visibleRoutes({ ...base, proof: false })
-    expect(visible.find((r) => r.path === '/')).toBeUndefined()
+    expect(visible.find((r) => r.path === '/')).toBeDefined()
+    const visibleWithProof = visibleRoutes({ ...base, proof: true })
+    expect(visibleWithProof.find((r) => r.path === '/')).toBeDefined()
   })
 
   it('groups Usage and Billing under a Billing group, not Govern', () => {

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -32,7 +32,7 @@ export type RouteDef = {
 }
 
 export const ROUTES: RouteDef[] = [
-  { path: '/', label: 'Overview', group: 'Run', element: () => <Instruments />, when: (c) => c.proof },
+  { path: '/', label: 'Overview', group: 'Run', element: () => <Instruments /> },
   { path: '/sandboxes', label: 'Sandboxes', group: 'Run', element: () => <SandboxList /> },
   { path: '/sandboxes/$id', label: 'Sandbox', group: 'Run', element: () => <SandboxDetail />, hidden: true },
   { path: '/forks', label: 'Fork tree', group: 'Run', element: () => <ForkTree /> },

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -19,8 +19,8 @@ import { Projects } from '../views/Projects'
 import { Settings } from '../views/Settings'
 import { Retention } from '../views/Retention'
 
-export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Settings'
-export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Settings']
+export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Billing'
+export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Billing']
 
 export type RouteDef = {
   path: string
@@ -44,9 +44,11 @@ export const ROUTES: RouteDef[] = [
   { path: '/projects', label: 'Projects', group: 'Govern', element: () => <Projects />, when: (c) => c.teams },
   { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Audit /> },
   { path: '/retention', label: 'Data and retention', group: 'Govern', element: () => <Retention /> },
-  { path: '/usage', label: 'Usage', group: 'Govern', element: () => <Usage /> },
-  { path: '/billing', label: 'Billing', group: 'Govern', element: () => <Billing />, when: (c) => c.billing },
-  { path: '/settings', label: 'Settings', group: 'Settings', element: () => <Settings /> },
+  { path: '/usage', label: 'Usage', group: 'Billing', element: () => <Usage /> },
+  { path: '/billing', label: 'Billing', group: 'Billing', element: () => <Billing />, when: (c) => c.billing },
+  // Account settings is reached from the top-bar account menu, not the sidebar;
+  // the route stays registered (and palette-searchable) but hidden from nav.
+  { path: '/settings', label: 'Settings', group: 'Govern', element: () => <Settings />, hidden: true },
 ]
 
 export function visibleRoutes(caps: Capabilities): RouteDef[] {

--- a/web/app/src/router.test.tsx
+++ b/web/app/src/router.test.tsx
@@ -54,22 +54,28 @@ describe('console router', () => {
     expect(Object.keys(router.routesByPath)).toContain('/billing')
   })
 
-  it('redirects / to first visible route when proof is off (no dead-end on gated path)', async () => {
-    // When proof:false, the '/' (Overview) route is not built. Navigating to
-    // '/' must resolve to the first visible route (Sandboxes) rather than a
-    // "Not Found" dead-end. This test genuinely fails without the not-found
-    // redirect in createConsoleRouter.
+  it('resolves / to the Overview view when proof is off (Overview is always built)', async () => {
+    // Overview is a real operational home now, so the '/' route is always built
+    // regardless of the proof capability. Navigating to '/' must show Overview.
     const noproofCaps: Capabilities = { ...caps, proof: false }
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       const url = String(input)
       if (url.endsWith('/console/capabilities')) {
         return Promise.resolve(new Response(JSON.stringify(noproofCaps), { status: 200, headers: { 'content-type': 'application/json' } }))
       }
-      return Promise.resolve(new Response(JSON.stringify({ sandboxes: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      if (url.endsWith('/console/sandboxes')) {
+        return Promise.resolve(new Response(JSON.stringify({ sandboxes: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.endsWith('/console/instruments')) {
+        return Promise.resolve(new Response(JSON.stringify({ org_id: 'o1', activate_p50_ms: 0, activate_p99_ms: 0, forks_served: 0, cow_savings_bytes: 0, marginal_bytes_per_fork: 0 }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.endsWith('/console/audit')) {
+        return Promise.resolve(new Response(JSON.stringify({ events: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
     })
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const router = createConsoleRouter(noproofCaps)
-    // Navigate to '/' which is not a built route when proof:false.
     await router.navigate({ to: '/' })
     render(
       <QueryClientProvider client={client}>
@@ -78,8 +84,8 @@ describe('console router', () => {
         </ToastProvider>
       </QueryClientProvider>,
     )
-    // Must show Sandboxes (first visible route), never "Not Found".
-    await waitFor(() => expect(screen.getByRole('heading', { name: /Sandboxes/i })).toBeInTheDocument())
+    // Must show the Overview heading, never "Not Found".
+    await waitFor(() => expect(screen.getByRole('heading', { name: /Overview/i })).toBeInTheDocument())
     expect(screen.queryByText('Not Found')).not.toBeInTheDocument()
   })
 })

--- a/web/app/src/views/Instruments.test.tsx
+++ b/web/app/src/views/Instruments.test.tsx
@@ -4,33 +4,210 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Instruments } from './Instruments'
 import { fmtBytes } from '../api'
 
+// Mock TanStack Router Link so Instruments renders without a full router context.
+vi.mock('@tanstack/react-router', () => ({
+  Link: (p: { to: string; children: React.ReactNode; className?: string }) =>
+    <a href={p.to} className={p.className}>{p.children}</a>,
+}))
+
+// Mock the data hooks so tests are deterministic; the real hooks call fetch and
+// go through react-query, which is fine for integration-style tests but makes
+// it hard to test capability-gated panels in isolation.
+vi.mock('../data/instruments', () => ({
+  useInstruments: vi.fn(),
+}))
+vi.mock('../data/sandboxes', () => ({
+  useSandboxes: vi.fn(),
+}))
+vi.mock('../data/account', () => ({
+  useBilling: vi.fn(),
+  useAudit: vi.fn(),
+}))
+vi.mock('../data/query', () => ({
+  useCapabilities: vi.fn(),
+}))
+
+import { useInstruments } from '../data/instruments'
+import { useSandboxes } from '../data/sandboxes'
+import { useBilling, useAudit } from '../data/account'
+import { useCapabilities } from '../data/query'
+
+const mockUseInstruments = useInstruments as ReturnType<typeof vi.fn>
+const mockUseSandboxes = useSandboxes as ReturnType<typeof vi.fn>
+const mockUseBilling = useBilling as ReturnType<typeof vi.fn>
+const mockUseAudit = useAudit as ReturnType<typeof vi.fn>
+const mockUseCapabilities = useCapabilities as ReturnType<typeof vi.fn>
+
 function wrap(ui: React.ReactElement) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
 }
 
+const instrumentsData = {
+  org_id: 'o1',
+  activate_p50_ms: 27,
+  activate_p99_ms: 41,
+  forks_served: 10,
+  cow_savings_bytes: 2415919104,
+  marginal_bytes_per_fork: 3145728,
+}
+
+const sandboxesData = [
+  { id: 'sb-aaa', org_id: 'o1', template: 'python', node: 'w1', phase: 'Running', vcpus: 2, mem_bytes: 1073741824, created_at: '2026-01-01T00:00:00Z' },
+  { id: 'sb-bbb', org_id: 'o1', template: 'python', node: 'w1', phase: 'Running', vcpus: 2, mem_bytes: 1073741824, created_at: '2026-01-01T00:00:00Z' },
+  { id: 'sb-ccc', org_id: 'o1', template: 'python', node: 'w1', phase: 'Stopped', vcpus: 2, mem_bytes: 1073741824, created_at: '2026-01-01T00:00:00Z' },
+]
+
+const auditData = [
+  { org_id: 'o1', actor_id: 'alice', action: 'fork', target: 'sb-aaa', detail: '', at: '2026-01-01T10:00:00Z' },
+  { org_id: 'o1', actor_id: 'bob', action: 'terminate', target: 'sb-bbb', detail: '', at: '2026-01-01T09:00:00Z' },
+]
+
+const billingData = {
+  org_id: 'o1',
+  status: 'active',
+  balance_cents: 5000,
+  spend_cents: 1234,
+  soft_cap_cents: 0,
+  hard_cap_cents: 0,
+  ledger_entries: [],
+}
+
+const capsNoBilling = {
+  edition: 'community' as const,
+  billing: false,
+  signup: false,
+  teams: true,
+  idp: 'oidc',
+  orgSwitcher: false,
+  secrets: { providers: ['kube'] },
+  proof: true,
+  ownership: 'self-hosted' as const,
+}
+
+const capsWithBilling = { ...capsNoBilling, billing: true }
+
 beforeEach(() => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify({ org_id: 'o1', activate_p50_ms: 27, activate_p99_ms: 41, forks_served: 10, cow_savings_bytes: 2415919104, marginal_bytes_per_fork: 3145728 }), {
-      status: 200, headers: { 'content-type': 'application/json' },
-    }),
-  )
+  vi.clearAllMocks()
+  mockUseInstruments.mockReturnValue({ data: instrumentsData, isLoading: false, error: null })
+  mockUseSandboxes.mockReturnValue({ data: sandboxesData, isLoading: false, error: null })
+  mockUseBilling.mockReturnValue({ data: billingData, isLoading: false, error: null })
+  mockUseAudit.mockReturnValue({ data: auditData, isLoading: false, error: null })
+  mockUseCapabilities.mockReturnValue({ data: capsNoBilling, isLoading: false, error: null })
 })
 
-describe('Instruments cockpit', () => {
-  it('renders the measured activate latency and CoW density tiles', async () => {
+describe('Instruments (Overview) cockpit', () => {
+  it('renders the PageHeader with the Overview title', async () => {
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: /Overview/i })).toBeInTheDocument())
+  })
+
+  it('renders the measured activate latency and CoW density tiles when data is present', async () => {
     wrap(<Instruments />)
     await waitFor(() => expect(screen.getByText('27')).toBeInTheDocument())
     expect(screen.getByText(/Activate P50/i)).toBeInTheDocument()
-    // P99 tile
     expect(screen.getByText(/Activate P99/i)).toBeInTheDocument()
     expect(screen.getByText('41')).toBeInTheDocument()
-    // Forks served tile
     expect(screen.getByText(/Forks served/i)).toBeInTheDocument()
     expect(screen.getByText('10')).toBeInTheDocument()
-    // CoW savings tile: mock returns cow_savings_bytes: 2415919104
     expect(screen.getByText(fmtBytes(2415919104))).toBeInTheDocument()
-    // Marginal bytes per fork tile: mock returns marginal_bytes_per_fork: 3145728
     expect(screen.getByText(fmtBytes(3145728))).toBeInTheDocument()
+  })
+
+  it('shows an inline note instead of tiles when no measured signal exists, but still renders operational panels', async () => {
+    mockUseInstruments.mockReturnValue({
+      data: { ...instrumentsData, forks_served: 0, activate_p50_ms: 0 },
+      isLoading: false,
+      error: null,
+    })
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByText(/No measured signal yet/i)).toBeInTheDocument())
+    // Operational panels still render
+    expect(screen.getByText(/Running now/i)).toBeInTheDocument()
+    expect(screen.getByText(/Recent activity/i)).toBeInTheDocument()
+  })
+})
+
+describe('Running now panel', () => {
+  it('counts only Running-phase sandboxes and shows the count prominently', async () => {
+    wrap(<Instruments />)
+    // 2 of 3 sandboxes are Running
+    await waitFor(() => expect(screen.getByText('2')).toBeInTheDocument())
+    expect(screen.getByText(/Running now/i)).toBeInTheDocument()
+  })
+
+  it('lists up to 5 running sandbox ids in monospace within the Running now panel', async () => {
+    wrap(<Instruments />)
+    // Wait for the panel to render; both Running sandboxes must appear (sb-aaa
+    // also appears in the Recent activity panel as an audit target, so use
+    // getAllByText and assert at least one match is a list item in the panel).
+    await waitFor(() => {
+      const matches = screen.getAllByText('sb-aaa')
+      // At least one instance is the running-panel list item (li.mono)
+      expect(matches.some((el) => el.tagName === 'LI')).toBe(true)
+    })
+    const bbbMatches = screen.getAllByText('sb-bbb')
+    expect(bbbMatches.some((el) => el.tagName === 'LI')).toBe(true)
+    // Stopped sandbox must NOT appear in the running list
+    const cccLiItems = screen.queryAllByText('sb-ccc').filter((el) => el.tagName === 'LI')
+    expect(cccLiItems).toHaveLength(0)
+  })
+
+  it('links to /sandboxes from the footer', async () => {
+    wrap(<Instruments />)
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /View sandboxes/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/sandboxes')
+    })
+  })
+
+  it('shows the empty state when no sandboxes are running', async () => {
+    mockUseSandboxes.mockReturnValue({ data: [], isLoading: false, error: null })
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByText(/No sandboxes running/i)).toBeInTheDocument())
+  })
+})
+
+describe('Spend this month panel', () => {
+  it('is hidden when capabilities.billing is false', async () => {
+    mockUseCapabilities.mockReturnValue({ data: capsNoBilling, isLoading: false, error: null })
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByText(/Running now/i)).toBeInTheDocument())
+    expect(screen.queryByText(/Spend this month/i)).not.toBeInTheDocument()
+  })
+
+  it('is shown when capabilities.billing is true and displays formatted spend', async () => {
+    mockUseCapabilities.mockReturnValue({ data: capsWithBilling, isLoading: false, error: null })
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByText(/Spend this month/i)).toBeInTheDocument())
+    // spend_cents: 1234 -> $12.34
+    expect(screen.getByText('$12.34')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /View billing/i })
+    expect(link).toHaveAttribute('href', '/billing')
+  })
+})
+
+describe('Recent activity panel', () => {
+  it('lists up to 5 recent audit events', async () => {
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByText(/Recent activity/i)).toBeInTheDocument())
+    // Each event shows actor_id action target
+    expect(screen.getByText(/alice/i)).toBeInTheDocument()
+    expect(screen.getByText(/bob/i)).toBeInTheDocument()
+  })
+
+  it('links to /audit from the footer', async () => {
+    wrap(<Instruments />)
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /View audit log/i })
+      expect(link).toHaveAttribute('href', '/audit')
+    })
+  })
+
+  it('shows the empty state when there are no audit events', async () => {
+    mockUseAudit.mockReturnValue({ data: [], isLoading: false, error: null })
+    wrap(<Instruments />)
+    await waitFor(() => expect(screen.getByText(/No activity yet/i)).toBeInTheDocument())
   })
 })

--- a/web/app/src/views/Instruments.tsx
+++ b/web/app/src/views/Instruments.tsx
@@ -1,42 +1,192 @@
-// The cockpit: the org's OWN measured numbers, not a welcome screen. Activate
-// latency (warm-claim P50/P99, their cluster), CoW density (memory saved by
-// page-sharing) and marginal bytes per fork, forks served. Every headline metric
-// carries a "Reproduce this" affordance pointing at the in-repo bench. No number
-// is invented here; all values come from /console/instruments.
+// The operational home: proof-hero band of the org's own measured numbers
+// (activate latency, CoW density, forks served) plus three operational panels
+// (running sandboxes, spend this month, recent activity). Every number is real:
+// the proof tiles come from /console/instruments, the panels from their own
+// endpoints. No number is invented here.
+import { Link } from '@tanstack/react-router'
 import { useInstruments } from '../data/instruments'
+import { useSandboxes } from '../data/sandboxes'
+import { useBilling, useAudit } from '../data/account'
+import { useCapabilities } from '../data/query'
 import { StatTile } from '../ui/StatTile'
 import { Skeleton } from '../ui/Skeleton'
-import { EmptyState } from '../ui/EmptyState'
 import { fmtBytes } from '../api'
 import { PageHeader } from '../ui/PageHeader'
+import { Card } from '@mitos/brand'
+import type { AuditEvent } from '../api'
 
 const BENCH = 'bench/husk-activate-latency.sh'
 
-export function Instruments() {
+function fmtDollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+function fmtRelative(isoAt: string): string {
+  // Short human-readable timestamp; real value from the event record.
+  try {
+    const d = new Date(isoAt)
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return isoAt
+  }
+}
+
+// ---- Proof hero band -------------------------------------------------------
+
+function ProofHero() {
   const { data, isLoading, error } = useInstruments()
-  if (error) return <EmptyState title="Overview unavailable" body="The telemetry pipeline could not be read for this organization." />
-  if (isLoading || !data) return <Skeleton rows={4} />
+
+  if (error) {
+    return (
+      <p className="t-dim" style={{ marginTop: 'var(--space-4)', marginBottom: 'var(--space-5)' }}>
+        Proof metrics unavailable.
+      </p>
+    )
+  }
+  if (isLoading || !data) return <Skeleton rows={2} />
 
   const noData = data.forks_served === 0 && data.activate_p50_ms === 0
   if (noData) {
     return (
-      <EmptyState
-        title="No measured signal yet"
-        body="Fork a sandbox to see this org's activate latency and CoW density here. Only measured signal emits light."
-      />
+      <p className="t-dim" style={{ marginTop: 'var(--space-4)', marginBottom: 'var(--space-5)' }}>
+        No measured signal yet. Fork a sandbox to see activate latency and CoW density here.
+      </p>
     )
   }
 
   return (
-    <section>
-      <PageHeader title="Overview" lede="This organization's measured signal. Every number is reproducible." />
-      <div className="cockpit-grid">
-        <StatTile label="Activate P50" value={String(Math.round(data.activate_p50_ms))} unit="ms" hint="warm-claim, your cluster" reproduce={{ label: 'Reproduce this', command: BENCH }} />
-        <StatTile label="Activate P99" value={String(Math.round(data.activate_p99_ms))} unit="ms" hint="warm-claim, your cluster" reproduce={{ label: 'Reproduce this', command: BENCH }} />
-        <StatTile label="CoW savings" value={fmtBytes(data.cow_savings_bytes)} hint="memory not spent, forks share parent pages" reproduce={{ label: 'Reproduce this', command: BENCH }} />
-        <StatTile label="Marginal / fork" value={fmtBytes(data.marginal_bytes_per_fork)} hint="mean private-dirty set per fork" reproduce={{ label: 'Reproduce this', command: BENCH }} />
-        <StatTile label="Forks served" value={String(data.forks_served)} hint="total for this org" />
+    <div className="cockpit-grid">
+      <StatTile label="Activate P50" value={String(Math.round(data.activate_p50_ms))} unit="ms" hint="warm-claim, your cluster" reproduce={{ label: 'Reproduce this', command: BENCH }} />
+      <StatTile label="Activate P99" value={String(Math.round(data.activate_p99_ms))} unit="ms" hint="warm-claim, your cluster" reproduce={{ label: 'Reproduce this', command: BENCH }} />
+      <StatTile label="CoW savings" value={fmtBytes(data.cow_savings_bytes)} hint="memory not spent, forks share parent pages" reproduce={{ label: 'Reproduce this', command: BENCH }} />
+      <StatTile label="Marginal / fork" value={fmtBytes(data.marginal_bytes_per_fork)} hint="mean private-dirty set per fork" reproduce={{ label: 'Reproduce this', command: BENCH }} />
+      <StatTile label="Forks served" value={String(data.forks_served)} hint="total for this org" />
+    </div>
+  )
+}
+
+// ---- Running now panel -----------------------------------------------------
+
+function RunningNowPanel() {
+  const { data, isLoading } = useSandboxes()
+
+  const running = (data ?? []).filter((s) => s.phase === 'Running')
+
+  return (
+    <Card>
+      <h2 style={{ marginBottom: 'var(--space-4)' }}>Running now</h2>
+      {isLoading ? (
+        <Skeleton rows={2} />
+      ) : running.length === 0 ? (
+        <p className="t-dim">No sandboxes running.</p>
+      ) : (
+        <>
+          <div style={{ fontSize: 'var(--step-4)', fontFamily: 'var(--mono)', color: 'var(--cyan)', marginBottom: 'var(--space-3)' }}>
+            {running.length}
+          </div>
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {running.slice(0, 5).map((s) => (
+              <li key={s.id} className="mono" style={{ fontSize: 'var(--step--1)', padding: 'var(--space-1) 0', borderBottom: '1px solid var(--hairline)', color: 'var(--ink-2)' }}>
+                {s.id}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      <div style={{ marginTop: 'var(--space-4)' }}>
+        <Link to="/sandboxes" className="t-dim" style={{ fontSize: 'var(--step--1)', color: 'var(--cyan)', textDecoration: 'none' }}>
+          View sandboxes
+        </Link>
       </div>
+    </Card>
+  )
+}
+
+// ---- Spend this month panel ------------------------------------------------
+
+function SpendPanel() {
+  const { data, isLoading } = useBilling()
+
+  return (
+    <Card>
+      <h2 style={{ marginBottom: 'var(--space-4)' }}>Spend this month</h2>
+      {isLoading ? (
+        <Skeleton rows={1} />
+      ) : !data ? (
+        <p className="t-dim">Billing data unavailable.</p>
+      ) : (
+        <div style={{ fontSize: 'var(--step-4)', fontFamily: 'var(--mono)', color: 'var(--cyan)' }}>
+          {fmtDollars(data.spend_cents)}
+        </div>
+      )}
+      <div style={{ marginTop: 'var(--space-4)' }}>
+        <Link to="/billing" className="t-dim" style={{ fontSize: 'var(--step--1)', color: 'var(--cyan)', textDecoration: 'none' }}>
+          View billing
+        </Link>
+      </div>
+    </Card>
+  )
+}
+
+// ---- Recent activity panel -------------------------------------------------
+
+function RecentActivityPanel() {
+  const { data, isLoading } = useAudit()
+
+  const events: AuditEvent[] = data ?? []
+
+  return (
+    <Card>
+      <h2 style={{ marginBottom: 'var(--space-4)' }}>Recent activity</h2>
+      {isLoading ? (
+        <Skeleton rows={3} />
+      ) : events.length === 0 ? (
+        <p className="t-dim">No activity yet.</p>
+      ) : (
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {events.slice(0, 5).map((e, i) => (
+            <li key={i} style={{ padding: 'var(--space-2) 0', borderBottom: '1px solid var(--hairline)', fontSize: 'var(--step--1)' }}>
+              <span style={{ color: 'var(--ink)' }}>{e.actor_id}</span>
+              {' '}
+              <span className="t-dim">{e.action}</span>
+              {' '}
+              <span className="mono" style={{ color: 'var(--ink-2)' }}>{e.target}</span>
+              <span className="t-dim" style={{ float: 'right' }}>{fmtRelative(e.at)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div style={{ marginTop: 'var(--space-4)' }}>
+        <Link to="/audit" className="t-dim" style={{ fontSize: 'var(--step--1)', color: 'var(--cyan)', textDecoration: 'none' }}>
+          View audit log
+        </Link>
+      </div>
+    </Card>
+  )
+}
+
+// ---- Operational panels grid -----------------------------------------------
+
+function OperationalPanels() {
+  const { data: caps } = useCapabilities()
+
+  return (
+    <div className="overview-panels" style={{ marginTop: 'var(--space-7)' }}>
+      <RunningNowPanel />
+      {caps?.billing && <SpendPanel />}
+      <RecentActivityPanel />
+    </div>
+  )
+}
+
+// ---- Overview (Instruments) ------------------------------------------------
+
+export function Instruments() {
+  return (
+    <section>
+      <PageHeader title="Overview" lede="This organization's measured signal, and what's happening right now." />
+      <ProofHero />
+      <OperationalPanels />
     </section>
   )
 }

--- a/web/packages/brand/src/base.css
+++ b/web/packages/brand/src/base.css
@@ -266,6 +266,20 @@ a { color: var(--cyan); }
   margin-top: var(--space-5);
 }
 
+/* Overview operational panels: responsive card grid below the proof hero band.
+   Multi-column on desktop, single column on mobile. Reuses .card and tokens. */
+.overview-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+  gap: var(--space-5);
+}
+
+@media (max-width: 768px) {
+  .overview-panels {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Fork-tree visualization: Division motif node styles. Colors are signal
    tokens only; no raw hex. The SVG is aria-hidden; the table is the a11y
    source of truth. */


### PR DESCRIPTION
## Summary

Workstreams 4 and 5 of the console shell upgrade, building on the shell foundation (brand, top bar, page headers) merged in #386.

Design spec: `docs/superpowers/specs/2026-06-25-console-shell-website-continuity-design.md`.

## What landed

**WS4: navigation regroup**
- Usage and Billing move out of the heavy Govern group into their own Billing group (financial, not governance). Govern keeps Members, Projects, Audit, and Data and retention.
- The Settings sidebar group is removed; account settings is reached from the top-bar account menu now. The /settings route stays registered and command-palette searchable, just hidden from the sidebar.

**WS5: Overview becomes an operational home**
- The proof metrics (activate P50/P99, CoW savings, marginal per fork, forks served) stay as a hero band with their "Reproduce this" affordance.
- Three operational panels below, every number real and composed from existing endpoints:
  - Running now: the count and a short list of running sandboxes, linking to Sandboxes.
  - Spend this month: the real spend for the org (only when billing is enabled), linking to Billing.
  - Recent activity: the latest audit events, linking to the Audit log.
- Each panel handles its own loading and empty state, so one slow query never blanks the others.
- The home is now always present (the proof-only gate is removed): when there is no measured signal yet, the hero shows an inline note while the operational panels still render, so the home is never a dead end.

## Verification

- `pnpm -C web/app test` 123 passing; `typecheck` clean; `build` succeeds.
- No em or en dashes in changed files.
- Desktop and mobile verified via the Playwright screenshot harness.

## Honesty

No dead controls and no fabricated numbers: the Spend panel shows real cents, Running now counts real sandboxes, and Recent activity lists real audit events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)