### PR TITLE
feat(saas): wire console usage + fork-tree to real cluster data

### DIFF
--- a/cmd/console/datasources.go
+++ b/cmd/console/datasources.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/saas/console/clusterforktree"
+	"mitos.run/mitos/internal/saas/console/clusterinstruments"
+	"mitos.run/mitos/internal/usage"
+)
+
+// buildUsageStore returns the usage store the console reads through. When the
+// controller's internal usage API is configured (MITOS_USAGE_API_URL +
+// MITOS_USAGE_API_TOKEN), the console reads the SAME per-org usage the
+// controller's collector recorded over that machine-to-machine HTTP seam (there
+// is no shared database). Absent that config it falls back to an empty in-memory
+// store (with a warning) so the console still starts for local dev and tests.
+// The org is always scoped from the gateway-verified request, never the client.
+func buildUsageStore(logger *slog.Logger) usage.UsageStore {
+	base := os.Getenv("MITOS_USAGE_API_URL")
+	token := os.Getenv("MITOS_USAGE_API_TOKEN")
+	if base != "" && token != "" {
+		logger.Info("usage store: controller internal usage API (org-scoped HTTP)", "url", base)
+		return usage.NewHTTPStore(base, token, nil)
+	}
+	if base != "" && token == "" {
+		logger.Warn("MITOS_USAGE_API_URL is set but MITOS_USAGE_API_TOKEN is empty; using in-memory usage store")
+	} else {
+		logger.Warn("MITOS_USAGE_API_URL unset; using in-memory usage store (dev/local only, no real usage)")
+	}
+	return usage.NewMemUsageStore()
+}
+
+// buildInstruments returns the proof-snapshot source: the cluster-backed source
+// (org-scoped over the controller's v1 Sandbox records) when a kube client is
+// available, falling back to the in-memory source (with a warning) in dev /
+// outside a cluster so the console still starts.
+func buildInstruments(logger *slog.Logger) console.InstrumentsSource {
+	c, err := kubeClient()
+	if err != nil {
+		logger.Warn("cluster instruments unavailable (not in cluster?); using in-memory instruments", "err", err.Error())
+		return console.NewMemInstruments()
+	}
+	logger.Info("instruments: cluster (org-scoped v1 Sandbox measurements)")
+	return clusterinstruments.New(c)
+}
+
+// buildForkTree returns the fork-tree source: the cluster-backed source
+// (org-scoped over the controller's v1 Sandbox records) when a kube client is
+// available, falling back to the in-memory source (with a warning) in dev /
+// outside a cluster so the console still starts.
+func buildForkTree(logger *slog.Logger) console.ForkTreeSource {
+	c, err := kubeClient()
+	if err != nil {
+		logger.Warn("cluster fork tree unavailable (not in cluster?); using in-memory fork tree", "err", err.Error())
+		return console.NewMemForkTree()
+	}
+	logger.Info("fork tree: cluster (org-scoped v1 Sandbox query)")
+	return clusterforktree.New(c)
+}

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -36,7 +36,6 @@ import (
 	"mitos.run/mitos/internal/saas/console"
 	"mitos.run/mitos/internal/saas/oidcauth"
 	"mitos.run/mitos/internal/saas/pgstore"
-	"mitos.run/mitos/internal/usage"
 )
 
 func main() {
@@ -72,7 +71,13 @@ func main() {
 
 	con := console.New(console.Deps{
 		Accounts: accounts,
-		Usage:    usage.NewMemUsageStore(),
+		// The usage store the console reads: the controller's internal usage API
+		// (the SAME usage the collector recorded) when configured, in-memory in dev.
+		Usage: buildUsageStore(logger),
+		// The proof-snapshot and fork-tree sources: org-scoped cluster queries when
+		// in a cluster, in-memory otherwise.
+		Instruments: buildInstruments(logger),
+		ForkTree:    buildForkTree(logger),
 		Billing: console.BillingReader{
 			Ledger: billing.NewMemCreditLedger(),
 			Status: statusStore,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,6 +17,7 @@ import (
 	"mitos.run/mitos/internal/eventfeed"
 	"mitos.run/mitos/internal/kms"
 	"mitos.run/mitos/internal/observability"
+	"mitos.run/mitos/internal/usage"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -68,6 +69,7 @@ func main() {
 	var enablePrincipalWebhook bool
 	var usageCollector bool
 	var usageCollectorInterval time.Duration
+	var usageAPIAddr string
 	var vitalsSampler bool
 	var vitalsSamplerInterval time.Duration
 	var exposeProxyAdminURL string
@@ -96,6 +98,7 @@ func main() {
 	flag.BoolVar(&workspaceMemorySnapshots, "workspace-memory-snapshots", false, "Bind the workspace memory-snapshot seams (checkpoint-on-terminate, resume-on-activate, principal-bound existence) to the husk live-VM snapshot path so a checkpointed workspace head becomes RESUMABLE: a later claim with the SAME principal resumes the VM memory image paired with the workspace content. A memory image carries secrets-in-RAM and is bound to the capturing claim's ServiceAccount; it is NEVER served across principals (fail-closed refusal). Off by default: a checkpoint-on-terminate then fails loud rather than producing a falsely-resumable revision. The real bare-metal VM-memory image requires a KVM-capable kubelet and is cluster-gated; see docs/workspaces.md.")
 	flag.BoolVar(&usageCollector, "usage-collector", false, "Run the live multi-node metering scraper: on a fixed interval, scrape every forkd node's GET /v1/metering, attribute each sandbox to its org via the trusted mitos.run/org husk-pod label, integrate idempotently into per-(org, sandbox, window) usage records, and publish the per-org mitos_usage_*_total Prometheus series. OFF by default so a self-host deployment that does not want metering is unaffected; turn it on for hosted/multi-tenant. The records land in an in-memory store for now (a durable store is a follow-up); the per-org metric is always published on /metrics. The path carries only ids, byte counts, and seconds, never secret values.")
 	flag.DurationVar(&usageCollectorInterval, "usage-collector-interval", 60*time.Second, "Interval between usage metering scrapes when --usage-collector is set. Defaults to the usage window (60s). Only used when --usage-collector is on.")
+	flag.StringVar(&usageAPIAddr, "usage-api-address", "", "Serve the INTERNAL usage API (GET /internal/usage) on this address (for example :8092) so the hosted console can read the SAME per-org usage the collector recorded, without a shared database. Bearer-gated by the MITOS_USAGE_API_TOKEN environment variable (empty token fails closed: every request is refused). Empty address disables the listener. Only meaningful with --usage-collector on. The endpoint is machine-to-machine: the org is taken from the X-Mitos-Org header the console sets after it verified the session, and the store still scopes every read to that org. The path carries only ids, byte counts, and seconds, never secret values.")
 	flag.BoolVar(&vitalsSampler, "vitals-sampler", false, "Run the guest vitals sampler: on a fixed interval, scrape every forkd node's GET /v1/vitals/node, attribute each sandbox to its org via the trusted mitos.run/org husk-pod label, aggregate per (org, pool), and publish the mitos_guest_cpu_steal_percent, mitos_guest_mem_balloon_bytes, mitos_guest_mem_used_bytes, and mitos_guest_process_count Prometheus gauges. cpu_steal is the MAX across the bucket (the worst-starved sandbox); memory and process_count are SUMs (the fleet footprint). OFF by default so a self-host deployment without guest telemetry is unaffected; turn it on for hosted/multi-tenant. The path carries only ids (for org resolution), pool names, and numeric vitals plus the process-list length, never argv, env, process command lines, pids, or secret values.")
 	flag.DurationVar(&vitalsSamplerInterval, "vitals-sampler-interval", 60*time.Second, "Interval between guest vitals samples when --vitals-sampler is set. Defaults to the usage window (60s). Only used when --vitals-sampler is on.")
 	flag.StringVar(&exposeProxyAdminURL, "expose-proxy-admin-url", "", "Expose proxy admin endpoint base URL for route-sync (POST /internal/routes); empty disables")
@@ -434,16 +437,41 @@ func main() {
 	// same access class as /metrics and /healthz), so the scraper uses the http
 	// scheme; an https operational mux is a documented follow-up.
 	if usageCollector {
+		// One shared store: the collector writes per-org usage records into it, and
+		// the internal usage API serves reads of the SAME store to the console, so
+		// the console shows exactly what was collected without a shared database.
+		usageStore := usage.NewMemUsageStore()
 		if err := mgr.Add(&controller.UsageCollectorRunnable{
 			Registry:   nodeRegistry,
 			Client:     mgr.GetClient(),
 			Cadence:    usageCollectorInterval,
 			HTTPScheme: "http",
+			Store:      usageStore,
 		}); err != nil {
 			logger.Error(err, "unable to add usage collector")
 			os.Exit(1)
 		}
 		logger.Info("usage collector: enabled", "interval", usageCollectorInterval.String())
+
+		// Internal usage API (machine-to-machine, bearer-gated) so the hosted
+		// console can read the collected per-org usage. The token is read from the
+		// environment and never logged; an empty token makes the handler fail closed.
+		if usageAPIAddr != "" {
+			usageAPIToken := os.Getenv("MITOS_USAGE_API_TOKEN")
+			if usageAPIToken == "" {
+				logger.Info("WARNING: --usage-api-address is set but MITOS_USAGE_API_TOKEN is empty; the internal usage API will refuse every request (fail closed)")
+			}
+			if err := mgr.Add(&controller.UsageAPIRunnable{
+				Store:  usageStore,
+				Prices: usage.DefaultPriceList(),
+				Addr:   usageAPIAddr,
+				Token:  usageAPIToken,
+			}); err != nil {
+				logger.Error(err, "unable to add internal usage API")
+				os.Exit(1)
+			}
+			logger.Info("internal usage API: enabled", "addr", usageAPIAddr, "tokenConfigured", usageAPIToken != "")
+		}
 	}
 
 	// Guest vitals sampler (issue #164 Phase 1.a), OFF by default. When enabled it

--- a/internal/controller/usage_api.go
+++ b/internal/controller/usage_api.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"mitos.run/mitos/internal/usage"
+)
+
+// UsageAPIRunnable is the manager Runnable that serves the controller's INTERNAL
+// usage API: a machine-to-machine HTTP endpoint the hosted console reads so it
+// can show the SAME per-org usage the collector recorded, without a shared
+// database. The collector (UsageCollectorRunnable) writes into Store; this
+// runnable serves reads of the same Store, org-scoped and bearer-gated.
+//
+// It is mounted on its OWN listener (not the controller's metrics or webhook
+// mux) so the bearer-gated usage surface is separate from the public
+// operational endpoints. It is OFF unless a Token is set: an empty token fails
+// closed (the handler refuses every request), and an empty Addr disables the
+// listener entirely.
+//
+// SECURITY: the org is taken from the InternalOrgHeader the console sets (the
+// console derived it from the gateway-verified session); the store still scopes
+// every read to that org, so a bad header can only ever return that org's data,
+// never a cross-org bleed. The bearer token is never logged.
+type UsageAPIRunnable struct {
+	// Store is the SAME usage store the collector writes into; reads here reflect
+	// the collected usage. Required.
+	Store usage.UsageStore
+	// Prices is the price list used to fill the cost estimate in the response.
+	Prices usage.PriceList
+	// Addr is the listen address for the internal usage API (for example :8092).
+	Addr string
+	// Token is the shared bearer secret the console presents. Empty fails closed.
+	Token string
+}
+
+// Start serves the internal usage API until ctx is canceled. It builds the
+// org-scoped, bearer-gated handler over the shared store and listens on Addr.
+func (u *UsageAPIRunnable) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("usage-api")
+	if u.Addr == "" {
+		logger.Info("internal usage API disabled (no address)")
+		<-ctx.Done()
+		return nil
+	}
+	prices := u.Prices
+	if (prices == usage.PriceList{}) {
+		prices = usage.DefaultPriceList()
+	}
+	mux := http.NewServeMux()
+	mux.Handle("GET /internal/usage", usage.NewInternalUsageHandler(u.Store, prices, u.Token))
+
+	srv := &http.Server{
+		Addr:              u.Addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("internal usage API listening", "addr", u.Addr, "tokenConfigured", u.Token != "")
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("serve internal usage api: %w", err)
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}

--- a/internal/saas/console/clusterforktree/clusterforktree.go
+++ b/internal/saas/console/clusterforktree/clusterforktree.go
@@ -1,0 +1,73 @@
+// Package clusterforktree is the real console.ForkTreeSource: it builds an org's
+// live fork tree from the controller's v1 Sandbox records scoped to one org.
+// Under hard isolation each org's sandboxes live in its own namespace
+// (tenant.NamespaceForOrg), so org scoping is the namespace boundary plus the
+// org label as defense in depth: an org only ever sees its own namespace's
+// sandboxes, exactly like the cluster sandbox control (internal/saas/console/
+// clustersandbox) and the cross-tenant boundary in internal/saas/controlplane.
+//
+// The edges are the fork lineage: a Sandbox created from another sandbox
+// (spec.source.fromSandbox) carries that source as its parent. A Sandbox with no
+// fromSandbox source is a root. The CoW byte split (private-dirty vs shared) is
+// per-node metering that is NOT carried on the Sandbox CR; it is left zero here
+// and is the documented metering follow-up (the same #33 metering the usage
+// collector scrapes), so this source never fabricates a CoW number it has not
+// measured.
+package clusterforktree
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+// Source implements console.ForkTreeSource against the Kubernetes API.
+type Source struct {
+	c client.Client
+}
+
+// New builds the cluster-backed fork-tree source.
+func New(c client.Client) *Source {
+	return &Source{c: c}
+}
+
+// Tree returns the org's fork tree from its namespace, filtered by the org label.
+// It only ever returns the named org's nodes: the List is scoped to the org's
+// namespace AND matches the org label, so a sandbox in another org's namespace is
+// never observed.
+func (s *Source) Tree(ctx context.Context, orgID string) (console.ForkTree, error) {
+	var list v1.SandboxList
+	if err := s.c.List(ctx, &list,
+		client.InNamespace(tenant.NamespaceForOrg(orgID)),
+		client.MatchingLabels(tenant.OrgLabels(orgID)),
+	); err != nil {
+		return console.ForkTree{}, fmt.Errorf("list sandboxes: %w", err)
+	}
+	nodes := make([]console.ForkNode, 0, len(list.Items))
+	for i := range list.Items {
+		nodes = append(nodes, nodeOf(&list.Items[i]))
+	}
+	return console.ForkTree{OrgID: orgID, Nodes: nodes}, nil
+}
+
+// nodeOf maps a v1.Sandbox to a fork-tree node. The parent is the live sandbox
+// this one was forked from (spec.source.fromSandbox); a sandbox started from a
+// pool snapshot or a workspace revision is a root (empty parent). The CoW byte
+// split is not on the CR and is left zero (the metering follow-up).
+func nodeOf(sb *v1.Sandbox) console.ForkNode {
+	parent := ""
+	if sb.Spec.Source.FromSandbox != nil {
+		parent = sb.Spec.Source.FromSandbox.Name
+	}
+	return console.ForkNode{
+		ID:        sb.Name,
+		ParentID:  parent,
+		Phase:     string(sb.Status.Phase),
+		CreatedAt: sb.CreationTimestamp.Time,
+	}
+}

--- a/internal/saas/console/clusterforktree/clusterforktree_test.go
+++ b/internal/saas/console/clusterforktree/clusterforktree_test.go
@@ -1,0 +1,119 @@
+package clusterforktree
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+func scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1.AddToScheme(s); err != nil {
+		t.Fatalf("add v1 scheme: %v", err)
+	}
+	return s
+}
+
+// root builds a v1.Sandbox started from a pool (a fork-tree root) owned by org.
+func root(org, name, phase string) *v1.Sandbox {
+	return &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tenant.NamespaceForOrg(org),
+			Labels:    tenant.OrgLabels(org),
+		},
+		Spec:   v1.SandboxSpec{Source: v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "python"}}},
+		Status: v1.SandboxStatus{Phase: v1.SandboxPhase(phase)},
+	}
+}
+
+// fork builds a v1.Sandbox forked from parent, owned by org.
+func fork(org, name, parent, phase string) *v1.Sandbox {
+	sb := root(org, name, phase)
+	sb.Spec.Source = v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: parent}}
+	return sb
+}
+
+func newSource(t *testing.T, objs ...client.Object) *Source {
+	t.Helper()
+	c := fakeclient.NewClientBuilder().WithScheme(scheme(t)).WithObjects(objs...).Build()
+	return New(c)
+}
+
+// TestTreeScopedToOrgNamespace asserts the fork tree returns ONLY the caller
+// org's sandboxes: bob's, in bob's namespace, are never seen by alice.
+func TestTreeScopedToOrgNamespace(t *testing.T) {
+	c := newSource(t,
+		root("alice", "sb-a1", "Ready"),
+		fork("alice", "sb-a2", "sb-a1", "Ready"),
+		root("bob", "sb-b1", "Ready"),
+	)
+	tree, err := c.Tree(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	if tree.OrgID != "alice" {
+		t.Fatalf("org = %q, want alice", tree.OrgID)
+	}
+	if len(tree.Nodes) != 2 {
+		t.Fatalf("alice saw %d nodes, want 2: %+v", len(tree.Nodes), tree.Nodes)
+	}
+	for _, n := range tree.Nodes {
+		if n.ID == "sb-b1" {
+			t.Fatalf("bob node sb-b1 leaked into alice fork tree")
+		}
+	}
+}
+
+// TestTreeMapsForkLineage asserts a forked sandbox carries its source as parent
+// and a pool-started sandbox is a root (empty parent).
+func TestTreeMapsForkLineage(t *testing.T) {
+	c := newSource(t,
+		root("alice", "sb-a1", "Ready"),
+		fork("alice", "sb-a2", "sb-a1", "Pending"),
+	)
+	tree, err := c.Tree(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	byID := map[string]console.ForkNode{}
+	for _, n := range tree.Nodes {
+		byID[n.ID] = n
+	}
+	if got := byID["sb-a1"].ParentID; got != "" {
+		t.Fatalf("root parent = %q, want empty", got)
+	}
+	if got := byID["sb-a2"].ParentID; got != "sb-a1" {
+		t.Fatalf("fork parent = %q, want sb-a1", got)
+	}
+	if got := byID["sb-a2"].Phase; got != "Pending" {
+		t.Fatalf("fork phase = %q, want Pending", got)
+	}
+}
+
+// TestTreeEmptyOrgIsEmpty asserts an org with no sandboxes gets an empty,
+// org-scoped tree, never another org's nodes.
+func TestTreeEmptyOrgIsEmpty(t *testing.T) {
+	c := newSource(t, root("bob", "sb-b1", "Ready"))
+	tree, err := c.Tree(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	if len(tree.Nodes) != 0 {
+		t.Fatalf("alice tree = %+v, want empty", tree.Nodes)
+	}
+}
+
+// TestImplementsForkTreeSource is a compile-time seam assertion.
+func TestImplementsForkTreeSource(t *testing.T) {
+	var _ console.ForkTreeSource = (*Source)(nil)
+}

--- a/internal/saas/console/clusterinstruments/clusterinstruments.go
+++ b/internal/saas/console/clusterinstruments/clusterinstruments.go
@@ -1,0 +1,98 @@
+// Package clusterinstruments is the real console.InstrumentsSource: it measures
+// an org's proof snapshot from the controller's v1 Sandbox records scoped to one
+// org. Under hard isolation each org's sandboxes live in its own namespace
+// (tenant.NamespaceForOrg), so org scoping is the namespace boundary plus the
+// org label as defense in depth: an org only ever sees its own namespace's
+// sandboxes, mirroring the cross-tenant boundary in internal/saas/controlplane.
+//
+// MEASURED, NEVER FABRICATED (the docs/saas/pricing.md no-unverified-numbers
+// rule): every value comes from the org's own Sandbox records.
+//   - ForksServed is the count of the org's sandboxes that were forked from
+//     another sandbox (spec.source.fromSandbox), the org's fork fan-out.
+//   - ActivateP50/P99Millis are percentiles of the org's measured
+//     status.startupLatencyMs across its Ready sandboxes (the same activate path
+//     bench/husk-activate-latency.sh times).
+//
+// CoWSavingsBytes and MarginalBytesPerFork are per-node CoW metering that is NOT
+// carried on the Sandbox CR; they are left zero here and are the documented
+// metering follow-up (the same #33 metering the usage collector scrapes), so
+// this source never reports a CoW number it has not measured.
+package clusterinstruments
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+// Source implements console.InstrumentsSource against the Kubernetes API.
+type Source struct {
+	c client.Client
+}
+
+// New builds the cluster-backed instruments source.
+func New(c client.Client) *Source {
+	return &Source{c: c}
+}
+
+// Snapshot measures the org's proof metrics from its own sandboxes. It returns a
+// zero-but-org-scoped snapshot for an org with no sandboxes, and NEVER another
+// org's metrics: the List is scoped to the org's namespace AND matches the org
+// label.
+func (s *Source) Snapshot(ctx context.Context, orgID string) (console.Instruments, error) {
+	var list v1.SandboxList
+	if err := s.c.List(ctx, &list,
+		client.InNamespace(tenant.NamespaceForOrg(orgID)),
+		client.MatchingLabels(tenant.OrgLabels(orgID)),
+	); err != nil {
+		return console.Instruments{}, fmt.Errorf("list sandboxes: %w", err)
+	}
+
+	out := console.Instruments{OrgID: orgID}
+	latencies := make([]float64, 0, len(list.Items))
+	for i := range list.Items {
+		sb := &list.Items[i]
+		if sb.Spec.Source.FromSandbox != nil {
+			out.ForksServed++
+		}
+		if sb.Status.StartupLatencyMs > 0 {
+			latencies = append(latencies, float64(sb.Status.StartupLatencyMs))
+		}
+	}
+	out.ActivateP50Millis = percentile(latencies, 50)
+	out.ActivateP99Millis = percentile(latencies, 99)
+	return out, nil
+}
+
+// percentile returns the p-th percentile (nearest-rank) of vs, or 0 for an empty
+// set. It sorts a copy so the caller's slice is untouched. p is clamped to
+// [0, 100].
+func percentile(vs []float64, p int) float64 {
+	if len(vs) == 0 {
+		return 0
+	}
+	if p < 0 {
+		p = 0
+	}
+	if p > 100 {
+		p = 100
+	}
+	s := make([]float64, len(vs))
+	copy(s, vs)
+	sort.Float64s(s)
+	// Nearest-rank: rank = ceil(p/100 * N), 1-based, clamped to [1, N].
+	rank := (p*len(s) + 99) / 100
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(s) {
+		rank = len(s)
+	}
+	return s[rank-1]
+}

--- a/internal/saas/console/clusterinstruments/clusterinstruments_test.go
+++ b/internal/saas/console/clusterinstruments/clusterinstruments_test.go
@@ -1,0 +1,112 @@
+package clusterinstruments
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+func scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1.AddToScheme(s); err != nil {
+		t.Fatalf("add v1 scheme: %v", err)
+	}
+	return s
+}
+
+// sbWith builds a v1.Sandbox owned by org with the given fork source and
+// startup latency.
+func sbWith(org, name string, forked bool, latencyMs int64) *v1.Sandbox {
+	src := v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "python"}}
+	if forked {
+		src = v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: "parent"}}
+	}
+	return &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tenant.NamespaceForOrg(org),
+			Labels:    tenant.OrgLabels(org),
+		},
+		Spec:   v1.SandboxSpec{Source: src},
+		Status: v1.SandboxStatus{Phase: v1.SandboxPhase("Ready"), StartupLatencyMs: latencyMs},
+	}
+}
+
+func newSource(t *testing.T, objs ...client.Object) *Source {
+	t.Helper()
+	c := fakeclient.NewClientBuilder().WithScheme(scheme(t)).WithObjects(objs...).Build()
+	return New(c)
+}
+
+// TestSnapshotMeasuresCallerOrg asserts the snapshot counts the org's forks and
+// computes its activate-latency percentiles from its OWN sandboxes.
+func TestSnapshotMeasuresCallerOrg(t *testing.T) {
+	c := newSource(t,
+		sbWith("alice", "sb-a1", false, 20),
+		sbWith("alice", "sb-a2", true, 27),
+		sbWith("alice", "sb-a3", true, 41),
+	)
+	snap, err := c.Snapshot(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.OrgID != "alice" {
+		t.Fatalf("org = %q, want alice", snap.OrgID)
+	}
+	if snap.ForksServed != 2 {
+		t.Fatalf("forks_served = %d, want 2 (the two fromSandbox sandboxes)", snap.ForksServed)
+	}
+	if snap.ActivateP50Millis != 27 {
+		t.Fatalf("activate_p50_ms = %v, want 27 (median of 20,27,41)", snap.ActivateP50Millis)
+	}
+	if snap.ActivateP99Millis != 41 {
+		t.Fatalf("activate_p99_ms = %v, want 41 (top of 20,27,41)", snap.ActivateP99Millis)
+	}
+}
+
+// TestSnapshotScopedToCallerOrg asserts alice's metrics never include bob's
+// sandboxes: the proof read is org-scoped to the namespace + label.
+func TestSnapshotScopedToCallerOrg(t *testing.T) {
+	c := newSource(t,
+		sbWith("alice", "sb-a1", true, 27),
+		sbWith("bob", "sb-b1", true, 99),
+		sbWith("bob", "sb-b2", true, 99),
+	)
+	alice, err := c.Snapshot(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("alice Snapshot: %v", err)
+	}
+	if alice.ForksServed != 1 {
+		t.Fatalf("alice forks_served = %d, want 1 (bob's 2 forks must not leak)", alice.ForksServed)
+	}
+	if alice.ActivateP50Millis == 99 {
+		t.Fatalf("alice saw bob's latency 99; cross-org leak")
+	}
+}
+
+// TestSnapshotEmptyOrgIsZero asserts an org with no sandboxes gets a zero,
+// org-scoped snapshot rather than another org's numbers.
+func TestSnapshotEmptyOrgIsZero(t *testing.T) {
+	c := newSource(t, sbWith("bob", "sb-b1", true, 99))
+	snap, err := c.Snapshot(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.OrgID != "alice" || snap.ForksServed != 0 || snap.ActivateP50Millis != 0 {
+		t.Fatalf("empty-org snapshot = %+v, want zero scoped to alice", snap)
+	}
+}
+
+// TestImplementsInstrumentsSource is a compile-time seam assertion.
+func TestImplementsInstrumentsSource(t *testing.T) {
+	var _ console.InstrumentsSource = (*Source)(nil)
+}

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -198,6 +198,7 @@ func (c *Console) routes() {
 	mux.HandleFunc("POST /console/keys", c.handleCreateKey)
 	mux.HandleFunc("POST /console/keys/{id}/revoke", c.handleRevokeKey)
 	mux.HandleFunc("GET /console/usage", c.handleUsage)
+	mux.Handle("GET /console/usage/api", c.usageAPIHandler())
 	mux.HandleFunc("GET /console/billing", c.handleBilling)
 	mux.HandleFunc("GET /console/billing/portal", c.handleBillingPortal)
 	mux.HandleFunc("GET /console/sandboxes", c.handleListSandboxes)
@@ -378,6 +379,31 @@ func (c *Console) handleRevokeKey(w http.ResponseWriter, r *http.Request) {
 }
 
 // --- Usage / cost (over #211) ---
+
+// usageAPIHandler mounts the #211 usage API (usage.NewUsageHandler) on the
+// console so the SPA can query the org's records/totals/cost in the canonical
+// usage-API shape, served from the SAME store and price list the console's own
+// usage view reads. It is ORG-SCOPED via the gateway-verified identity: the org
+// is taken from the console request context (attached by the session/gateway
+// middleware, never from the client) and bridged into the usage handler's own
+// org context, so a request authenticated as org A can never read org B. A
+// request with no org context is refused before the usage handler runs.
+func (c *Console) usageAPIHandler() http.Handler {
+	inner := usage.NewUsageHandler(c.deps.Usage, c.deps.Prices)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, orgID, e, ok := c.caller(r)
+		if !ok {
+			apierr.Encode(w, e)
+			return
+		}
+		// Re-derive the org ONLY from the verified console context and inject it
+		// into the usage handler's context. The usage handler reads the org from
+		// usage.OrgFromContext and ignores any org in the query, so the client can
+		// never widen the scope.
+		ctx := usage.WithOrg(r.Context(), orgID)
+		inner.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
 
 func (c *Console) handleUsage(w http.ResponseWriter, r *http.Request) {
 	_, orgID, e, ok := c.caller(r)

--- a/internal/saas/console/usageapi_test.go
+++ b/internal/saas/console/usageapi_test.go
@@ -1,0 +1,82 @@
+package console
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"mitos.run/mitos/internal/usage"
+)
+
+// TestUsageAPIMountedOrgScoped asserts the mounted #211 usage API at
+// /console/usage/api serves the caller org's records in the canonical usage-API
+// shape, derived from the gateway-verified org context.
+func TestUsageAPIMountedOrgScoped(t *testing.T) {
+	f := newFixture(t)
+	w := f.req(t, "GET", "/console/usage/api", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp usage.UsageResponse
+	decode(t, w, &resp)
+	if resp.OrgID != f.aliceOrg {
+		t.Fatalf("org_id = %q, want alice", resp.OrgID)
+	}
+	if len(resp.Records) != 1 || resp.Records[0].SandboxID != "a-sb" {
+		t.Fatalf("records = %+v, want exactly alice's a-sb", resp.Records)
+	}
+	for _, rec := range resp.Records {
+		if rec.OrgID != f.aliceOrg {
+			t.Fatalf("cross-org record in alice usage api: %+v", rec)
+		}
+	}
+}
+
+// TestUsageAPIMountedCannotReadOtherOrg asserts a request authenticated as bob
+// reads ONLY bob's usage through the mounted API: org A can never read org B.
+func TestUsageAPIMountedCannotReadOtherOrg(t *testing.T) {
+	f := newFixture(t)
+	w := f.req(t, "GET", "/console/usage/api", "", f.bobAcct, f.bobOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp usage.UsageResponse
+	decode(t, w, &resp)
+	if resp.OrgID != f.bobOrg {
+		t.Fatalf("org_id = %q, want bob", resp.OrgID)
+	}
+	for _, rec := range resp.Records {
+		if rec.OrgID == f.aliceOrg || rec.SandboxID == "a-sb" {
+			t.Fatalf("bob read alice's usage through the mounted api: %+v", rec)
+		}
+	}
+}
+
+// TestUsageAPIMountedIgnoresClientOrg asserts the mounted API never trusts an org
+// the client tries to inject via a query parameter: the org comes only from the
+// verified context.
+func TestUsageAPIMountedIgnoresClientOrg(t *testing.T) {
+	f := newFixture(t)
+	// bob tries to read alice's org by naming it in the query; it must be ignored.
+	w := f.req(t, "GET", "/console/usage/api?org="+f.aliceOrg, "", f.bobAcct, f.bobOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp usage.UsageResponse
+	decode(t, w, &resp)
+	if resp.OrgID != f.bobOrg {
+		t.Fatalf("org_id = %q, want bob (client-named org must be ignored)", resp.OrgID)
+	}
+}
+
+// TestUsageAPIMountedRequiresAuth asserts the mounted API is refused without a
+// caller/org context.
+func TestUsageAPIMountedRequiresAuth(t *testing.T) {
+	c := New(Deps{})
+	r := httptest.NewRequest("GET", "/console/usage/api", nil)
+	w := httptest.NewRecorder()
+	c.ServeHTTP(w, r)
+	if w.Code == http.StatusOK {
+		t.Fatalf("unauthenticated usage api returned 200; must be refused")
+	}
+}

--- a/internal/usage/api.go
+++ b/internal/usage/api.go
@@ -142,12 +142,18 @@ func (h *UsageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	totals := rollUp(records)
-	resp := UsageResponse{
+	writeUsageJSON(w, UsageResponse{
 		OrgID:   orgID,
 		Records: records,
 		Totals:  totals,
 		Cost:    h.prices.cost(totals),
-	}
+	})
+}
+
+// writeUsageJSON writes a UsageResponse as a 200 JSON body. It is shared by the
+// public usage API and the internal M2M usage API so both emit the identical
+// shape the console decodes.
+func writeUsageJSON(w http.ResponseWriter, resp UsageResponse) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)

--- a/internal/usage/httpstore.go
+++ b/internal/usage/httpstore.go
@@ -1,0 +1,105 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// InternalOrgHeader carries the org id on the controller's INTERNAL usage API
+// (the machine-to-machine seam the console reads). The endpoint is bearer-gated
+// by a shared secret and is NOT browser-facing, so the org is supplied by the
+// trusted caller (the console, which itself derived the org from the
+// gateway-verified session) in this header, exactly as the identity-resolve
+// endpoint trusts its caller. It is never read from a public, session-bearing
+// path; the public usage API (UsageHandler) reads the org from the context the
+// gateway attached, never from a header.
+const InternalOrgHeader = "X-Mitos-Org"
+
+// ErrReadOnly is returned by a read-only UsageStore (the HTTP-backed store the
+// console reads through) on a write. The console never writes usage; only the
+// controller's collector does, into its own store.
+var ErrReadOnly = errors.New("usage: store is read-only")
+
+// HTTPStore is a read-only UsageStore that reads an org's usage records from the
+// controller's INTERNAL usage API over HTTP. It is the seam that lets the
+// console (a separate process) read the SAME usage the controller's collector
+// recorded, without a shared database: the controller mounts the internal usage
+// API over its collector store, and the console reads it through this client.
+//
+// SECURITY: the request carries the internal bearer token (a shared secret,
+// never logged) and the org id in InternalOrgHeader. The org is supplied by the
+// console, which derived it from the gateway-verified session, so a tenant can
+// never read another org's usage: the console only ever sets its own caller's
+// org. The endpoint is M2M and not reachable by a browser session.
+type HTTPStore struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+// NewHTTPStore builds the read-only HTTP-backed usage store over the controller's
+// internal usage API base URL (for example http://mitos-controller:8092). The
+// token is the internal bearer shared secret. client may be nil (a default
+// client with a bounded timeout is used).
+func NewHTTPStore(baseURL, token string, client *http.Client) *HTTPStore {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &HTTPStore{baseURL: baseURL, token: token, client: client}
+}
+
+// UpsertRecord is a no-op error: the console never writes usage, only reads it.
+func (s *HTTPStore) UpsertRecord(_ context.Context, _ UsageRecord) error {
+	return ErrReadOnly
+}
+
+// ListRecords reads the org's records in [from, to) from the controller's
+// internal usage API. The org is sent in InternalOrgHeader (the M2M trust
+// boundary), the optional window bounds as RFC3339 query parameters. It returns
+// only the named org's records: the controller's handler scopes the store read
+// to that org.
+func (s *HTTPStore) ListRecords(ctx context.Context, orgID string, from, to time.Time) ([]UsageRecord, error) {
+	u, err := url.Parse(s.baseURL + "/internal/usage")
+	if err != nil {
+		return nil, fmt.Errorf("parse internal usage url: %w", err)
+	}
+	q := u.Query()
+	if !from.IsZero() {
+		q.Set("from", from.UTC().Format(time.RFC3339))
+	}
+	if !to.IsZero() {
+		q.Set("to", to.UTC().Format(time.RFC3339))
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build internal usage request: %w", err)
+	}
+	req.Header.Set(InternalOrgHeader, orgID)
+	if s.token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.token)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("read internal usage: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("internal usage api returned status %d", resp.StatusCode)
+	}
+	var out UsageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode internal usage: %w", err)
+	}
+	if out.Records == nil {
+		return []UsageRecord{}, nil
+	}
+	return out.Records, nil
+}

--- a/internal/usage/internalapi.go
+++ b/internal/usage/internalapi.go
@@ -1,0 +1,96 @@
+package usage
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"mitos.run/mitos/internal/apierr"
+)
+
+// InternalUsageHandler serves an org's usage over a MACHINE-TO-MACHINE endpoint
+// the controller mounts so a separate process (the console) can read the SAME
+// usage the controller's collector recorded, without a shared database. Unlike
+// the public UsageHandler (which reads the org from the gateway-attached
+// context), this endpoint is bearer-gated by a shared secret and takes the org
+// from InternalOrgHeader: its only caller is the console, which already derived
+// the org from the gateway-verified session, so the org in the header is a
+// trusted upstream fact, exactly like the identity-resolve endpoint.
+//
+// SECURITY: the bearer token is compared in constant time and is never logged.
+// The org is still scoped at the store: ListRecords returns only the named org's
+// records, so even a malformed header can only ever return that org's data, never
+// a cross-org bleed. A missing/empty org or a bad token is refused.
+type InternalUsageHandler struct {
+	store  UsageStore
+	prices PriceList
+	token  string
+}
+
+// NewInternalUsageHandler builds the M2M usage handler over a usage store, a
+// price list, and the shared bearer token. An empty token disables the endpoint
+// (every request is refused) so a misconfiguration fails closed rather than
+// serving usage unauthenticated.
+func NewInternalUsageHandler(store UsageStore, prices PriceList, token string) *InternalUsageHandler {
+	return &InternalUsageHandler{store: store, prices: prices, token: token}
+}
+
+// ServeHTTP authenticates the bearer token, reads the org from InternalOrgHeader,
+// and serves that org's usage. It returns the same UsageResponse shape the public
+// usage API does so the console can reuse one decoder.
+func (h *InternalUsageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		apierr.Encode(w, apierr.Get(apierr.CodeNotFound).
+			WithCause("the internal usage endpoint serves GET only"))
+		return
+	}
+	if h.token == "" || !bearerEquals(r.Header.Get("Authorization"), h.token) {
+		apierr.Encode(w, apierr.Get(apierr.CodeUnauthorized).
+			WithCause("the internal usage endpoint requires a valid bearer token"))
+		return
+	}
+	orgID := r.Header.Get(InternalOrgHeader)
+	if orgID == "" {
+		apierr.Encode(w, apierr.Get(apierr.CodeUnauthorized).
+			WithCause("the internal usage request carries no organization header"))
+		return
+	}
+
+	from, err := parseTime(r.URL.Query().Get("from"))
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the from query parameter is not an RFC3339 timestamp"))
+		return
+	}
+	to, err := parseTime(r.URL.Query().Get("to"))
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("the to query parameter is not an RFC3339 timestamp"))
+		return
+	}
+
+	records, err := h.store.ListRecords(r.Context(), orgID, from, to)
+	if err != nil {
+		apierr.Encode(w, apierr.Get(apierr.CodeInternal).
+			WithCause("the usage store could not list records"))
+		return
+	}
+	totals := rollUp(records)
+	writeUsageJSON(w, UsageResponse{
+		OrgID:   orgID,
+		Records: records,
+		Totals:  totals,
+		Cost:    h.prices.cost(totals),
+	})
+}
+
+// bearerEquals reports whether the Authorization header carries exactly
+// "Bearer <token>", comparing the token in constant time. A missing prefix or a
+// length mismatch is a non-match without leaking timing.
+func bearerEquals(header, token string) bool {
+	const prefix = "Bearer "
+	if len(header) <= len(prefix) || header[:len(prefix)] != prefix {
+		return false
+	}
+	got := header[len(prefix):]
+	return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
+}

--- a/internal/usage/internalapi_test.go
+++ b/internal/usage/internalapi_test.go
@@ -1,0 +1,150 @@
+package usage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// seedStore returns a MemUsageStore with one record per org.
+func seedStore(t *testing.T) (*MemUsageStore, time.Time) {
+	t.Helper()
+	store := NewMemUsageStore()
+	now := time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC)
+	if err := store.UpsertRecord(context.Background(), UsageRecord{OrgID: "alice", SandboxID: "a-sb", Window: now, VCPUSeconds: 100, EgressBytes: 1 << 30}); err != nil {
+		t.Fatalf("seed alice: %v", err)
+	}
+	if err := store.UpsertRecord(context.Background(), UsageRecord{OrgID: "bob", SandboxID: "b-sb", Window: now, VCPUSeconds: 999}); err != nil {
+		t.Fatalf("seed bob: %v", err)
+	}
+	return store, now
+}
+
+// TestInternalUsageHandlerRoundTrip asserts the internal handler serves the
+// header org's records when the bearer token matches.
+func TestInternalUsageHandlerRoundTrip(t *testing.T) {
+	store, _ := seedStore(t)
+	h := NewInternalUsageHandler(store, DefaultPriceList(), "s3cr3t")
+
+	r := httptest.NewRequest("GET", "/internal/usage", nil)
+	r.Header.Set("Authorization", "Bearer s3cr3t")
+	r.Header.Set(InternalOrgHeader, "alice")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestInternalUsageHandlerBadTokenRefused asserts a wrong/missing bearer token
+// is refused before any usage is served.
+func TestInternalUsageHandlerBadTokenRefused(t *testing.T) {
+	store, _ := seedStore(t)
+	h := NewInternalUsageHandler(store, DefaultPriceList(), "s3cr3t")
+
+	for _, auth := range []string{"", "Bearer wrong", "s3cr3t"} {
+		r := httptest.NewRequest("GET", "/internal/usage", nil)
+		if auth != "" {
+			r.Header.Set("Authorization", auth)
+		}
+		r.Header.Set(InternalOrgHeader, "alice")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code == http.StatusOK {
+			t.Fatalf("auth=%q served usage; must be refused", auth)
+		}
+	}
+}
+
+// TestInternalUsageHandlerEmptyTokenFailsClosed asserts a handler built with an
+// empty token refuses every request rather than serving usage unauthenticated.
+func TestInternalUsageHandlerEmptyTokenFailsClosed(t *testing.T) {
+	store, _ := seedStore(t)
+	h := NewInternalUsageHandler(store, DefaultPriceList(), "")
+	r := httptest.NewRequest("GET", "/internal/usage", nil)
+	r.Header.Set(InternalOrgHeader, "alice")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code == http.StatusOK {
+		t.Fatalf("empty-token handler served usage; must fail closed")
+	}
+}
+
+// TestHTTPStoreReadsOnlyItsOrg drives the HTTPStore against the internal handler
+// end-to-end and asserts each org reads ONLY its own records, never the other's.
+func TestHTTPStoreReadsOnlyItsOrg(t *testing.T) {
+	store, _ := seedStore(t)
+	h := NewInternalUsageHandler(store, DefaultPriceList(), "s3cr3t")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	client := NewHTTPStore(srv.URL, "s3cr3t", srv.Client())
+
+	alice, err := client.ListRecords(context.Background(), "alice", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("alice ListRecords: %v", err)
+	}
+	if len(alice) != 1 || alice[0].SandboxID != "a-sb" {
+		t.Fatalf("alice records = %+v, want exactly a-sb", alice)
+	}
+	for _, rec := range alice {
+		if rec.OrgID != "alice" {
+			t.Fatalf("cross-org record in alice read: %+v", rec)
+		}
+	}
+
+	bob, err := client.ListRecords(context.Background(), "bob", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("bob ListRecords: %v", err)
+	}
+	if len(bob) != 1 || bob[0].SandboxID != "b-sb" {
+		t.Fatalf("bob records = %+v, want exactly b-sb", bob)
+	}
+}
+
+// TestHTTPStoreEmptyOrgIsEmpty asserts an org with no usage reads as an empty,
+// non-nil slice (never another org's records).
+func TestHTTPStoreEmptyOrgIsEmpty(t *testing.T) {
+	store, _ := seedStore(t)
+	h := NewInternalUsageHandler(store, DefaultPriceList(), "s3cr3t")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	client := NewHTTPStore(srv.URL, "s3cr3t", srv.Client())
+	recs, err := client.ListRecords(context.Background(), "carol", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("carol ListRecords: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("carol records = %+v, want empty", recs)
+	}
+}
+
+// TestHTTPStoreBadTokenErrors asserts the client surfaces an error (never a
+// silent empty success) when the controller refuses the token.
+func TestHTTPStoreBadTokenErrors(t *testing.T) {
+	store, _ := seedStore(t)
+	h := NewInternalUsageHandler(store, DefaultPriceList(), "s3cr3t")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	client := NewHTTPStore(srv.URL, "wrong", srv.Client())
+	if _, err := client.ListRecords(context.Background(), "alice", time.Time{}, time.Time{}); err == nil {
+		t.Fatalf("bad-token ListRecords returned nil error; want an error")
+	}
+}
+
+// TestHTTPStoreUpsertIsReadOnly asserts the console-side store rejects writes.
+func TestHTTPStoreUpsertIsReadOnly(t *testing.T) {
+	client := NewHTTPStore("http://unused", "t", http.DefaultClient)
+	if err := client.UpsertRecord(context.Background(), UsageRecord{OrgID: "alice"}); err == nil {
+		t.Fatalf("UpsertRecord returned nil; want ErrReadOnly")
+	}
+}
+
+// TestHTTPStoreImplementsUsageStore is a compile-time seam assertion.
+func TestHTTPStoreImplementsUsageStore(t *testing.T) {
+	var _ UsageStore = (*HTTPStore)(nil)
+}


### PR DESCRIPTION
**Hosted SaaS campaign, Phase 4.** The console serves real per-org usage and fork topology instead of in-memory fakes.

## What
- The collector runs in the controller; the console is a separate process, so it reads usage over a new **internal M2M usage API** (`UsageAPIRunnable`, bearer-gated with a constant-time token compare that fails closed, org from a trusted header). The console's `HTTPStore` is a read-only `UsageStore` over that API.
- **clusterforktree**: builds the fork tree by listing Sandboxes in the org namespace (`tenant.NamespaceForOrg` + org-label scoped) and mapping fork lineage. **clusterinstruments**: measures forks-served and activate p50/p99 from the org's own Sandbox records. Both enforce the same cross-tenant boundary as the control plane (an org only ever sees its own namespace).
- The console mounts the public usage API at `GET /console/usage/api`, bridging the gateway-verified org into the handler so a client can never widen scope.
- `cmd/console`/`cmd/controller` construct the real sources when configured (`MITOS_USAGE_API_URL`/`_TOKEN`, kube client), with an in-memory dev fallback behind config-absence and a startup log line naming the active mode. The usage API token is never logged.

## Honest metering
CoW-savings and private/shared bytes depend on per-node metering (#33) not present on the Sandbox CR; they are left zero and documented, not fabricated (no-unverified-numbers). Forks-served and activate latencies are genuinely measured from the org's own records.

## Tests
Internal usage API round-trip + bad/empty-token-refused + cross-org isolation; HTTPStore org-scoping + read-only; fork-tree and instruments scoped to the caller org (two-org isolation); the mounted console usage API rejects a client-supplied org and requires auth. Build/vet/lint (both arches) clean; `go mod tidy` adds no deps.

Builds on #412 (Postgres) and #410 (tenancy); composes with the control plane's cross-tenant boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)