### PR TITLE
fix(chart): emit console OIDC redirect URL and add console.extraEnv

### DIFF
--- a/deploy/charts/charttest/console_test.go
+++ b/deploy/charts/charttest/console_test.go
@@ -98,6 +98,30 @@ func TestGatewayGatedByEnabled(t *testing.T) {
 	}
 }
 
+// TestConsoleOIDCRedirectURL asserts the chart emits MITOS_CONSOLE_OIDC_REDIRECT_URL
+// when console.oidc.redirectURL is set. The console sends this value as the OAuth
+// redirect_uri; without it the IdP rejects the login, so OIDC is unusable via the
+// chart.
+func TestConsoleOIDCRedirectURL(t *testing.T) {
+	out := render(t, "console.oidc.redirectURL=https://app.mitos.run/auth/callback")
+	mustEnv(t, out, "MITOS_CONSOLE_OIDC_REDIRECT_URL", "https://app.mitos.run/auth/callback")
+}
+
+// TestConsoleOIDCRedirectURLOmittedByDefault asserts the redirect env is absent
+// when redirectURL is unset, so installs that do not use OIDC are unaffected.
+func TestConsoleOIDCRedirectURLOmittedByDefault(t *testing.T) {
+	if strings.Contains(render(t), "MITOS_CONSOLE_OIDC_REDIRECT_URL") {
+		t.Fatal("MITOS_CONSOLE_OIDC_REDIRECT_URL rendered when console.oidc.redirectURL is unset")
+	}
+}
+
+// TestConsoleExtraEnv asserts arbitrary console.extraEnv entries pass through, so
+// operators can inject env the chart does not model.
+func TestConsoleExtraEnv(t *testing.T) {
+	out := render(t, "console.extraEnv[0].name=MITOS_CONSOLE_CUSTOM", "console.extraEnv[0].value=on")
+	mustEnv(t, out, "MITOS_CONSOLE_CUSTOM", "on")
+}
+
 func mustContain(t *testing.T, out, want string) {
 	t.Helper()
 	if !strings.Contains(out, want) {

--- a/deploy/charts/mitos/templates/console.yaml
+++ b/deploy/charts/mitos/templates/console.yaml
@@ -123,6 +123,10 @@ spec:
                   name: {{ .Values.console.oidc.clientSecretRef }}
                   key: client-secret
             {{- end }}
+            {{- if .Values.console.oidc.redirectURL }}
+            - name: MITOS_CONSOLE_OIDC_REDIRECT_URL
+              value: {{ .Values.console.oidc.redirectURL | quote }}
+            {{- end }}
             - name: MITOS_CONSOLE_SECRET_PROVIDERS
               value: {{ include "mitos.console.secretProviders" . | quote }}
             {{- if .Values.console.secrets.openbao.enabled }}
@@ -130,6 +134,9 @@ spec:
               value: {{ .Values.console.secrets.openbao.address | quote }}
             - name: MITOS_CONSOLE_OPENBAO_PER_ORG
               value: {{ .Values.console.secrets.openbao.perOrg | quote }}
+            {{- end }}
+            {{- with .Values.console.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -250,6 +250,15 @@ console:
     clientID: ""
     # Name of an existing Secret with key "client-secret". Empty omits it.
     clientSecretRef: ""
+    # The OAuth redirect_uri the console sends to the IdP and that the IdP must
+    # have registered. The console mounts its callback at /auth/callback, so this
+    # is normally https://<console-host>/auth/callback. Empty omits the env var
+    # (installs without OIDC are unaffected); when OIDC is configured this MUST be
+    # set or the login flow fails with an empty redirect_uri.
+    redirectURL: ""
+  # Extra env vars appended verbatim to the console container, for env the chart
+  # does not model (mirrors controller.extraEnv).
+  extraEnv: []
   # Secret-store providers advertised in capabilities and wired into the binary.
   secrets:
     kube:


### PR DESCRIPTION
## What

The console binary reads `MITOS_CONSOLE_OIDC_REDIRECT_URL` (internal/saas/oidcauth/verifier.go) and sends it as the OAuth `redirect_uri`. Chart v0.13.0 emitted the issuer, client id, and client secret but NOT the redirect URL, and the console block had no `extraEnv` hook, so OIDC login could not complete via the chart (an empty `redirect_uri` is rejected by the IdP).

## Change

- Add `console.oidc.redirectURL` to values; emit `MITOS_CONSOLE_OIDC_REDIRECT_URL` only when set, so installs without OIDC are unaffected.
- Add a `console.extraEnv` passthrough mirroring `controller.extraEnv`.
- Cover both in the chart render suite (deploy/charts/charttest).

Found while standing up the first prod-QA deployment. No security surface change (env passthrough only).

Closes #398