### PR TITLE
feat(console): B3d-3 resource project tagging (sandboxes)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-console-b3d3-resource-tagging.md
+++ b/docs/superpowers/plans/2026-06-26-console-b3d3-resource-tagging.md
@@ -1,0 +1,112 @@
+# Console B3d-3: resource project tagging (sandboxes) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`). Do NOT invoke finishing-a-development-branch; implement, test, commit, report.
+
+**Goal:** Let a sandbox be assigned to a project, so per-project access can be enforced in B3d-4. A console-level resource-to-project mapping store, a `project_id` on the sandbox view (populated on list and inspect), and a `PUT /console/sandboxes/{id}/project` endpoint, surfaced in the sandbox list and detail UI.
+
+**Architecture:** A console `ResourceProjectStore` maps `(orgID, resourceType, resourceID) -> projectID`. The sandbox list/inspect handlers join each `SandboxView` with its stored project. A gated PUT endpoint sets the mapping (validating the project belongs to the org, reusing the B3d-2 `validateProjectInOrg` helper). This is bounded to sandboxes (the primary forkable resource); secrets/templates can follow the same pattern. The deeper controller/CRD label propagation is a separate follow-up; this slice keeps the assignment in the console mapping, which B3d-4 reads for enforcement. The UI states assignment plainly.
+
+**Tech Stack:** Go (`internal/saas/console`), React+Vite+TS, Vitest + vitest-axe.
+
+## Global Constraints
+
+- **Security invariants (unchanged):** org from request context only; the resource-project mapping is per-org and never cross-org; setting a sandbox's project requires `projects.manage`; the target project must belong to the caller's org (reuse `validateProjectInOrg`); an empty `project_id` unassigns. Deny by default.
+- **Honesty:** the UI shows the assigned project (or "Unassigned") and states that per-project access enforcement applies once enabled (B3d-4); it does not claim enforcement that is not yet active.
+- **Punctuation (strict):** no em/en dashes. **Go:** gofmt + both golangci-lint clean; `fmt.Errorf("...: %w", err)`. **Commits:** conventional + DCO; explicit-path staging.
+- **TDD:** failing test first. TypeScript strict; web suite + `go test ./internal/saas/...` green.
+
+## File Structure
+
+- `internal/saas/console/resourceprojects.go` (create) - `ResourceProjectStore` seam + `MemResourceProjectStore` fake, the set-project handler.
+- `internal/saas/console/seams.go` (modify) - add `ProjectID string json:"project_id"` to `SandboxView`.
+- `internal/saas/console/console.go` (modify) - populate `ProjectID` in list/inspect; `Deps.ResourceProjects` default; route; auth-gate entry.
+- Go tests alongside.
+- `web/app/src/api.ts` (modify - SandboxView gains project_id; `api.setSandboxProject`), `web/app/src/data/sandboxes.ts` (modify - hook), `web/app/src/views/sandboxes/SandboxList.tsx` + `SandboxDetail.tsx` (modify - show + set project), tests.
+
+---
+
+### Task 1: resource-project store + sandbox tagging endpoint (Go)
+
+**Files:**
+- Create: `internal/saas/console/resourceprojects.go`
+- Modify: `internal/saas/console/seams.go`, `internal/saas/console/console.go`
+- Test: `internal/saas/console/resourceprojects_test.go`
+
+Read `projectmembers.go` (the `validateProjectInOrg` helper and the seam/fake/nil-default pattern), `authz.go` (`c.authorize`), `console.go` (handleListSandboxes at ~484, handleInspectSandbox, routes, auth-gate table), `seams.go` (SandboxView).
+
+**Interfaces:**
+- `ResourceProjectStore`: `Project(ctx, orgID, resourceType, resourceID string) (string, error)` (returns "" if unassigned), `SetProject(ctx, orgID, resourceType, resourceID, projectID string) error`. `NewMemResourceProjectStore()` fake (per-org keyed). `Deps.ResourceProjects` nil-defaults.
+- `SandboxView` gains `ProjectID string json:"project_id"`.
+- In `handleListSandboxes` and `handleInspectSandbox`, after fetching, set each box's `ProjectID` from `c.deps.ResourceProjects.Project(ctx, orgID, "sandbox", box.ID)`.
+- `PUT /console/sandboxes/{id}/project` body `{ project_id string }` -> gated `projects.manage`; if `project_id` is non-empty, validate it belongs to the org (`validateProjectInOrg`); then `SetProject(ctx, orgID, "sandbox", id, project_id)`. Empty `project_id` unassigns (skip the project validation when empty).
+
+- [ ] **Step 1: Write failing tests** (`resourceprojects_test.go`): an admin PUTs `{project_id:P}` (P seeded in the org) for sandbox S, then GET /console/sandboxes shows S with `project_id == P`; a member (no projects.manage) gets 403 on PUT; PUT with a project id not in the org returns 404; PUT with empty project_id unassigns (subsequent list shows ""). Use New(Deps{Accounts, Projects (seeded), Sandboxes (a MemSandboxControl with a seeded box), ResourceProjects}) + WithCaller + seeded admin/member memberships.
+
+- [ ] **Step 2: Run, confirm fail.** `go test ./internal/saas/console/ -run 'ResourceProject|SandboxProject'` Expected: FAIL.
+
+- [ ] **Step 3: Implement** resourceprojects.go (store + fake + handler), the SandboxView field, the list/inspect population, the Deps default + route + auth-gate entry.
+
+- [ ] **Step 4: Run; gofmt; both lint.** Expected: green/clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add internal/saas/console/resourceprojects.go internal/saas/console/seams.go internal/saas/console/console.go internal/saas/console/resourceprojects_test.go internal/saas/console/console_test.go
+git commit -s -m "feat(console): resource-to-project mapping and sandbox project tagging"
+```
+
+---
+
+### Task 2: sandbox project UI (frontend)
+
+**Files:**
+- Modify: `web/app/src/api.ts`, `web/app/src/data/sandboxes.ts`, `web/app/src/views/sandboxes/SandboxList.tsx`, `web/app/src/views/sandboxes/SandboxDetail.tsx`
+- Test: extend `web/app/src/views/sandboxes/SandboxList.test.tsx` (or SandboxDetail.test.tsx)
+
+**Interfaces:**
+- `SandboxView` TS type gains `project_id?: string`. `api.setSandboxProject(id, projectId)` (PUT). Hook `useSetSandboxProject()` (invalidate ['sandboxes'] and the detail).
+- SandboxList: add a "Project" column showing the project id or "Unassigned".
+- SandboxDetail: a "Project" control - a select of the org's projects (from useProjects) plus an "Unassigned" option - that calls useSetSandboxProject on change, with a short honest note that per-project access enforcement applies when enabled.
+
+- [ ] **Step 1: Write the failing test** (extend a sandboxes test): render the list with a sandbox carrying `project_id:'p1'`; assert the Project column shows it; render the detail and assert changing the project select calls the PUT.
+
+- [ ] **Step 2: Run, confirm fail.** Expected: FAIL.
+
+- [ ] **Step 3: Implement** the api/type/hook additions and the list column + detail control.
+
+- [ ] **Step 4: Run the test, full suite, typecheck.** Expected: PASS, clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add web/app/src/api.ts web/app/src/data/sandboxes.ts web/app/src/views/sandboxes/SandboxList.tsx web/app/src/views/sandboxes/SandboxDetail.tsx web/app/src/views/sandboxes/SandboxList.test.tsx
+git commit -s -m "feat(console): show and assign a sandbox's project"
+```
+
+---
+
+### Task 3: a11y, final verification
+
+**Files:**
+- Modify: `web/packages/brand/src/base.css` (only if needed)
+- Create/extend: a sandbox a11y test if the detail control needs it
+
+- [ ] **Step 1: a11y.** Ensure the project select in SandboxDetail is labelled; extend or add an axe test covering it; zero violations.
+- [ ] **Step 2: Styles** for any new classes (token-driven, responsive); reuse existing where possible.
+- [ ] **Step 3: Final verification.** `pnpm -C web/app test` (0) ; `typecheck` ; `build` ; `go test ./internal/saas/...` (green) ; both golangci-lint clean ; dash grep empty over changed files.
+- [ ] **Step 4: Commit.**
+
+```bash
+git add web/packages/brand/src/base.css web/app/src/views/sandboxes/
+git commit -s -m "feat(console): sandbox project control styles and accessibility"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (B3d-3):** resource-to-project mapping + sandbox `project_id` (Task 1), set-project endpoint gated by projects.manage with org-validated project (Task 1), UI to show + assign (Task 2), honest framing that enforcement applies in B3d-4 (Task 2). Covered. Secrets/templates tagging and controller-label propagation are deliberate follow-ups.
+
+**Security invariants:** org from context; mapping per-org; project validated to belong to org; manage gated; isolation tested (Task 1).
+
+**Type consistency:** Go `SandboxView.project_id` matches the TS type; the PUT endpoint backs the hook. No drift.

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -85,6 +85,12 @@ type Deps struct {
 	// empty in-memory store so the BFF is safe to instantiate without a real
 	// backend.
 	ProjectMembers ProjectMembershipStore
+	// ResourceProjects is the org-scoped store that maps resources (sandboxes,
+	// etc.) to projects. It backs the PUT /console/sandboxes/{id}/project
+	// endpoint and is consulted in list and inspect handlers to populate each
+	// sandbox's project_id field. Defaults to an empty in-memory store so the
+	// BFF is safe to instantiate without a real backend.
+	ResourceProjects ResourceProjectStore
 	// Capabilities is the deployment edition + feature flags the console
 	// advertises at GET /console/capabilities. Left zero, it defaults to the
 	// self-hosted community edition.
@@ -147,6 +153,9 @@ func New(deps Deps) *Console {
 	if deps.ProjectMembers == nil {
 		deps.ProjectMembers = NewMemProjectMembershipStore()
 	}
+	if deps.ResourceProjects == nil {
+		deps.ResourceProjects = NewMemResourceProjectStore()
+	}
 	if deps.Logs == nil {
 		// Default to an authorizing streamer over the (already-defaulted)
 		// sandbox control with an empty transport: it enforces org ownership and
@@ -195,6 +204,7 @@ func (c *Console) routes() {
 	mux.HandleFunc("GET /console/sandboxes/{id}", c.handleInspectSandbox)
 	mux.HandleFunc("DELETE /console/sandboxes/{id}", c.handleTerminateSandbox)
 	mux.HandleFunc("GET /console/sandboxes/{id}/logs", c.handleSandboxLogs)
+	mux.HandleFunc("PUT /console/sandboxes/{id}/project", c.handleSetSandboxProject)
 	mux.HandleFunc("GET /console/members", c.handleListMembers)
 	mux.HandleFunc("GET /console/audit", c.handleAudit)
 	mux.HandleFunc("GET /console/audit/export", c.handleAuditExport)
@@ -495,6 +505,12 @@ func (c *Console) handleListSandboxes(w http.ResponseWriter, r *http.Request) {
 	if boxes == nil {
 		boxes = []SandboxView{}
 	}
+	for i := range boxes {
+		pid, err := c.deps.ResourceProjects.Project(r.Context(), orgID, "sandbox", boxes[i].ID)
+		if err == nil {
+			boxes[i].ProjectID = pid
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"org_id": orgID, "sandboxes": boxes})
 }
 
@@ -508,6 +524,10 @@ func (c *Console) handleInspectSandbox(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.failSandbox(w, err)
 		return
+	}
+	pid, err := c.deps.ResourceProjects.Project(r.Context(), orgID, "sandbox", sb.ID)
+	if err == nil {
+		sb.ProjectID = pid
 	}
 	writeJSON(w, http.StatusOK, sb)
 }

--- a/internal/saas/console/console_test.go
+++ b/internal/saas/console/console_test.go
@@ -517,6 +517,7 @@ func TestEveryEndpointRefusesMissingOrgContext(t *testing.T) {
 		{"GET", "/console/projects/x/members"},
 		{"POST", "/console/projects/x/members"},
 		{"DELETE", "/console/projects/x/members/y"},
+		{"PUT", "/console/sandboxes/x/project"},
 	}
 	for _, ep := range endpoints {
 		// No WithCaller: the request carries no org context.

--- a/internal/saas/console/resourceprojects.go
+++ b/internal/saas/console/resourceprojects.go
@@ -1,0 +1,116 @@
+package console
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// ResourceProjectStore is the org-scoped seam that records which project a
+// given resource (e.g. a sandbox) belongs to. All methods are scoped to orgID:
+// a write for orgA must never affect orgB, and a read for orgA must never return
+// orgB data. An unassigned resource returns "" from Project.
+type ResourceProjectStore interface {
+	// Project returns the project id assigned to the resource, or "" if none.
+	Project(ctx context.Context, orgID, resourceType, resourceID string) (string, error)
+	// SetProject assigns or clears the project for the resource. An empty
+	// projectID clears the assignment.
+	SetProject(ctx context.Context, orgID, resourceType, resourceID, projectID string) error
+}
+
+// MemResourceProjectStore is the in-memory tested default for
+// ResourceProjectStore. It is keyed first by org so that cross-org reads always
+// return "". Safe for concurrent use.
+type MemResourceProjectStore struct {
+	mu    sync.RWMutex
+	byOrg map[string]map[string]string // orgID -> "type:id" -> projectID
+}
+
+// NewMemResourceProjectStore returns an empty in-memory resource-project store.
+func NewMemResourceProjectStore() *MemResourceProjectStore {
+	return &MemResourceProjectStore{
+		byOrg: map[string]map[string]string{},
+	}
+}
+
+func storeKey(resourceType, resourceID string) string {
+	return resourceType + ":" + resourceID
+}
+
+// Project returns the project id assigned to the resource for the org, or "" if
+// none is assigned.
+func (m *MemResourceProjectStore) Project(_ context.Context, orgID, resourceType, resourceID string) (string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.byOrg[orgID] == nil {
+		return "", nil
+	}
+	return m.byOrg[orgID][storeKey(resourceType, resourceID)], nil
+}
+
+// SetProject assigns or clears the project for the resource. An empty projectID
+// removes the mapping from the store.
+func (m *MemResourceProjectStore) SetProject(_ context.Context, orgID, resourceType, resourceID, projectID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if projectID == "" {
+		if m.byOrg[orgID] != nil {
+			delete(m.byOrg[orgID], storeKey(resourceType, resourceID))
+		}
+		return nil
+	}
+	if m.byOrg[orgID] == nil {
+		m.byOrg[orgID] = map[string]string{}
+	}
+	m.byOrg[orgID][storeKey(resourceType, resourceID)] = projectID
+	return nil
+}
+
+// setSandboxProjectRequest is the body of PUT /console/sandboxes/{id}/project.
+type setSandboxProjectRequest struct {
+	ProjectID string `json:"project_id"`
+}
+
+// handleSetSandboxProject assigns or clears the project for a sandbox. Gated by
+// PermManageProjects. If project_id is non-empty it must belong to the caller's
+// org; empty project_id clears the assignment.
+func (c *Console) handleSetSandboxProject(w http.ResponseWriter, r *http.Request) {
+	_, orgID, e, ok := c.authorize(r, saas.PermManageProjects)
+	if !ok {
+		apierr.Encode(w, e)
+		return
+	}
+	sandboxID := r.PathValue("id")
+	var req setSandboxProjectRequest
+	if err := decodeBody(r, &req); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the set-sandbox-project body is not valid JSON"))
+		return
+	}
+	if req.ProjectID != "" {
+		found, err := c.validateProjectInOrg(r, orgID, req.ProjectID)
+		if err != nil {
+			apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+				WithCause("the project list could not be read"))
+			return
+		}
+		if !found {
+			apierr.Encode(w, apierr.Get(apierr.CodeNotFound).
+				WithCause("the project does not exist or does not belong to this organization"))
+			return
+		}
+	}
+	if err := c.deps.ResourceProjects.SetProject(r.Context(), orgID, "sandbox", sandboxID, req.ProjectID); err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause(fmt.Sprintf("the sandbox project could not be stored: %s", err.Error())))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"sandbox_id": sandboxID,
+		"project_id": req.ProjectID,
+	})
+}

--- a/internal/saas/console/resourceprojects_test.go
+++ b/internal/saas/console/resourceprojects_test.go
@@ -1,0 +1,239 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/saas"
+)
+
+// resourceProjectsFixture wires a console with two orgs (alice and bob), a
+// seeded project and sandbox in alice's org, and an admin + member caller in
+// alice's org so the permission tests have the full matrix.
+type resourceProjectsFixture struct {
+	con        *Console
+	store      *saas.MemStore
+	projects   *MemProjectStore
+	sandboxes  *MemSandboxControl
+	resProj    *MemResourceProjectStore
+	aliceAcct  string
+	aliceOrg   string
+	bobAcct    string
+	bobOrg     string
+	adminAcct  string // RoleAdmin in alice's org: has projects.manage
+	memberAcct string // RoleMember in alice's org: no projects.manage
+	projectID  string // seeded project in alice's org
+	sandboxID  string // seeded sandbox in alice's org
+}
+
+func newResourceProjectsFixture(t *testing.T) *resourceProjectsFixture {
+	t.Helper()
+	store := saas.NewMemStore()
+	keys := saas.NewKeyService(store)
+	accounts := saas.NewAccountService(store, keys)
+	ctx := context.Background()
+
+	alice, aliceOrg, err := accounts.SignUp(ctx, "rp-alice@example.com")
+	if err != nil {
+		t.Fatalf("SignUp alice: %v", err)
+	}
+	bob, bobOrg, err := accounts.SignUp(ctx, "rp-bob@example.com")
+	if err != nil {
+		t.Fatalf("SignUp bob: %v", err)
+	}
+
+	// admin has RoleAdmin in alice's org (has projects.manage).
+	admin, _, err := accounts.SignUp(ctx, "rp-admin@example.com")
+	if err != nil {
+		t.Fatalf("SignUp admin: %v", err)
+	}
+	if err := store.PutMembership(ctx, saas.Membership{
+		AccountID: admin.ID,
+		OrgID:     aliceOrg.ID,
+		Role:      saas.RoleAdmin,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed admin membership: %v", err)
+	}
+
+	// member has RoleMember in alice's org (no projects.manage).
+	member, _, err := accounts.SignUp(ctx, "rp-member@example.com")
+	if err != nil {
+		t.Fatalf("SignUp member: %v", err)
+	}
+	if err := store.PutMembership(ctx, saas.Membership{
+		AccountID: member.ID,
+		OrgID:     aliceOrg.ID,
+		Role:      saas.RoleMember,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed member membership: %v", err)
+	}
+
+	projects := NewMemProjectStore()
+	p, err := projects.Create(ctx, aliceOrg.ID, "ProjectA", "desc")
+	if err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	sandboxes := NewMemSandboxControl()
+	sandboxID := "rp-sb-1"
+	sandboxes.Add(SandboxView{
+		ID:    sandboxID,
+		OrgID: aliceOrg.ID,
+		Phase: "Running",
+	})
+
+	resProj := NewMemResourceProjectStore()
+	con := New(Deps{
+		Accounts:        accounts,
+		Projects:        projects,
+		Sandboxes:       sandboxes,
+		ResourceProjects: resProj,
+		Now:             time.Now,
+	})
+	return &resourceProjectsFixture{
+		con:        con,
+		store:      store,
+		projects:   projects,
+		sandboxes:  sandboxes,
+		resProj:    resProj,
+		aliceAcct:  alice.ID,
+		aliceOrg:   aliceOrg.ID,
+		bobAcct:    bob.ID,
+		bobOrg:     bobOrg.ID,
+		adminAcct:  admin.ID,
+		memberAcct: member.ID,
+		projectID:  p.ID,
+		sandboxID:  sandboxID,
+	}
+}
+
+func (f *resourceProjectsFixture) req(t *testing.T, method, target, body, acct, org string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, target, nil)
+	} else {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	}
+	r = r.WithContext(WithCaller(r.Context(), acct, org))
+	w := httptest.NewRecorder()
+	f.con.ServeHTTP(w, r)
+	return w
+}
+
+// TestResourceProjectAdminSetsAndListReflects verifies that an admin PUT
+// assigns a project to a sandbox and a subsequent GET /console/sandboxes
+// returns that sandbox with project_id set.
+func TestResourceProjectAdminSetsAndListReflects(t *testing.T) {
+	f := newResourceProjectsFixture(t)
+
+	// Admin PUTs project assignment.
+	body := `{"project_id":"` + f.projectID + `"}`
+	pw := f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project", body, f.adminAcct, f.aliceOrg)
+	if pw.Code != http.StatusOK {
+		t.Fatalf("PUT /console/sandboxes/{id}/project status = %d, want 200; body=%s", pw.Code, pw.Body.String())
+	}
+
+	// GET list should reflect the project_id.
+	gw := f.req(t, "GET", "/console/sandboxes", "", f.aliceAcct, f.aliceOrg)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET /console/sandboxes status = %d, want 200; body=%s", gw.Code, gw.Body.String())
+	}
+	var resp struct {
+		Sandboxes []SandboxView `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(gw.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, gw.Body.String())
+	}
+	if len(resp.Sandboxes) != 1 {
+		t.Fatalf("sandboxes = %+v, want 1", resp.Sandboxes)
+	}
+	if resp.Sandboxes[0].ProjectID != f.projectID {
+		t.Errorf("sandbox project_id = %q, want %q", resp.Sandboxes[0].ProjectID, f.projectID)
+	}
+}
+
+// TestResourceProjectInspectReflects verifies that GET /console/sandboxes/{id}
+// returns the sandbox with project_id set after a PUT assignment.
+func TestResourceProjectInspectReflects(t *testing.T) {
+	f := newResourceProjectsFixture(t)
+
+	// Admin assigns the project.
+	body := `{"project_id":"` + f.projectID + `"}`
+	f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project", body, f.adminAcct, f.aliceOrg)
+
+	// Inspect the sandbox directly.
+	gw := f.req(t, "GET", "/console/sandboxes/"+f.sandboxID, "", f.aliceAcct, f.aliceOrg)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET /console/sandboxes/{id} status = %d, want 200; body=%s", gw.Code, gw.Body.String())
+	}
+	var sb SandboxView
+	if err := json.Unmarshal(gw.Body.Bytes(), &sb); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, gw.Body.String())
+	}
+	if sb.ProjectID != f.projectID {
+		t.Errorf("sandbox project_id = %q, want %q", sb.ProjectID, f.projectID)
+	}
+}
+
+// TestResourceProjectMemberGetsForbidden verifies that a caller with RoleMember
+// (no projects.manage) gets 403 on PUT.
+func TestResourceProjectMemberGetsForbidden(t *testing.T) {
+	f := newResourceProjectsFixture(t)
+
+	body := `{"project_id":"` + f.projectID + `"}`
+	pw := f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project", body, f.memberAcct, f.aliceOrg)
+	if pw.Code != http.StatusForbidden {
+		t.Errorf("member PUT = %d, want 403; body=%s", pw.Code, pw.Body.String())
+	}
+}
+
+// TestResourceProjectUnknownProjectReturns404 verifies that a PUT with a
+// project_id that does not belong to the org returns 404.
+func TestResourceProjectUnknownProjectReturns404(t *testing.T) {
+	f := newResourceProjectsFixture(t)
+
+	body := `{"project_id":"not-in-org"}`
+	pw := f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project", body, f.adminAcct, f.aliceOrg)
+	if pw.Code != http.StatusNotFound {
+		t.Errorf("PUT unknown project = %d, want 404; body=%s", pw.Code, pw.Body.String())
+	}
+}
+
+// TestResourceProjectEmptyUnassigns verifies that a PUT with an empty
+// project_id unassigns the sandbox, and a subsequent GET shows "".
+func TestResourceProjectEmptyUnassigns(t *testing.T) {
+	f := newResourceProjectsFixture(t)
+
+	// First, assign a project.
+	body := `{"project_id":"` + f.projectID + `"}`
+	f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project", body, f.adminAcct, f.aliceOrg)
+
+	// Now unassign with empty project_id.
+	uw := f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project", `{"project_id":""}`, f.adminAcct, f.aliceOrg)
+	if uw.Code != http.StatusOK {
+		t.Fatalf("PUT empty project_id status = %d, want 200; body=%s", uw.Code, uw.Body.String())
+	}
+
+	// GET list should now show empty project_id.
+	gw := f.req(t, "GET", "/console/sandboxes", "", f.aliceAcct, f.aliceOrg)
+	var resp struct {
+		Sandboxes []SandboxView `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(gw.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Sandboxes) != 1 {
+		t.Fatalf("sandboxes = %+v, want 1", resp.Sandboxes)
+	}
+	if resp.Sandboxes[0].ProjectID != "" {
+		t.Errorf("sandbox project_id = %q, want empty after unassign", resp.Sandboxes[0].ProjectID)
+	}
+}

--- a/internal/saas/console/resourceprojects_test.go
+++ b/internal/saas/console/resourceprojects_test.go
@@ -91,11 +91,11 @@ func newResourceProjectsFixture(t *testing.T) *resourceProjectsFixture {
 
 	resProj := NewMemResourceProjectStore()
 	con := New(Deps{
-		Accounts:        accounts,
-		Projects:        projects,
-		Sandboxes:       sandboxes,
+		Accounts:         accounts,
+		Projects:         projects,
+		Sandboxes:        sandboxes,
 		ResourceProjects: resProj,
-		Now:             time.Now,
+		Now:              time.Now,
 	})
 	return &resourceProjectsFixture{
 		con:        con,
@@ -157,6 +157,41 @@ func TestResourceProjectAdminSetsAndListReflects(t *testing.T) {
 	}
 	if resp.Sandboxes[0].ProjectID != f.projectID {
 		t.Errorf("sandbox project_id = %q, want %q", resp.Sandboxes[0].ProjectID, f.projectID)
+	}
+}
+
+// TestResourceProjectCrossOrgIsolation locks the per-org keying invariant
+// directly at the store: after alice's org tags a sandbox, bob's org never sees
+// that tag for the same resource id, and a tag bob's org sets for the same id is
+// independent. This is defense in depth in case the handler-level project
+// validation is ever bypassed or refactored.
+func TestResourceProjectCrossOrgIsolation(t *testing.T) {
+	f := newResourceProjectsFixture(t)
+	ctx := context.Background()
+
+	// Alice's org tags the sandbox with its project.
+	pw := f.req(t, "PUT", "/console/sandboxes/"+f.sandboxID+"/project",
+		`{"project_id":"`+f.projectID+`"}`, f.adminAcct, f.aliceOrg)
+	if pw.Code != http.StatusOK {
+		t.Fatalf("alice PUT status = %d, want 200; body=%s", pw.Code, pw.Body.String())
+	}
+
+	// Bob's org must NOT see alice's tag for the same resource id.
+	got, err := f.resProj.Project(ctx, f.bobOrg, "sandbox", f.sandboxID)
+	if err != nil {
+		t.Fatalf("Project(bobOrg): %v", err)
+	}
+	if got != "" {
+		t.Fatalf("bob's org sees alice's tag %q for the same sandbox id; per-org keying leaked", got)
+	}
+
+	// Alice's tag is intact.
+	aliceTag, err := f.resProj.Project(ctx, f.aliceOrg, "sandbox", f.sandboxID)
+	if err != nil {
+		t.Fatalf("Project(aliceOrg): %v", err)
+	}
+	if aliceTag != f.projectID {
+		t.Fatalf("alice tag = %q, want %q", aliceTag, f.projectID)
 	}
 }
 

--- a/internal/saas/console/seams.go
+++ b/internal/saas/console/seams.go
@@ -71,6 +71,10 @@ type SandboxView struct {
 	VCPUs     int32     `json:"vcpus"`
 	MemBytes  int64     `json:"mem_bytes"`
 	CreatedAt time.Time `json:"created_at"`
+	// ProjectID is the project this sandbox is assigned to. Empty string means
+	// unassigned. It is populated by the resource-project store in the list and
+	// inspect handlers; it is never stored in the SandboxControl itself.
+	ProjectID string `json:"project_id"`
 }
 
 // SandboxControl is the live-sandbox seam the console inspects and terminates

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -40,6 +40,7 @@ export type SandboxView = {
   vcpus: number
   mem_bytes: number
   created_at: string
+  project_id?: string
 }
 
 export type ForkNode = {
@@ -148,6 +149,15 @@ export const api = {
   terminateSandbox: async (id: string) => {
     const r = await fetch(`/console/sandboxes/${encodeURIComponent(id)}`, { method: 'DELETE', credentials: 'same-origin' })
     if (!r.ok && r.status !== 204) throw new Error(`terminate: ${r.status}`)
+  },
+  setSandboxProject: async (id: string, projectId: string) => {
+    const r = await fetch(`/console/sandboxes/${encodeURIComponent(id)}/project`, {
+      method: 'PUT',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ project_id: projectId }),
+    })
+    if (!r.ok) throw new Error(`set sandbox project: ${r.status}`)
   },
   sandboxLogs: async (id: string) => {
     const r = await fetch(`/console/sandboxes/${encodeURIComponent(id)}/logs`, { credentials: 'same-origin' })

--- a/web/app/src/data/sandboxes.ts
+++ b/web/app/src/data/sandboxes.ts
@@ -16,6 +16,17 @@ export function useSandboxLogs(id: string) {
   return useQuery<string>({ queryKey: ['sandbox-logs', id], queryFn: () => api.sandboxLogs(id), enabled: !!id })
 }
 
+export function useSetSandboxProject() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (v: { id: string; projectId: string }) => api.setSandboxProject(v.id, v.projectId),
+    onSettled: (_data, _err, v) => {
+      void qc.invalidateQueries({ queryKey: ['sandboxes'] })
+      void qc.invalidateQueries({ queryKey: ['sandbox', v.id] })
+    },
+  })
+}
+
 export function useTerminateSandbox() {
   const qc = useQueryClient()
   return useMutation({

--- a/web/app/src/views/sandboxes/SandboxDetail.test.tsx
+++ b/web/app/src/views/sandboxes/SandboxDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { waitFor, screen } from '@testing-library/react'
+import { fireEvent, waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderAt } from '../../test/utils'
 import type { Capabilities } from '../../api'
@@ -9,12 +9,27 @@ const caps: Capabilities = {
   orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted',
 }
 
+const projects = [
+  { id: 'proj-a', org_id: 'o', name: 'Alpha', description: '', created_at: '2026-01-01T00:00:00Z' },
+  { id: 'proj-b', org_id: 'o', name: 'Beta', description: '', created_at: '2026-01-02T00:00:00Z' },
+]
+
+let putCalls: { url: string; body: unknown }[] = []
+
 beforeEach(() => {
-  vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+  putCalls = []
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
     const url = String(input)
+    const method = (init?.method ?? 'GET').toUpperCase()
     if (url.endsWith('/console/capabilities')) return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
     if (url.includes('/console/sandboxes/s1/logs')) return Promise.resolve(new Response('boot ok\nlistening', { status: 200 }))
-    if (url.includes('/console/sandboxes/s1')) return Promise.resolve(new Response(JSON.stringify({ id: 's1', org_id: 'o', template: 'python-3.12', node: 'w1', phase: 'Running', vcpus: 2, mem_bytes: 2147483648, created_at: '2026-01-01T00:00:00Z' }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.includes('/console/sandboxes/s1/project') && method === 'PUT') {
+      const body = init?.body ? JSON.parse(String(init.body)) as unknown : undefined
+      putCalls.push({ url, body })
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+    }
+    if (url.includes('/console/sandboxes/s1')) return Promise.resolve(new Response(JSON.stringify({ id: 's1', org_id: 'o', template: 'python-3.12', node: 'w1', phase: 'Running', vcpus: 2, mem_bytes: 2147483648, created_at: '2026-01-01T00:00:00Z', project_id: 'proj-a' }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/projects')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
     if (url.endsWith('/console/forktree')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', nodes: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
     return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
   })
@@ -27,5 +42,40 @@ describe('SandboxDetail', () => {
     expect(screen.getByText('python-3.12')).toBeInTheDocument()
     await userEvent.click(screen.getByRole('tab', { name: /logs/i }))
     await waitFor(() => expect(screen.getByText(/listening/)).toBeInTheDocument())
+  })
+
+  it('renders a Project select with the current project pre-selected', async () => {
+    await renderAt('/sandboxes/s1', caps)
+    // wait until projects have loaded and the correct option is selected
+    await waitFor(() => {
+      const select = screen.getByLabelText(/project/i) as HTMLSelectElement
+      expect(select.value).toBe('proj-a')
+    })
+  })
+
+  it('includes an Unassigned option and options for each org project', async () => {
+    await renderAt('/sandboxes/s1', caps)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument())
+    expect(screen.getByRole('option', { name: /unassigned/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Beta' })).toBeInTheDocument()
+  })
+
+  it('calls PUT /console/sandboxes/{id}/project with the chosen project id on change', async () => {
+    await renderAt('/sandboxes/s1', caps)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument())
+    const select = screen.getByLabelText(/project/i)
+    fireEvent.change(select, { target: { value: 'proj-b' } })
+    await waitFor(() => expect(putCalls.length).toBe(1))
+    expect(putCalls[0].url).toContain('/console/sandboxes/s1/project')
+    expect(putCalls[0].body).toEqual({ project_id: 'proj-b' })
+  })
+
+  it('calls PUT with empty string when Unassigned is selected', async () => {
+    await renderAt('/sandboxes/s1', caps)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument())
+    const select = screen.getByLabelText(/project/i)
+    fireEvent.change(select, { target: { value: '' } })
+    await waitFor(() => expect(putCalls.length).toBe(1))
+    expect(putCalls[0].body).toEqual({ project_id: '' })
   })
 })

--- a/web/app/src/views/sandboxes/SandboxDetail.tsx
+++ b/web/app/src/views/sandboxes/SandboxDetail.tsx
@@ -4,7 +4,8 @@
 // and Spending are honest placeholders. Reads the $id route param.
 import { useState } from 'react'
 import { useParams } from '@tanstack/react-router'
-import { useSandbox } from '../../data/sandboxes'
+import { useSandbox, useSetSandboxProject } from '../../data/sandboxes'
+import { useProjects } from '../../data/org'
 import { Tabs, type TabDef } from '../../ui/Tabs'
 import { Skeleton } from '../../ui/Skeleton'
 import { EmptyState } from '../../ui/EmptyState'
@@ -17,6 +18,37 @@ const TABS: TabDef[] = [
   { key: 'forks', label: 'Fork tree' },
 ]
 
+function ProjectControl({ id, projectId }: { id: string; projectId?: string }) {
+  const { data: projects = [] } = useProjects()
+  const setProject = useSetSandboxProject()
+
+  function onChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setProject.mutate({ id, projectId: e.target.value })
+  }
+
+  return (
+    <div style={{ marginBottom: 'var(--space-4)' }}>
+      <label htmlFor="sandbox-project-select" style={{ display: 'block', marginBottom: 'var(--space-2)' }} className="t-dim">
+        Project
+      </label>
+      <select
+        id="sandbox-project-select"
+        value={projectId ?? ''}
+        onChange={onChange}
+        disabled={setProject.isPending}
+      >
+        <option value="">Unassigned</option>
+        {projects.map((p) => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+      <p className="t-dim" style={{ marginTop: 'var(--space-2)', fontSize: 'var(--text-sm)' }}>
+        Per-project access enforcement applies to this sandbox when enabled.
+      </p>
+    </div>
+  )
+}
+
 export function SandboxDetail() {
   const { id } = useParams({ from: '/sandboxes/$id' })
   const [tab, setTab] = useState('overview')
@@ -26,6 +58,7 @@ export function SandboxDetail() {
   return (
     <section>
       <h2 className="mono">{sb.id}</h2>
+      <ProjectControl id={sb.id} projectId={sb.project_id} />
       <Tabs tabs={TABS} active={tab} onChange={setTab} ariaLabel="Sandbox detail sections" />
       <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`} tabIndex={0} style={{ marginTop: 'var(--space-5)' }}>
         {tab === 'overview' && <OverviewTab sb={sb} />}

--- a/web/app/src/views/sandboxes/SandboxList.test.tsx
+++ b/web/app/src/views/sandboxes/SandboxList.test.tsx
@@ -1,5 +1,5 @@
 // Behavior test for the live sandboxes list. Asserts row count, status dot,
-// terminate action (optimistic remove), and the empty-state fallback.
+// terminate action (optimistic remove), the empty-state fallback, and project column.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -15,7 +15,7 @@ const caps: Capabilities = {
 }
 
 const sandboxes = [
-  { id: 'sb-1', org_id: 'o1', template: 'python-3.12', node: 'w1', phase: 'Running', vcpus: 2, mem_bytes: 2147483648, created_at: '2026-01-01T00:00:00Z' },
+  { id: 'sb-1', org_id: 'o1', template: 'python-3.12', node: 'w1', phase: 'Running', vcpus: 2, mem_bytes: 2147483648, created_at: '2026-01-01T00:00:00Z', project_id: 'p1' },
   { id: 'sb-2', org_id: 'o1', template: 'node-22', node: 'w2', phase: 'Pending', vcpus: 1, mem_bytes: 1073741824, created_at: '2026-01-02T00:00:00Z' },
 ]
 
@@ -113,5 +113,13 @@ describe('SandboxList', () => {
     fireEvent.click(firstTerminate)
     await waitFor(() => expect(screen.getByText('sb-1')).toBeInTheDocument())
     expect(screen.getByText('sb-2')).toBeInTheDocument()
+  })
+
+  it('shows project_id in the Project column and "Unassigned" when empty', async () => {
+    await renderAt('/sandboxes', caps)
+    await waitFor(() => expect(screen.getByRole('table', { name: /sandboxes/i })).toBeInTheDocument())
+    // sb-1 has project_id 'p1', sb-2 has no project_id
+    expect(screen.getByText('p1')).toBeInTheDocument()
+    expect(screen.getByText('Unassigned')).toBeInTheDocument()
   })
 })

--- a/web/app/src/views/sandboxes/SandboxList.tsx
+++ b/web/app/src/views/sandboxes/SandboxList.tsx
@@ -69,6 +69,7 @@ export function SandboxList() {
               <th scope="col">Template</th>
               <th scope="col">Node</th>
               <th scope="col">Phase</th>
+              <th scope="col">Project</th>
               <th scope="col">vCPUs</th>
               <th scope="col">Memory</th>
               <th scope="col"><span className="sr-only">Actions</span></th>
@@ -86,6 +87,7 @@ export function SandboxList() {
                   <StatusDot entity={phaseEntity(s.phase)} />
                   {' '}{s.phase}
                 </td>
+                <td>{s.project_id ? s.project_id : <span className="t-dim">Unassigned</span>}</td>
                 <td>{s.vcpus}</td>
                 <td className="mono">{fmtBytes(s.mem_bytes)}</td>
                 <td>

--- a/web/app/src/views/sandboxes/Sandboxes.a11y.test.tsx
+++ b/web/app/src/views/sandboxes/Sandboxes.a11y.test.tsx
@@ -10,11 +10,20 @@ const caps: Capabilities = {
   edition: 'community', billing: false, signup: false, teams: true, idp: 'oidc',
   orgSwitcher: false, secrets: { providers: ['kube'] }, proof: true, ownership: 'self-hosted',
 }
+
+const projects = [
+  { id: 'proj-a', org_id: 'o', name: 'Alpha', description: '', created_at: '2026-01-01T00:00:00Z' },
+]
+
 beforeEach(() => {
   vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
     const url = String(input)
     if (url.endsWith('/console/capabilities')) return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
-    if (url.endsWith('/console/sandboxes')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', sandboxes: [{ id: 's1', org_id: 'o', template: 't', node: 'n', phase: 'Running', vcpus: 1, mem_bytes: 1024, created_at: '' }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/sandboxes')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', sandboxes: [{ id: 's1', org_id: 'o', template: 't', node: 'n', phase: 'Running', vcpus: 1, mem_bytes: 1024, created_at: '', project_id: 'proj-a' }] }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.includes('/console/sandboxes/s1/logs')) return Promise.resolve(new Response('boot ok', { status: 200 }))
+    if (url.includes('/console/sandboxes/s1')) return Promise.resolve(new Response(JSON.stringify({ id: 's1', org_id: 'o', template: 't', node: 'n', phase: 'Running', vcpus: 1, mem_bytes: 1024, created_at: '', project_id: 'proj-a' }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/projects')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', projects }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    if (url.endsWith('/console/forktree')) return Promise.resolve(new Response(JSON.stringify({ org_id: 'o', nodes: [] }), { status: 200, headers: { 'content-type': 'application/json' } }))
     return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
   })
 })
@@ -23,6 +32,17 @@ describe('Sandboxes accessibility', () => {
   it('the list has no axe violations', async () => {
     const { container } = await renderAt('/sandboxes', caps)
     await waitFor(() => expect(screen.getByRole('table', { name: /live sandboxes/i })).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('the detail view with project control has no axe violations', async () => {
+    const { container } = await renderAt('/sandboxes/s1', caps)
+    // Wait until the project select is rendered and populated with the org projects.
+    await waitFor(() => {
+      const select = screen.getByLabelText(/project/i) as HTMLSelectElement
+      expect(select).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument()
+    })
     expect(await axe(container)).toHaveNoViolations()
   })
 })


### PR DESCRIPTION
## Summary

Third slice of B3d. A sandbox can be assigned to a project, so per-project access can be ENFORCED in B3d-4. This slice only tags and surfaces the assignment; the UI says so honestly.

## What landed

- A console `ResourceProjectStore` mapping (org, resourceType, resourceID) to a project, per-org keyed.
- `project_id` on the sandbox view, populated on list and inspect.
- `PUT /console/sandboxes/{id}/project`, gated by projects.manage, validating the target project belongs to the caller's org (404 otherwise); an empty project_id unassigns.
- UI: a Project column on the sandbox list and a project select on the sandbox detail, with an honest note that per-project access enforcement applies when enabled (B3d-4).

## Security (reviewed)

Org isolation holds on two layers: the mapping store is per-org keyed (a sandbox id cannot collide across orgs), and a sandbox can only be assigned to a project in the caller's own org (validated before any write). The list/inspect join always uses the context org, so a box is never tagged or read against another org's project. A Viewer or Member gets 403 on assign. A direct cross-org store-isolation test locks the invariant.

## Verification

- `go test ./internal/saas/...` green; both golangci-lint clean.
- web suite 154 passing; typecheck + build clean; axe zero violations.
- No em or en dashes.

Bounded to sandboxes (the primary forkable resource); secrets/templates tagging and controller-label propagation are deliberate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)