### PR TITLE
feat(console): B3d-2 per-project membership

### DIFF
--- a/docs/superpowers/plans/2026-06-26-console-b3d2-project-membership.md
+++ b/docs/superpowers/plans/2026-06-26-console-b3d2-project-membership.md
@@ -1,0 +1,114 @@
+# Console B3d-2: per-project membership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Do NOT invoke finishing-a-development-branch; implement, test, commit, report.
+
+**Goal:** Let Owner/Admin assign a role to an account scoped to a single project (Admin of project A, Viewer of project B), with a project-membership store, endpoints under `/console/projects/{id}/members`, and a project-detail UI to manage them. Resource enforcement by project role is the NEXT slice (B3d-3 tags resources, B3d-4 enforces); this slice stores and surfaces the assignments and says so honestly.
+
+**Architecture:** A console-level `ProjectMembership { AccountID, ProjectID, Role }` + a per-org `ProjectMembershipStore` seam. Endpoints are gated by the B3d-1 `authorize` helper (manage -> projects.manage, read -> read) and validate that the project belongs to the caller's org by listing the org's projects. A project-detail view (`/projects/$id`) lists members and assigns/revokes roles.
+
+**Tech Stack:** Go (`internal/saas/console`), React+Vite+TS, TanStack Router/Query, Vitest + vitest-axe.
+
+## Global Constraints
+
+- **Security invariants (unchanged from B3d-1):** org from request context only; project membership is per-org and never cross-org; managing project membership requires `projects.manage` (Owner/Admin); a project id is only valid if it belongs to the caller's org (validated by listing the org's projects). Deny by default.
+- **Honesty:** the UI states plainly that per-project roles take effect on resources once resources are assigned to projects (B3d-3+); it must not claim enforcement that does not exist yet.
+- **Punctuation (strict):** no em/en dashes. **Go:** gofmt + both golangci-lint invocations clean; `fmt.Errorf("...: %w", err)`. **Commits:** conventional + DCO; explicit-path staging.
+- **TDD:** failing test first. TypeScript strict; web suite + `go test ./internal/saas/...` green.
+
+## File Structure
+
+- `internal/saas/console/projectmembers.go` (create) - `ProjectMembership`, `ProjectMembershipStore` seam + `MemProjectMembershipStore` fake, the list/assign/revoke handlers.
+- `internal/saas/console/console.go` (modify) - `Deps.ProjectMembers` default; routes; auth-gate entries.
+- Go tests alongside.
+- `web/app/src/api.ts`, `web/app/src/data/projectmembers.ts` (create), `web/app/src/views/projects/ProjectDetail.tsx` (create), `web/app/src/views/Projects.tsx` (link rows to the detail), `web/app/src/nav/routes.tsx` (route). Tests alongside.
+- `web/packages/brand/src/base.css` (modify) if needed.
+
+---
+
+### Task 1: project-membership store + endpoints (Go)
+
+**Files:**
+- Create: `internal/saas/console/projectmembers.go`
+- Modify: `internal/saas/console/console.go`
+- Test: `internal/saas/console/projectmembers_test.go`
+
+Read `projects.go` (the ProjectStore seam + MemProjectStore), `customroles.go` / `retention.go` (seam + fake + nil-default pattern), `authz.go` (`c.authorize(r, perm)`), `console.go` (routes, the auth-gate table in console_test.go, `caller`, decodeBody, writeJSON, apierr).
+
+**Interfaces:**
+- `ProjectMembership = { AccountID string; ProjectID string; Role saas.Role }` (JSON `account_id`, `project_id`, `role`).
+- `ProjectMembershipStore`: `List(ctx, orgID, projectID) ([]ProjectMembership, error)`, `Assign(ctx, orgID, projectID, accountID string, role saas.Role) error`, `Revoke(ctx, orgID, projectID, accountID string) error`. `NewMemProjectMembershipStore()` fake (keyed by org then project; never cross-org). `Deps.ProjectMembers` nil-defaults to the fake.
+- `GET /console/projects/{id}/members` -> `{ project_id, members: [ProjectMembership] }`, gated `read`.
+- `POST /console/projects/{id}/members` body `{ account_id, role }` -> assign; gated `projects.manage`.
+- `DELETE /console/projects/{id}/members/{accountID}` -> revoke; gated `projects.manage`.
+- All three: resolve `{id}` via `r.PathValue("id")`, validate it belongs to the caller's org (list `c.deps.Projects.List(ctx, orgID)` and confirm the id is present; else 404). Org from context only.
+
+- [ ] **Step 1: Write failing tests** (`projectmembers_test.go`): an admin assigns account X role viewer in project P and lists it back; a member (no projects.manage) gets 403 on POST and DELETE but 200 on GET; assigning to a project id that is not in the caller's org returns 404; orgB cannot list orgA's project members (isolation). Use the in-memory Accounts + ProjectStore + WithCaller like authz_enforce_test.go / customroles_test.go. Seed a project via the ProjectStore first.
+
+- [ ] **Step 2: Run, confirm fail.** `go test ./internal/saas/console/ -run 'ProjectMember'` Expected: FAIL.
+
+- [ ] **Step 3: Implement** projectmembers.go (type + store + fake + 3 handlers using `c.authorize`), wire `Deps.ProjectMembers` nil-default + the 3 routes in console.go, and add the 3 routes to the auth-gate table in console_test.go.
+
+- [ ] **Step 4: Run; gofmt; both lint.** `go test ./internal/saas/console/` ; both golangci-lint invocations. Expected: green/clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add internal/saas/console/projectmembers.go internal/saas/console/console.go internal/saas/console/projectmembers_test.go internal/saas/console/console_test.go
+git commit -s -m "feat(console): per-project membership store and endpoints"
+```
+
+---
+
+### Task 2: project-detail UI with member management (frontend)
+
+**Files:**
+- Modify: `web/app/src/api.ts`, `web/app/src/views/Projects.tsx`, `web/app/src/nav/routes.tsx`
+- Create: `web/app/src/data/projectmembers.ts`, `web/app/src/views/projects/ProjectDetail.tsx`, `web/app/src/views/projects/ProjectDetail.test.tsx`
+
+**Interfaces:**
+- `ProjectMembership` TS type (snake_case to match Go); `api.projectMembers(projectId)`, `api.assignProjectMember(projectId, accountId, role)`, `api.revokeProjectMember(projectId, accountId)`. Hooks `useProjectMembers(projectId)`, `useAssignProjectMember(projectId)`, `useRevokeProjectMember(projectId)` (invalidate `['project-members', projectId]`).
+- `ProjectDetail` view: route `/projects/$id` (hidden from nav; reached by clicking a project). `<PageHeader>` with the project name; a members table (account + role + revoke) and an assign form (account id input + role select with the built-in roles + a Save). An honest note: "Per-project roles take effect on resources once resources are assigned to projects." Use the existing role-select / table patterns from Members.tsx.
+- `Projects.tsx`: make each project row link to `/projects/$id` (a router Link on the name).
+
+- [ ] **Step 1: Write the failing test** (`ProjectDetail.test.tsx`): render `/projects/p1`, mock capabilities + project members `[{account_id:'a@x', project_id:'p1', role:'viewer'}]`; assert the member renders, and assigning a new member (type account + pick role + Save) calls the POST.
+
+- [ ] **Step 2: Run, confirm fail.** `pnpm -C web/app test src/views/projects/ProjectDetail.test.tsx` Expected: FAIL.
+
+- [ ] **Step 3: Implement** the api additions, hooks, ProjectDetail view + route, and the Projects row link.
+
+- [ ] **Step 4: Run the test, full suite, typecheck.** Expected: PASS, clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add web/app/src/api.ts web/app/src/data/projectmembers.ts web/app/src/views/projects/ProjectDetail.tsx web/app/src/views/projects/ProjectDetail.test.tsx web/app/src/views/Projects.tsx web/app/src/nav/routes.tsx
+git commit -s -m "feat(console): project detail view with per-project member management"
+```
+
+---
+
+### Task 3: a11y, styles, final verification
+
+**Files:**
+- Modify: `web/packages/brand/src/base.css` (only if new classes are needed)
+- Create: `web/app/src/views/projects/ProjectDetail.a11y.test.tsx`
+
+- [ ] **Step 1: Axe a11y test** for `/projects/$id` (members table + assign form labelled; zero violations). Fix any real violation.
+- [ ] **Step 2: Styles** for any new classes (token-driven, responsive); reuse `.tbl`, `.page-header`, form classes where possible.
+- [ ] **Step 3: Final verification.** `pnpm -C web/app test` (0) ; `typecheck` ; `build` ; `go test ./internal/saas/...` (green) ; both golangci-lint clean ; dash grep empty over changed files.
+- [ ] **Step 4: Commit.**
+
+```bash
+git add web/packages/brand/src/base.css web/app/src/views/projects/ProjectDetail.a11y.test.tsx
+git commit -s -m "feat(console): project detail styles and accessibility checks"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (B3d-2):** project-membership store + endpoints (Task 1), project-detail UI to assign/list/revoke per-project roles (Task 2), honest framing that enforcement on resources is a later slice (Task 2). Covered.
+
+**Security invariants:** org from context; project validated to belong to the org; manage gated by projects.manage; isolation tested (Task 1).
+
+**Type consistency:** Go `ProjectMembership` JSON tags match the TS type (Task 2); the endpoints (Task 1) back the hooks (Task 2). No drift.

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -80,6 +80,11 @@ type Deps struct {
 	// built-in role. Defaults to an empty in-memory store so the BFF is safe to
 	// instantiate without a real custom-role backend.
 	CustomRoles CustomRoleStore
+	// ProjectMembers is the per-org, per-project membership store. It backs the
+	// GET/POST/DELETE /console/projects/{id}/members endpoints. Defaults to an
+	// empty in-memory store so the BFF is safe to instantiate without a real
+	// backend.
+	ProjectMembers ProjectMembershipStore
 	// Capabilities is the deployment edition + feature flags the console
 	// advertises at GET /console/capabilities. Left zero, it defaults to the
 	// self-hosted community edition.
@@ -138,6 +143,9 @@ func New(deps Deps) *Console {
 	}
 	if deps.CustomRoles == nil {
 		deps.CustomRoles = NewMemCustomRoleStore()
+	}
+	if deps.ProjectMembers == nil {
+		deps.ProjectMembers = NewMemProjectMembershipStore()
 	}
 	if deps.Logs == nil {
 		// Default to an authorizing streamer over the (already-defaulted)
@@ -203,6 +211,9 @@ func (c *Console) routes() {
 	mux.HandleFunc("GET /console/forktree", c.handleForkTree)
 	mux.HandleFunc("GET /console/projects", c.handleListProjects)
 	mux.HandleFunc("POST /console/projects", c.handleCreateProject)
+	mux.HandleFunc("GET /console/projects/{id}/members", c.handleListProjectMembers)
+	mux.HandleFunc("POST /console/projects/{id}/members", c.handleAssignProjectMember)
+	mux.HandleFunc("DELETE /console/projects/{id}/members/{accountID}", c.handleRevokeProjectMember)
 	mux.HandleFunc("POST /console/members/{accountID}/role", c.handleSetMemberRole)
 	mux.HandleFunc("GET /console/account", c.handleGetAccount)
 	mux.HandleFunc("PATCH /console/account", c.handlePatchAccount)

--- a/internal/saas/console/console_test.go
+++ b/internal/saas/console/console_test.go
@@ -514,6 +514,9 @@ func TestEveryEndpointRefusesMissingOrgContext(t *testing.T) {
 		{"GET", "/console/roles"},
 		{"POST", "/console/roles"},
 		{"DELETE", "/console/roles/myrole"},
+		{"GET", "/console/projects/x/members"},
+		{"POST", "/console/projects/x/members"},
+		{"DELETE", "/console/projects/x/members/y"},
 	}
 	for _, ep := range endpoints {
 		// No WithCaller: the request carries no org context.

--- a/internal/saas/console/projectmembers.go
+++ b/internal/saas/console/projectmembers.go
@@ -1,0 +1,218 @@
+package console
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// ProjectMembership is a per-project role assignment: one account holds a role
+// within one project in one org. The org is never carried over the wire; it is
+// resolved from the caller's authenticated context.
+type ProjectMembership struct {
+	AccountID string    `json:"account_id"`
+	ProjectID string    `json:"project_id"`
+	Role      saas.Role `json:"role"`
+}
+
+// ProjectMembershipStore is the per-org, per-project membership seam. All
+// methods are scoped to both orgID and projectID: a write for orgA must never
+// affect orgB, and a read for orgA must never return orgB's memberships.
+type ProjectMembershipStore interface {
+	// List returns all memberships for the project in the given org.
+	List(ctx context.Context, orgID, projectID string) ([]ProjectMembership, error)
+	// Assign creates or replaces the account's role in the project.
+	Assign(ctx context.Context, orgID, projectID, accountID string, role saas.Role) error
+	// Revoke removes the account's membership from the project. It is not an
+	// error to revoke a membership that does not exist.
+	Revoke(ctx context.Context, orgID, projectID, accountID string) error
+}
+
+// MemProjectMembershipStore is the in-memory tested default. It is keyed first
+// by org then by project: cross-org reads always return an empty slice.
+type MemProjectMembershipStore struct {
+	mu    sync.RWMutex
+	byOrg map[string]map[string]map[string]ProjectMembership
+}
+
+// NewMemProjectMembershipStore returns an empty in-memory membership store.
+func NewMemProjectMembershipStore() *MemProjectMembershipStore {
+	return &MemProjectMembershipStore{
+		byOrg: map[string]map[string]map[string]ProjectMembership{},
+	}
+}
+
+// List returns all memberships for the project in the given org (copies; never
+// cross-org).
+func (m *MemProjectMembershipStore) List(_ context.Context, orgID, projectID string) ([]ProjectMembership, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	src := m.byOrg[orgID][projectID]
+	out := make([]ProjectMembership, 0, len(src))
+	for _, pm := range src {
+		out = append(out, pm)
+	}
+	return out, nil
+}
+
+// Assign creates or replaces the account's role within the project for the org.
+func (m *MemProjectMembershipStore) Assign(_ context.Context, orgID, projectID, accountID string, role saas.Role) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.byOrg[orgID] == nil {
+		m.byOrg[orgID] = map[string]map[string]ProjectMembership{}
+	}
+	if m.byOrg[orgID][projectID] == nil {
+		m.byOrg[orgID][projectID] = map[string]ProjectMembership{}
+	}
+	m.byOrg[orgID][projectID][accountID] = ProjectMembership{
+		AccountID: accountID,
+		ProjectID: projectID,
+		Role:      role,
+	}
+	return nil
+}
+
+// Revoke removes the account's membership from the project. It is not an error
+// to revoke a membership that does not exist.
+func (m *MemProjectMembershipStore) Revoke(_ context.Context, orgID, projectID, accountID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.byOrg[orgID] == nil || m.byOrg[orgID][projectID] == nil {
+		return nil
+	}
+	delete(m.byOrg[orgID][projectID], accountID)
+	return nil
+}
+
+// --- Handlers ---
+
+// validateProjectInOrg checks that the given project id belongs to the caller's
+// org. It lists the org's projects and returns (true, nil) if found,
+// (false, nil) if not found, or (false, err) on store failure.
+func (c *Console) validateProjectInOrg(r *http.Request, orgID, projectID string) (bool, error) {
+	projects, err := c.deps.Projects.List(r.Context(), orgID)
+	if err != nil {
+		return false, err
+	}
+	for _, p := range projects {
+		if p.ID == projectID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// handleListProjectMembers returns the list of per-project role assignments for
+// the caller's org and project. Gated by PermReadOnly.
+func (c *Console) handleListProjectMembers(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.authorize(r, saas.PermReadOnly)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	projectID := r.PathValue("id")
+	found, err := c.validateProjectInOrg(r, orgID, projectID)
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the project list could not be read"))
+		return
+	}
+	if !found {
+		apierr.Encode(w, apierr.Get(apierr.CodeNotFound).
+			WithCause("the project does not exist or does not belong to this organization"))
+		return
+	}
+	memberships, err := c.deps.ProjectMembers.List(r.Context(), orgID, projectID)
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the project members could not be listed"))
+		return
+	}
+	if memberships == nil {
+		memberships = []ProjectMembership{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"project_id": projectID,
+		"members":    memberships,
+	})
+}
+
+// assignMemberRequest is the body of POST /console/projects/{id}/members.
+type assignMemberRequest struct {
+	AccountID string    `json:"account_id"`
+	Role      saas.Role `json:"role"`
+}
+
+// handleAssignProjectMember assigns an account to a role in the project. Gated
+// by PermManageProjects.
+func (c *Console) handleAssignProjectMember(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.authorize(r, saas.PermManageProjects)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	projectID := r.PathValue("id")
+	found, err := c.validateProjectInOrg(r, orgID, projectID)
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the project list could not be read"))
+		return
+	}
+	if !found {
+		apierr.Encode(w, apierr.Get(apierr.CodeNotFound).
+			WithCause("the project does not exist or does not belong to this organization"))
+		return
+	}
+	var req assignMemberRequest
+	if err := decodeBody(r, &req); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the assign-member body is not valid JSON"))
+		return
+	}
+	if err := c.deps.ProjectMembers.Assign(r.Context(), orgID, projectID, req.AccountID, req.Role); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the project member could not be assigned"))
+		return
+	}
+	writeJSON(w, http.StatusOK, ProjectMembership{
+		AccountID: req.AccountID,
+		ProjectID: projectID,
+		Role:      req.Role,
+	})
+}
+
+// handleRevokeProjectMember removes an account's membership from a project.
+// Gated by PermManageProjects.
+func (c *Console) handleRevokeProjectMember(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.authorize(r, saas.PermManageProjects)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	projectID := r.PathValue("id")
+	found, err := c.validateProjectInOrg(r, orgID, projectID)
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the project list could not be read"))
+		return
+	}
+	if !found {
+		apierr.Encode(w, apierr.Get(apierr.CodeNotFound).
+			WithCause("the project does not exist or does not belong to this organization"))
+		return
+	}
+	accountID := r.PathValue("accountID")
+	if err := c.deps.ProjectMembers.Revoke(r.Context(), orgID, projectID, accountID); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the project member could not be revoked"))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"project_id": projectID,
+		"revoked":    accountID,
+	})
+}

--- a/internal/saas/console/projectmembers_test.go
+++ b/internal/saas/console/projectmembers_test.go
@@ -1,0 +1,247 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/saas"
+)
+
+// projectMembersFixture wires a console with two orgs (alice and bob), a
+// seeded project in alice's org, and an admin + member caller in alice's org
+// so the permission tests have the full matrix.
+type projectMembersFixture struct {
+	con        *Console
+	store      *saas.MemStore
+	members    *MemProjectMembershipStore
+	projects   *MemProjectStore
+	aliceAcct  string
+	aliceOrg   string
+	bobAcct    string
+	bobOrg     string
+	adminAcct  string // RoleAdmin in alice's org: has projects.manage
+	memberAcct string // RoleMember in alice's org: no projects.manage, has read
+	projectID  string // seeded project in alice's org
+}
+
+func newProjectMembersFixture(t *testing.T) *projectMembersFixture {
+	t.Helper()
+	store := saas.NewMemStore()
+	keys := saas.NewKeyService(store)
+	accounts := saas.NewAccountService(store, keys)
+	ctx := context.Background()
+
+	alice, aliceOrg, err := accounts.SignUp(ctx, "pmem-alice@example.com")
+	if err != nil {
+		t.Fatalf("SignUp alice: %v", err)
+	}
+	bob, bobOrg, err := accounts.SignUp(ctx, "pmem-bob@example.com")
+	if err != nil {
+		t.Fatalf("SignUp bob: %v", err)
+	}
+
+	// admin is a second user with RoleAdmin in alice's org (has projects.manage).
+	admin, _, err := accounts.SignUp(ctx, "pmem-admin@example.com")
+	if err != nil {
+		t.Fatalf("SignUp admin: %v", err)
+	}
+	if err := store.PutMembership(ctx, saas.Membership{
+		AccountID: admin.ID,
+		OrgID:     aliceOrg.ID,
+		Role:      saas.RoleAdmin,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed admin membership: %v", err)
+	}
+
+	// member is a regular member in alice's org (no projects.manage).
+	member, _, err := accounts.SignUp(ctx, "pmem-member@example.com")
+	if err != nil {
+		t.Fatalf("SignUp member: %v", err)
+	}
+	if err := store.PutMembership(ctx, saas.Membership{
+		AccountID: member.ID,
+		OrgID:     aliceOrg.ID,
+		Role:      saas.RoleMember,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed member membership: %v", err)
+	}
+
+	projects := NewMemProjectStore()
+	p, err := projects.Create(ctx, aliceOrg.ID, "ProjectA", "desc")
+	if err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	members := NewMemProjectMembershipStore()
+	con := New(Deps{
+		Accounts:       accounts,
+		Projects:       projects,
+		ProjectMembers: members,
+		Now:            time.Now,
+	})
+	return &projectMembersFixture{
+		con:        con,
+		store:      store,
+		members:    members,
+		projects:   projects,
+		aliceAcct:  alice.ID,
+		aliceOrg:   aliceOrg.ID,
+		bobAcct:    bob.ID,
+		bobOrg:     bobOrg.ID,
+		adminAcct:  admin.ID,
+		memberAcct: member.ID,
+		projectID:  p.ID,
+	}
+}
+
+func (f *projectMembersFixture) req(t *testing.T, method, target, body, acct, org string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, target, nil)
+	} else {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	}
+	r = r.WithContext(WithCaller(r.Context(), acct, org))
+	w := httptest.NewRecorder()
+	f.con.ServeHTTP(w, r)
+	return w
+}
+
+// TestProjectMembersAdminAssignAndList verifies that an admin can POST a
+// membership and GET it back in the list.
+func TestProjectMembersAdminAssignAndList(t *testing.T) {
+	f := newProjectMembersFixture(t)
+
+	// Admin assigns account "x" as viewer in the project.
+	body := `{"account_id":"x","role":"viewer"}`
+	pw := f.req(t, "POST", "/console/projects/"+f.projectID+"/members", body, f.adminAcct, f.aliceOrg)
+	if pw.Code != http.StatusOK {
+		t.Fatalf("POST /console/projects/{id}/members status = %d, want 200; body=%s", pw.Code, pw.Body.String())
+	}
+
+	// GET lists the membership.
+	gw := f.req(t, "GET", "/console/projects/"+f.projectID+"/members", "", f.aliceAcct, f.aliceOrg)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET /console/projects/{id}/members status = %d, want 200; body=%s", gw.Code, gw.Body.String())
+	}
+	var resp struct {
+		ProjectID string              `json:"project_id"`
+		Members   []ProjectMembership `json:"members"`
+	}
+	if err := json.Unmarshal(gw.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode GET response: %v; body=%s", err, gw.Body.String())
+	}
+	if resp.ProjectID != f.projectID {
+		t.Errorf("project_id = %q, want %q", resp.ProjectID, f.projectID)
+	}
+	if len(resp.Members) != 1 {
+		t.Fatalf("members = %+v, want 1 member", resp.Members)
+	}
+	if resp.Members[0].AccountID != "x" || resp.Members[0].Role != saas.RoleViewer {
+		t.Errorf("member = %+v, want {account_id:x role:viewer}", resp.Members[0])
+	}
+}
+
+// TestProjectMembersMemberCanGetButNotAssignOrRevoke verifies that a caller
+// with RoleMember (no projects.manage) gets 200 on GET but 403 on POST and
+// DELETE.
+func TestProjectMembersMemberCanGetButNotAssignOrRevoke(t *testing.T) {
+	f := newProjectMembersFixture(t)
+
+	// member GET: allowed (PermReadOnly).
+	gw := f.req(t, "GET", "/console/projects/"+f.projectID+"/members", "", f.memberAcct, f.aliceOrg)
+	if gw.Code != http.StatusOK {
+		t.Errorf("member GET = %d, want 200; body=%s", gw.Code, gw.Body.String())
+	}
+
+	// member POST: forbidden (no projects.manage).
+	pw := f.req(t, "POST", "/console/projects/"+f.projectID+"/members",
+		`{"account_id":"y","role":"viewer"}`, f.memberAcct, f.aliceOrg)
+	if pw.Code != http.StatusForbidden {
+		t.Errorf("member POST = %d, want 403; body=%s", pw.Code, pw.Body.String())
+	}
+
+	// member DELETE: forbidden (no projects.manage).
+	dw := f.req(t, "DELETE", "/console/projects/"+f.projectID+"/members/y", "", f.memberAcct, f.aliceOrg)
+	if dw.Code != http.StatusForbidden {
+		t.Errorf("member DELETE = %d, want 403; body=%s", dw.Code, dw.Body.String())
+	}
+}
+
+// TestProjectMembersUnknownProjectReturns404 verifies that GET/POST/DELETE on
+// a project id not in the caller's org return 404.
+func TestProjectMembersUnknownProjectReturns404(t *testing.T) {
+	f := newProjectMembersFixture(t)
+
+	gw := f.req(t, "GET", "/console/projects/no-such-project/members", "", f.aliceAcct, f.aliceOrg)
+	if gw.Code != http.StatusNotFound {
+		t.Errorf("GET unknown project = %d, want 404; body=%s", gw.Code, gw.Body.String())
+	}
+
+	pw := f.req(t, "POST", "/console/projects/no-such-project/members",
+		`{"account_id":"x","role":"viewer"}`, f.adminAcct, f.aliceOrg)
+	if pw.Code != http.StatusNotFound {
+		t.Errorf("POST unknown project = %d, want 404; body=%s", pw.Code, pw.Body.String())
+	}
+
+	dw := f.req(t, "DELETE", "/console/projects/no-such-project/members/x", "", f.adminAcct, f.aliceOrg)
+	if dw.Code != http.StatusNotFound {
+		t.Errorf("DELETE unknown project = %d, want 404; body=%s", dw.Code, dw.Body.String())
+	}
+}
+
+// TestProjectMembersOrgIsolation verifies that orgB cannot list orgA's project
+// members. Alice's project is not visible to bob's org context; the endpoint
+// returns 404 (project not found in bob's org).
+func TestProjectMembersOrgIsolation(t *testing.T) {
+	f := newProjectMembersFixture(t)
+
+	// Seed a membership in alice's project.
+	ctx := context.Background()
+	if err := f.members.Assign(ctx, f.aliceOrg, f.projectID, "x", saas.RoleViewer); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+
+	// Bob requests alice's project id but is authenticated as bob's org.
+	gw := f.req(t, "GET", "/console/projects/"+f.projectID+"/members", "", f.bobAcct, f.bobOrg)
+	// The project does not exist in bob's org so we expect 404, not a data leak.
+	if gw.Code != http.StatusNotFound {
+		t.Errorf("orgB GET orgA project = %d, want 404; body=%s", gw.Code, gw.Body.String())
+	}
+}
+
+// TestProjectMembersRevokeRemovesMembership verifies that DELETE removes the
+// membership and a subsequent GET no longer lists it.
+func TestProjectMembersRevokeRemovesMembership(t *testing.T) {
+	f := newProjectMembersFixture(t)
+
+	// Assign first.
+	f.req(t, "POST", "/console/projects/"+f.projectID+"/members",
+		`{"account_id":"z","role":"viewer"}`, f.adminAcct, f.aliceOrg)
+
+	// Revoke.
+	dw := f.req(t, "DELETE", "/console/projects/"+f.projectID+"/members/z", "", f.adminAcct, f.aliceOrg)
+	if dw.Code != http.StatusOK {
+		t.Fatalf("DELETE = %d, want 200; body=%s", dw.Code, dw.Body.String())
+	}
+
+	// GET should return empty list.
+	gw := f.req(t, "GET", "/console/projects/"+f.projectID+"/members", "", f.aliceAcct, f.aliceOrg)
+	var resp struct {
+		Members []ProjectMembership `json:"members"`
+	}
+	if err := json.Unmarshal(gw.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	if len(resp.Members) != 0 {
+		t.Errorf("after revoke, members = %+v, want empty", resp.Members)
+	}
+}

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -62,6 +62,7 @@ export type BillingView = { org_id: string; status: string; balance_cents: numbe
 export type Role = 'owner' | 'admin' | 'billing' | 'member' | 'viewer'
 export type MemberView = { account_id: string; org_id: string; role: Role; created_at: string }
 export type ProjectView = { id: string; org_id: string; name: string; description: string; created_at: string }
+export type ProjectMembership = { account_id: string; project_id: string; role: Role }
 
 export type SinkType = 'webhook' | 's3' | 'splunk' | 'datadog'
 export type SinkView = { id: string; org_id: string; type: SinkType; endpoint: string; enabled: boolean; created_at: string }
@@ -272,6 +273,24 @@ export const api = {
     })
     if (!r.ok) throw new Error(`set retention policy: ${r.status}`)
     return (await r.json()) as DataRetentionPolicy
+  },
+  projectMembers: (projectId: string) =>
+    get<{ project_id: string; members: ProjectMembership[] }>(`/console/projects/${encodeURIComponent(projectId)}/members`).then((r) => r.members ?? []),
+  assignProjectMember: async (projectId: string, accountId: string, role: Role) => {
+    const r = await fetch(`/console/projects/${encodeURIComponent(projectId)}/members`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ account_id: accountId, role }),
+    })
+    if (!r.ok) throw new Error(`assign project member: ${r.status}`)
+  },
+  revokeProjectMember: async (projectId: string, accountId: string) => {
+    const r = await fetch(`/console/projects/${encodeURIComponent(projectId)}/members/${encodeURIComponent(accountId)}`, {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+    if (!r.ok && r.status !== 204) throw new Error(`revoke project member: ${r.status}`)
   },
 }
 

--- a/web/app/src/data/projectmembers.ts
+++ b/web/app/src/data/projectmembers.ts
@@ -1,0 +1,28 @@
+// Project-scoped member hooks: list, assign, and revoke per-project membership.
+// Mutations invalidate ['project-members', projectId] on success so the table
+// refreshes without a manual reload.
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api, type ProjectMembership, type Role } from '../api'
+
+export function useProjectMembers(projectId: string) {
+  return useQuery<ProjectMembership[]>({
+    queryKey: ['project-members', projectId],
+    queryFn: () => api.projectMembers(projectId),
+  })
+}
+
+export function useAssignProjectMember(projectId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (v: { accountId: string; role: Role }) => api.assignProjectMember(projectId, v.accountId, v.role),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['project-members', projectId] }),
+  })
+}
+
+export function useRevokeProjectMember(projectId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (accountId: string) => api.revokeProjectMember(projectId, accountId),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['project-members', projectId] }),
+  })
+}

--- a/web/app/src/nav/routes.tsx
+++ b/web/app/src/nav/routes.tsx
@@ -19,6 +19,7 @@ import { Projects } from '../views/Projects'
 import { Settings } from '../views/Settings'
 import { Retention } from '../views/Retention'
 import { Roles } from '../views/Roles'
+import { ProjectDetail } from '../views/projects/ProjectDetail'
 
 export type NavGroupName = 'Run' | 'Build' | 'Govern' | 'Billing'
 export const GROUP_ORDER: NavGroupName[] = ['Run', 'Build', 'Govern', 'Billing']
@@ -43,6 +44,7 @@ export const ROUTES: RouteDef[] = [
   { path: '/keys', label: 'API keys', group: 'Build', element: () => <Keys /> },
   { path: '/members', label: 'Members', group: 'Govern', element: () => <Members />, when: (c) => c.teams },
   { path: '/projects', label: 'Projects', group: 'Govern', element: () => <Projects />, when: (c) => c.teams },
+  { path: '/projects/$id', label: 'Project', group: 'Govern', element: () => <ProjectDetail />, hidden: true },
   { path: '/audit', label: 'Audit', group: 'Govern', element: () => <Audit /> },
   { path: '/retention', label: 'Data and retention', group: 'Govern', element: () => <Retention /> },
   { path: '/roles', label: 'Roles', group: 'Govern', element: () => <Roles />, when: (c) => c.teams },

--- a/web/app/src/views/Projects.tsx
+++ b/web/app/src/views/Projects.tsx
@@ -1,6 +1,7 @@
 // Projects view: create form (labelled name + description inputs) and project list.
 // Supports loading, empty, and error states.
 import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
 import { useProjects, useCreateProject } from '../data/org'
 import { Skeleton } from '../ui/Skeleton'
 import { EmptyState } from '../ui/EmptyState'
@@ -89,7 +90,9 @@ export function Projects() {
                 border: '1px solid var(--border, #e0e0e0)',
               }}
             >
-              <div style={{ fontWeight: 600 }}>{p.name}</div>
+              <div style={{ fontWeight: 600 }}>
+                <Link to="/projects/$id" params={{ id: p.id }}>{p.name}</Link>
+              </div>
               {p.description && (
                 <div className="t-dim" style={{ fontSize: 'var(--step--1)', marginTop: 'var(--space-1)' }}>
                   {p.description}

--- a/web/app/src/views/projects/ProjectDetail.a11y.test.tsx
+++ b/web/app/src/views/projects/ProjectDetail.a11y.test.tsx
@@ -1,0 +1,97 @@
+// Axe accessibility audit for the ProjectDetail view (/projects/$id):
+// members table with labelled headers and revoke buttons, plus the assign
+// form with labelled account input and role select. Zero violations required.
+// Uses vitest-axe (^0.1.0) which wraps axe-core and provides Vitest-compatible
+// matchers. Import path: 'vitest-axe' for axe(), 'vitest-axe/matchers' for the
+// custom expect matcher.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import * as matchers from 'vitest-axe/matchers'
+import { renderAt } from '../../test/utils'
+import type { Capabilities } from '../../api'
+
+expect.extend(matchers)
+
+const caps: Capabilities = {
+  edition: 'community',
+  billing: false,
+  signup: false,
+  teams: true,
+  idp: 'oidc',
+  orgSwitcher: false,
+  secrets: { providers: ['kube'] },
+  proof: true,
+  ownership: 'self-hosted',
+}
+
+const projects = [
+  { id: 'p1', org_id: 'o1', name: 'alpha', description: 'first project', created_at: '2026-01-01T00:00:00Z' },
+]
+
+const projectMembers = [
+  { account_id: 'a@x', project_id: 'p1', role: 'viewer' },
+  { account_id: 'b@x', project_id: 'p1', role: 'admin' },
+]
+
+function mockFetch() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input).split('?')[0]
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/projects') && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify({ org_id: 'o1', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify({ project_id: 'p1', members: projectMembers }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'POST') {
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 201, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/projects\/[^/]+\/members\//) && method === 'DELETE') {
+      return Promise.resolve(new Response('', { status: 204 }))
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+}
+
+beforeEach(() => {
+  mockFetch()
+})
+
+describe('ProjectDetail view accessibility', () => {
+  it('has no axe violations with the members table and assign form rendered', async () => {
+    const { container } = await renderAt('/projects/p1', caps)
+    // Wait for the member table to load before auditing.
+    await waitFor(() => expect(screen.getByText('a@x')).toBeInTheDocument())
+    // Confirm labelled form controls are present.
+    expect(screen.getByLabelText(/account id/i)).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument()
+    // Zero axe violations.
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations in the empty-members state', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input).split('?')[0]
+      const method = (init?.method ?? 'GET').toUpperCase()
+      if (url.endsWith('/console/capabilities')) {
+        return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.endsWith('/console/projects') && method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ org_id: 'o1', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ project_id: 'p1', members: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+    })
+    const { container } = await renderAt('/projects/p1', caps)
+    // Wait for the empty-state message to confirm rendering is complete.
+    await waitFor(() => expect(screen.getByText(/no project members yet/i)).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/web/app/src/views/projects/ProjectDetail.test.tsx
+++ b/web/app/src/views/projects/ProjectDetail.test.tsx
@@ -1,0 +1,158 @@
+// TDD suite for ProjectDetail: per-project member management.
+// Tests written before any implementation (RED phase).
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderAt } from '../../test/utils'
+import type { Capabilities } from '../../api'
+
+const caps: Capabilities = {
+  edition: 'community',
+  billing: false,
+  signup: false,
+  teams: true,
+  idp: 'oidc',
+  orgSwitcher: false,
+  secrets: { providers: ['kube'] },
+  proof: true,
+  ownership: 'self-hosted',
+}
+
+const projectMembers = [
+  { account_id: 'a@x', project_id: 'p1', role: 'viewer' },
+]
+
+const projects = [
+  { id: 'p1', org_id: 'o1', name: 'alpha', description: 'first project', created_at: '2026-01-01T00:00:00Z' },
+]
+
+function mockFetch(overrides: { assignStatus?: number } = {}) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input).split('?')[0]
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    if (url.endsWith('/console/capabilities')) {
+      return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.endsWith('/console/projects') && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify({ org_id: 'o1', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify({ project_id: 'p1', members: projectMembers }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'POST') {
+      const status = overrides.assignStatus ?? 201
+      return Promise.resolve(new Response(JSON.stringify({}), { status, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.match(/\/console\/projects\/[^/]+\/members\//) && method === 'DELETE') {
+      return Promise.resolve(new Response('', { status: 204 }))
+    }
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+  })
+}
+
+beforeEach(() => {
+  mockFetch()
+})
+
+describe('ProjectDetail view', () => {
+  it('renders the page header with the project name', async () => {
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/alpha/i))
+  })
+
+  it('renders the existing member row with account_id and role', async () => {
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByText('a@x')).toBeInTheDocument())
+    // The role badge appears in the table row
+    const badge = document.querySelector('.role-badge')
+    expect(badge).toBeTruthy()
+    expect(badge?.textContent).toBe('viewer')
+  })
+
+  it('renders a Revoke button for each member', async () => {
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByText('a@x')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument()
+  })
+
+  it('renders the assign form with account input, role select, and Save button', async () => {
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument())
+    expect(screen.getByLabelText(/account id/i)).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /assign|save/i })).toBeInTheDocument()
+  })
+
+  it('the role select contains all 5 built-in roles', async () => {
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument())
+    const select = screen.getByRole('combobox', { name: /role/i })
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.value)
+    expect(options).toContain('owner')
+    expect(options).toContain('admin')
+    expect(options).toContain('billing')
+    expect(options).toContain('member')
+    expect(options).toContain('viewer')
+  })
+
+  it('calls POST /console/projects/p1/members when assign form is submitted', async () => {
+    const postSpy = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 201, headers: { 'content-type': 'application/json' } }))
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input).split('?')[0]
+      const method = (init?.method ?? 'GET').toUpperCase()
+      if (url.endsWith('/console/capabilities')) {
+        return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.endsWith('/console/projects') && method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ org_id: 'o1', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ project_id: 'p1', members: projectMembers }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'POST') {
+        return postSpy(input, init)
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+    })
+
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByLabelText(/account id/i)).toBeInTheDocument())
+
+    await userEvent.type(screen.getByLabelText(/account id/i), 'new@user')
+    fireEvent.change(screen.getByRole('combobox', { name: /role/i }), { target: { value: 'admin' } })
+    fireEvent.click(screen.getByRole('button', { name: /assign|save/i }))
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled())
+    const [calledUrl, calledInit] = postSpy.mock.calls[0] as [string, RequestInit]
+    expect(calledUrl).toContain('/console/projects/p1/members')
+    const body = JSON.parse(calledInit.body as string) as { account_id: string; role: string }
+    expect(body.account_id).toBe('new@user')
+    expect(body.role).toBe('admin')
+  })
+
+  it('shows the empty state note when there are no members', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input).split('?')[0]
+      const method = (init?.method ?? 'GET').toUpperCase()
+      if (url.endsWith('/console/capabilities')) {
+        return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.endsWith('/console/projects') && method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ org_id: 'o1', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.match(/\/console\/projects\/[^/]+\/members$/) && method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ project_id: 'p1', members: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+    })
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByText(/no project members yet/i)).toBeInTheDocument())
+  })
+
+  it('shows an honest note about per-project roles', async () => {
+    await renderAt('/projects/p1', caps)
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument())
+    expect(screen.getByText(/per-project roles take effect/i)).toBeInTheDocument()
+  })
+})

--- a/web/app/src/views/projects/ProjectDetail.tsx
+++ b/web/app/src/views/projects/ProjectDetail.tsx
@@ -1,0 +1,144 @@
+// Per-project detail view: shows the project's members and lets admins
+// assign or revoke per-project roles. Reached by clicking a project name in
+// the Projects list. The route param is the project id.
+import { useState } from 'react'
+import { useParams } from '@tanstack/react-router'
+import { useProjects } from '../../data/org'
+import { useProjectMembers, useAssignProjectMember, useRevokeProjectMember } from '../../data/projectmembers'
+import { Skeleton } from '../../ui/Skeleton'
+import { useToast } from '../../ui/Toast'
+import { PageHeader } from '../../ui/PageHeader'
+import type { Role } from '../../api'
+
+const ROLES: Role[] = ['owner', 'admin', 'billing', 'member', 'viewer']
+
+export function ProjectDetail() {
+  const { id } = useParams({ from: '/projects/$id' })
+  const { data: projects = [] } = useProjects()
+  const { data: members = [], isLoading } = useProjectMembers(id)
+  const assign = useAssignProjectMember(id)
+  const revoke = useRevokeProjectMember(id)
+  const { notify } = useToast()
+
+  const [accountId, setAccountId] = useState('')
+  const [role, setRole] = useState<Role>('viewer')
+
+  const project = projects.find((p) => p.id === id)
+  const title = project ? project.name : `Project ${id}`
+
+  function onAssign(e: React.FormEvent) {
+    e.preventDefault()
+    assign.mutate(
+      { accountId, role },
+      {
+        onSuccess: () => {
+          setAccountId('')
+          setRole('viewer')
+          notify('Member assigned', 'ok')
+        },
+        onError: () => notify('Failed to assign member', 'error'),
+      },
+    )
+  }
+
+  function onRevoke(memberId: string) {
+    revoke.mutate(memberId, {
+      onSuccess: () => notify('Member revoked', 'ok'),
+      onError: () => notify('Failed to revoke member', 'error'),
+    })
+  }
+
+  return (
+    <section>
+      <PageHeader
+        title={title}
+        lede="Per-project membership. Assign roles scoped to this project."
+      />
+
+      <p className="t-dim" style={{ marginBottom: 'var(--space-5)' }}>
+        Per-project roles take effect on resources once resources are assigned to projects.
+      </p>
+
+      <h2 style={{ marginBottom: 'var(--space-4)' }}>Members</h2>
+
+      {isLoading ? (
+        <Skeleton rows={3} />
+      ) : members.length === 0 ? (
+        <p className="t-dim" style={{ marginBottom: 'var(--space-5)' }}>No project members yet.</p>
+      ) : (
+        <div style={{ overflowX: 'auto', marginBottom: 'var(--space-6)' }}>
+          <table className="tbl" aria-label="Project members">
+            <thead>
+              <tr>
+                <th scope="col">Account</th>
+                <th scope="col">Role</th>
+                <th scope="col"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.account_id}>
+                  <td>{m.account_id}</td>
+                  <td>
+                    <span className={`role-badge role-${m.role}`}>{m.role}</span>
+                  </td>
+                  <td>
+                    <button
+                      className="btn btn-ghost"
+                      onClick={() => onRevoke(m.account_id)}
+                      aria-label={`Revoke ${m.account_id}`}
+                    >
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h2 style={{ marginBottom: 'var(--space-4)' }}>Assign member</h2>
+
+      <form onSubmit={onAssign} style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+        <div>
+          <label htmlFor="assign-account-id" style={{ display: 'block', marginBottom: 'var(--space-1)', fontSize: 'var(--step--1)' }}>
+            Account ID
+          </label>
+          <input
+            id="assign-account-id"
+            className="mono"
+            placeholder="account@example.com"
+            value={accountId}
+            onChange={(e) => setAccountId(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="assign-role" style={{ display: 'block', marginBottom: 'var(--space-1)', fontSize: 'var(--step--1)' }}>
+            Role
+          </label>
+          <select
+            id="assign-role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as Role)}
+            aria-label="Role"
+          >
+            {ROLES.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          type="submit"
+          className="btn"
+          disabled={!accountId || assign.isPending}
+        >
+          Assign
+        </button>
+      </form>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Second slice of B3d. Owner/Admin can assign a role to an account scoped to a single project (Admin of project A, Viewer of project B). Per-project roles are stored and surfaced now; ENFORCEMENT on resources comes in B3d-3 (resource project tagging) and B3d-4 (per-project access). The UI says so honestly.

## What landed

- A console `ProjectMembership` store + `GET/POST/DELETE /console/projects/{id}/members`, gated by the B3d-1 authorize helper (read to list, projects.manage to assign/revoke). The project id is validated to belong to the caller's org before any membership read/write; an unknown or foreign id returns 404.
- A project-detail view `/projects/$id` (members table + assign form), linked from the Projects list.

## Security (reviewed)

Org isolation holds on two layers: org is sourced from request context only, and the membership store is per-org keyed so a project-id collision across orgs cannot cross over; a foreign/guessed project id 404s before any store op. A Viewer or Member gets 403 on assign/revoke. The UI does not claim enforcement that does not exist yet.

## Verification

- `go test ./internal/saas/...` green; both golangci-lint clean.
- web suite 148 passing; typecheck + build clean; axe zero violations.
- No em or en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)