### PR TITLE
feat(mcp): run the mitos-mcp backend exec/files over Connect (#358)

### DIFF
--- a/internal/agentcli/clusterbackend_test.go
+++ b/internal/agentcli/clusterbackend_test.go
@@ -2,22 +2,80 @@ package agentcli
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	connect "connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	v1 "mitos.run/mitos/api/v1"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// connectExecFake is a Connect SandboxHandler stub serving ExecStream for the
+// cluster-backend exec tests, which now ride the Connect runtime path (the
+// legacy /v1/exec JSON route is retired, issue #358). It records the bearer and
+// the sandbox id from the request headers and returns a canned exec result, or
+// a Connect error (optionally echoing the token, to prove redaction).
+type connectExecFake struct {
+	sandboxv1connect.UnimplementedSandboxHandler
+
+	stdout string
+	stderr string
+	exit   int32
+	// errMsg, when non-empty, makes ExecStream return a CodeInternal error whose
+	// message is errMsg with %TOKEN% replaced by the presented bearer token.
+	errMsg string
+
+	gotAuth    string
+	gotSandbox string
+	gotCommand string
+}
+
+func (f *connectExecFake) ExecStream(_ context.Context, req *connect.Request[sandboxv1.ExecStreamRequest], stream *connect.ServerStream[sandboxv1.ExecResponse]) error {
+	f.gotAuth = req.Header().Get("Authorization")
+	f.gotSandbox = req.Header().Get("X-Sandbox-Id")
+	f.gotCommand = req.Msg.GetCommand()
+	if f.errMsg != "" {
+		presented := strings.TrimPrefix(f.gotAuth, "Bearer ")
+		return connect.NewError(connect.CodeInternal, execErrString(strings.ReplaceAll(f.errMsg, "%TOKEN%", presented)))
+	}
+	if f.stdout != "" {
+		if err := stream.Send(&sandboxv1.ExecResponse{Msg: &sandboxv1.ExecResponse_Stdout{Stdout: []byte(f.stdout)}}); err != nil {
+			return err
+		}
+	}
+	if f.stderr != "" {
+		if err := stream.Send(&sandboxv1.ExecResponse{Msg: &sandboxv1.ExecResponse_Stderr{Stderr: []byte(f.stderr)}}); err != nil {
+			return err
+		}
+	}
+	return stream.Send(&sandboxv1.ExecResponse{Msg: &sandboxv1.ExecResponse_Exit{Exit: &sandboxv1.ExecExit{ExitCode: f.exit}}})
+}
+
+type execErrString string
+
+func (e execErrString) Error() string { return string(e) }
+
+// connectExecServer mounts the fake Connect Sandbox handler on an HTTP/1.1
+// httptest server.
+func connectExecServer(t *testing.T, fake *connectExecFake) *httptest.Server {
+	t.Helper()
+	path, handler := sandboxv1connect.NewSandboxHandler(fake)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
 
 func testScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -179,22 +237,10 @@ func TestClusterBackendForkCreatesFork(t *testing.T) {
 
 func TestClusterBackendExecSendsBearerAndRedactsToken(t *testing.T) {
 	const token = "super-secret-token-value"
-	var gotAuth string
-	var gotBody map[string]any
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		b, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(b, &gotBody)
-		if r.URL.Path == "/v1/exec" {
-			// Echo the token back in the error to prove redaction protects it.
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(`{"error":"boom token=` + token + `"}`))
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer srv.Close()
+	// The Connect runtime server echoes the presented bearer token into its error
+	// message; the backend must redact it before surfacing the error.
+	connFake := &connectExecFake{errMsg: "boom token=%TOKEN%"}
+	srv := connectExecServer(t, connFake)
 
 	endpoint := strings.TrimPrefix(srv.URL, "http://")
 	scheme := testScheme(t)
@@ -211,7 +257,7 @@ func TestClusterBackendExecSendsBearerAndRedactsToken(t *testing.T) {
 
 	_, err := be.Exec(context.Background(), "sbx-1", "echo hi", 10)
 	if err == nil {
-		t.Fatalf("Exec: want an error from the 500 response")
+		t.Fatalf("Exec: want an error from the failed exec RPC")
 	}
 	if strings.Contains(err.Error(), token) {
 		t.Fatalf("error leaked the token: %q", err.Error())
@@ -219,21 +265,20 @@ func TestClusterBackendExecSendsBearerAndRedactsToken(t *testing.T) {
 	if !strings.Contains(err.Error(), "REDACTED") {
 		t.Fatalf("error should show the token redacted, got: %q", err.Error())
 	}
-	if gotAuth != "Bearer "+token {
-		t.Fatalf("Authorization header = %q, want bearer token", gotAuth)
+	// The exec rode the Connect runtime path with the bearer token and the
+	// sandbox id on the headers (the SAME gate the SDK uses).
+	if connFake.gotAuth != "Bearer "+token {
+		t.Fatalf("Authorization header = %q, want bearer token", connFake.gotAuth)
 	}
-	if gotBody["command"] != "echo hi" || gotBody["sandbox"] != "sbx-1" {
-		t.Fatalf("exec body = %v, want sandbox/command set", gotBody)
+	if connFake.gotCommand != "echo hi" || connFake.gotSandbox != "sbx-1" {
+		t.Fatalf("exec command = %q, sandbox = %q, want 'echo hi' / sbx-1", connFake.gotCommand, connFake.gotSandbox)
 	}
 }
 
 func TestClusterBackendExecSuccess(t *testing.T) {
 	const token = "tkn"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"exit_code":5,"stdout":"out","stderr":"err"}`))
-	}))
-	defer srv.Close()
+	connFake := &connectExecFake{stdout: "out", stderr: "err", exit: 5}
+	srv := connectExecServer(t, connFake)
 	endpoint := strings.TrimPrefix(srv.URL, "http://")
 
 	scheme := testScheme(t)

--- a/internal/mcp/httpbackend.go
+++ b/internal/mcp/httpbackend.go
@@ -6,12 +6,17 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	connect "connectrpc.com/connect"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 )
 
 // sandboxIDRe is the allowlist for sandbox ids received from tool arguments
@@ -27,11 +32,18 @@ func validSandboxID(id string) bool {
 	return sandboxIDRe.MatchString(id)
 }
 
-// HTTPBackend implements SandboxBackend over the standalone sandbox-server REST
-// API (cmd/sandbox-server). It is the simplest real backend: one process, plain
-// HTTP, a single launch-time bearer token. A Kubernetes claim backend (create a
-// SandboxClaim, read its token Secret, exec via forkd) is a planned follow-up
-// and is intentionally not implemented here.
+// HTTPBackend implements SandboxBackend over the standalone sandbox-server. It
+// is the simplest real backend: one process, plain HTTP, a single launch-time
+// bearer token. A Kubernetes claim backend (create a SandboxClaim, read its
+// token Secret, exec via forkd) is a planned follow-up and is intentionally not
+// implemented here.
+//
+// Transport split (issue #358): the runtime calls (exec, file read, file write)
+// ride the Connect sandbox.v1.Sandbox protocol via the in-module generated
+// connect-go client (ExecStream, ReadFile, WriteFile RPCs); the lifecycle calls
+// (fork, terminate) stay on the legacy /v1 JSON routes via do. Both reach the
+// same baseURL with the same bearer token; the sandbox id rides the
+// X-Sandbox-Id header on the runtime RPCs.
 //
 // Token scoping: every request carries the launch-time bearer token, so the MCP
 // server can do exactly what that token authorizes on the sandbox-server and
@@ -152,61 +164,137 @@ func (b *HTTPBackend) Create(ctx context.Context, pool string) (string, error) {
 	return id, nil
 }
 
-type execResponse struct {
-	ExitCode int    `json:"exit_code"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
+// sandboxClient builds a Connect client for the runtime RPCs against baseURL,
+// mirroring cmd/kubectl-mitos/exec.go and bench/claim/main.go. The per-sandbox
+// bearer token and sandbox id are set as request headers by each caller, not
+// here, so this stays a thin constructor.
+func (b *HTTPBackend) sandboxClient() sandboxv1connect.SandboxClient {
+	return sandboxv1connect.NewSandboxClient(b.client, b.baseURL)
 }
 
-// Exec runs command in the sandbox via POST /v1/exec. A timeoutSec of 0 omits
-// the field so the server default applies.
+// runtimeHeaders sets the Authorization and X-Sandbox-Id headers on a Connect
+// request. The token is sent only when non-empty, matching the legacy do
+// behavior; the token VALUE is never logged.
+func (b *HTTPBackend) runtimeHeaders(h http.Header, sandboxID string) {
+	if b.token != "" {
+		h.Set("Authorization", "Bearer "+b.token)
+	}
+	h.Set("X-Sandbox-Id", sandboxID)
+}
+
+// connectError maps a Connect runtime failure to the backend's error shape. A
+// connect unauthenticated code becomes the same auth error the legacy /v1 path
+// produced (a 401 from the bearer-token gate); any other failure is wrapped
+// with op as context. The token value is redacted from any wrapped cause so it
+// never reaches an error string a caller, a log, or an LLM might see.
+func (b *HTTPBackend) connectError(op string, err error) error {
+	if connect.CodeOf(err) == connect.CodeUnauthenticated {
+		return fmt.Errorf("%s: status 401: %s", op, b.redact(err.Error()))
+	}
+	return errors.New(op + ": " + b.redact(err.Error()))
+}
+
+// Exec runs command in the sandbox over the Connect sandbox.v1.Sandbox/ExecStream
+// RPC (the HTTP/1.1-reachable non-interactive exec). It drains the server stream,
+// accumulating stdout and stderr chunks and reading the terminal exit code, then
+// folds the result into ExecResult. A timeoutSec of 0 passes 0 so the guest
+// default applies.
 func (b *HTTPBackend) Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (ExecResult, error) {
 	if !validSandboxID(sandboxID) {
 		return ExecResult{}, fmt.Errorf("exec: invalid sandbox id %q", sandboxID)
 	}
-	reqBody := map[string]any{
-		"sandbox": sandboxID,
-		"command": command,
-	}
+	timeout := 0
 	if timeoutSec > 0 {
-		reqBody["timeout"] = timeoutSec
+		timeout = timeoutSec
 	}
-	var resp execResponse
-	if err := b.do(ctx, http.MethodPost, "/v1/exec", reqBody, &resp); err != nil {
-		return ExecResult{}, err
+	req := connect.NewRequest(&sandboxv1.ExecStreamRequest{
+		Command:        command,
+		TimeoutSeconds: int32(timeout),
+	})
+	b.runtimeHeaders(req.Header(), sandboxID)
+
+	stream, err := b.sandboxClient().ExecStream(ctx, req)
+	if err != nil {
+		return ExecResult{}, b.connectError("exec", err)
 	}
-	return ExecResult(resp), nil
+	defer func() { _ = stream.Close() }()
+
+	var res ExecResult
+	var stdout, stderr strings.Builder
+	for stream.Receive() {
+		msg := stream.Msg()
+		if out := msg.GetStdout(); len(out) > 0 {
+			stdout.Write(out)
+		}
+		if errOut := msg.GetStderr(); len(errOut) > 0 {
+			stderr.Write(errOut)
+		}
+		if exit := msg.GetExit(); exit != nil {
+			res.ExitCode = int(exit.GetExitCode())
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return ExecResult{}, b.connectError("exec", err)
+	}
+	res.Stdout = stdout.String()
+	res.Stderr = stderr.String()
+	return res, nil
 }
 
-type readFileResponse struct {
-	Content string `json:"content"`
-}
-
-// ReadFile reads path from the sandbox via POST /v1/files/read.
+// ReadFile reads path from the sandbox over the Connect
+// sandbox.v1.Sandbox/ReadFile RPC, concatenating the streamed byte chunks into
+// the returned string.
 func (b *HTTPBackend) ReadFile(ctx context.Context, sandboxID, path string) (string, error) {
 	if !validSandboxID(sandboxID) {
 		return "", fmt.Errorf("read_file: invalid sandbox id %q", sandboxID)
 	}
-	var resp readFileResponse
-	if err := b.do(ctx, http.MethodPost, "/v1/files/read", map[string]any{
-		"sandbox": sandboxID,
-		"path":    path,
-	}, &resp); err != nil {
-		return "", err
+	req := connect.NewRequest(&sandboxv1.ReadFileRequest{Path: path})
+	b.runtimeHeaders(req.Header(), sandboxID)
+
+	stream, err := b.sandboxClient().ReadFile(ctx, req)
+	if err != nil {
+		return "", b.connectError("read_file", err)
 	}
-	return resp.Content, nil
+	defer func() { _ = stream.Close() }()
+
+	var content bytes.Buffer
+	for stream.Receive() {
+		if data := stream.Msg().GetData(); len(data) > 0 {
+			content.Write(data)
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return "", b.connectError("read_file", err)
+	}
+	return content.String(), nil
 }
 
-// WriteFile writes content to path in the sandbox via POST /v1/files/write.
+// WriteFile writes content to path in the sandbox over the Connect
+// sandbox.v1.Sandbox/WriteFile RPC: the first message carries the path (the
+// guest applies its default mode), then a single content chunk.
 func (b *HTTPBackend) WriteFile(ctx context.Context, sandboxID, path, content string) error {
 	if !validSandboxID(sandboxID) {
 		return fmt.Errorf("write_file: invalid sandbox id %q", sandboxID)
 	}
-	return b.do(ctx, http.MethodPost, "/v1/files/write", map[string]any{
-		"sandbox": sandboxID,
-		"path":    path,
-		"content": content,
-	}, nil)
+	stream := b.sandboxClient().WriteFile(ctx)
+	b.runtimeHeaders(stream.RequestHeader(), sandboxID)
+
+	if err := stream.Send(&sandboxv1.WriteFileRequest{
+		Msg: &sandboxv1.WriteFileRequest_Open{Open: &sandboxv1.WriteFileOpen{Path: path}},
+	}); err != nil {
+		return b.connectError("write_file", err)
+	}
+	if len(content) > 0 {
+		if err := stream.Send(&sandboxv1.WriteFileRequest{
+			Msg: &sandboxv1.WriteFileRequest_Data{Data: []byte(content)},
+		}); err != nil {
+			return b.connectError("write_file", err)
+		}
+	}
+	if _, err := stream.CloseAndReceive(); err != nil {
+		return b.connectError("write_file", err)
+	}
+	return nil
 }
 
 // Fork forks the sandbox replicas times. The sandbox-server fork endpoint has

--- a/internal/mcp/httpbackend_test.go
+++ b/internal/mcp/httpbackend_test.go
@@ -3,12 +3,137 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	connect "connectrpc.com/connect"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 )
+
+// fakeSandbox is a Connect sandbox.v1.Sandbox handler for the runtime RPCs the
+// HTTPBackend now rides (issue #358). It implements ExecStream, ReadFile, and
+// WriteFile with canned data and records the Authorization and X-Sandbox-Id
+// headers and request fields each call carried so tests can assert auth and
+// round-trip. requireToken, when set, rejects any call whose bearer token does
+// not match with connect CodeUnauthenticated, modeling the forkd token gate.
+type fakeSandbox struct {
+	sandboxv1connect.UnimplementedSandboxHandler
+
+	requireToken string
+
+	// recorded inputs.
+	execAuth       string
+	execSandboxID  string
+	execCommand    string
+	execTimeout    int32
+	readAuth       string
+	readSandboxID  string
+	readPath       string
+	writeAuth      string
+	writeSandboxID string
+	writePath      string
+	writeContent   []byte
+
+	// canned exec output.
+	execStdout   string
+	execStderr   string
+	execExitCode int32
+	// canned file content for ReadFile.
+	readContent string
+}
+
+func (f *fakeSandbox) checkToken(h http.Header) error {
+	if f.requireToken == "" {
+		return nil
+	}
+	if h.Get("Authorization") != "Bearer "+f.requireToken {
+		// Hostile-server modeling: echo the presented Authorization header (which
+		// carries the client's bearer token) into the error so the leak test can
+		// prove the backend redacts it before surfacing the error.
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("rejected: "+h.Get("Authorization")))
+	}
+	return nil
+}
+
+func (f *fakeSandbox) ExecStream(_ context.Context, req *connect.Request[sandboxv1.ExecStreamRequest], stream *connect.ServerStream[sandboxv1.ExecResponse]) error {
+	if err := f.checkToken(req.Header()); err != nil {
+		return err
+	}
+	f.execAuth = req.Header().Get("Authorization")
+	f.execSandboxID = req.Header().Get("X-Sandbox-Id")
+	f.execCommand = req.Msg.GetCommand()
+	f.execTimeout = req.Msg.GetTimeoutSeconds()
+	if f.execStdout != "" {
+		if err := stream.Send(&sandboxv1.ExecResponse{Msg: &sandboxv1.ExecResponse_Stdout{Stdout: []byte(f.execStdout)}}); err != nil {
+			return err
+		}
+	}
+	if f.execStderr != "" {
+		if err := stream.Send(&sandboxv1.ExecResponse{Msg: &sandboxv1.ExecResponse_Stderr{Stderr: []byte(f.execStderr)}}); err != nil {
+			return err
+		}
+	}
+	return stream.Send(&sandboxv1.ExecResponse{Msg: &sandboxv1.ExecResponse_Exit{Exit: &sandboxv1.ExecExit{ExitCode: f.execExitCode}}})
+}
+
+func (f *fakeSandbox) ReadFile(_ context.Context, req *connect.Request[sandboxv1.ReadFileRequest], stream *connect.ServerStream[sandboxv1.Chunk]) error {
+	if err := f.checkToken(req.Header()); err != nil {
+		return err
+	}
+	f.readAuth = req.Header().Get("Authorization")
+	f.readSandboxID = req.Header().Get("X-Sandbox-Id")
+	f.readPath = req.Msg.GetPath()
+	if f.readContent != "" {
+		if err := stream.Send(&sandboxv1.Chunk{Data: []byte(f.readContent)}); err != nil {
+			return err
+		}
+	}
+	return stream.Send(&sandboxv1.Chunk{Eof: true})
+}
+
+func (f *fakeSandbox) WriteFile(_ context.Context, stream *connect.ClientStream[sandboxv1.WriteFileRequest]) (*connect.Response[sandboxv1.WriteFileResult], error) {
+	if err := f.checkToken(stream.RequestHeader()); err != nil {
+		return nil, err
+	}
+	f.writeAuth = stream.RequestHeader().Get("Authorization")
+	f.writeSandboxID = stream.RequestHeader().Get("X-Sandbox-Id")
+	var written int64
+	for stream.Receive() {
+		msg := stream.Msg()
+		if open := msg.GetOpen(); open != nil {
+			f.writePath = open.GetPath()
+		}
+		if data := msg.GetData(); len(data) > 0 {
+			f.writeContent = append(f.writeContent, data...)
+			written += int64(len(data))
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&sandboxv1.WriteFileResult{BytesWritten: written}), nil
+}
+
+// connectServer stands up an httptest.Server that serves the Connect
+// sandbox.v1.Sandbox handler (runtime RPCs) AND the legacy /v1/fork and
+// /v1/sandboxes/ lifecycle JSON routes on one mux, so a single HTTPBackend can
+// exercise both transports against one baseURL. lifecycle handles the legacy
+// routes; it may be nil when a test needs only the runtime RPCs.
+func connectServer(t *testing.T, fake *fakeSandbox, lifecycle http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, handler := sandboxv1connect.NewSandboxHandler(fake)
+	mux.Handle(path, handler)
+	if lifecycle != nil {
+		mux.HandleFunc("/v1/", lifecycle)
+	}
+	return httptest.NewServer(mux)
+}
 
 // capturedRequest records what the backend sent so assertions can inspect the
 // method, path, headers, and decoded body of each HTTP call.
@@ -77,11 +202,13 @@ func TestHTTPBackendCreate(t *testing.T) {
 	}
 }
 
+// TestHTTPBackendExec asserts Exec rides the Connect ExecStream RPC: it folds
+// stdout chunks and the terminal exit code into ExecResult, passes the timeout
+// through, and carries BOTH the bearer token (Authorization) and the sandbox id
+// (X-Sandbox-Id) on the request.
 func TestHTTPBackendExec(t *testing.T) {
-	var got []capturedRequest
-	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
-		return http.StatusOK, map[string]any{"exit_code": 7, "stdout": "out", "stderr": "err"}
-	})
+	fake := &fakeSandbox{execStdout: "out", execStderr: "err", execExitCode: 7}
+	srv := connectServer(t, fake, nil)
 	defer srv.Close()
 
 	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
@@ -92,26 +219,41 @@ func TestHTTPBackendExec(t *testing.T) {
 	if res.ExitCode != 7 || res.Stdout != "out" || res.Stderr != "err" {
 		t.Fatalf("Exec result = %+v", res)
 	}
-	req := got[0]
-	if req.Method != http.MethodPost || req.Path != "/v1/exec" {
-		t.Fatalf("Exec sent %s %s, want POST /v1/exec", req.Method, req.Path)
+	if fake.execAuth != "Bearer tok-123" {
+		t.Fatalf("Exec Authorization = %q, want Bearer tok-123", fake.execAuth)
 	}
-	if req.Auth != "Bearer tok-123" {
-		t.Fatalf("Exec auth = %q", req.Auth)
+	if fake.execSandboxID != "sbx-1" {
+		t.Fatalf("Exec X-Sandbox-Id = %q, want sbx-1", fake.execSandboxID)
 	}
-	if req.Body["sandbox"] != "sbx-1" || req.Body["command"] != "echo hi" {
-		t.Fatalf("Exec body = %v", req.Body)
+	if fake.execCommand != "echo hi" {
+		t.Fatalf("Exec command = %q, want echo hi", fake.execCommand)
 	}
-	if req.Body["timeout"] != float64(12) {
-		t.Fatalf("Exec timeout = %v, want 12", req.Body["timeout"])
+	if fake.execTimeout != 12 {
+		t.Fatalf("Exec timeout = %d, want 12", fake.execTimeout)
 	}
 }
 
+// TestHTTPBackendExecZeroTimeout asserts a timeoutSec of 0 passes 0 on the wire
+// so the guest default applies.
+func TestHTTPBackendExecZeroTimeout(t *testing.T) {
+	fake := &fakeSandbox{execExitCode: 0}
+	srv := connectServer(t, fake, nil)
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	if _, err := b.Exec(context.Background(), "sbx-1", "true", 0); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if fake.execTimeout != 0 {
+		t.Fatalf("Exec timeout = %d, want 0", fake.execTimeout)
+	}
+}
+
+// TestHTTPBackendReadFile asserts ReadFile rides the Connect ReadFile RPC,
+// concatenating the streamed chunks, and carries both auth headers.
 func TestHTTPBackendReadFile(t *testing.T) {
-	var got []capturedRequest
-	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
-		return http.StatusOK, map[string]any{"content": "hello", "size": 5}
-	})
+	fake := &fakeSandbox{readContent: "hello"}
+	srv := connectServer(t, fake, nil)
 	defer srv.Close()
 
 	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
@@ -122,32 +264,40 @@ func TestHTTPBackendReadFile(t *testing.T) {
 	if content != "hello" {
 		t.Fatalf("ReadFile content = %q", content)
 	}
-	req := got[0]
-	if req.Method != http.MethodPost || req.Path != "/v1/files/read" {
-		t.Fatalf("ReadFile sent %s %s, want POST /v1/files/read", req.Method, req.Path)
+	if fake.readAuth != "Bearer tok-123" {
+		t.Fatalf("ReadFile Authorization = %q", fake.readAuth)
 	}
-	if req.Body["sandbox"] != "sbx-1" || req.Body["path"] != "/etc/hosts" {
-		t.Fatalf("ReadFile body = %v", req.Body)
+	if fake.readSandboxID != "sbx-1" {
+		t.Fatalf("ReadFile X-Sandbox-Id = %q, want sbx-1", fake.readSandboxID)
+	}
+	if fake.readPath != "/etc/hosts" {
+		t.Fatalf("ReadFile path = %q, want /etc/hosts", fake.readPath)
 	}
 }
 
+// TestHTTPBackendWriteFile asserts WriteFile rides the Connect WriteFile
+// client-stream RPC: the open carries the path, the content round-trips, and
+// both auth headers ride the request.
 func TestHTTPBackendWriteFile(t *testing.T) {
-	var got []capturedRequest
-	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
-		return http.StatusOK, map[string]any{"status": "ok"}
-	})
+	fake := &fakeSandbox{}
+	srv := connectServer(t, fake, nil)
 	defer srv.Close()
 
 	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
 	if err := b.WriteFile(context.Background(), "sbx-1", "/tmp/x", "data"); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	req := got[0]
-	if req.Method != http.MethodPost || req.Path != "/v1/files/write" {
-		t.Fatalf("WriteFile sent %s %s, want POST /v1/files/write", req.Method, req.Path)
+	if fake.writeAuth != "Bearer tok-123" {
+		t.Fatalf("WriteFile Authorization = %q", fake.writeAuth)
 	}
-	if req.Body["sandbox"] != "sbx-1" || req.Body["path"] != "/tmp/x" || req.Body["content"] != "data" {
-		t.Fatalf("WriteFile body = %v", req.Body)
+	if fake.writeSandboxID != "sbx-1" {
+		t.Fatalf("WriteFile X-Sandbox-Id = %q, want sbx-1", fake.writeSandboxID)
+	}
+	if fake.writePath != "/tmp/x" {
+		t.Fatalf("WriteFile path = %q, want /tmp/x", fake.writePath)
+	}
+	if string(fake.writeContent) != "data" {
+		t.Fatalf("WriteFile content = %q, want data", string(fake.writeContent))
 	}
 }
 
@@ -257,15 +407,14 @@ func TestHTTPBackendNon2xxIsError(t *testing.T) {
 
 // TestHTTPBackendNeverLeaksToken asserts the token never appears in an error
 // returned to the caller, even when the server echoes the Authorization header
-// back in its error body. The backend must not log; this test guards the error
-// path, the only string the backend surfaces.
+// (which carries the token) back in its error message. The backend must not
+// log; this test guards the error path, the only string the backend surfaces.
 func TestHTTPBackendNeverLeaksToken(t *testing.T) {
 	const token = "super-secret-token-value"
-	var got []capturedRequest
-	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
-		// Hostile server echoes the presented auth header into its error body.
-		return http.StatusInternalServerError, map[string]any{"error": cr.Auth}
-	})
+	// The fake requires a DIFFERENT token, so the presented (correct-for-client)
+	// token is rejected and echoed into the connect error message.
+	fake := &fakeSandbox{requireToken: "the-expected-token"}
+	srv := connectServer(t, fake, nil)
 	defer srv.Close()
 
 	b := NewHTTPBackend(srv.URL, token, srv.Client())
@@ -275,6 +424,28 @@ func TestHTTPBackendNeverLeaksToken(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), token) {
 		t.Fatalf("token leaked into error: %q", err.Error())
+	}
+}
+
+// TestHTTPBackendExecAuthError asserts a rejected bearer token (connect
+// unauthenticated) maps to an auth error that names the 401 status, mirroring
+// the legacy /v1 bearer-token gate, and never leaks the token.
+func TestHTTPBackendExecAuthError(t *testing.T) {
+	const token = "client-token"
+	fake := &fakeSandbox{requireToken: "server-expects-other"}
+	srv := connectServer(t, fake, nil)
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, token, srv.Client())
+	_, err := b.Exec(context.Background(), "sbx-1", "x", 0)
+	if err == nil {
+		t.Fatal("expected an auth error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("auth error should name 401, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("token leaked into auth error: %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
Part of the #358 full `/v1` retirement (chosen path). The `mitos-mcp` server's HTTP backend (`internal/mcp/httpbackend.go`) was a live caller of the legacy `/v1` runtime routes; migrate its runtime calls to Connect so those routes can be removed.

- `Exec` -> Connect `ExecStream` (folds stdout/stderr + exit); `ReadFile`/`WriteFile` -> the `ReadFile`/`WriteFile` RPCs. Each sets `Authorization: Bearer` + `X-Sandbox-Id`; a connect `unauthenticated` maps to the same auth error, token redacted.
- `Create`/`Fork` (`/v1/fork`) and `Terminate` (`DELETE /v1/sandboxes/{id}`) stay on the lifecycle routes (not being removed).
- Tests move to a Connect test server (`NewSandboxHandler` over a fake `ExecStream`/`ReadFile`/`WriteFile`), asserting the exec fold, both auth headers, file round-trips, and token-redacted auth errors.

`go build`/`test`/`vet` + both `golangci-lint` runs clean. This merges before the `/v1` route-removal PR (#390).

🤖 Generated with [Claude Code](https://claude.com/claude-code)