### PR TITLE
feat(saas): real hosted control plane (gateway creates + proxies real sandboxes)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,15 +2,15 @@
 // offering (issue #210). It terminates customer API key authentication, resolves
 // the owning organization, attaches an org context, enforces quota through the
 // QuotaEnforcer seam (issue #213 implements the real enforcer), and forwards
-// authenticated, org-scoped requests to the control plane through the
-// ControlPlane seam. It sits ABOVE the internal mTLS and per-sandbox token
-// plane; it does not replace it.
+// authenticated, org-scoped requests to the control plane. By default it forwards
+// to the REAL control plane (internal/saas/controlplane), which turns an
+// org-scoped request into Kubernetes actions on the mitos.run/v1 Sandbox kind and
+// reverse-proxies runtime calls (exec, files, run_code over Connect) to the
+// sandbox endpoint with the per-sandbox bearer token.
 //
-// This binary wires the in-memory store and a default-allow quota so it runs and
-// is smoke-testable end to end. The Postgres store, the real quota enforcer, the
-// real control-plane forward target, and TLS termination are documented
-// follow-ups (docs/saas/accounts-gateway.md). A customer key VALUE is never
-// logged; the gateway logs the key id, masked prefix, org id, and op only.
+// A customer key VALUE is never logged; the gateway logs the key id, masked
+// prefix, org id, and op only. The per-sandbox token is never logged and is
+// returned to the caller only on create.
 //
 // Production gate: this front door is NOT cleared for production tenants until
 // the external security review (issue #194) covers the public attack surface it
@@ -24,14 +24,24 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/saas"
+	"mitos.run/mitos/internal/saas/controlplane"
 )
 
-// stubControlPlane is the placeholder forward target this binary ships with: it
-// rejects every request with a clear message so an operator cannot mistake the
-// default build for a wired control plane. The real implementation forwards over
-// the internal mTLS plane to the controller and is a documented follow-up.
+// stubControlPlane is a dev-only forward target, selected with --allow-stub. It
+// rejects nothing and creates nothing: it echoes the resolved org and op so a
+// smoke test can confirm authn and org-resolution worked WITHOUT a live cluster.
+// It is never the default, so an operator cannot mistake a real deployment for a
+// wired control plane.
 type stubControlPlane struct{}
 
 func (stubControlPlane) Forward(_ context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
@@ -41,20 +51,65 @@ func (stubControlPlane) Forward(_ context.Context, req saas.ForwardRequest) (saa
 	return saas.ForwardResponse{Status: http.StatusOK, Body: body}, nil
 }
 
+// newScheme builds the scheme the control-plane client needs: corev1 (the
+// per-sandbox token Secret) and mitos.run/v1 (the Sandbox kind).
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	return scheme
+}
+
+// newControlPlane builds the real control plane over an in-cluster
+// controller-runtime client.
+func newControlPlane(readyTimeout time.Duration, defaultPool string) (saas.ControlPlane, error) {
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.New(cfg, client.Options{Scheme: newScheme()})
+	if err != nil {
+		return nil, err
+	}
+	opts := []controlplane.Option{controlplane.WithReadyTimeout(readyTimeout)}
+	if defaultPool != "" {
+		opts = append(opts, controlplane.WithDefaultPool(defaultPool))
+	}
+	return controlplane.New(c, opts...), nil
+}
+
 func main() {
 	addr := flag.String("addr", ":8080", "public listen address")
+	allowStub := flag.Bool("allow-stub", false, "DEV ONLY: forward to an in-memory stub control plane that creates nothing; the default is the real control plane")
+	readyTimeout := flag.Duration("ready-timeout", 120*time.Second, "how long a create waits for the sandbox to become Ready before returning a timeout error")
+	defaultPool := flag.String("default-pool", "", "fallback pool name used when a create request names neither a pool nor an image")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	// In-memory store and default-allow quota: the tested seams. Postgres and the
-	// real enforcer are documented follow-ups.
+	// real enforcer are documented follow-ups (other phases).
 	store := saas.NewMemStore()
 	keys := saas.NewKeyService(store)
-	gw := saas.NewGateway(keys, saas.AllowAllQuota{}, stubControlPlane{}, logger)
+
+	var cp saas.ControlPlane
+	if *allowStub {
+		logger.Warn("gateway running with the DEV stub control plane; no sandboxes are created (--allow-stub)")
+		cp = stubControlPlane{}
+	} else {
+		real, err := newControlPlane(*readyTimeout, *defaultPool)
+		if err != nil {
+			log.Fatalf("build control plane: %v", err)
+		}
+		cp = real
+		logger.Info("gateway using the real control plane", "ready_timeout", readyTimeout.String(), "default_pool", *defaultPool)
+	}
+
+	gw := saas.NewGateway(keys, saas.AllowAllQuota{}, cp, logger)
 
 	mux := http.NewServeMux()
 	mux.Handle("/v1/", gw)
+	mux.Handle("/sandbox.v1.Sandbox/", gw)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))

--- a/deploy/charts/charttest/gateway_test.go
+++ b/deploy/charts/charttest/gateway_test.go
@@ -1,0 +1,73 @@
+package charttest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGatewayServiceAccountRenders asserts the gateway ServiceAccount renders and
+// the gateway pod uses it: the real control plane needs an identity to bind its
+// ClusterRole to.
+func TestGatewayServiceAccountRenders(t *testing.T) {
+	out := render(t)
+	mustContain(t, out, "kind: ServiceAccount")
+	mustContain(t, out, "name: mitos-gateway")
+	mustContain(t, out, "serviceAccountName: mitos-gateway")
+}
+
+// TestGatewayRBACRenders asserts the gateway ClusterRole grants exactly the
+// least-privilege control-plane surface: Sandboxes lifecycle, SandboxPools read,
+// Secrets get (the per-sandbox token), and Namespaces get, bound to the gateway
+// ServiceAccount.
+func TestGatewayRBACRenders(t *testing.T) {
+	out := render(t)
+	clusterRole := section(t, out, "kind: ClusterRole\n", "mitos-gateway")
+	for _, want := range []string{"sandboxes", "sandboxpools", "secrets", "namespaces", "create", "delete"} {
+		if !strings.Contains(clusterRole, want) {
+			t.Errorf("gateway ClusterRole missing %q\n%s", want, clusterRole)
+		}
+	}
+	// The gateway must NOT grant write on Secrets: it only reads the token.
+	if strings.Contains(secretsRule(t, clusterRole), "update") || strings.Contains(secretsRule(t, clusterRole), "create") {
+		t.Error("gateway ClusterRole grants write on Secrets; it must only read the per-sandbox token")
+	}
+	mustContain(t, out, "kind: ClusterRoleBinding")
+}
+
+// TestGatewayRBACAbsentWhenDisabled asserts gateway.enabled=false removes the
+// gateway SA and RBAC along with the Deployment.
+func TestGatewayRBACAbsentWhenDisabled(t *testing.T) {
+	out := render(t, "gateway.enabled=false")
+	if strings.Contains(out, "name: mitos-gateway") {
+		t.Fatal("gateway.enabled=false still rendered a mitos-gateway resource")
+	}
+}
+
+// section returns the YAML document containing both marker and name, to scope an
+// assertion to one rendered resource.
+func section(t *testing.T, out, marker, name string) string {
+	t.Helper()
+	for _, doc := range strings.Split(out, "\n---") {
+		if strings.Contains(doc, marker) && strings.Contains(doc, "name: "+name) {
+			return doc
+		}
+	}
+	t.Fatalf("no rendered document with %q and name %q", marker, name)
+	return ""
+}
+
+// secretsRule returns the verbs block for the secrets resource within a rendered
+// ClusterRole, so a test can assert it is read-only.
+func secretsRule(t *testing.T, clusterRole string) string {
+	t.Helper()
+	idx := strings.Index(clusterRole, "- secrets")
+	if idx < 0 {
+		return ""
+	}
+	rest := clusterRole[idx:]
+	// Stop at the next resources block so we only see the secrets rule's verbs.
+	if next := strings.Index(rest[len("- secrets"):], "resources:"); next >= 0 {
+		return rest[:next]
+	}
+	return rest
+}

--- a/deploy/charts/mitos/templates/gateway-rbac.yaml
+++ b/deploy/charts/mitos/templates/gateway-rbac.yaml
@@ -1,0 +1,76 @@
+{{- /*
+RBAC for the public gateway's real control plane (ROADMAP SaaS P1). The gateway
+turns an authenticated, org-scoped customer request into Kubernetes actions on
+the mitos.run/v1 Sandbox kind and reads the per-sandbox token Secret to proxy
+runtime calls. It runs as its own ServiceAccount with a least-privilege
+ClusterRole: Sandboxes (the lifecycle verbs), SandboxPools (read, to validate a
+named pool), Secrets (get, the per-sandbox token only), and Namespaces (get, to
+surface a clear error when an org namespace is not provisioned). It does NOT get
+cluster-wide write on Secrets; it only reads the token Secret the controller
+wrote. Gated by gateway.enabled.
+*/}}
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mitos-gateway
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+{{- include "mitos.imagePullSecrets" . | nindent 0 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mitos-gateway
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+rules:
+  - apiGroups:
+      - mitos.run
+    resources:
+      - sandboxes
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - mitos.run
+    resources:
+      - sandboxpools
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mitos-gateway
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+subjects:
+  - kind: ServiceAccount
+    name: mitos-gateway
+    namespace: {{ include "mitos.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mitos-gateway
+{{- end }}

--- a/deploy/charts/mitos/templates/gateway.yaml
+++ b/deploy/charts/mitos/templates/gateway.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         {{- include "mitos.selectorLabels" (dict "root" . "component" "gateway") | nindent 8 }}
     spec:
+      serviceAccountName: mitos-gateway
       {{- include "mitos.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true

--- a/internal/saas/controlplane/controlplane.go
+++ b/internal/saas/controlplane/controlplane.go
@@ -1,0 +1,99 @@
+// Package controlplane is the real hosted control plane behind the public
+// gateway (issue #210, ROADMAP SaaS P1). It turns an authenticated, org-scoped
+// ForwardRequest into real Kubernetes actions on the mitos.run/v1 Sandbox kind
+// and reverse-proxies runtime calls (exec, files, run_code over the Connect
+// sandbox.v1.Sandbox service) to the sandbox endpoint with the per-sandbox
+// bearer token.
+//
+// Security: this is the cross-tenant boundary. The org id is taken ONLY from
+// ForwardRequest.OrgID (the gateway verified it from the customer key); a
+// customer can never influence it. Every Get, List, Delete, and proxy is scoped
+// to NamespaceForOrg(orgID) AND re-checks the mitos.run/org label on the object,
+// so a request that names another org's sandbox id returns not_found and never
+// mutates or reaches it. The per-sandbox token is read from the controller-owned
+// Secret and is returned to the caller ONLY on create (so the SDK can address the
+// sandbox directly); it is never logged and never placed in an error.
+package controlplane
+
+import (
+	"net/http"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Defaults for the readiness poll. A create call blocks until the sandbox is
+// Ready, Failed, or the timeout elapses; these bound that wait.
+const (
+	defaultReadyTimeout = 120 * time.Second
+	defaultPollInterval = 250 * time.Millisecond
+)
+
+// K8sControlPlane is the real ControlPlane. It holds a controller-runtime client
+// (the lifecycle path), an http.Client (the runtime reverse proxy), and config.
+type K8sControlPlane struct {
+	c            client.Client
+	httpClient   *http.Client
+	readyTimeout time.Duration
+	pollInterval time.Duration
+	// defaultPool is the pool a create request falls back to when it names neither
+	// a pool nor an image. Empty means a create without a pool is rejected.
+	defaultPool string
+	now          func() time.Time
+}
+
+// Option configures a K8sControlPlane.
+type Option func(*K8sControlPlane)
+
+// WithReadyTimeout sets the create readiness poll ceiling. A non-positive value
+// is ignored (the default stands).
+func WithReadyTimeout(d time.Duration) Option {
+	return func(k *K8sControlPlane) {
+		if d > 0 {
+			k.readyTimeout = d
+		}
+	}
+}
+
+// WithPollInterval sets the create readiness poll interval. A non-positive value
+// is ignored.
+func WithPollInterval(d time.Duration) Option {
+	return func(k *K8sControlPlane) {
+		if d > 0 {
+			k.pollInterval = d
+		}
+	}
+}
+
+// WithDefaultPool sets the fallback pool name used when a create request names
+// neither a pool nor an image.
+func WithDefaultPool(name string) Option {
+	return func(k *K8sControlPlane) { k.defaultPool = name }
+}
+
+// WithHTTPClient overrides the runtime-proxy HTTP client (tests inject one that
+// targets an httptest.Server).
+func WithHTTPClient(h *http.Client) Option {
+	return func(k *K8sControlPlane) {
+		if h != nil {
+			k.httpClient = h
+		}
+	}
+}
+
+// New builds a K8sControlPlane over the given controller-runtime client. The
+// client's scheme MUST have mitos.run/v1 and corev1 registered so the control
+// plane can read Sandboxes and the per-sandbox token Secret.
+func New(c client.Client, opts ...Option) *K8sControlPlane {
+	k := &K8sControlPlane{
+		c:            c,
+		httpClient:   &http.Client{Timeout: 0}, // no overall timeout: streams are long-lived.
+		readyTimeout: defaultReadyTimeout,
+		pollInterval: defaultPollInterval,
+		now:          time.Now,
+	}
+	for _, o := range opts {
+		o(k)
+	}
+	return k
+}

--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -1,0 +1,517 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/saas"
+	"mitos.run/mitos/internal/tenant"
+)
+
+const (
+	orgA = "alpha"
+	orgB = "bravo"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1: %v", err)
+	}
+	return scheme
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fakeclient.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithStatusSubresource(&v1.Sandbox{}).
+		WithObjects(objs...).
+		Build()
+}
+
+// readySandbox builds a Ready sandbox in the org namespace with the org label,
+// plus its token Secret.
+func readySandbox(org, name, endpoint, token string) (*v1.Sandbox, *corev1.Secret) {
+	ns := tenant.NamespaceForOrg(org)
+	sb := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    tenant.OrgLabels(org),
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "default"}}},
+		Status: v1.SandboxStatus{
+			Phase:    v1.SandboxReady,
+			Endpoint: endpoint,
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name + tokenSecretSuffix, Namespace: ns},
+		Data:       map[string][]byte{"token": []byte(token), "endpoint": []byte(endpoint)},
+	}
+	return sb, secret
+}
+
+func decodeBody(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode response %q: %v", string(b), err)
+	}
+	return m
+}
+
+// ----- create -----
+
+// TestCreateBuildsSandboxAndReturnsTokenOnReady asserts a create builds a
+// Sandbox in mitos-org-<org> with the org label and the right pool, polls to
+// Ready, and returns id+endpoint+token (the token comes from the Secret).
+func TestCreateBuildsSandboxAndReturnsTokenOnReady(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
+
+	// Flip the created sandbox to Ready and seed its token Secret in the
+	// background, mimicking the controller.
+	stop := flipToReadyWhenCreated(t, c, orgA, "10.1.2.3:9091", "tok-secret-value")
+	defer stop()
+
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"default","env":{"FOO":"bar"}}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	m := decodeBody(t, resp.Body)
+	if m["phase"] != "Ready" {
+		t.Errorf("phase = %v, want Ready", m["phase"])
+	}
+	if m["endpoint"] != "10.1.2.3:9091" {
+		t.Errorf("endpoint = %v", m["endpoint"])
+	}
+	if m["token"] != "tok-secret-value" {
+		t.Errorf("token = %v, want the Secret token", m["token"])
+	}
+	name, _ := m["id"].(string)
+	if !strings.HasPrefix(name, "sb-") {
+		t.Errorf("id = %v, want sb- prefix", m["id"])
+	}
+
+	// Verify the object: org namespace, org label, pool, env.
+	var sb v1.Sandbox
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgA), Name: name}, &sb); err != nil {
+		t.Fatalf("get created sandbox: %v", err)
+	}
+	if sb.Namespace != "mitos-org-alpha" {
+		t.Errorf("namespace = %q, want mitos-org-alpha", sb.Namespace)
+	}
+	if sb.Labels[tenant.OrgLabelKey] != orgA {
+		t.Errorf("org label = %q, want %q", sb.Labels[tenant.OrgLabelKey], orgA)
+	}
+	if sb.Spec.Source.PoolRef == nil || sb.Spec.Source.PoolRef.Name != "default" {
+		t.Errorf("poolRef = %+v, want default", sb.Spec.Source.PoolRef)
+	}
+	if len(sb.Spec.Env) != 1 || sb.Spec.Env[0].Name != "FOO" || sb.Spec.Env[0].Value != "bar" {
+		t.Errorf("env = %+v, want FOO=bar", sb.Spec.Env)
+	}
+}
+
+// TestCreateUsesDefaultPoolWhenUnset asserts a create with no pool/image uses the
+// configured default pool.
+func TestCreateUsesDefaultPoolWhenUnset(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second), WithDefaultPool("base"))
+	stop := flipToReadyWhenCreated(t, c, orgA, "1.2.3.4:9091", "tok")
+	defer stop()
+
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.create", Body: []byte(`{}`)})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	name := decodeBody(t, resp.Body)["id"].(string)
+	var sb v1.Sandbox
+	_ = c.Get(context.Background(), client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgA), Name: name}, &sb)
+	if sb.Spec.Source.PoolRef.Name != "base" {
+		t.Errorf("poolRef = %v, want base", sb.Spec.Source.PoolRef)
+	}
+}
+
+// TestCreateNoPoolNoDefaultRejected asserts a create with neither pool nor a
+// default is a 400-style LLM-legible error and creates nothing.
+func TestCreateNoPoolNoDefaultRejected(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c, WithPollInterval(5*time.Millisecond))
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.create", Body: []byte(`{}`)})
+	if resp.Status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", resp.Status, resp.Body)
+	}
+	var list v1.SandboxList
+	_ = c.List(context.Background(), &list)
+	if len(list.Items) != 0 {
+		t.Errorf("created %d sandboxes for a rejected request", len(list.Items))
+	}
+}
+
+// TestCreateFailedReturnsRejectionMessage asserts a Failed phase yields an
+// LLM-legible error carrying the rejection condition message.
+func TestCreateFailedReturnsRejectionMessage(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
+	stop := flipWhenCreated(t, c, orgA, func(sb *v1.Sandbox) {
+		sb.Status.Phase = v1.SandboxFailed
+		sb.Status.Conditions = []metav1.Condition{{
+			Type: "Ready", Status: metav1.ConditionFalse, Reason: "PoolMissing",
+			Message: "pool default was not found", LastTransitionTime: metav1.Now(),
+		}}
+	})
+	defer stop()
+
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"default"}`)})
+	if resp.Status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body = %s", resp.Status, resp.Body)
+	}
+	if !strings.Contains(string(resp.Body), "pool default was not found") {
+		t.Errorf("error body missing the rejection message: %s", resp.Body)
+	}
+}
+
+// TestCreateTimeoutReturnsClearError asserts a sandbox that never becomes Ready
+// times out with a 504-style error.
+func TestCreateTimeoutReturnsClearError(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(40*time.Millisecond))
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"default"}`)})
+	if resp.Status != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504; body = %s", resp.Status, resp.Body)
+	}
+	if !strings.Contains(string(resp.Body), "did not become ready") {
+		t.Errorf("timeout error not actionable: %s", resp.Body)
+	}
+}
+
+// TestCreateMissingNamespaceClearError asserts a missing org namespace surfaces a
+// clear error naming the org and never panics. The fake client does not enforce
+// namespace existence, so this drives the helper directly.
+func TestCreateMissingNamespaceClearError(t *testing.T) {
+	e := namespaceMissingErr("ghost", tenant.NamespaceForOrg("ghost"))
+	if e.Status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", e.Status)
+	}
+	if !strings.Contains(e.Cause, "mitos-org-ghost") || !strings.Contains(e.Cause, "ghost") {
+		t.Errorf("namespace error does not name the org: %q", e.Cause)
+	}
+}
+
+// ----- status / list / terminate -----
+
+func TestStatusReturnsOwnedSandbox(t *testing.T) {
+	sb, secret := readySandbox(orgA, "sb-aaaa", "10.0.0.1:9091", "tok")
+	c := newFakeClient(t, sb, secret)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.status", Path: "/v1/sandboxes/sb-aaaa"})
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	m := decodeBody(t, resp.Body)
+	if m["id"] != "sb-aaaa" || m["phase"] != "Ready" {
+		t.Errorf("status payload = %v", m)
+	}
+	if strings.Contains(string(resp.Body), "tok") {
+		t.Errorf("status leaked the token: %s", resp.Body)
+	}
+}
+
+func TestListReturnsOnlyCallerOrg(t *testing.T) {
+	a1, s1 := readySandbox(orgA, "sb-a1", "1.1.1.1:9091", "t1")
+	a2, s2 := readySandbox(orgA, "sb-a2", "1.1.1.2:9091", "t2")
+	b1, s3 := readySandbox(orgB, "sb-b1", "2.2.2.1:9091", "t3")
+	c := newFakeClient(t, a1, a2, b1, s1, s2, s3)
+	cp := New(c)
+
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.list", Path: "/v1/sandboxes"})
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	var out struct {
+		Sandboxes []map[string]any `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(out.Sandboxes) != 2 {
+		t.Fatalf("list returned %d sandboxes, want 2 (org A only)", len(out.Sandboxes))
+	}
+	for _, s := range out.Sandboxes {
+		if s["id"] == "sb-b1" {
+			t.Fatal("list leaked org B's sandbox to org A")
+		}
+	}
+}
+
+func TestTerminateDeletesOwnedSandbox(t *testing.T) {
+	sb, secret := readySandbox(orgA, "sb-del", "1.1.1.1:9091", "tok")
+	c := newFakeClient(t, sb, secret)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.terminate", Path: "/v1/sandboxes/sb-del"})
+	if resp.Status != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", resp.Status, resp.Body)
+	}
+	var got v1.Sandbox
+	err := c.Get(context.Background(), client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgA), Name: "sb-del"}, &got)
+	if err == nil {
+		t.Error("sandbox still exists after terminate")
+	}
+}
+
+// ----- CROSS-TENANT isolation (critical) -----
+
+// TestCrossTenantStatusIsNotFound asserts org A cannot read org B's sandbox: the
+// id resolves to 404, never leaking that it exists.
+func TestCrossTenantStatusIsNotFound(t *testing.T) {
+	b1, s3 := readySandbox(orgB, "sb-secret", "2.2.2.2:9091", "t")
+	c := newFakeClient(t, b1, s3)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.status", Path: "/v1/sandboxes/sb-secret"})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for cross-org status", resp.Status)
+	}
+}
+
+// TestCrossTenantTerminateIsNotFoundAndDoesNotDelete asserts org A cannot delete
+// org B's sandbox: 404 AND the object survives.
+func TestCrossTenantTerminateIsNotFoundAndDoesNotDelete(t *testing.T) {
+	b1, s3 := readySandbox(orgB, "sb-victim", "2.2.2.2:9091", "t")
+	c := newFakeClient(t, b1, s3)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.terminate", Path: "/v1/sandboxes/sb-victim"})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for cross-org terminate", resp.Status)
+	}
+	var got v1.Sandbox
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgB), Name: "sb-victim"}, &got); err != nil {
+		t.Fatalf("org B's sandbox was deleted by org A's terminate: %v", err)
+	}
+}
+
+// TestCrossTenantSameNamespaceMislabeledIsNotFound asserts that even an object
+// physically in org A's namespace but carrying a different org label is treated
+// as not-owned: the org-label re-check, not just the namespace, is the boundary.
+func TestCrossTenantSameNamespaceMislabeledIsNotFound(t *testing.T) {
+	// An object in mitos-org-alpha but labeled for org B (a defense-in-depth case).
+	sb := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sb-mislabeled",
+			Namespace: tenant.NamespaceForOrg(orgA),
+			Labels:    tenant.OrgLabels(orgB),
+		},
+	}
+	c := newFakeClient(t, sb)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.status", Path: "/v1/sandboxes/sb-mislabeled"})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for a mislabeled object", resp.Status)
+	}
+}
+
+// ----- runtime proxy -----
+
+// TestProxyForwardsWithTokenAndSandboxID asserts a runtime call reaches the
+// sandbox endpoint with Authorization: Bearer <token> and X-Sandbox-Id, streams
+// the request and response, and strips a client-supplied Authorization.
+func TestProxyForwardsWithTokenAndSandboxID(t *testing.T) {
+	var gotAuth, gotSandboxID, gotBody, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotSandboxID = r.Header.Get("X-Sandbox-Id")
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/connect+json")
+		_, _ = w.Write([]byte(`{"streamed":true}`))
+	}))
+	defer srv.Close()
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+	sb, secret := readySandbox(orgA, "sb-run", endpoint, "the-real-token")
+	c := newFakeClient(t, sb, secret)
+	cp := New(c, WithHTTPClient(srv.Client()))
+
+	hdr := http.Header{}
+	hdr.Set("X-Sandbox-Id", "sb-run")
+	hdr.Set("Content-Type", "application/json")
+	hdr.Set("Authorization", "Bearer attacker-supplied")
+
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID:      orgA,
+		Op:         "sandbox.runtime",
+		Path:       "/sandbox.v1.Sandbox/Exec",
+		Method:     http.MethodPost,
+		Header:     hdr,
+		BodyStream: strings.NewReader(`{"cmd":["echo","hi"]}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d", resp.Status)
+	}
+	if resp.BodyStream == nil {
+		t.Fatal("expected a streamed response body")
+	}
+	got, _ := io.ReadAll(resp.BodyStream)
+	_ = resp.BodyStream.Close()
+	if string(got) != `{"streamed":true}` {
+		t.Errorf("proxied body = %q", got)
+	}
+	if gotAuth != "Bearer the-real-token" {
+		t.Errorf("upstream Authorization = %q, want the per-sandbox token (client value must be stripped)", gotAuth)
+	}
+	if gotSandboxID != "sb-run" {
+		t.Errorf("upstream X-Sandbox-Id = %q", gotSandboxID)
+	}
+	if gotBody != `{"cmd":["echo","hi"]}` {
+		t.Errorf("upstream body = %q", gotBody)
+	}
+	if gotPath != "/sandbox.v1.Sandbox/Exec" {
+		t.Errorf("upstream path = %q", gotPath)
+	}
+}
+
+// TestProxyCrossOrgNeverReachesEndpoint asserts a runtime call naming another
+// org's sandbox is 404 AND never hits the endpoint.
+func TestProxyCrossOrgNeverReachesEndpoint(t *testing.T) {
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+	// Sandbox belongs to org B.
+	sb, secret := readySandbox(orgB, "sb-bonly", endpoint, "tok")
+	c := newFakeClient(t, sb, secret)
+	cp := New(c, WithHTTPClient(srv.Client()))
+
+	hdr := http.Header{}
+	hdr.Set("X-Sandbox-Id", "sb-bonly")
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.runtime", Path: "/sandbox.v1.Sandbox/Exec", Method: http.MethodPost, Header: hdr,
+		BodyStream: strings.NewReader("{}"),
+	})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for cross-org proxy", resp.Status)
+	}
+	if reached {
+		t.Fatal("cross-org runtime call REACHED the sandbox endpoint; the boundary failed")
+	}
+}
+
+// TestProxyUnknownSandboxIsNotFound asserts a runtime call for a sandbox that
+// does not exist for the caller org is 404.
+func TestProxyUnknownSandboxIsNotFound(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c)
+	hdr := http.Header{}
+	hdr.Set("X-Sandbox-Id", "sb-nope")
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.runtime", Path: "/sandbox.v1.Sandbox/Exec", Header: hdr})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.Status)
+	}
+}
+
+// TestTokenNeverAppearsInErrorOrNonCreateResponse asserts the per-sandbox token
+// is returned ONLY on create: status and list responses, and every error body,
+// are scanned and must not contain it.
+func TestTokenNeverAppearsInErrorOrNonCreateResponse(t *testing.T) {
+	const secretToken = "super-secret-token-value"
+	sb, secret := readySandbox(orgA, "sb-scan", "10.0.0.9:9091", secretToken)
+	c := newFakeClient(t, sb, secret)
+	cp := New(c)
+	ctx := context.Background()
+
+	// status (owned), list, and a cross-org status (404) must not leak the token.
+	for _, req := range []saas.ForwardRequest{
+		{OrgID: orgA, Op: "sandbox.status", Path: "/v1/sandboxes/sb-scan"},
+		{OrgID: orgA, Op: "sandbox.list", Path: "/v1/sandboxes"},
+		{OrgID: orgB, Op: "sandbox.status", Path: "/v1/sandboxes/sb-scan"},
+	} {
+		resp, _ := cp.Forward(ctx, req)
+		if strings.Contains(string(resp.Body), secretToken) {
+			t.Fatalf("op %s leaked the token in its response body: %s", req.Op, resp.Body)
+		}
+	}
+}
+
+// ----- test helpers -----
+
+// flipToReadyWhenCreated watches the org namespace for a newly created sandbox
+// and flips it to Ready, seeding its token Secret, mimicking the controller.
+func flipToReadyWhenCreated(t *testing.T, c client.Client, org, endpoint, token string) (stop func()) {
+	return flipWhenCreated(t, c, org, func(sb *v1.Sandbox) {
+		sb.Status.Phase = v1.SandboxReady
+		sb.Status.Endpoint = endpoint
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: sb.Name + tokenSecretSuffix, Namespace: sb.Namespace},
+			Data:       map[string][]byte{"token": []byte(token), "endpoint": []byte(endpoint)},
+		}
+		_ = c.Create(context.Background(), secret)
+	})
+}
+
+// flipWhenCreated polls the org namespace until a sandbox appears, then applies
+// mutate to its status. It mimics the controller asynchronously moving the phase.
+func flipWhenCreated(t *testing.T, c client.Client, org string, mutate func(*v1.Sandbox)) (stop func()) {
+	t.Helper()
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		ns := tenant.NamespaceForOrg(org)
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			var list v1.SandboxList
+			if err := c.List(context.Background(), &list, client.InNamespace(ns)); err == nil {
+				for i := range list.Items {
+					sb := &list.Items[i]
+					if sb.Status.Phase == "" {
+						mutate(sb)
+						_ = c.Status().Update(context.Background(), sb)
+						return
+					}
+				}
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
+}

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -1,0 +1,412 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+	"mitos.run/mitos/internal/tenant"
+)
+
+// tokenSecretSuffix mirrors the controller's per-sandbox token Secret name
+// (internal/controller/token_secret.go): <sandbox-name>-sandbox-token, with keys
+// token and endpoint.
+const tokenSecretSuffix = "-sandbox-token"
+
+// Forward dispatches an authenticated, org-scoped request to the matching
+// Kubernetes action or the runtime reverse proxy. orgID is taken ONLY from
+// req.OrgID and bounds every effect: the namespace is NamespaceForOrg(orgID) and
+// the org label is re-checked on every object, so a key for org A can never act
+// on or reach org B.
+func (k *K8sControlPlane) Forward(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	switch req.Op {
+	case "sandbox.create":
+		return k.create(ctx, req)
+	case "sandbox.status":
+		return k.status(ctx, req)
+	case "sandbox.list":
+		return k.list(ctx, req)
+	case "sandbox.terminate":
+		return k.terminate(ctx, req)
+	case "sandbox.runtime":
+		return k.proxy(ctx, req)
+	default:
+		return errResp(apierr.Get(apierr.CodeNotFound).
+			WithCause(fmt.Sprintf("unknown operation %q", req.Op))), nil
+	}
+}
+
+// createBody is the create request shape. Either pool or image selects the
+// origin pool; env, secrets, ttl/timeout, workspace, and replicas are optional.
+type createBody struct {
+	Pool      string            `json:"pool,omitempty"`
+	Image     string            `json:"image,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	Secrets   []secretMountReq  `json:"secrets,omitempty"`
+	Timeout   string            `json:"timeout,omitempty"`
+	TTL       string            `json:"ttl,omitempty"`
+	Workspace string            `json:"workspace,omitempty"`
+	Replicas  int32             `json:"replicas,omitempty"`
+}
+
+// secretMountReq is the create request's secret-mount shape, mapped onto
+// v1.SecretMount.
+type secretMountReq struct {
+	Name      string `json:"name"`
+	SecretRef struct {
+		Name string `json:"name"`
+		Key  string `json:"key"`
+	} `json:"secretRef"`
+	EnvVar    string `json:"envVar,omitempty"`
+	MountPath string `json:"mountPath,omitempty"`
+}
+
+// create builds and submits a Sandbox in the org namespace, then polls it to a
+// terminal create outcome. On Ready it returns 201 with the id, endpoint, phase,
+// and the per-sandbox token (returned ONLY here). On Failed it returns the
+// rejection condition as an LLM-legible 4xx; on timeout a 504-style error.
+func (k *K8sControlPlane) create(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	var body createBody
+	if len(req.Body) > 0 {
+		if err := json.Unmarshal(req.Body, &body); err != nil {
+			return errResp(apierr.Get(apierr.CodeInvalidJSON).
+				WithCause("the create request body is not valid JSON")), nil
+		}
+	}
+
+	pool := body.Pool
+	if pool == "" {
+		pool = body.Image
+	}
+	if pool == "" {
+		pool = k.defaultPool
+	}
+	if pool == "" {
+		return errResp(apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the create request names neither a pool nor an image and no default pool is configured")), nil
+	}
+
+	ns := tenant.NamespaceForOrg(req.OrgID)
+	name := generateName()
+
+	sb := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    tenant.OrgLabels(req.OrgID),
+		},
+		Spec: v1.SandboxSpec{
+			Source: v1.SandboxSource{
+				PoolRef: &v1.LocalObjectReference{Name: pool},
+			},
+		},
+	}
+	if body.Replicas > 1 {
+		sb.Spec.Replicas = body.Replicas
+	}
+	if len(body.Env) > 0 {
+		sb.Spec.Env = make([]corev1.EnvVar, 0, len(body.Env))
+		for kk, vv := range body.Env {
+			sb.Spec.Env = append(sb.Spec.Env, corev1.EnvVar{Name: kk, Value: vv})
+		}
+	}
+	for _, sm := range body.Secrets {
+		sb.Spec.Secrets = append(sb.Spec.Secrets, v1.SecretMount{
+			Name: sm.Name,
+			SecretRef: corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: sm.SecretRef.Name},
+				Key:                  sm.SecretRef.Key,
+			},
+			EnvVar:    sm.EnvVar,
+			MountPath: sm.MountPath,
+		})
+	}
+	if body.Workspace != "" {
+		sb.Spec.WorkspaceRef = &v1.LocalObjectReference{Name: body.Workspace}
+	}
+	if d, ok := parseDuration(body.TTL, body.Timeout); ok {
+		sb.Spec.Lifetime = &v1.SandboxLifetime{TTL: &metav1.Duration{Duration: d}}
+	}
+
+	if err := k.c.Create(ctx, sb); err != nil {
+		switch {
+		case apierrors.IsAlreadyExists(err):
+			return errResp(withStatus(apierr.Get(apierr.CodeInternal).
+				WithCause("a sandbox with the generated name already exists; retry"), http.StatusConflict)), nil
+		case isNamespaceMissing(err, ns):
+			return errResp(namespaceMissingErr(req.OrgID, ns)), nil
+		case apierrors.IsInvalid(err), apierrors.IsBadRequest(err):
+			return errResp(apierr.Get(apierr.CodeInvalidJSON).
+				WithCause("the sandbox spec was rejected by the api server as invalid")), nil
+		default:
+			return errResp(apierr.Get(apierr.CodeInternal).
+				WithCause("could not create the sandbox object")), nil
+		}
+	}
+
+	return k.pollReady(ctx, ns, name, req.OrgID)
+}
+
+// pollReady blocks until the sandbox reaches Ready (returns 201 + token), Failed
+// (returns the rejection message), or the readiness timeout (504-style).
+func (k *K8sControlPlane) pollReady(ctx context.Context, ns, name, orgID string) (saas.ForwardResponse, error) {
+	deadline := k.now().Add(k.readyTimeout)
+	ticker := time.NewTicker(k.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		var sb v1.Sandbox
+		if err := k.c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &sb); err != nil {
+			if apierrors.IsNotFound(err) {
+				// The object vanished mid-create (a terminate raced the poll).
+				return errResp(apierr.Get(apierr.CodeNotFound).
+					WithCause("the sandbox was removed before it became ready")), nil
+			}
+			return errResp(apierr.Get(apierr.CodeInternal).
+				WithCause("could not read the sandbox status while waiting for readiness")), nil
+		}
+
+		switch sb.Status.Phase {
+		case v1.SandboxReady:
+			return k.readyResponse(ctx, &sb)
+		case v1.SandboxFailed:
+			return errResp(withStatus(apierr.Get(apierr.CodeInternal).
+				WithCause("the sandbox failed to start: "+failureReason(&sb)), http.StatusBadGateway)), nil
+		}
+
+		if !k.now().Before(deadline) {
+			return errResp(withStatus(apierr.Get(apierr.CodeInternal).
+				WithCause(fmt.Sprintf("the sandbox did not become ready within %s; it is still %s", k.readyTimeout, phaseOrUnknown(&sb))), http.StatusGatewayTimeout)), nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return errResp(apierr.Get(apierr.CodeCanceled).
+				WithCause("the create request was canceled while waiting for the sandbox to become ready")), nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// readyResponse reads the per-sandbox token Secret and returns the 201 create
+// payload. The token is returned ONLY here and is never logged.
+func (k *K8sControlPlane) readyResponse(ctx context.Context, sb *v1.Sandbox) (saas.ForwardResponse, error) {
+	endpoint := sb.Status.Endpoint
+	token, err := k.readToken(ctx, sb.Namespace, sb.Name)
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).
+			WithCause("the sandbox is ready but its access token secret could not be read")), nil
+	}
+	payload := map[string]any{
+		"id":       sb.Name,
+		"endpoint": endpoint,
+		"token":    token,
+		"phase":    string(v1.SandboxReady),
+	}
+	return jsonResp(http.StatusCreated, payload), nil
+}
+
+// readToken reads data.token from the controller-owned <name>-sandbox-token
+// Secret in the sandbox namespace.
+func (k *K8sControlPlane) readToken(ctx context.Context, ns, name string) (string, error) {
+	var secret corev1.Secret
+	key := client.ObjectKey{Namespace: ns, Name: name + tokenSecretSuffix}
+	if err := k.c.Get(ctx, key, &secret); err != nil {
+		return "", fmt.Errorf("read token secret %s/%s: %w", ns, key.Name, err)
+	}
+	tok := string(secret.Data["token"])
+	if tok == "" {
+		return "", fmt.Errorf("token secret %s/%s has no token", ns, key.Name)
+	}
+	return tok, nil
+}
+
+// status returns the org-scoped sandbox status. A sandbox that does not exist OR
+// carries a different org label returns not_found, so another org's existence is
+// never revealed.
+func (k *K8sControlPlane) status(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	id := idFromPath(req.Path)
+	if id == "" {
+		return errResp(apierr.Get(apierr.CodeNotFound).WithCause("no sandbox id in the request path")), nil
+	}
+	sb, ok := k.getOwned(ctx, req.OrgID, id)
+	if !ok {
+		return notFound(id), nil
+	}
+	return jsonResp(http.StatusOK, sandboxSummary(sb)), nil
+}
+
+// list returns every sandbox in the org namespace carrying the org label.
+func (k *K8sControlPlane) list(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	ns := tenant.NamespaceForOrg(req.OrgID)
+	var sbs v1.SandboxList
+	err := k.c.List(ctx, &sbs,
+		client.InNamespace(ns),
+		client.MatchingLabels(tenant.OrgLabels(req.OrgID)),
+	)
+	if err != nil {
+		if isNamespaceMissing(err, ns) {
+			return errResp(namespaceMissingErr(req.OrgID, ns)), nil
+		}
+		return errResp(apierr.Get(apierr.CodeInternal).WithCause("could not list sandboxes for the organization")), nil
+	}
+	items := make([]map[string]any, 0, len(sbs.Items))
+	for i := range sbs.Items {
+		// Defense in depth: the namespace AND the label selector already bound the
+		// list to this org; re-checking the label keeps the invariant local.
+		if sbs.Items[i].Labels[tenant.OrgLabelKey] != req.OrgID {
+			continue
+		}
+		items = append(items, sandboxSummary(&sbs.Items[i]))
+	}
+	return jsonResp(http.StatusOK, map[string]any{"sandboxes": items}), nil
+}
+
+// terminate deletes an org-owned sandbox. A missing or cross-org id returns
+// not_found and never deletes another org's object.
+func (k *K8sControlPlane) terminate(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	id := idFromPath(req.Path)
+	if id == "" {
+		return errResp(apierr.Get(apierr.CodeNotFound).WithCause("no sandbox id in the request path")), nil
+	}
+	sb, ok := k.getOwned(ctx, req.OrgID, id)
+	if !ok {
+		return notFound(id), nil
+	}
+	if err := k.c.Delete(ctx, sb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return notFound(id), nil
+		}
+		return errResp(apierr.Get(apierr.CodeInternal).WithCause("could not terminate the sandbox")), nil
+	}
+	return saas.ForwardResponse{Status: http.StatusNoContent}, nil
+}
+
+// getOwned reads the named sandbox from the org namespace and verifies its org
+// label. It returns (nil, false) for a missing object OR an org-label mismatch,
+// collapsing both to not_found so a cross-org probe cannot map ids. The org id is
+// taken ONLY from the verified request.
+func (k *K8sControlPlane) getOwned(ctx context.Context, orgID, name string) (*v1.Sandbox, bool) {
+	ns := tenant.NamespaceForOrg(orgID)
+	var sb v1.Sandbox
+	if err := k.c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &sb); err != nil {
+		return nil, false
+	}
+	if sb.Labels[tenant.OrgLabelKey] != orgID {
+		// The object lives in the org namespace but is not labeled for this org:
+		// never act on it, never reveal it.
+		return nil, false
+	}
+	return &sb, true
+}
+
+// sandboxSummary is the per-sandbox JSON in status and list responses. It never
+// carries the token.
+func sandboxSummary(sb *v1.Sandbox) map[string]any {
+	return map[string]any{
+		"id":        sb.Name,
+		"phase":     string(sb.Status.Phase),
+		"endpoint":  sb.Status.Endpoint,
+		"createdAt": sb.CreationTimestamp.UTC().Format(time.RFC3339),
+	}
+}
+
+// failureReason extracts the rejection message from a Failed sandbox's Ready
+// condition so the create error is actionable. It never carries a secret.
+func failureReason(sb *v1.Sandbox) string {
+	for i := range sb.Status.Conditions {
+		c := sb.Status.Conditions[i]
+		if c.Type == "Ready" && c.Message != "" {
+			return c.Message
+		}
+	}
+	return "no failure detail was reported by the controller"
+}
+
+func phaseOrUnknown(sb *v1.Sandbox) string {
+	if sb.Status.Phase == "" {
+		return "Pending"
+	}
+	return string(sb.Status.Phase)
+}
+
+// idFromPath returns the last non-empty path segment as the sandbox id.
+func idFromPath(path string) string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, "/")
+	return parts[len(parts)-1]
+}
+
+// parseDuration prefers ttl, then timeout, returning the parsed duration and true
+// when one is a valid Go duration.
+func parseDuration(ttl, timeout string) (time.Duration, bool) {
+	for _, s := range []string{ttl, timeout} {
+		if s == "" {
+			continue
+		}
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
+}
+
+// generateName returns a sandbox name "sb-" plus 8 hex chars of crypto entropy.
+func generateName() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return "sb-" + hex.EncodeToString(b)
+}
+
+// isNamespaceMissing reports whether err indicates the org namespace does not
+// exist (a create or list raced ahead of provisioning). The api server reports a
+// missing target namespace as a NotFound whose status details name the
+// namespaces kind and the namespace name.
+func isNamespaceMissing(err error, ns string) bool {
+	if !apierrors.IsNotFound(err) {
+		return false
+	}
+	if d := statusDetails(err); d != nil && d.Kind == "namespaces" && d.Name == ns {
+		return true
+	}
+	return false
+}
+
+// statusDetails returns the k8s status details when err is an APIStatus error.
+func statusDetails(err error) *metav1.StatusDetails {
+	var s apierrors.APIStatus
+	if errors.As(err, &s) {
+		return s.Status().Details
+	}
+	return nil
+}
+
+// namespaceMissingErr is the actionable error when the org namespace is absent.
+func namespaceMissingErr(orgID, ns string) apierr.Error {
+	return withStatus(apierr.Get(apierr.CodeInternal).
+		WithCause(fmt.Sprintf("the namespace %s for organization %s does not exist yet; it is provisioned when the organization is onboarded", ns, orgID)),
+		http.StatusServiceUnavailable)
+}
+
+// notFound is the canonical org-isolation not_found: a missing or cross-org id.
+func notFound(id string) saas.ForwardResponse {
+	return errResp(apierr.Get(apierr.CodeNotFound).
+		WithCause(fmt.Sprintf("no sandbox %q exists for this organization", id)))
+}

--- a/internal/saas/controlplane/proxy.go
+++ b/internal/saas/controlplane/proxy.go
@@ -1,0 +1,162 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// connectService is the Connect service the sandbox serves runtime calls on.
+const connectService = "/sandbox.v1.Sandbox/"
+
+// proxy reverse-proxies a runtime call (exec, files, run_code over Connect) to
+// the org-owned sandbox endpoint, attaching the per-sandbox bearer token and the
+// X-Sandbox-Id header. The sandbox id is resolved from the X-Sandbox-Id header or
+// the request path; the sandbox is read org-scoped and its org label re-checked,
+// so a cross-org id returns not_found and is NEVER proxied. The request and
+// response bodies are streamed, not buffered, so ExecStream is carried.
+func (k *K8sControlPlane) proxy(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	method := connectMethod(req)
+	if method == "" {
+		return errResp(apierr.Get(apierr.CodeNotFound).
+			WithCause("the runtime path does not name a sandbox.v1.Sandbox method")), nil
+	}
+
+	id := sandboxIDFromRuntime(req)
+	if id == "" {
+		return errResp(apierr.Get(apierr.CodeNotFound).
+			WithCause("no sandbox id was supplied; set the X-Sandbox-Id header or use /v1/sandboxes/<id>/<verb>")), nil
+	}
+
+	// Org-scoped read with the org-label re-check: a missing or cross-org sandbox
+	// collapses to not_found and never reaches the endpoint.
+	sb, ok := k.getOwned(ctx, req.OrgID, id)
+	if !ok {
+		return notFound(id), nil
+	}
+	if sb.Status.Endpoint == "" {
+		return errResp(apierr.Get(apierr.CodeNotFound).
+			WithCause(fmt.Sprintf("sandbox %q has no runtime endpoint yet; it is not Ready", id))), nil
+	}
+
+	token, err := k.readToken(ctx, sb.Namespace, sb.Name)
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).
+			WithCause("the per-sandbox access token secret could not be read")), nil
+	}
+
+	body := req.BodyStream
+	if body == nil {
+		body = strings.NewReader("")
+		if len(req.Body) > 0 {
+			body = strings.NewReader(string(req.Body))
+		}
+	}
+
+	target := "http://" + sb.Status.Endpoint + connectService + method
+	httpMethod := req.Method
+	if httpMethod == "" {
+		httpMethod = http.MethodPost
+	}
+	outReq, err := http.NewRequestWithContext(ctx, httpMethod, target, body)
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).WithCause("could not build the runtime proxy request")), nil
+	}
+
+	// Copy only the curated headers the gateway forwarded, then OVERWRITE the
+	// credential: the client Authorization is stripped (the gateway already
+	// excluded it) and replaced with the per-sandbox token, and X-Sandbox-Id is
+	// set from the control-plane-resolved name, never trusted from the client.
+	copyRuntimeHeaders(outReq.Header, req.Header)
+	outReq.Header.Set("Authorization", "Bearer "+token)
+	outReq.Header.Set("X-Sandbox-Id", sb.Name)
+
+	resp, err := k.httpClient.Do(outReq)
+	if err != nil {
+		return errResp(withStatus(apierr.Get(apierr.CodeInternal).
+			WithCause("the sandbox runtime endpoint could not be reached"), http.StatusBadGateway)), nil
+	}
+
+	// Stream the response back: the body is handed to the gateway as a stream and
+	// closed there, so a long-lived Connect response is never buffered.
+	header := http.Header{}
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		header.Set("Content-Type", ct)
+	}
+	return saas.ForwardResponse{
+		Status:     resp.StatusCode,
+		Header:     header,
+		BodyStream: resp.Body,
+	}, nil
+}
+
+// connectMethod returns the Connect method name from the runtime request: the
+// last path segment of a /sandbox.v1.Sandbox/<Method> path, or the verb mapped
+// from a /v1/sandboxes/<id>/<verb> alias.
+func connectMethod(req saas.ForwardRequest) string {
+	path := req.Path
+	if i := strings.Index(path, connectService); i >= 0 {
+		m := path[i+len(connectService):]
+		if m != "" && !strings.Contains(m, "/") {
+			return m
+		}
+		return ""
+	}
+	p := strings.TrimPrefix(path, "/v1/")
+	if !strings.HasPrefix(p, "sandboxes/") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(p, "sandboxes/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	switch parts[1] {
+	case "exec":
+		return "Exec"
+	case "files":
+		return "Files"
+	case "run_code":
+		return "RunCode"
+	default:
+		return ""
+	}
+}
+
+// sandboxIDFromRuntime resolves the target sandbox id: the X-Sandbox-Id header
+// (native Connect path) or the /v1/sandboxes/<id>/<verb> path segment.
+func sandboxIDFromRuntime(req saas.ForwardRequest) string {
+	if req.Header != nil {
+		if id := req.Header.Get("X-Sandbox-Id"); id != "" {
+			return id
+		}
+	}
+	p := strings.TrimPrefix(req.Path, "/v1/")
+	if strings.HasPrefix(p, "sandboxes/") {
+		parts := strings.Split(strings.TrimPrefix(p, "sandboxes/"), "/")
+		if len(parts) >= 1 && parts[0] != "" {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+// copyRuntimeHeaders copies the content-negotiation headers from the gateway's
+// curated set onto the outbound request. It deliberately never copies
+// Authorization (the credential is set by the caller from the per-sandbox token).
+func copyRuntimeHeaders(dst, src http.Header) {
+	if src == nil {
+		return
+	}
+	for _, key := range []string{"Content-Type", "Accept", "Connect-Protocol-Version", "Connect-Timeout-Ms"} {
+		if v := src.Get(key); v != "" {
+			dst.Set(key, v)
+		}
+	}
+}
+
+// compile-time assertion that K8sControlPlane satisfies the seam.
+var _ saas.ControlPlane = (*K8sControlPlane)(nil)

--- a/internal/saas/controlplane/response.go
+++ b/internal/saas/controlplane/response.go
@@ -1,0 +1,64 @@
+package controlplane
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// errResp renders an apierr.Error as the public {"error": {...}} envelope and a
+// ForwardResponse with the error's HTTP status. The token is never part of an
+// error, so this is always safe to return to the caller.
+func errResp(e apierr.Error) saas.ForwardResponse {
+	var buf bytes.Buffer
+	apierr.Encode(&statusRecorder{buf: &buf}, e)
+	status := e.Status
+	if status == 0 {
+		status = http.StatusInternalServerError
+	}
+	return saas.ForwardResponse{
+		Status: status,
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   buf.Bytes(),
+	}
+}
+
+// jsonResp marshals payload and returns a ForwardResponse with the given status.
+func jsonResp(status int, payload any) saas.ForwardResponse {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).WithCause("could not encode the response"))
+	}
+	return saas.ForwardResponse{
+		Status: status,
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   b,
+	}
+}
+
+// statusRecorder is a minimal http.ResponseWriter that captures only the body
+// written by apierr.Encode (the status is taken from the Error directly).
+type statusRecorder struct {
+	buf    *bytes.Buffer
+	header http.Header
+}
+
+func (s *statusRecorder) Header() http.Header {
+	if s.header == nil {
+		s.header = http.Header{}
+	}
+	return s.header
+}
+func (s *statusRecorder) Write(p []byte) (int, error) { return s.buf.Write(p) }
+func (s *statusRecorder) WriteHeader(int)             {}
+
+// withStatus returns a copy of e with its HTTP status overridden. apierr.Error
+// has no WithStatus method, so the control plane sets the exported field on a
+// copy. The status drives the gateway's echoed response code.
+func withStatus(e apierr.Error, status int) apierr.Error {
+	e.Status = status
+	return e
+}

--- a/internal/saas/gateway.go
+++ b/internal/saas/gateway.go
@@ -14,6 +14,47 @@ import (
 // gateway with an unbounded upload. It mirrors the daemon sandbox API ceiling.
 const maxBodyBytes = 8 << 20 // 8 MiB
 
+// opRuntime is the public operation for a runtime proxy call (exec, files,
+// run_code over the Connect sandbox.v1.Sandbox service). It is reverse-proxied to
+// the sandbox endpoint by the control plane, not handled as a lifecycle verb. It
+// requires the sandbox scope because it acts inside a running sandbox.
+const opRuntime = "sandbox.runtime"
+
+// runtimeMethod returns the Connect method name and true when path is a runtime
+// proxy call, otherwise "", false. Two shapes are accepted: the native Connect
+// path /sandbox.v1.Sandbox/<Method>, and the friendly
+// /v1/sandboxes/<id>/{exec,files,run_code} alias. The control plane resolves the
+// sandbox id from the X-Sandbox-Id header (native) or the path (alias).
+func runtimeMethod(path string) (string, bool) {
+	const connectPrefix = "/sandbox.v1.Sandbox/"
+	if strings.HasPrefix(path, connectPrefix) {
+		m := strings.TrimPrefix(path, connectPrefix)
+		if m != "" && !strings.Contains(m, "/") {
+			return m, true
+		}
+		return "", false
+	}
+	p := strings.TrimPrefix(path, "/v1/")
+	if !strings.HasPrefix(p, "sandboxes/") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(p, "sandboxes/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return "", false
+	}
+	switch parts[1] {
+	case "exec":
+		return "Exec", true
+	case "files":
+		return "Files", true
+	case "run_code":
+		return "RunCode", true
+	default:
+		return "", false
+	}
+}
+
 // requiredScopeFor maps a public operation to the scope a key must carry. A
 // read-only op is satisfied by either scope; a mutating op requires the sandbox
 // scope. An unknown op requires the sandbox scope (fail closed).
@@ -56,9 +97,14 @@ func NewGateway(keys *KeyService, quota QuotaEnforcer, cp ControlPlane, log *slo
 }
 
 // opFromPath derives the public operation name from the request path and method.
-// The gateway exposes a flat surface under /v1/sandboxes; the op is used for
-// scope selection, quota accounting, and forwarding.
+// The gateway exposes a flat surface under /v1/sandboxes plus the Connect runtime
+// service; the op is used for scope selection, quota accounting, and forwarding.
+// A runtime proxy call (Connect path or the /v1/sandboxes/<id>/{exec,files,
+// run_code} alias) maps to opRuntime; the lifecycle verbs map as before.
 func opFromPath(method, path string) string {
+	if _, ok := runtimeMethod(path); ok {
+		return opRuntime
+	}
 	p := strings.TrimPrefix(path, "/v1/")
 	switch {
 	case p == "sandboxes" && method == http.MethodGet:
@@ -109,20 +155,32 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
-	if err != nil {
-		g.fail(w, apierr.Get(apierr.CodeInternal).WithCause("read request body failed"))
-		return
-	}
-	if len(body) > maxBodyBytes {
-		g.fail(w, apierr.Get(apierr.CodeBodyTooLarge).
-			WithCause("the forwarded request body exceeds the gateway limit"))
-		return
-	}
-
 	// The OrgID forwarded is taken ONLY from the verified key. The request body
 	// and path cannot influence it, so a key for org A cannot address org B.
-	fwd := ForwardRequest{OrgID: orgID, Op: op, Path: r.URL.Path, Body: body}
+	fwd := ForwardRequest{OrgID: orgID, Op: op, Path: r.URL.Path, Method: r.Method}
+
+	if op == opRuntime {
+		// Runtime (exec, files, run_code over Connect) is reverse-proxied and may
+		// carry an unbounded stream (ExecStream), so the body is NOT buffered or
+		// size-capped here; it is streamed by the control plane. Only a curated set
+		// of headers crosses the seam, and the client Authorization is NEVER
+		// forwarded: the control plane attaches the per-sandbox token itself.
+		fwd.BodyStream = r.Body
+		fwd.Header = curatedRuntimeHeaders(r.Header)
+	} else {
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
+		if err != nil {
+			g.fail(w, apierr.Get(apierr.CodeInternal).WithCause("read request body failed"))
+			return
+		}
+		if len(body) > maxBodyBytes {
+			g.fail(w, apierr.Get(apierr.CodeBodyTooLarge).
+				WithCause("the forwarded request body exceeds the gateway limit"))
+			return
+		}
+		fwd.Body = body
+	}
+
 	g.log.Info("gateway forward", "key_id", res.Key.ID, "key_prefix", res.Key.Prefix, "org", orgID, "op", op)
 
 	resp, err := g.cp.Forward(r.Context(), fwd)
@@ -135,9 +193,37 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if status == 0 {
 		status = http.StatusOK
 	}
-	w.Header().Set("Content-Type", "application/json")
+	// A control-plane response may carry its own headers (the runtime proxy sets
+	// Content-Type so a streamed Connect body is decodable). Default to JSON for
+	// the lifecycle ops.
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
 	w.WriteHeader(status)
+	if resp.BodyStream != nil {
+		// Stream the response without buffering (this carries a streamed Connect
+		// response), then close the upstream body.
+		defer func() { _ = resp.BodyStream.Close() }()
+		_, _ = io.Copy(w, resp.BodyStream)
+		return
+	}
 	_, _ = w.Write(resp.Body)
+}
+
+// curatedRuntimeHeaders copies only the headers the runtime proxy needs across
+// the control-plane seam. The client Authorization is deliberately EXCLUDED: the
+// control plane attaches the per-sandbox bearer token, so a customer cannot
+// influence the credential presented to the sandbox.
+func curatedRuntimeHeaders(in http.Header) http.Header {
+	out := http.Header{}
+	for _, k := range []string{"X-Sandbox-Id", "Content-Type", "Accept", "Connect-Protocol-Version", "Connect-Timeout-Ms"} {
+		if v := in.Get(k); v != "" {
+			out.Set(k, v)
+		}
+	}
+	return out
 }
 
 // failVerify maps a key-verification error to the public envelope. A missing,

--- a/internal/saas/gateway_test.go
+++ b/internal/saas/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,12 +14,15 @@ import (
 )
 
 // fakeControlPlane records every ForwardRequest it receives so a test can assert
-// exactly which org the gateway attached. It returns a canned response.
+// exactly which org the gateway attached. It returns a canned response, which may
+// carry a streamed body and custom headers (the runtime proxy case).
 type fakeControlPlane struct {
-	got      []ForwardRequest
-	respBody []byte
-	respCode int
-	err      error
+	got        []ForwardRequest
+	respBody   []byte
+	respStream io.ReadCloser
+	respHeader http.Header
+	respCode   int
+	err        error
 }
 
 func (f *fakeControlPlane) Forward(_ context.Context, req ForwardRequest) (ForwardResponse, error) {
@@ -30,7 +34,7 @@ func (f *fakeControlPlane) Forward(_ context.Context, req ForwardRequest) (Forwa
 	if code == 0 {
 		code = http.StatusOK
 	}
-	return ForwardResponse{Status: code, Body: f.respBody}, nil
+	return ForwardResponse{Status: code, Body: f.respBody, BodyStream: f.respStream, Header: f.respHeader}, nil
 }
 
 // denyQuota is a QuotaEnforcer that always denies, to exercise the quota seam.
@@ -260,6 +264,77 @@ func TestGatewayCrossOrgIsolation(t *testing.T) {
 	}
 	if cp.got[1].OrgID != "org-b" {
 		t.Errorf("key B request forwarded with OrgID %q, want org-b", cp.got[1].OrgID)
+	}
+}
+
+// TestGatewayRoutesRuntimeConnectPath asserts a Connect runtime path is routed as
+// the sandbox.runtime op, the request body is handed across the seam UNBUFFERED
+// (BodyStream, not Body), the curated headers (X-Sandbox-Id, Content-Type) cross,
+// and the client Authorization is NOT placed in the forwarded header.
+func TestGatewayRoutesRuntimeConnectPath(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	req := httptest.NewRequest(http.MethodPost, "/sandbox.v1.Sandbox/Exec", strings.NewReader(`{"cmd":["true"]}`))
+	req.Header.Set("Authorization", "Bearer "+f.rawA)
+	req.Header.Set("X-Sandbox-Id", "sb-1")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	f.gw.ServeHTTP(rec, req)
+
+	if len(f.cp.got) != 1 {
+		t.Fatalf("control plane saw %d requests, want 1", len(f.cp.got))
+	}
+	g := f.cp.got[0]
+	if g.Op != "sandbox.runtime" {
+		t.Errorf("op = %q, want sandbox.runtime", g.Op)
+	}
+	if g.OrgID != "org-a" {
+		t.Errorf("orgID = %q, want org-a", g.OrgID)
+	}
+	if g.BodyStream == nil {
+		t.Error("runtime request body was buffered into Body, want an unbuffered BodyStream")
+	} else {
+		b, _ := io.ReadAll(g.BodyStream)
+		if string(b) != `{"cmd":["true"]}` {
+			t.Errorf("streamed body = %q", b)
+		}
+	}
+	if g.Header.Get("X-Sandbox-Id") != "sb-1" {
+		t.Errorf("forwarded X-Sandbox-Id = %q", g.Header.Get("X-Sandbox-Id"))
+	}
+	if g.Header.Get("Authorization") != "" {
+		t.Errorf("client Authorization was forwarded across the seam: %q (it must be stripped)", g.Header.Get("Authorization"))
+	}
+}
+
+// TestGatewayRoutesRuntimeAliasPath asserts the /v1/sandboxes/<id>/exec friendly
+// alias also routes as the runtime op.
+func TestGatewayRoutesRuntimeAliasPath(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	rec := doRequest(f.gw, http.MethodPost, "/v1/sandboxes/sb-7/exec", f.rawA, `{}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(f.cp.got) != 1 || f.cp.got[0].Op != "sandbox.runtime" {
+		t.Errorf("op = %+v, want sandbox.runtime", f.cp.got)
+	}
+}
+
+// TestGatewayStreamsRuntimeResponse asserts a control-plane response carrying a
+// BodyStream is streamed to the caller with the control-plane Content-Type.
+func TestGatewayStreamsRuntimeResponse(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	f.cp.respBody = nil
+	f.cp.respStream = io.NopCloser(strings.NewReader(`{"streamed":true}`))
+	f.cp.respHeader = http.Header{"Content-Type": []string{"application/connect+json"}}
+	rec := doRequest(f.gw, http.MethodPost, "/sandbox.v1.Sandbox/Exec", f.rawA, `{}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if rec.Body.String() != `{"streamed":true}` {
+		t.Errorf("streamed response = %q", rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/connect+json" {
+		t.Errorf("Content-Type = %q, want the control-plane value", ct)
 	}
 }
 

--- a/internal/saas/seams.go
+++ b/internal/saas/seams.go
@@ -1,6 +1,10 @@
 package saas
 
-import "context"
+import (
+	"context"
+	"io"
+	"net/http"
+)
 
 // QuotaEnforcer is the seam the quota and rate-limit workstream (issue #213)
 // implements. The gateway calls Check after it has authenticated the key and
@@ -26,18 +30,42 @@ func (AllowAllQuota) Check(_ context.Context, _ string, _ string) error { return
 // the control plane. OrgID is attached by the gateway after key verification and
 // is the ONLY org the forward target may act on; the target must scope every
 // effect to it. Op is the public operation; Body is the opaque request payload.
+//
+// Method and Header carry the original request method and a curated subset of the
+// request headers, populated by the gateway for the runtime-proxy op
+// (sandbox.runtime): the control plane reverse-proxies the request to the
+// sandbox endpoint and needs the method (Connect is POST) and the
+// X-Sandbox-Id / Content-Type headers. For the lifecycle ops (create, status,
+// list, terminate) these may be empty; the control plane reads Body and Path.
+//
+// BodyStream, when non-nil, is the unbuffered request body the control plane MUST
+// stream to the sandbox (this carries ExecStream, which must not be buffered).
+// When BodyStream is nil the control plane uses Body. The gateway sets exactly
+// one for a runtime op and Body for the lifecycle ops.
 type ForwardRequest struct {
-	OrgID string
-	Op    string
-	Path  string
-	Body  []byte
+	OrgID      string
+	Op         string
+	Path       string
+	Method     string
+	Header     http.Header
+	Body       []byte
+	BodyStream io.Reader
 }
 
 // ForwardResponse is the control plane's reply. Status is an HTTP-style status
-// the gateway echoes; Body is the opaque response payload.
+// the gateway echoes; Body is the opaque buffered response payload (used by the
+// lifecycle ops). Header carries response headers the gateway echoes (the
+// runtime proxy sets Content-Type so a streamed Connect response is decodable).
+//
+// BodyStream, when non-nil, is an unbuffered response body the gateway streams to
+// the caller and then closes (the runtime proxy sets it so a streaming Connect
+// response is not buffered in the gateway). When BodyStream is nil the gateway
+// writes Body.
 type ForwardResponse struct {
-	Status int
-	Body   []byte
+	Status     int
+	Header     http.Header
+	Body       []byte
+	BodyStream io.ReadCloser
 }
 
 // ControlPlane is the seam the gateway forwards authenticated, org-scoped


### PR DESCRIPTION
**Hosted SaaS campaign, Phase 1 (the keystone).** Replaces `cmd/gateway`'s `stubControlPlane` (which echoed JSON and created nothing) with a real Kubernetes-backed control plane: an authenticated, org-scoped customer request now becomes a real sandbox, and runtime calls proxy to it.

## What
- `internal/saas/controlplane` (new): `K8sControlPlane` over a controller-runtime client. `sandbox.create` builds a `v1.Sandbox` in `tenant.NamespaceForOrg(org)` with the org label, polls to Ready, returns `id`/`endpoint`/`token` (token only on create); `status`/`list`/`terminate` are org-scoped; `sandbox.runtime` reverse-proxies the Connect call to the sandbox endpoint with the per-sandbox bearer token, streaming.
- Gateway: `ForwardRequest` gains `Method`/`Header`/`BodyStream`; the Connect runtime path and `/v1/sandboxes/<id>/{exec,files,run_code}` route to the streaming proxy. `cmd/gateway` wires the real control plane by default (stub only behind `--allow-stub`).
- Chart: gateway ServiceAccount + least-privilege RBAC (sandboxes CRUD; pools/secrets/namespaces read).

## Cross-tenant boundary (security core)
`orgID` comes **only** from the gateway-verified request; every op is scoped to the org namespace **and** re-checks the `mitos.run/org` label (`getOwned`), collapsing missing-object and cross-org-label alike to `not_found` so another org is never revealed or acted on. The proxy verifies ownership **before** reaching the endpoint and replaces the credential with the per-sandbox token; the gateway curates runtime headers so the client `Authorization` never crosses the seam. Tokens are never logged or returned except on create. Proven by `TestCrossTenant*`, `TestProxyCrossOrgNeverReachesEndpoint`, `TestProxyUnknownSandboxIsNotFound`, `TestGatewayRoutesRuntimeConnectPath`, `TestTokenNeverAppearsInErrorOrNonCreateResponse`.

`go build`/`test`/`vet` + both `golangci-lint` runs clean; chart render tested.

Next phases: per-org namespace provisioning (#288), durable Postgres, usage/console wiring, Paddle billing, onboarding, abuse/quota enforcement, telemetry.

Part of the hosted SaaS epic #208 / #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)