### PR TITLE
feat(saas): real Paddle billing provider (#212)

### DIFF
--- a/cmd/console/billing.go
+++ b/cmd/console/billing.go
@@ -9,6 +9,7 @@ import (
 
 	"mitos.run/mitos/internal/saas/billing"
 	"mitos.run/mitos/internal/saas/billingprovider"
+	"mitos.run/mitos/internal/saas/billingprovider/paddle"
 	"mitos.run/mitos/internal/saas/billingprovider/stripe"
 	"mitos.run/mitos/internal/saas/console"
 )
@@ -38,19 +39,37 @@ type billingWiring struct {
 }
 
 // setupBilling builds the billing provider wiring when billing is enabled. The
-// provider is currently Stripe (selected like the secret providers); a Merchant
-// of Record plugs in here as a sibling. The webhook is fully functional
-// (signature-verified status sync); the live portal-session API call is injected
-// via the provider's Portal func and is the remaining external adapter, so until
-// it is set the portal endpoint simply 404s.
+// provider is selected by configuration the same way the secret providers are:
+// Paddle (our Merchant of Record: the legal seller, which handles global
+// sales-tax/VAT) is selected when its API key and webhook secret are present;
+// otherwise the Stripe provider remains the default. Both are siblings behind the
+// provider-neutral seam, so the dunning/status core never names a provider. The
+// webhook is fully functional (signature-verified status sync); the Paddle portal
+// link is served by a live Paddle Billing API call, while the Stripe portal call
+// stays an injected adapter, so for Stripe the portal endpoint 404s until set.
+//
+// Secrets: the Paddle API key and webhook secret are read from env and never
+// logged; only the selected provider's Name() is logged.
 func setupBilling(logger *slog.Logger, status billing.StatusStore) billingWiring {
 	if !envBool("MITOS_CONSOLE_BILLING") {
 		return billingWiring{portal: nil} // console fills the no-portal default
 	}
-	provider := stripe.New(stripe.Config{
-		SigningSecret: os.Getenv("MITOS_CONSOLE_STRIPE_WEBHOOK_SECRET"),
-		Tolerance:     5 * time.Minute,
-	})
+	var provider billingprovider.Provider
+	paddleKey := os.Getenv("MITOS_CONSOLE_PADDLE_API_KEY")
+	paddleSecret := os.Getenv("MITOS_CONSOLE_PADDLE_WEBHOOK_SECRET")
+	if paddleKey != "" && paddleSecret != "" {
+		provider = paddle.New(paddle.Config{
+			APIKey:        paddleKey,
+			WebhookSecret: paddleSecret,
+			BaseURL:       envOr("MITOS_CONSOLE_PADDLE_BASE_URL", paddle.LiveBaseURL),
+			Tolerance:     5 * time.Minute,
+		})
+	} else {
+		provider = stripe.New(stripe.Config{
+			SigningSecret: os.Getenv("MITOS_CONSOLE_STRIPE_WEBHOOK_SECRET"),
+			Tolerance:     5 * time.Minute,
+		})
+	}
 	customers := billingprovider.NewMemCustomers() // durable mapping is a follow-up
 	logger.Info("billing enabled", "provider", provider.Name())
 	return billingWiring{

--- a/deploy/charts/charttest/console_test.go
+++ b/deploy/charts/charttest/console_test.go
@@ -115,6 +115,54 @@ func TestConsoleOIDCRedirectURLOmittedByDefault(t *testing.T) {
 	}
 }
 
+// TestPaddleAbsentByDefault asserts the Paddle env is not rendered in the default
+// community install (billing off), so no billing provider config leaks in.
+func TestPaddleAbsentByDefault(t *testing.T) {
+	out := render(t)
+	if strings.Contains(out, "MITOS_CONSOLE_PADDLE_API_KEY") {
+		t.Fatal("Paddle API key env rendered by default; billing must be opt-in")
+	}
+	if strings.Contains(out, "MITOS_CONSOLE_PADDLE_WEBHOOK_SECRET") {
+		t.Fatal("Paddle webhook secret env rendered by default")
+	}
+}
+
+// TestPaddleSecretRefWiring asserts that when billing is enabled and the Paddle
+// secret refs are set, the API key and webhook secret are injected via
+// secretKeyRef ONLY (never as plaintext values), and the base URL passes through.
+func TestPaddleSecretRefWiring(t *testing.T) {
+	out := render(t,
+		"console.billing.enabled=true",
+		"console.billing.paddle.apiKeySecretRef.name=mitos-paddle",
+		"console.billing.paddle.webhookSecretRef.name=mitos-paddle",
+		"console.billing.paddle.baseURL=https://sandbox-api.paddle.com",
+	)
+	mustNamedSecretKeyRef(t, out, "MITOS_CONSOLE_PADDLE_API_KEY", "mitos-paddle", "api-key")
+	mustNamedSecretKeyRef(t, out, "MITOS_CONSOLE_PADDLE_WEBHOOK_SECRET", "mitos-paddle", "webhook-secret")
+	mustEnv(t, out, "MITOS_CONSOLE_PADDLE_BASE_URL", "https://sandbox-api.paddle.com")
+}
+
+// TestPaddleSecretValuesNeverPlaintext asserts the chart NEVER renders a Paddle
+// secret as a plaintext env value: only the secretKeyRef indirection is allowed.
+func TestPaddleSecretValuesNeverPlaintext(t *testing.T) {
+	out := render(t,
+		"console.billing.enabled=true",
+		"console.billing.paddle.apiKeySecretRef.name=mitos-paddle",
+		"console.billing.paddle.webhookSecretRef.name=mitos-paddle",
+	)
+	lines := strings.Split(out, "\n")
+	for i, ln := range lines {
+		for _, name := range []string{"MITOS_CONSOLE_PADDLE_API_KEY", "MITOS_CONSOLE_PADDLE_WEBHOOK_SECRET"} {
+			if strings.TrimSpace(ln) == "- name: "+name && i+1 < len(lines) {
+				next := strings.TrimSpace(lines[i+1])
+				if strings.HasPrefix(next, "value:") {
+					t.Fatalf("%s rendered as plaintext value; must use secretKeyRef", name)
+				}
+			}
+		}
+	}
+}
+
 // TestConsoleExtraEnv asserts arbitrary console.extraEnv entries pass through, so
 // operators can inject env the chart does not model.
 func TestConsoleExtraEnv(t *testing.T) {
@@ -187,6 +235,35 @@ func controllerClusterRole(t *testing.T, out string) string {
 	}
 	t.Fatal("mitos-controller ClusterRole not found in rendered manifests")
 	return ""
+}
+
+// mustNamedSecretKeyRef asserts an env var with the given name is sourced from a
+// secretKeyRef pointing at secretName/key, and never carries a plaintext value.
+func mustNamedSecretKeyRef(t *testing.T, out, name, secretName, key string) {
+	t.Helper()
+	needle := "- name: " + name
+	lines := strings.Split(out, "\n")
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) != needle {
+			continue
+		}
+		end := i + 6
+		if end > len(lines) {
+			end = len(lines)
+		}
+		block := strings.Join(lines[i:end], "\n")
+		if !strings.Contains(block, "secretKeyRef:") {
+			t.Fatalf("env %s is not sourced from a secretKeyRef", name)
+		}
+		if !strings.Contains(block, `name: "`+secretName+`"`) {
+			t.Fatalf("env %s secretKeyRef does not reference secret %q", name, secretName)
+		}
+		if !strings.Contains(block, `key: "`+key+`"`) {
+			t.Fatalf("env %s secretKeyRef does not use key %q", name, key)
+		}
+		return
+	}
+	t.Fatalf("env %s not found in rendered manifests", name)
 }
 
 func mustContain(t *testing.T, out, want string) {

--- a/deploy/charts/mitos/templates/console.yaml
+++ b/deploy/charts/mitos/templates/console.yaml
@@ -112,6 +112,38 @@ spec:
               value: {{ .Values.console.signup | quote }}
             - name: MITOS_CONSOLE_BILLING
               value: {{ .Values.console.billing.enabled | quote }}
+            {{- /*
+            Paddle (Merchant of Record) selection. The provider switches to Paddle
+            only when BOTH the API key and the webhook signing secret are present;
+            otherwise the binary keeps the Stripe default. Both are SECRETS,
+            injected via secretKeyRef ONLY: their values never appear in the
+            rendered manifests. Gated by billing.enabled so the env is inert when
+            billing is off.
+            */}}
+            {{- if .Values.console.billing.enabled }}
+            {{- with .Values.console.billing.paddle.apiKeySecretRef }}
+            {{- if .name }}
+            - name: MITOS_CONSOLE_PADDLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | quote }}
+                  key: {{ .key | default "api-key" | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.console.billing.paddle.webhookSecretRef }}
+            {{- if .name }}
+            - name: MITOS_CONSOLE_PADDLE_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | quote }}
+                  key: {{ .key | default "webhook-secret" | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.console.billing.paddle.baseURL }}
+            - name: MITOS_CONSOLE_PADDLE_BASE_URL
+              value: {{ .Values.console.billing.paddle.baseURL | quote }}
+            {{- end }}
+            {{- end }}
             - name: MITOS_CONSOLE_OIDC_ISSUER
               value: {{ .Values.console.oidc.issuerURL | quote }}
             - name: MITOS_CONSOLE_OIDC_CLIENT_ID

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -321,9 +321,40 @@ console:
       # "namespace" (one OpenBao namespace per org).
       perOrg: path
   billing:
-    # Stripe billing surface. Hosted sets true; community keeps it off so the
-    # billing routes never mount.
+    # Billing surface. Hosted sets true; community keeps it off so the billing
+    # routes never mount. The provider is selected by configuration: Paddle (our
+    # Merchant of Record, which is the legal seller and handles global
+    # sales-tax/VAT) is used when paddle.apiKeySecretRef and
+    # paddle.webhookSecretRef are both set; otherwise the Stripe default applies.
     enabled: false
+    # Paddle (Merchant of Record) configuration. The API key and webhook signing
+    # secret are SECRETS and are injected ONLY via secretKeyRef (env valueFrom),
+    # never as plaintext values in the rendered manifests. Create the Secret out
+    # of band, for example:
+    #
+    #   kubectl create secret generic mitos-paddle \
+    #     --namespace mitos-system \
+    #     --from-literal=api-key='pdl_live_...' \
+    #     --from-literal=webhook-secret='pdl_ntfset_...'
+    #
+    # then set both refs below to name=mitos-paddle. When either ref is unset the
+    # Paddle env is not rendered and the billing default (Stripe) applies.
+    paddle:
+      # Reference an existing Secret holding the Paddle Billing API key.
+      apiKeySecretRef:
+        # Name of the Secret in the release namespace. Empty omits the env.
+        name: ""
+        # Key within that Secret holding the Paddle API key.
+        key: "api-key"
+      # Reference an existing Secret holding the Paddle webhook signing secret.
+      webhookSecretRef:
+        # Name of the Secret in the release namespace. Empty omits the env.
+        name: ""
+        # Key within that Secret holding the webhook signing secret.
+        key: "webhook-secret"
+      # Paddle API host. Default is live; set to https://sandbox-api.paddle.com
+      # for the sandbox. Empty uses the binary's built-in live default.
+      baseURL: ""
   ingress:
     enabled: false
     className: ""

--- a/internal/saas/billingprovider/paddle/paddle.go
+++ b/internal/saas/billingprovider/paddle/paddle.go
@@ -1,0 +1,259 @@
+// Package paddle is the Paddle Billing implementation of
+// billingprovider.Provider. Paddle is a Merchant of Record: it is the legal
+// seller and handles global sales-tax/VAT, so Mitos does not. The provider
+// verifies the Paddle-Signature header (HMAC-SHA256 over "ts:body", with a
+// timestamp tolerance for replay protection) and maps Paddle Billing event types
+// onto the neutral billingprovider.Event. The dunning/status core stays
+// provider-neutral; this package is a sibling to the Stripe provider, selected at
+// wiring time.
+//
+// The Paddle Billing API is reached with net/http + encoding/json (no
+// third-party SDK), a bearer API key, and a configurable base URL so the sandbox
+// (https://sandbox-api.paddle.com) and live (https://api.paddle.com) hosts and a
+// test httptest.Server are interchangeable.
+//
+// Security: the API key and the webhook signing secret are NEVER logged, NEVER
+// placed in error messages, and NEVER returned to a caller. They live only in the
+// Provider struct and the request headers.
+package paddle
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"mitos.run/mitos/internal/saas/billing"
+	"mitos.run/mitos/internal/saas/billingprovider"
+)
+
+// LiveBaseURL is the Paddle Billing live API host.
+const LiveBaseURL = "https://api.paddle.com"
+
+// SandboxBaseURL is the Paddle Billing sandbox API host.
+const SandboxBaseURL = "https://sandbox-api.paddle.com"
+
+// defaultTolerance is the replay window applied when Config.Tolerance is zero.
+const defaultTolerance = 5 * time.Minute
+
+// Config wires the Paddle provider. APIKey and WebhookSecret are SECRETS.
+type Config struct {
+	// APIKey is the Paddle Billing API key (bearer token). Empty disables the
+	// portal API call; the webhook still verifies on WebhookSecret alone.
+	APIKey string
+	// WebhookSecret is the endpoint's signing secret (the per-notification
+	// destination secret). Empty makes VerifyWebhook fail closed.
+	WebhookSecret string
+	// BaseURL is the Paddle API host; defaults to LiveBaseURL. Point it at
+	// SandboxBaseURL for the sandbox, or at an httptest.Server in tests.
+	BaseURL string
+	// HTTPClient is the client used for API calls; defaults to a 15s client.
+	HTTPClient *http.Client
+	// Now is the clock used for timestamp tolerance (testable); defaults to
+	// time.Now.
+	Now func() time.Time
+	// Tolerance is the maximum age of a signed event; defaults to 5 minutes. A
+	// negative value disables the timestamp check.
+	Tolerance time.Duration
+}
+
+// Provider implements billingprovider.Provider for Paddle Billing.
+type Provider struct {
+	apiKey    string
+	secret    string
+	baseURL   string
+	http      *http.Client
+	now       func() time.Time
+	tolerance time.Duration
+}
+
+// New builds the Paddle provider from cfg, applying the documented defaults.
+func New(cfg Config) *Provider {
+	base := cfg.BaseURL
+	if base == "" {
+		base = LiveBaseURL
+	}
+	base = strings.TrimRight(base, "/")
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	tol := cfg.Tolerance
+	if tol == 0 {
+		tol = defaultTolerance
+	}
+	return &Provider{
+		apiKey:    cfg.APIKey,
+		secret:    cfg.WebhookSecret,
+		baseURL:   base,
+		http:      client,
+		now:       now,
+		tolerance: tol,
+	}
+}
+
+// Name identifies the provider in logs and capabilities.
+func (p *Provider) Name() string { return "paddle" }
+
+// VerifyWebhook authenticates the Paddle-Signature header against body and maps
+// the Paddle event type to a neutral billing status. A verification error means
+// the request is forged, replayed, or malformed and the caller MUST refuse it.
+func (p *Provider) VerifyWebhook(r *http.Request, body []byte) (billingprovider.Event, error) {
+	if err := p.verifySignature(r.Header.Get("Paddle-Signature"), body); err != nil {
+		return billingprovider.Event{}, err
+	}
+	// Paddle Billing webhook envelope. The customer id lives at data.customer_id
+	// for subscription and transaction events; subscription.canceled etc. all
+	// carry it. We read only what the neutral event needs.
+	var ev struct {
+		EventType string `json:"event_type"`
+		Data      struct {
+			CustomerID string `json:"customer_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return billingprovider.Event{}, fmt.Errorf("paddle: malformed event: %w", err)
+	}
+	return billingprovider.Event{
+		Status:      statusFor(ev.EventType),
+		CustomerRef: ev.Data.CustomerID,
+	}, nil
+}
+
+// statusFor maps Paddle Billing event types to the neutral billing status,
+// matching the Stripe provider's semantics: a healthy subscription/transaction is
+// active, a payment failure or past_due is the dunning trigger, and a cancellation
+// suspends. Unmapped types return "" (acknowledged but ignored).
+func statusFor(eventType string) billing.BillingStatus {
+	switch eventType {
+	case "subscription.created",
+		"subscription.activated",
+		"subscription.resumed",
+		"subscription.updated",
+		"transaction.completed",
+		"transaction.paid":
+		return billing.StatusActive
+	case "subscription.past_due",
+		"transaction.payment_failed":
+		return billing.StatusPastDue
+	case "subscription.canceled",
+		"subscription.paused":
+		return billing.StatusSuspended
+	default:
+		return ""
+	}
+}
+
+// verifySignature implements Paddle Billing's scheme: the Paddle-Signature header
+// is "ts=<unix>;h1=<hex hmac>", where h1 = hex(HMAC_SHA256(secret, "<ts>:<body>")).
+// The comparison is constant time and an optional timestamp tolerance bounds
+// replay. It fails CLOSED: an empty secret, a missing or malformed header, a bad
+// timestamp, or a mismatched MAC all return an error.
+func (p *Provider) verifySignature(header string, body []byte) error {
+	if p.secret == "" {
+		return errors.New("paddle: no webhook signing secret configured")
+	}
+	var ts, h1 string
+	for _, part := range strings.Split(header, ";") {
+		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "ts":
+			ts = v
+		case "h1":
+			h1 = v
+		}
+	}
+	if ts == "" || h1 == "" {
+		return errors.New("paddle: malformed Paddle-Signature header")
+	}
+	if p.tolerance >= 0 {
+		sec, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil {
+			return errors.New("paddle: bad signature timestamp")
+		}
+		if d := p.now().Sub(time.Unix(sec, 0)); d > p.tolerance || d < -p.tolerance {
+			return errors.New("paddle: signature timestamp outside tolerance")
+		}
+	}
+	want, err := hex.DecodeString(h1)
+	if err != nil {
+		return errors.New("paddle: signature is not valid hex")
+	}
+	mac := hmac.New(sha256.New, []byte(p.secret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte(":"))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	if subtle.ConstantTimeCompare(want, expected) != 1 {
+		return errors.New("paddle: signature mismatch")
+	}
+	return nil
+}
+
+// PortalURL returns a Paddle-hosted customer portal URL ("manage subscription")
+// for the customer, via Paddle Billing's POST
+// /customers/{id}/portal-sessions endpoint. The console deep-links to it rather
+// than rebuilding payment UI. The API key is sent as a bearer token and is never
+// surfaced in the returned error.
+func (p *Provider) PortalURL(ctx context.Context, customerRef string) (string, error) {
+	if p.apiKey == "" {
+		return "", errors.New("paddle: customer portal not configured (no API key)")
+	}
+	if customerRef == "" {
+		return "", errors.New("paddle: empty customer reference")
+	}
+	url := p.baseURL + "/customers/" + customerRef + "/portal-sessions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return "", fmt.Errorf("paddle: build portal request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("paddle: portal request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("paddle: read portal response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("paddle: portal API returned status %d", resp.StatusCode)
+	}
+	// Paddle Billing portal-sessions response shape:
+	// { "data": { "urls": { "general": { "overview": "https://..." } } } }
+	var out struct {
+		Data struct {
+			URLs struct {
+				General struct {
+					Overview string `json:"overview"`
+				} `json:"general"`
+			} `json:"urls"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return "", fmt.Errorf("paddle: malformed portal response: %w", err)
+	}
+	if out.Data.URLs.General.Overview == "" {
+		return "", errors.New("paddle: portal response had no overview URL")
+	}
+	return out.Data.URLs.General.Overview, nil
+}

--- a/internal/saas/billingprovider/paddle/paddle_test.go
+++ b/internal/saas/billingprovider/paddle/paddle_test.go
@@ -1,0 +1,266 @@
+package paddle
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/saas/billing"
+	"mitos.run/mitos/internal/saas/billingprovider"
+)
+
+const secret = "pdl_ntfset_test"
+
+var now = time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+// sigHeader computes a valid Paddle-Signature header for body at time t with the
+// given secret: ts=<unix>;h1=hex(HMAC_SHA256(secret, "<ts>:<body>")).
+func sigHeader(sec string, t time.Time, body string) string {
+	mac := hmac.New(sha256.New, []byte(sec))
+	fmt.Fprintf(mac, "%d:%s", t.Unix(), body)
+	return fmt.Sprintf("ts=%d;h1=%s", t.Unix(), hex.EncodeToString(mac.Sum(nil)))
+}
+
+func provider() *Provider {
+	return New(Config{
+		WebhookSecret: secret,
+		Now:           func() time.Time { return now },
+		Tolerance:     5 * time.Minute,
+	})
+}
+
+func verifyWith(t *testing.T, header, body string) (billingprovider.Event, error) {
+	t.Helper()
+	r := httptest.NewRequest("POST", "/webhooks/billing", strings.NewReader(body))
+	if header != "" {
+		r.Header.Set("Paddle-Signature", header)
+	}
+	return provider().VerifyWebhook(r, []byte(body))
+}
+
+func verify(t *testing.T, sec string, ts time.Time, body string) (billingprovider.Event, error) {
+	t.Helper()
+	return verifyWith(t, sigHeader(sec, ts, body), body)
+}
+
+// TestImplementsProvider is a compile-time seam check.
+func TestImplementsProvider(t *testing.T) {
+	var _ billingprovider.Provider = (*Provider)(nil)
+}
+
+// TestValidSignaturePastDue asserts a correctly-signed subscription.past_due maps
+// to past_due with the customer ref extracted.
+func TestValidSignaturePastDue(t *testing.T) {
+	body := `{"event_type":"subscription.past_due","data":{"customer_id":"ctm_x"}}`
+	ev, err := verify(t, secret, now, body)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if ev.Status != billing.StatusPastDue || ev.CustomerRef != "ctm_x" {
+		t.Fatalf("event = %+v, want past_due/ctm_x", ev)
+	}
+}
+
+// TestTamperedBodyRejected asserts a body changed after signing fails (the MAC no
+// longer matches).
+func TestTamperedBodyRejected(t *testing.T) {
+	signed := `{"event_type":"subscription.past_due","data":{"customer_id":"ctm_x"}}`
+	header := sigHeader(secret, now, signed)
+	tampered := `{"event_type":"subscription.activated","data":{"customer_id":"ctm_x"}}`
+	if _, err := verifyWith(t, header, tampered); err == nil {
+		t.Fatal("tampered body accepted")
+	}
+}
+
+// TestForgedSignatureRejected asserts a wrong-secret signature errors.
+func TestForgedSignatureRejected(t *testing.T) {
+	body := `{"event_type":"subscription.past_due","data":{"customer_id":"ctm_x"}}`
+	if _, err := verify(t, "pdl_ntfset_wrong", now, body); err == nil {
+		t.Fatal("forged signature accepted")
+	}
+}
+
+// TestMissingSignatureRejected asserts a request with no Paddle-Signature header
+// is refused.
+func TestMissingSignatureRejected(t *testing.T) {
+	body := `{"event_type":"subscription.past_due","data":{"customer_id":"ctm_x"}}`
+	if _, err := verifyWith(t, "", body); err == nil {
+		t.Fatal("missing signature accepted")
+	}
+}
+
+// TestMalformedSignatureRejected asserts a header that lacks ts/h1 is refused.
+func TestMalformedSignatureRejected(t *testing.T) {
+	body := `{"event_type":"subscription.past_due","data":{"customer_id":"ctm_x"}}`
+	if _, err := verifyWith(t, "garbage", body); err == nil {
+		t.Fatal("malformed signature accepted")
+	}
+}
+
+// TestStaleTimestampRejected asserts replay protection via the tolerance window.
+func TestStaleTimestampRejected(t *testing.T) {
+	body := `{"event_type":"subscription.past_due","data":{"customer_id":"ctm_x"}}`
+	if _, err := verify(t, secret, now.Add(-time.Hour), body); err == nil {
+		t.Fatal("stale signature accepted")
+	}
+}
+
+// TestEmptySecretFailsClosed asserts a provider with no signing secret refuses
+// every webhook, even one carrying a structurally valid header.
+func TestEmptySecretFailsClosed(t *testing.T) {
+	p := New(Config{Now: func() time.Time { return now }})
+	body := `{"event_type":"subscription.activated","data":{"customer_id":"ctm_x"}}`
+	r := httptest.NewRequest("POST", "/webhooks/billing", strings.NewReader(body))
+	r.Header.Set("Paddle-Signature", sigHeader(secret, now, body))
+	if _, err := p.VerifyWebhook(r, []byte(body)); err == nil {
+		t.Fatal("empty secret accepted a webhook; must fail closed")
+	}
+}
+
+// TestEventMapping covers the representative Paddle event types and the neutral
+// status each drives, matching the Stripe provider's semantics.
+func TestEventMapping(t *testing.T) {
+	cases := []struct {
+		eventType string
+		want      billing.BillingStatus
+	}{
+		{"subscription.created", billing.StatusActive},
+		{"subscription.activated", billing.StatusActive},
+		{"subscription.resumed", billing.StatusActive},
+		{"subscription.updated", billing.StatusActive},
+		{"transaction.completed", billing.StatusActive},
+		{"transaction.paid", billing.StatusActive},
+		{"subscription.past_due", billing.StatusPastDue},
+		{"transaction.payment_failed", billing.StatusPastDue},
+		{"subscription.canceled", billing.StatusSuspended},
+		{"subscription.paused", billing.StatusSuspended},
+		{"customer.updated", ""}, // unmapped: acknowledged, ignored
+	}
+	for _, tc := range cases {
+		t.Run(tc.eventType, func(t *testing.T) {
+			body := fmt.Sprintf(`{"event_type":%q,"data":{"customer_id":"ctm_x"}}`, tc.eventType)
+			ev, err := verify(t, secret, now, body)
+			if err != nil {
+				t.Fatalf("verify: %v", err)
+			}
+			if ev.Status != tc.want {
+				t.Fatalf("%s -> %q, want %q", tc.eventType, ev.Status, tc.want)
+			}
+		})
+	}
+}
+
+// TestNegativeToleranceDisablesTimestampCheck asserts a negative tolerance allows
+// an old-but-correctly-signed event (the check is opt-out).
+func TestNegativeToleranceDisablesTimestampCheck(t *testing.T) {
+	p := New(Config{WebhookSecret: secret, Now: func() time.Time { return now }, Tolerance: -1})
+	body := `{"event_type":"subscription.activated","data":{"customer_id":"ctm_x"}}`
+	r := httptest.NewRequest("POST", "/webhooks/billing", strings.NewReader(body))
+	r.Header.Set("Paddle-Signature", sigHeader(secret, now.Add(-72*time.Hour), body))
+	if _, err := p.VerifyWebhook(r, []byte(body)); err != nil {
+		t.Fatalf("negative tolerance still enforced timestamp: %v", err)
+	}
+}
+
+// TestPortalURL asserts PortalURL POSTs to the correct path with the bearer key
+// and parses the overview URL from the Paddle response.
+func TestPortalURL(t *testing.T) {
+	const apiKey = "pdl_live_secretkey"
+	var gotPath, gotMethod, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"urls":{"general":{"overview":"https://customer.paddle.com/session/abc"}}}}`))
+	}))
+	defer srv.Close()
+
+	p := New(Config{APIKey: apiKey, BaseURL: srv.URL})
+	url, err := p.PortalURL(context.Background(), "ctm_42")
+	if err != nil {
+		t.Fatalf("PortalURL: %v", err)
+	}
+	if url != "https://customer.paddle.com/session/abc" {
+		t.Fatalf("url = %q", url)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/customers/ctm_42/portal-sessions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer "+apiKey {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+}
+
+// TestPortalURLNotConfigured asserts the portal call errors when no API key is
+// set (the console then hides the manage-subscription affordance).
+func TestPortalURLNotConfigured(t *testing.T) {
+	p := New(Config{})
+	if _, err := p.PortalURL(context.Background(), "ctm_42"); err == nil {
+		t.Fatal("portal returned a URL without an API key")
+	}
+}
+
+// TestPortalURLAPIError asserts a non-2xx Paddle response surfaces as a wrapped
+// Go error WITHOUT leaking the API key.
+func TestPortalURLAPIError(t *testing.T) {
+	const apiKey = "pdl_live_topsecret_DEADBEEF"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"detail":"forbidden"}}`))
+	}))
+	defer srv.Close()
+
+	p := New(Config{APIKey: apiKey, BaseURL: srv.URL})
+	_, err := p.PortalURL(context.Background(), "ctm_42")
+	if err == nil {
+		t.Fatal("expected an error for a 403 response")
+	}
+	if strings.Contains(err.Error(), apiKey) {
+		t.Fatalf("API key leaked in error: %v", err)
+	}
+}
+
+// TestAPIKeyNeverInErrors is the secret-hygiene gate: across every error path the
+// PortalURL surface can take, the API key must never appear in the returned error
+// string.
+func TestAPIKeyNeverInErrors(t *testing.T) {
+	const apiKey = "pdl_live_NEVER_LOG_ME_1234567890"
+
+	// 1. Non-2xx response.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	// 2. Malformed JSON response.
+	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer malformed.Close()
+	// 3. Empty overview URL.
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"urls":{"general":{"overview":""}}}}`))
+	}))
+	defer empty.Close()
+
+	for _, base := range []string{bad.URL, malformed.URL, empty.URL, "http://127.0.0.1:1"} {
+		p := New(Config{APIKey: apiKey, BaseURL: base, HTTPClient: &http.Client{Timeout: time.Second}})
+		_, err := p.PortalURL(context.Background(), "ctm_42")
+		if err == nil {
+			continue
+		}
+		if strings.Contains(err.Error(), apiKey) {
+			t.Fatalf("API key leaked in error for base %s: %v", base, err)
+		}
+	}
+}


### PR DESCRIPTION
**Hosted SaaS campaign, Phase 5.** A real Merchant-of-Record billing provider (Paddle) behind the existing `billingprovider.Provider` seam. Paddle is the seller of record and handles tax/VAT.

## What
- `internal/saas/billingprovider/paddle` implements the 3-method `Provider` (`Name`, `VerifyWebhook`, `PortalURL`) over Paddle's Billing REST API with `net/http` + `encoding/json` and a bearer API key (**no new dependency**; configurable base URL for sandbox vs live).
- **Webhook verification**: `Paddle-Signature: ts=<unix>;h1=<hex>` where `h1 = HMAC-SHA256(secret, "ts:body")`. Constant-time compare (`crypto/subtle`), configurable timestamp tolerance. **Fails closed** on empty secret, missing/malformed header, bad hex, stale timestamp, or MAC mismatch.
- Paddle event types map onto the provider-neutral billing statuses the Stripe provider already drives (`active` / `past_due` / `suspended`), so dunning + spend-cap behavior stays provider-agnostic.
- `cmd/console` selects Paddle when both `MITOS_CONSOLE_PADDLE_API_KEY` and `MITOS_CONSOLE_PADDLE_WEBHOOK_SECRET` are set, else keeps the Stripe default; webhook mounts on the existing `/webhooks/billing` route.
- Chart injects the API key + webhook secret via **secretKeyRef only** (never plaintext), gated by `billing.enabled`; `baseURL` is a plain value. Secrets never logged or in errors.

## Tests
Valid signature passes; tampered body, forged/missing/malformed signature, stale timestamp, and empty secret all reject; 11-row event→status mapping; PortalURL request shape + API-error wrapping without leaking the key; secret-hygiene; chart secretKeyRef wiring. Build/vet/lint (both arches) clean; `go mod tidy` adds no deps.

**Review note (Paddle API field names):** the webhook envelope (`event_type`, `data.customer_id`) and portal endpoint (`POST /customers/{id}/portal-sessions` -> `data.urls.general.overview`) are assumed from Paddle Billing docs; worth confirming against a live sandbox. Only the response structs need adjusting if a field differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)