### PR TITLE
feat(saas): onboarding HTTP + real SMTP email + tenant provisioning on signup (#215)

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -127,6 +127,14 @@ func main() {
 			logger.Warn("MITOS_CONSOLE_OIDC_ISSUER unset; /auth login flow not mounted (BFF requires a session)")
 		}
 	}
+	// The onboarding funnel is PUBLIC and unauthenticated by design: signup and
+	// verify are how a brand-new user with no session creates an account. They are
+	// mounted OUTSIDE the session middleware. They are gated by the same
+	// server-controlled signup flag (caps.Signup, the #208 gate); when off, nothing
+	// is mounted and the funnel stays in waitlist mode. The SMTP password and the
+	// verify token are never logged.
+	mountOnboarding(mux, logger, accounts, store, capsGate{signup: caps.Signup})
+
 	// The billing webhook is PUBLIC by design: it is authenticated by the
 	// provider's signature, not a session, so it is mounted OUTSIDE the session
 	// middleware. It verifies the signature before touching any billing state.

--- a/cmd/console/onboarding.go
+++ b/cmd/console/onboarding.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/saas"
+	"mitos.run/mitos/internal/saas/billing"
+	"mitos.run/mitos/internal/saas/onboarding"
+	"mitos.run/mitos/internal/saas/orgprovision"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// mountOnboarding constructs the onboarding funnel and, when signup is enabled,
+// mounts its PUBLIC unauthenticated endpoints on mux. It is the signup ->
+// tenant-provisioned wiring:
+//
+//   - the funnel mode is ModeOpen only when MITOS_CONSOLE_SIGNUP is on (the #208
+//     server-controlled gate); otherwise it stays in waitlist mode and the public
+//     verify path provisions nothing;
+//   - the EmailSender is the real SMTP sender when MITOS_SMTP_HOST is set, and the
+//     dev log/fake sender otherwise. The active mode is logged (never the
+//     password);
+//   - the OrgProvisioner creates the cluster-scoped Org custom resource via a
+//     controller-runtime client when MITOS_CONSOLE_ORG_TENANCY is on, so a verified
+//     signup provisions the per-org namespace. With no client it is skipped with a
+//     warning rather than failing signup.
+//
+// The pending-signup store is the in-memory MemPendingStore: a pending,
+// unverified signup is short-lived (token TTL) and cheap to lose on a console
+// restart (the user simply signs up again), so it does not need the durable store.
+// Provisioned accounts/orgs DO live in the durable saas.Store.
+func mountOnboarding(mux *http.ServeMux, logger *slog.Logger, accounts *saas.AccountService, store saas.Store, caps signupGate) {
+	if !caps.signupEnabled() {
+		logger.Info("onboarding signup disabled (waitlist mode); public signup endpoints not mounted")
+		return
+	}
+
+	email := buildEmailSender(logger)
+	prov := buildOrgProvisioner(logger)
+
+	opts := []onboarding.Option{
+		onboarding.WithMode(onboarding.ModeOpen),
+		onboarding.WithLogger(logger),
+	}
+	if prov != nil {
+		opts = append(opts, onboarding.WithOrgProvisioner(prov))
+	}
+
+	svc := onboarding.NewService(
+		accounts,
+		store,
+		onboarding.NewMemPendingStore(),
+		billing.NewMemCreditLedger(),
+		email,
+		opts...,
+	)
+	onboarding.NewHandler(svc, logger).Routes(mux)
+	logger.Info("onboarding signup endpoints mounted",
+		"mode", "open",
+		"org_provisioner", prov != nil,
+	)
+}
+
+// signupGate is the minimal capability surface mountOnboarding reads, so the
+// wiring does not depend on the full Capabilities struct.
+type signupGate interface{ signupEnabled() bool }
+
+// capsGate adapts the console capabilities Signup flag.
+type capsGate struct{ signup bool }
+
+func (g capsGate) signupEnabled() bool { return g.signup }
+
+// buildEmailSender returns the real SMTP sender when MITOS_SMTP_HOST is set, and
+// the dev log/fake sender otherwise. The SMTP password is read from the
+// environment and is NEVER logged. The active mode is logged at startup.
+func buildEmailSender(logger *slog.Logger) onboarding.EmailSender {
+	host := os.Getenv("MITOS_SMTP_HOST")
+	if host == "" {
+		logger.Warn("MITOS_SMTP_HOST unset; using the DEV log email sender (no real verification email is delivered)")
+		return devLogEmailSender{log: logger}
+	}
+	port := 587
+	if p := os.Getenv("MITOS_SMTP_PORT"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			port = n
+		}
+	}
+	sender, err := onboarding.NewSMTPEmailSender(onboarding.SMTPConfig{
+		Host:          host,
+		Port:          port,
+		Username:      os.Getenv("MITOS_SMTP_USERNAME"),
+		Password:      os.Getenv("MITOS_SMTP_PASSWORD"),
+		From:          os.Getenv("MITOS_SMTP_FROM"),
+		VerifyBaseURL: os.Getenv("MITOS_ONBOARDING_VERIFY_URL"),
+	})
+	if err != nil {
+		// A misconfigured SMTP block falls back to the dev sender with a warning
+		// rather than failing the whole console; the warning never contains the
+		// password. The error from NewSMTPEmailSender only reports missing non-secret
+		// fields (host/from/verify url).
+		logger.Warn("SMTP email sender misconfigured; falling back to the DEV log sender", "err", err.Error())
+		return devLogEmailSender{log: logger}
+	}
+	logger.Info("onboarding using the real SMTP email sender",
+		"host", host,
+		"port", port,
+		"from", os.Getenv("MITOS_SMTP_FROM"),
+	)
+	return sender
+}
+
+// buildOrgProvisioner returns an OrgProvisioner backed by an in-cluster
+// controller-runtime client when MITOS_CONSOLE_ORG_TENANCY is enabled. With the
+// flag off, or when no in-cluster config is available (pure dev), it returns nil
+// so a verified signup skips namespace provisioning with a warning rather than
+// failing.
+func buildOrgProvisioner(logger *slog.Logger) onboarding.OrgProvisioner {
+	if !envBool("MITOS_CONSOLE_ORG_TENANCY") {
+		logger.Info("MITOS_CONSOLE_ORG_TENANCY off; verified signups will NOT provision a tenant namespace")
+		return nil
+	}
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		logger.Warn("no Kubernetes config available; verified signups will NOT provision a tenant namespace", "err", err.Error())
+		return nil
+	}
+	c, err := client.New(cfg, client.Options{Scheme: onboardingScheme()})
+	if err != nil {
+		logger.Warn("could not build Kubernetes client; verified signups will NOT provision a tenant namespace", "err", err.Error())
+		return nil
+	}
+	logger.Info("onboarding org provisioning enabled; verified signups create the cluster-scoped Org custom resource")
+	return orgprovision.New(c)
+}
+
+// onboardingScheme builds the scheme the org provisioner needs: client-go core
+// plus mitos.run/v1 (the Org kind).
+func onboardingScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	return scheme
+}
+
+// devLogEmailSender is the development EmailSender: it logs that a verification
+// email WOULD have been sent, WITHOUT logging the token (the token is a secret).
+// It is the default when SMTP is not configured, so local runs work without a
+// mail server while never leaking the token.
+type devLogEmailSender struct{ log *slog.Logger }
+
+func (d devLogEmailSender) SendVerification(_ context.Context, _ string, _ string) error {
+	// Never log the email or the token; only that a send occurred.
+	d.log.Info("dev email sender: verification email suppressed (configure SMTP to deliver real mail)")
+	return nil
+}

--- a/cmd/console/onboarding_test.go
+++ b/cmd/console/onboarding_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"mitos.run/mitos/internal/saas"
+)
+
+// TestMountOnboardingGatedBySignup asserts the public signup endpoint is mounted
+// only when signup is enabled. With signup off (waitlist), the route is absent.
+func TestMountOnboardingGatedBySignup(t *testing.T) {
+	t.Setenv("MITOS_SMTP_HOST", "")
+	t.Setenv("MITOS_CONSOLE_ORG_TENANCY", "")
+	logger := slog.New(slog.NewTextHandler(new(bytes.Buffer), nil))
+	store := saas.NewMemStore()
+	keys := saas.NewKeyService(store)
+	accounts := saas.NewAccountService(store, keys)
+
+	// Disabled: no route.
+	muxOff := http.NewServeMux()
+	mountOnboarding(muxOff, logger, accounts, store, capsGate{signup: false})
+	roff := httptest.NewRequest(http.MethodPost, "/onboarding/signup", strings.NewReader(`{"email":"a@b.com"}`))
+	rroff := httptest.NewRecorder()
+	muxOff.ServeHTTP(rroff, roff)
+	if rroff.Code != http.StatusNotFound {
+		t.Fatalf("signup-off: expected 404 (route not mounted), got %d", rroff.Code)
+	}
+
+	// Enabled: route is mounted and accepts.
+	muxOn := http.NewServeMux()
+	mountOnboarding(muxOn, logger, accounts, store, capsGate{signup: true})
+	ron := httptest.NewRequest(http.MethodPost, "/onboarding/signup", strings.NewReader(`{"email":"a@b.com"}`))
+	ron.Header.Set("Content-Type", "application/json")
+	rron := httptest.NewRecorder()
+	muxOn.ServeHTTP(rron, ron)
+	if rron.Code != http.StatusAccepted {
+		t.Fatalf("signup-on: expected 202, got %d (body %s)", rron.Code, rron.Body.String())
+	}
+}
+
+// TestDevLogEmailSenderNeverLogsToken asserts the dev fallback sender logs that a
+// send occurred but NEVER writes the email or the token.
+func TestDevLogEmailSenderNeverLogsToken(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	sender := devLogEmailSender{log: logger}
+	if err := sender.SendVerification(context.Background(), "secret@example.com", "super-secret-token"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "super-secret-token") {
+		t.Fatalf("dev sender logged the token: %q", out)
+	}
+	if strings.Contains(out, "secret@example.com") {
+		t.Fatalf("dev sender logged the email: %q", out)
+	}
+}
+
+// TestBuildEmailSenderFallsBackWhenSMTPUnset asserts that with no SMTP host the
+// builder returns the dev sender rather than nil or a panic.
+func TestBuildEmailSenderFallsBackWhenSMTPUnset(t *testing.T) {
+	t.Setenv("MITOS_SMTP_HOST", "")
+	logger := slog.New(slog.NewTextHandler(new(bytes.Buffer), nil))
+	if _, ok := buildEmailSender(logger).(devLogEmailSender); !ok {
+		t.Fatal("expected dev log email sender when SMTP is not configured")
+	}
+}
+
+// TestBuildOrgProvisionerNilWhenTenancyOff asserts the provisioner is nil when
+// MITOS_CONSOLE_ORG_TENANCY is off, so signups do not try to reach an apiserver.
+func TestBuildOrgProvisionerNilWhenTenancyOff(t *testing.T) {
+	t.Setenv("MITOS_CONSOLE_ORG_TENANCY", "")
+	logger := slog.New(slog.NewTextHandler(new(bytes.Buffer), nil))
+	if buildOrgProvisioner(logger) != nil {
+		t.Fatal("expected nil provisioner when org tenancy is off")
+	}
+}

--- a/deploy/charts/charttest/console_test.go
+++ b/deploy/charts/charttest/console_test.go
@@ -210,6 +210,94 @@ func TestOrgTenancyEnabledAddsFlagAndRBAC(t *testing.T) {
 	}
 }
 
+// consoleClusterRole extracts the mitos-console ClusterRole YAML document from the
+// rendered manifests so an RBAC assertion targets that role specifically.
+func consoleClusterRole(t *testing.T, out string) string {
+	t.Helper()
+	docs := strings.Split(out, "\n---\n")
+	for _, d := range docs {
+		if strings.Contains(d, "kind: ClusterRole") && strings.Contains(d, "name: mitos-console") {
+			return d
+		}
+	}
+	t.Fatal("mitos-console ClusterRole not found in rendered manifests")
+	return ""
+}
+
+// TestOnboardingSMTPAbsentByDefault asserts the default render wires no SMTP env,
+// so a self-host install does not advertise a mail server it does not have.
+func TestOnboardingSMTPAbsentByDefault(t *testing.T) {
+	out := render(t)
+	for _, env := range []string{"MITOS_SMTP_HOST", "MITOS_SMTP_PASSWORD", "MITOS_ONBOARDING_VERIFY_URL", "MITOS_CONSOLE_ORG_TENANCY"} {
+		if strings.Contains(out, env) {
+			t.Fatalf("%s rendered by default; onboarding SMTP/tenancy must be opt-in", env)
+		}
+	}
+}
+
+// TestOnboardingSMTPSecretKeyRefWiring asserts that when SMTP is configured the
+// host/port/from are plain env and the username/password come from a secretKeyRef
+// ONLY (never an inline plaintext value).
+func TestOnboardingSMTPSecretKeyRefWiring(t *testing.T) {
+	out := render(t,
+		"console.signup=true",
+		"console.onboarding.verifyURL=https://app.mitos.run/auth/verify",
+		"console.onboarding.smtp.host=smtp.example.com",
+		"console.onboarding.smtp.from=no-reply@mitos.run",
+		"console.onboarding.smtp.credentialsSecretRef=mitos-smtp",
+	)
+	mustEnv(t, out, "MITOS_SMTP_HOST", "smtp.example.com")
+	mustEnv(t, out, "MITOS_SMTP_FROM", "no-reply@mitos.run")
+	mustEnv(t, out, "MITOS_ONBOARDING_VERIFY_URL", "https://app.mitos.run/auth/verify")
+
+	// The password MUST be a secretKeyRef into the configured secret, never a plain
+	// value. Assert the secretKeyRef block is present for the password key.
+	if !strings.Contains(out, "name: MITOS_SMTP_PASSWORD") {
+		t.Fatal("MITOS_SMTP_PASSWORD env not rendered when SMTP credentials secret is set")
+	}
+	if !strings.Contains(out, "secretKeyRef") || !strings.Contains(out, "name: mitos-smtp") {
+		t.Fatal("SMTP password not sourced from the configured secretKeyRef")
+	}
+	// The chart models no password VALUE at all: it can only be sourced from the
+	// secret, so the password env must be immediately followed by valueFrom, never
+	// a plain value. Assert the line after the password env name is valueFrom.
+	if !passwordUsesValueFrom(out) {
+		t.Fatal("SMTP password not rendered as a valueFrom/secretKeyRef; must never be a plaintext value")
+	}
+}
+
+// passwordUsesValueFrom reports whether the MITOS_SMTP_PASSWORD env is sourced
+// from valueFrom (and thus a secretKeyRef), never an inline plaintext value.
+func passwordUsesValueFrom(out string) bool {
+	lines := strings.Split(out, "\n")
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "- name: MITOS_SMTP_PASSWORD" && i+1 < len(lines) {
+			return strings.TrimSpace(lines[i+1]) == "valueFrom:"
+		}
+	}
+	return false
+}
+
+// TestConsoleOrgsRBACOnlyWhenClusterOnboarding asserts the console ClusterRole
+// gains orgs get/create/update ONLY when cluster onboarding is enabled, and never
+// the delete verb (the console never deletes orgs).
+func TestConsoleOrgsRBACOnlyWhenClusterOnboarding(t *testing.T) {
+	// Off by default: no orgs rule.
+	if hasResourceRule(consoleClusterRole(t, render(t)), "orgs") {
+		t.Fatal("console ClusterRole grants orgs by default; must be gated behind console.onboarding.clusterProvisioning")
+	}
+	// On: orgs rule present.
+	out := render(t,
+		"console.signup=true",
+		"console.onboarding.clusterProvisioning=true",
+	)
+	role := consoleClusterRole(t, out)
+	if !hasResourceRule(role, "orgs") {
+		t.Fatal("console ClusterRole missing orgs rule when cluster onboarding is enabled")
+	}
+	mustEnv(t, out, "MITOS_CONSOLE_ORG_TENANCY", "true")
+}
+
 // hasResourceRule reports whether the rendered ClusterRole lists the given
 // resource as a rule entry (a YAML "- <resource>" list line), so a comment that
 // mentions the word does not falsely satisfy the check.

--- a/deploy/charts/mitos/templates/console.yaml
+++ b/deploy/charts/mitos/templates/console.yaml
@@ -31,6 +31,17 @@ rules:
   - apiGroups: ["mitos.run"]
     resources: ["sandboxes", "sandboxpools", "workspaces", "workspacerevisions"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.console.onboarding.clusterProvisioning }}
+  # Cluster onboarding (issue #215): a verified signup creates the cluster-scoped
+  # Org custom resource, which the controller's OrgReconciler turns into a per-org
+  # namespace. The console needs get/create/update on orgs to do this idempotently
+  # (CreateOrUpdate). It never deletes orgs and never touches the org status. Only
+  # granted when cluster onboarding is enabled.
+  - apiGroups: ["mitos.run"]
+    resources:
+      - orgs
+    verbs: ["get", "create", "update"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -161,6 +172,41 @@ spec:
             {{- end }}
             - name: MITOS_CONSOLE_SECRET_PROVIDERS
               value: {{ include "mitos.console.secretProviders" . | quote }}
+            {{- /*
+            Onboarding (issue #215). The public signup/verify endpoints are mounted
+            only when console.signup is true; this env configures HOW the
+            verification email is delivered and WHETHER a verified signup provisions
+            the per-org namespace. The SMTP password is sourced from a Secret ONLY,
+            never inlined as a plain env value.
+            */}}
+            {{- if .Values.console.onboarding.verifyURL }}
+            - name: MITOS_ONBOARDING_VERIFY_URL
+              value: {{ .Values.console.onboarding.verifyURL | quote }}
+            {{- end }}
+            {{- if .Values.console.onboarding.clusterProvisioning }}
+            - name: MITOS_CONSOLE_ORG_TENANCY
+              value: "true"
+            {{- end }}
+            {{- if .Values.console.onboarding.smtp.host }}
+            - name: MITOS_SMTP_HOST
+              value: {{ .Values.console.onboarding.smtp.host | quote }}
+            - name: MITOS_SMTP_PORT
+              value: {{ .Values.console.onboarding.smtp.port | quote }}
+            - name: MITOS_SMTP_FROM
+              value: {{ .Values.console.onboarding.smtp.from | quote }}
+            {{- if .Values.console.onboarding.smtp.credentialsSecretRef }}
+            - name: MITOS_SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.console.onboarding.smtp.credentialsSecretRef }}
+                  key: username
+            - name: MITOS_SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.console.onboarding.smtp.credentialsSecretRef }}
+                  key: password
+            {{- end }}
+            {{- end }}
             {{- if .Values.console.secrets.openbao.enabled }}
             - name: MITOS_CONSOLE_OPENBAO_ADDR
               value: {{ .Values.console.secrets.openbao.address | quote }}

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -355,6 +355,36 @@ console:
       # Paddle API host. Default is live; set to https://sandbox-api.paddle.com
       # for the sandbox. Empty uses the binary's built-in live default.
       baseURL: ""
+  # Public self-serve onboarding (issue #215): the unauthenticated signup +
+  # verify endpoints and the verification email. The public endpoints are mounted
+  # only when console.signup is true (the #208 gate); this block configures HOW
+  # the verification email is delivered and WHETHER a verified signup provisions
+  # the per-org tenant namespace.
+  onboarding:
+    # The base URL the verification link points at. The console appends the
+    # one-time token as a ?token= query parameter. Normally
+    # https://<console-host>/auth/verify. Required when SMTP is configured.
+    verifyURL: ""
+    # When true, a verified signup creates the cluster-scoped Org custom resource,
+    # which the controller's OrgReconciler turns into a per-org namespace. Requires
+    # controller.orgTenancy.enabled and the console orgs RBAC (rendered below when
+    # this is on). When false (default), a verified signup creates the account and
+    # org in the store but provisions no namespace.
+    clusterProvisioning: false
+    # SMTP delivery for the verification email. host/port/from are plain config;
+    # the username and password are sourced from a Secret ONLY (never inlined).
+    # When smtp.host is empty the console uses the DEV log sender (no real email is
+    # delivered) and logs that mode at startup.
+    smtp:
+      host: ""
+      port: 587
+      from: ""
+      # Name of an existing Secret holding the SMTP credentials. The username is
+      # read from key "username" and the password from key "password". Empty omits
+      # the auth env entirely (the console then uses the dev log sender unless host
+      # is set with anonymous relay, which is uncommon). The password VALUE is
+      # never placed in the chart or in a plain env var.
+      credentialsSecretRef: ""
   ingress:
     enabled: false
     className: ""

--- a/internal/saas/onboarding/http.go
+++ b/internal/saas/onboarding/http.go
@@ -1,0 +1,200 @@
+package onboarding
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/mail"
+	"strings"
+
+	"mitos.run/mitos/internal/saas"
+)
+
+// maxSignupBody bounds the SignUp request body to defeat a slow-loris / oversize
+// body abuse vector on this PUBLIC endpoint.
+const maxSignupBody = 1 << 14 // 16 KiB
+
+// Handler serves the PUBLIC, unauthenticated onboarding endpoints:
+//
+//	POST /onboarding/signup   {"email": "..."} -> 202 (always the same shape)
+//	POST /onboarding/verify   {"token": "..."} -> 200 with the account/org/key
+//	GET  /onboarding/verify?token=... -> 200 (browser-friendly link target)
+//
+// SignUp NEVER reveals whether an email already has an account: it returns the
+// same accepted response in every case so a probe cannot enumerate accounts. The
+// raw verify token is delivered only to the user's inbox by the EmailSender; it
+// is never returned by SignUp and never logged. Verify is the only place a token
+// is accepted, and a bad / expired / used token yields a generic failure.
+type Handler struct {
+	svc *Service
+	log *slog.Logger
+}
+
+// NewHandler builds the onboarding HTTP handler over svc. If log is nil a
+// discarding logger is used. The handler logs counts and non-secret status only,
+// never an email or a token.
+func NewHandler(svc *Service, log *slog.Logger) *Handler {
+	if log == nil {
+		log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Handler{svc: svc, log: log}
+}
+
+// Routes registers the onboarding routes on mux. It is the single place a binary
+// mounts the public funnel so the route set stays consistent.
+func (h *Handler) Routes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /onboarding/signup", h.signUp)
+	mux.HandleFunc("POST /onboarding/verify", h.verify)
+	mux.HandleFunc("GET /onboarding/verify", h.verify)
+}
+
+// signUp handles POST /onboarding/signup. It validates and normalizes the email,
+// calls the service, and ALWAYS returns the same accepted response regardless of
+// whether the email already exists, so no account enumeration is possible.
+func (h *Handler) signUp(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := decodeJSON(w, r, &req); err != nil {
+		return // decodeJSON already wrote the error
+	}
+	email, ok := normalizeEmail(req.Email)
+	if !ok {
+		// A malformed email is a client error and reveals nothing about accounts.
+		writeJSONError(w, http.StatusBadRequest, "a valid email address is required")
+		return
+	}
+
+	_, err := h.svc.SignUp(r.Context(), email)
+	// Account enumeration guard: a duplicate email (ErrConflict) returns the SAME
+	// accepted response as a fresh signup. Any OTHER error is a genuine server
+	// fault and is surfaced (without the email) so it is not silently swallowed.
+	if err != nil && !errors.Is(err, saas.ErrConflict) {
+		h.log.Error("onboarding signup", "err", err)
+		writeJSONError(w, http.StatusInternalServerError, "could not start onboarding; please try again")
+		return
+	}
+	h.log.Info("onboarding signup accepted")
+
+	// Uniform body: never leak whether a verification email was actually sent.
+	writeJSON(w, http.StatusAccepted, map[string]string{
+		"status":  "accepted",
+		"message": "if that address can sign up, a verification email is on its way",
+	})
+}
+
+// verify handles POST/GET /onboarding/verify. It reads the token from the JSON
+// body (POST) or the query string (GET, the email-link target), calls the
+// service, and returns the provisioned account/org and the one-time first key on
+// success. A bad / expired / used token yields a generic failure that reveals
+// nothing about the token.
+func (h *Handler) verify(w http.ResponseWriter, r *http.Request) {
+	token := ""
+	if r.Method == http.MethodGet {
+		token = r.URL.Query().Get("token")
+	} else {
+		var req struct {
+			Token string `json:"token"`
+		}
+		if err := decodeJSON(w, r, &req); err != nil {
+			return
+		}
+		token = req.Token
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		writeJSONError(w, http.StatusBadRequest, "a verification token is required")
+		return
+	}
+
+	res, err := h.svc.Verify(r.Context(), token)
+	if err != nil {
+		// All token-resolution failures (invalid, expired, waitlist) collapse to a
+		// single generic response so a probe cannot tell them apart. A genuine
+		// downstream provisioning fault is a 500. The error is logged WITHOUT the
+		// token (the service errors never carry it).
+		if errors.Is(err, ErrTokenInvalid) || errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrWaitlistMode) {
+			h.log.Info("onboarding verify rejected", "reason", classifyVerifyErr(err))
+			writeJSONError(w, http.StatusBadRequest, "this verification link is invalid or has expired")
+			return
+		}
+		h.log.Error("onboarding verify", "err", err)
+		writeJSONError(w, http.StatusInternalServerError, "could not complete verification; please try again")
+		return
+	}
+
+	// The raw first key is shown EXACTLY ONCE here (empty on an idempotent
+	// re-verify). The account email is the caller's own, returned to confirm.
+	out := map[string]any{
+		"accountId":   res.Account.ID,
+		"orgId":       res.Org.ID,
+		"email":       res.Account.Email,
+		"alreadyDone": res.AlreadyDone,
+	}
+	if res.FirstKey.RawKey != "" {
+		out["apiKey"] = res.FirstKey.RawKey
+		out["apiKeyId"] = res.FirstKey.Record.ID
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// classifyVerifyErr maps a verify error to a short non-secret reason for the log.
+func classifyVerifyErr(err error) string {
+	switch {
+	case errors.Is(err, ErrTokenExpired):
+		return "expired"
+	case errors.Is(err, ErrWaitlistMode):
+		return "waitlist"
+	default:
+		return "invalid"
+	}
+}
+
+// normalizeEmail trims, lowercases, and validates an email address. It returns
+// the normalized address and whether it is structurally valid. Normalization
+// (lowercasing) makes the no-enumeration guarantee robust: Foo@x and foo@x map to
+// the same stored account.
+func normalizeEmail(raw string) (string, bool) {
+	e := strings.TrimSpace(raw)
+	if e == "" || len(e) > 254 {
+		return "", false
+	}
+	addr, err := mail.ParseAddress(e)
+	if err != nil {
+		return "", false
+	}
+	// Reject a display-name form ("Foo <foo@x>"); we want the bare address.
+	if addr.Name != "" {
+		return "", false
+	}
+	at := strings.LastIndex(addr.Address, "@")
+	if at <= 0 || at == len(addr.Address)-1 {
+		return "", false
+	}
+	return strings.ToLower(addr.Address), true
+}
+
+// decodeJSON reads a bounded JSON body into v, rejecting unknown fields and
+// oversize bodies. On error it writes a 400 and returns the error so the caller
+// stops.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) error {
+	dec := json.NewDecoder(io.LimitReader(r.Body, maxSignupBody))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return err
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/saas/onboarding/http_test.go
+++ b/internal/saas/onboarding/http_test.go
@@ -1,0 +1,164 @@
+package onboarding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newHandler(t *testing.T, mode Mode) (*Handler, *harness) {
+	t.Helper()
+	h := newHarness(t, mode)
+	return NewHandler(h.svc, nil), h
+}
+
+func postJSON(t *testing.T, h *Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.Routes(mux)
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestSignupReturnsAcceptedAndSendsEmail(t *testing.T) {
+	h, hr := newHandler(t, ModeOpen)
+	rr := postJSON(t, h, "/onboarding/signup", `{"email":"new@example.com"}`)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status %d, want 202; body %s", rr.Code, rr.Body.String())
+	}
+	if hr.email.LastToken("new@example.com") == "" {
+		t.Fatal("signup did not send a verification email")
+	}
+	// Body must not contain a token.
+	if strings.Contains(rr.Body.String(), hr.email.LastToken("new@example.com")) {
+		t.Fatal("signup response leaked the verification token")
+	}
+}
+
+// TestSignupDoesNotEnumerate asserts a signup for an EXISTING email returns the
+// exact same status and body as a fresh signup, so a probe cannot tell whether
+// an account already exists.
+func TestSignupDoesNotEnumerate(t *testing.T) {
+	h, hr := newHandler(t, ModeOpen)
+	// Pre-create an account for taken@example.com.
+	if _, _, err := hr.svc.accounts.SignUp(context.Background(), "taken@example.com"); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	fresh := postJSON(t, h, "/onboarding/signup", `{"email":"fresh@example.com"}`)
+	taken := postJSON(t, h, "/onboarding/signup", `{"email":"taken@example.com"}`)
+
+	if fresh.Code != taken.Code {
+		t.Fatalf("status differs: fresh=%d taken=%d (enumeration leak)", fresh.Code, taken.Code)
+	}
+	if fresh.Body.String() != taken.Body.String() {
+		t.Fatalf("body differs between fresh and taken email (enumeration leak):\nfresh=%s\ntaken=%s", fresh.Body.String(), taken.Body.String())
+	}
+}
+
+func TestSignupNormalizesEmail(t *testing.T) {
+	h, hr := newHandler(t, ModeOpen)
+	rr := postJSON(t, h, "/onboarding/signup", `{"email":"  MixedCase@Example.COM "}`)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status %d, want 202", rr.Code)
+	}
+	if hr.email.LastToken("mixedcase@example.com") == "" {
+		t.Fatal("email was not normalized to lowercase/trimmed before signup")
+	}
+}
+
+func TestSignupRejectsBadEmail(t *testing.T) {
+	h, _ := newHandler(t, ModeOpen)
+	for _, body := range []string{`{"email":"not-an-email"}`, `{"email":""}`, `{"email":"a@"}`, `{"email":"Foo <foo@x.com>"}`} {
+		rr := postJSON(t, h, "/onboarding/signup", body)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("body %s: status %d, want 400", body, rr.Code)
+		}
+	}
+}
+
+func TestVerifyHappyPathReturnsKey(t *testing.T) {
+	h, hr := newHandler(t, ModeOpen)
+	postJSON(t, h, "/onboarding/signup", `{"email":"verify@example.com"}`)
+	tok := hr.email.LastToken("verify@example.com")
+
+	rr := postJSON(t, h, "/onboarding/verify", `{"token":"`+tok+`"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body %s", rr.Code, rr.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["orgId"] == "" || out["accountId"] == "" {
+		t.Fatalf("missing account/org in response: %v", out)
+	}
+	if out["apiKey"] == nil || out["apiKey"] == "" {
+		t.Fatalf("missing one-time api key in response: %v", out)
+	}
+}
+
+func TestVerifyGetLinkTarget(t *testing.T) {
+	h, hr := newHandler(t, ModeOpen)
+	postJSON(t, h, "/onboarding/signup", `{"email":"link@example.com"}`)
+	tok := hr.email.LastToken("link@example.com")
+
+	mux := http.NewServeMux()
+	h.Routes(mux)
+	req := httptest.NewRequest(http.MethodGet, "/onboarding/verify?token="+tok, nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET verify status %d, want 200; body %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestVerifyBadTokenIsGeneric asserts an unknown token yields a generic 400 that
+// reveals nothing.
+func TestVerifyBadTokenIsGeneric(t *testing.T) {
+	h, _ := newHandler(t, ModeOpen)
+	rr := postJSON(t, h, "/onboarding/verify", `{"token":"totally-bogus"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), "totally-bogus") {
+		t.Fatal("verify error echoed the presented token")
+	}
+}
+
+func TestSignupRejectsUnknownFields(t *testing.T) {
+	h, _ := newHandler(t, ModeOpen)
+	rr := postJSON(t, h, "/onboarding/signup", `{"email":"x@y.com","admin":true}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400 (unknown field rejected)", rr.Code)
+	}
+}
+
+// TestVerifyTokenIsSingleUse asserts a used token cannot be reused to provision a
+// second time; the second verify is the idempotent already-done path, not a new
+// key issue.
+func TestVerifyTokenIsSingleUse(t *testing.T) {
+	h, hr := newHandler(t, ModeOpen)
+	postJSON(t, h, "/onboarding/signup", `{"email":"once@example.com"}`)
+	tok := hr.email.LastToken("once@example.com")
+
+	first := postJSON(t, h, "/onboarding/verify", `{"token":"`+tok+`"}`)
+	second := postJSON(t, h, "/onboarding/verify", `{"token":"`+tok+`"}`)
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("verify codes first=%d second=%d", first.Code, second.Code)
+	}
+	var out2 map[string]any
+	_ = json.Unmarshal(second.Body.Bytes(), &out2)
+	if out2["alreadyDone"] != true {
+		t.Fatalf("second verify should be idempotent already-done, got %v", out2)
+	}
+	if _, ok := out2["apiKey"]; ok {
+		t.Fatal("re-verify must not issue a second api key")
+	}
+}

--- a/internal/saas/onboarding/provision_test.go
+++ b/internal/saas/onboarding/provision_test.go
@@ -1,0 +1,139 @@
+package onboarding
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// captureProvisioner records the org id and display name it was asked to
+// provision, and can be made to fail to drive the error path.
+type captureProvisioner struct {
+	mu    sync.Mutex
+	calls []struct{ orgID, displayName string }
+	err   error
+}
+
+func (c *captureProvisioner) Provision(_ context.Context, orgID, displayName string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return c.err
+	}
+	c.calls = append(c.calls, struct{ orgID, displayName string }{orgID, displayName})
+	return nil
+}
+
+func (c *captureProvisioner) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.calls)
+}
+
+// signUpAndVerify drives a full signup + verify and returns the verify result.
+func signUpAndVerify(t *testing.T, h *harness, email string) VerifyResult {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := h.svc.SignUp(ctx, email); err != nil {
+		t.Fatalf("sign up: %v", err)
+	}
+	tok := h.email.LastToken(email)
+	if tok == "" {
+		t.Fatal("no token captured")
+	}
+	res, err := h.svc.Verify(ctx, tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	return res
+}
+
+// TestVerifyProvisionsOrgCR asserts a verified signup calls the OrgProvisioner
+// with the org id and display name so the OrgReconciler can stand up the
+// per-org namespace.
+func TestVerifyProvisionsOrgCR(t *testing.T) {
+	h := newHarness(t, ModeOpen)
+	prov := &captureProvisioner{}
+	h.svc.provision = prov
+
+	res := signUpAndVerify(t, h, "tenant@example.com")
+
+	if prov.count() != 1 {
+		t.Fatalf("provisioner called %d times, want 1", prov.count())
+	}
+	got := prov.calls[0]
+	if got.orgID != res.Org.ID {
+		t.Fatalf("provisioned org id %q, want %q", got.orgID, res.Org.ID)
+	}
+	if got.displayName != res.Org.Name {
+		t.Fatalf("provisioned display name %q, want %q", got.displayName, res.Org.Name)
+	}
+}
+
+// TestVerifyWithoutProvisionerSkipsWithWarning asserts that with no provisioner
+// configured the verify still succeeds (account + org created in the store) and
+// logs a warning instead of failing the signup.
+func TestVerifyWithoutProvisionerSkipsWithWarning(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	h := newHarness(t, ModeOpen)
+	h.svc.provision = nil
+	h.svc.logger = logger
+
+	res := signUpAndVerify(t, h, "noprov@example.com")
+	if res.Account.ID == "" || res.Org.ID == "" {
+		t.Fatal("expected account and org to be provisioned in the store")
+	}
+	if !strings.Contains(buf.String(), "skipping tenant namespace provisioning") {
+		t.Fatalf("expected skip warning in log, got %q", buf.String())
+	}
+}
+
+// TestVerifyProvisionerErrorFailsVerify asserts a provisioner error fails the
+// verify so the user can retry idempotently rather than landing in an org with
+// no namespace.
+func TestVerifyProvisionerErrorFailsVerify(t *testing.T) {
+	h := newHarness(t, ModeOpen)
+	h.svc.provision = &captureProvisioner{err: errors.New("apiserver down")}
+
+	ctx := context.Background()
+	if _, err := h.svc.SignUp(ctx, "fail@example.com"); err != nil {
+		t.Fatalf("sign up: %v", err)
+	}
+	tok := h.email.LastToken("fail@example.com")
+	_, err := h.svc.Verify(ctx, tok)
+	if err == nil {
+		t.Fatal("expected verify to fail when the provisioner errors")
+	}
+	if strings.Contains(err.Error(), tok) {
+		t.Fatal("verify error leaked the raw token")
+	}
+}
+
+// TestReVerifyDoesNotReprovision asserts the idempotent re-verify path (already
+// verified) does not call the provisioner a second time: provisioning happened
+// on the first verify and the OrgProvisioner itself is idempotent.
+func TestReVerifyDoesNotReprovision(t *testing.T) {
+	h := newHarness(t, ModeOpen)
+	prov := &captureProvisioner{}
+	h.svc.provision = prov
+
+	ctx := context.Background()
+	if _, err := h.svc.SignUp(ctx, "again@example.com"); err != nil {
+		t.Fatalf("sign up: %v", err)
+	}
+	tok := h.email.LastToken("again@example.com")
+	if _, err := h.svc.Verify(ctx, tok); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if _, err := h.svc.Verify(ctx, tok); err != nil {
+		t.Fatalf("second verify: %v", err)
+	}
+	if prov.count() != 1 {
+		t.Fatalf("provisioner called %d times across two verifies, want 1", prov.count())
+	}
+}

--- a/internal/saas/onboarding/service.go
+++ b/internal/saas/onboarding/service.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -43,6 +45,22 @@ var (
 	// ErrTokenExpired is returned when a verify token resolved but is past expiry.
 	ErrTokenExpired = errors.New("onboarding: verification token has expired")
 )
+
+// OrgProvisioner is the seam that materializes the tenant isolation stack for a
+// freshly verified org: in cluster mode it creates the cluster-scoped Org custom
+// resource (api/v1.Org, name = org id), which the OrgReconciler turns into a
+// per-org namespace (mitos-org-<id>) with its quota and default-deny policy.
+//
+// It is OPTIONAL: a pure dev deployment with no Kubernetes client supplies none,
+// and Verify skips provisioning with a warning rather than failing the signup.
+// Implementations MUST be idempotent: a re-verify (or a controller retry) calls
+// Provision again with the same id, and an already-existing Org is a success, not
+// an error.
+type OrgProvisioner interface {
+	// Provision ensures the tenant Org resource exists for orgID with the given
+	// display name. It MUST treat an already-existing org as success.
+	Provision(ctx context.Context, orgID, displayName string) error
+}
 
 // EmailSender is the seam that delivers the verification email. The fake
 // (FakeEmailSender) is the tested default; the real SMTP/provider is a follow-up
@@ -201,7 +219,9 @@ type Service struct {
 	ledger    billing.CreditLedger
 	credit    billing.Money
 	email     EmailSender
+	provision OrgProvisioner
 	events    EventRecorder
+	logger    *slog.Logger
 	now       func() time.Time
 	idgen     func() string
 	tokengen  func() (string, error)
@@ -237,6 +257,22 @@ func WithTokenTTL(d time.Duration) Option { return func(s *Service) { s.tokenTTL
 // WithEventRecorder sets the funnel instrumentation sink.
 func WithEventRecorder(r EventRecorder) Option { return func(s *Service) { s.events = r } }
 
+// WithOrgProvisioner sets the tenant Org-CR provisioner. When unset, a verified
+// signup creates the account and org in the store but provisions no Kubernetes
+// namespace (pure dev mode); Verify logs a warning in that case.
+func WithOrgProvisioner(p OrgProvisioner) Option { return func(s *Service) { s.provision = p } }
+
+// WithLogger sets the structured logger. It is used only for non-secret
+// operational lines (for example the skip-provisioning warning); it never logs an
+// email or a token. When unset, a discarding logger is used.
+func WithLogger(l *slog.Logger) Option {
+	return func(s *Service) {
+		if l != nil {
+			s.logger = l
+		}
+	}
+}
+
 // NewService builds an onboarding service. accounts and ledger are required; the
 // remaining dependencies default to the in-memory tested implementations.
 func NewService(accounts *saas.AccountService, store saas.Store, pending PendingStore, ledger billing.CreditLedger, email EmailSender, opts ...Option) *Service {
@@ -249,6 +285,7 @@ func NewService(accounts *saas.AccountService, store saas.Store, pending Pending
 		credit:    billing.DefaultSignupCredit(),
 		email:     email,
 		events:    nopRecorder{},
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 		now:       time.Now,
 		idgen:     randomID,
 		tokengen:  randomToken,
@@ -397,6 +434,21 @@ func (s *Service) Verify(ctx context.Context, rawToken string) (VerifyResult, er
 	}
 	if err != nil {
 		return VerifyResult{}, fmt.Errorf("onboarding verify: provision account: %w", err)
+	}
+
+	// Provision the tenant isolation stack: create the cluster-scoped Org custom
+	// resource so the OrgReconciler stands up the per-org namespace (#288). This is
+	// the signup -> namespace integration. In pure dev mode no provisioner is wired,
+	// so skip with a warning rather than failing the signup. A provisioner that
+	// errors DOES fail the verify so the user can retry it idempotently rather than
+	// landing in an org with no namespace; the provisioner is required to be
+	// idempotent so a retry is safe.
+	if s.provision != nil {
+		if err := s.provision.Provision(ctx, org.ID, org.Name); err != nil {
+			return VerifyResult{}, fmt.Errorf("onboarding verify: provision tenant org: %w", err)
+		}
+	} else {
+		s.logger.Warn("onboarding verify: no org provisioner configured; skipping tenant namespace provisioning", "org", org.ID)
 	}
 
 	// Grant the free signup credit (#212). The ledger keys the grant by org id so a

--- a/internal/saas/onboarding/smtp.go
+++ b/internal/saas/onboarding/smtp.go
@@ -1,0 +1,182 @@
+package onboarding
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SMTPConfig configures the real SMTP EmailSender. The password is a SECRET: it
+// is read from the environment / a mounted secret by the caller and is NEVER
+// logged or placed in an error message. Host, Port, From, and the verify base URL
+// are plain configuration.
+type SMTPConfig struct {
+	// Host is the SMTP server hostname (for example smtp.example.com).
+	Host string
+	// Port is the SMTP submission port (commonly 587 for STARTTLS).
+	Port int
+	// Username is the SMTP auth username.
+	Username string
+	// Password is the SMTP auth password. SECRET: never logged, never in errors.
+	Password string
+	// From is the envelope and header From address.
+	From string
+	// VerifyBaseURL is the base the verify link is built from; the token is added
+	// as a query parameter. For example https://app.mitos.run/auth/verify.
+	VerifyBaseURL string
+	// TLSServerName overrides the TLS server name used for STARTTLS verification.
+	// Empty defaults to Host. Used in tests to point at 127.0.0.1 while presenting
+	// a cert for another name.
+	TLSServerName string
+}
+
+// addr returns the host:port dial target.
+func (c SMTPConfig) addr() string {
+	return net.JoinHostPort(c.Host, fmt.Sprintf("%d", c.Port))
+}
+
+// smtpDialer is the seam over the SMTP transport so the sender is unit-tested
+// without a live server. The production implementation dials a real SMTP server,
+// upgrades to STARTTLS, authenticates, and delivers. Tests inject a fake.
+type smtpDialer func(ctx context.Context, cfg SMTPConfig, from string, to []string, msg []byte) error
+
+// SMTPEmailSender delivers the verification email over SMTP with STARTTLS and
+// username/password auth, using only the standard library (net/smtp). It builds
+// the verify link from VerifyBaseURL and the one-time token. The email body
+// carries no secret beyond that one-time token, and the SMTP password is never
+// logged or surfaced in an error.
+type SMTPEmailSender struct {
+	cfg  SMTPConfig
+	dial smtpDialer
+}
+
+// NewSMTPEmailSender builds the real SMTP sender. It returns an error if the
+// required non-secret configuration (host, from, verify base URL) is missing, so
+// a misconfiguration fails fast at startup rather than at first signup.
+func NewSMTPEmailSender(cfg SMTPConfig) (*SMTPEmailSender, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("smtp email sender: host is required")
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 587
+	}
+	if cfg.From == "" {
+		return nil, fmt.Errorf("smtp email sender: from address is required")
+	}
+	if cfg.VerifyBaseURL == "" {
+		return nil, fmt.Errorf("smtp email sender: verify base url is required")
+	}
+	if _, err := url.Parse(cfg.VerifyBaseURL); err != nil {
+		return nil, fmt.Errorf("smtp email sender: invalid verify base url: %w", err)
+	}
+	return &SMTPEmailSender{cfg: cfg, dial: realSMTPDial}, nil
+}
+
+// SendVerification builds the verify link from the configured base URL and the
+// one-time token, composes a plain-text message, and delivers it over SMTP. The
+// token is treated as a secret: it appears only in the verify link in the message
+// body delivered to the user's inbox, never in a log line or returned error.
+func (s *SMTPEmailSender) SendVerification(ctx context.Context, email, token string) error {
+	link, err := verifyLink(s.cfg.VerifyBaseURL, token)
+	if err != nil {
+		return fmt.Errorf("smtp email sender: build verify link: %w", err)
+	}
+	msg := buildVerificationMessage(s.cfg.From, email, link)
+	if err := s.dial(ctx, s.cfg, s.cfg.From, []string{email}, msg); err != nil {
+		// The dialer is responsible for never embedding the password in its error;
+		// realSMTPDial wraps only transport-level context.
+		return fmt.Errorf("smtp email sender: deliver verification: %w", err)
+	}
+	return nil
+}
+
+// verifyLink appends the token to the base URL as a query parameter, preserving
+// any existing query. The token is url-encoded.
+func verifyLink(base, token string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("token", token)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// buildVerificationMessage composes a minimal RFC 5322 plain-text message. The
+// only sensitive content is the one-time verify link in the body.
+func buildVerificationMessage(from, to, link string) []byte {
+	var b strings.Builder
+	b.WriteString("From: " + from + "\r\n")
+	b.WriteString("To: " + to + "\r\n")
+	b.WriteString("Subject: Verify your Mitos email\r\n")
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=utf-8\r\n")
+	b.WriteString("\r\n")
+	b.WriteString("Welcome to Mitos.\r\n\r\n")
+	b.WriteString("Confirm your email address to finish creating your account:\r\n\r\n")
+	b.WriteString(link + "\r\n\r\n")
+	b.WriteString("This link is single-use and expires soon. If you did not request it, ignore this email.\r\n")
+	return []byte(b.String())
+}
+
+// realSMTPDial performs the production SMTP delivery: connect, EHLO, STARTTLS,
+// AUTH, and send. It uses only the standard library. On any failure it returns a
+// transport-level error that never contains the password.
+func realSMTPDial(ctx context.Context, cfg SMTPConfig, from string, to []string, msg []byte) error {
+	d := net.Dialer{Timeout: 30 * time.Second}
+	conn, err := d.DialContext(ctx, "tcp", cfg.addr())
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	c, err := smtp.NewClient(conn, cfg.Host)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("smtp client: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	serverName := cfg.TLSServerName
+	if serverName == "" {
+		serverName = cfg.Host
+	}
+	if ok, _ := c.Extension("STARTTLS"); ok {
+		if err := c.StartTLS(&tls.Config{ServerName: serverName, MinVersion: tls.VersionTLS12}); err != nil {
+			return fmt.Errorf("starttls: %w", err)
+		}
+	}
+	if cfg.Username != "" {
+		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+		if err := c.Auth(auth); err != nil {
+			// Do NOT wrap %w here: the std smtp Auth error can echo server text but
+			// never the password; still, keep the message generic so no credential
+			// material is surfaced.
+			return fmt.Errorf("smtp auth failed for user %q", cfg.Username)
+		}
+	}
+	if err := c.Mail(from); err != nil {
+		return fmt.Errorf("mail from: %w", err)
+	}
+	for _, rcpt := range to {
+		if err := c.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("rcpt to: %w", err)
+		}
+	}
+	wc, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("data: %w", err)
+	}
+	if _, err := wc.Write(msg); err != nil {
+		_ = wc.Close()
+		return fmt.Errorf("write body: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("close body: %w", err)
+	}
+	return c.Quit()
+}

--- a/internal/saas/onboarding/smtp_test.go
+++ b/internal/saas/onboarding/smtp_test.go
@@ -1,0 +1,116 @@
+package onboarding
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newTestSMTP(t *testing.T) (*SMTPEmailSender, *capturedSMTP) {
+	t.Helper()
+	s, err := NewSMTPEmailSender(SMTPConfig{
+		Host:          "smtp.example.com",
+		Port:          587,
+		Username:      "postmaster@example.com",
+		Password:      "s3cr3t-smtp-password",
+		From:          "no-reply@mitos.run",
+		VerifyBaseURL: "https://app.mitos.run/auth/verify",
+	})
+	if err != nil {
+		t.Fatalf("new smtp sender: %v", err)
+	}
+	cap := &capturedSMTP{}
+	s.dial = cap.dial
+	return s, cap
+}
+
+type capturedSMTP struct {
+	cfg  SMTPConfig
+	from string
+	to   []string
+	msg  []byte
+	err  error
+}
+
+func (c *capturedSMTP) dial(_ context.Context, cfg SMTPConfig, from string, to []string, msg []byte) error {
+	c.cfg, c.from, c.to, c.msg = cfg, from, to, msg
+	return c.err
+}
+
+func TestSMTPSenderAddressesMessageAndCarriesToken(t *testing.T) {
+	s, cap := newTestSMTP(t)
+	if err := s.SendVerification(context.Background(), "user@example.com", "tok-abc123"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if cap.from != "no-reply@mitos.run" {
+		t.Fatalf("envelope from %q, want no-reply@mitos.run", cap.from)
+	}
+	if len(cap.to) != 1 || cap.to[0] != "user@example.com" {
+		t.Fatalf("envelope to %v, want [user@example.com]", cap.to)
+	}
+	body := string(cap.msg)
+	if !strings.Contains(body, "To: user@example.com") {
+		t.Fatalf("message missing To header: %q", body)
+	}
+	if !strings.Contains(body, "From: no-reply@mitos.run") {
+		t.Fatalf("message missing From header: %q", body)
+	}
+	if !strings.Contains(body, "token=tok-abc123") {
+		t.Fatalf("message missing verify token link: %q", body)
+	}
+}
+
+// TestSMTPSenderNeverLeaksPassword asserts the password appears nowhere in the
+// composed message or in an error returned on transport failure.
+func TestSMTPSenderNeverLeaksPassword(t *testing.T) {
+	const password = "s3cr3t-smtp-password"
+	s, cap := newTestSMTP(t)
+
+	// Success path: password must not be in the message bytes or the config the
+	// dialer logs (it is in cfg, but the body it transmits must not echo it).
+	if err := s.SendVerification(context.Background(), "u@example.com", "tok-1"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if strings.Contains(string(cap.msg), password) {
+		t.Fatal("password leaked into the email body")
+	}
+
+	// Failure path: a transport error must not contain the password.
+	cap.err = errors.New("connection refused")
+	err := s.SendVerification(context.Background(), "u@example.com", "tok-2")
+	if err == nil {
+		t.Fatal("expected delivery error")
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("password leaked into error: %v", err)
+	}
+}
+
+func TestNewSMTPSenderValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  SMTPConfig
+	}{
+		{"no host", SMTPConfig{From: "a@b.c", VerifyBaseURL: "https://x/y"}},
+		{"no from", SMTPConfig{Host: "h", VerifyBaseURL: "https://x/y"}},
+		{"no verify url", SMTPConfig{Host: "h", From: "a@b.c"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewSMTPEmailSender(tc.cfg); err == nil {
+				t.Fatal("expected config validation error")
+			}
+		})
+	}
+}
+
+func TestVerifyLinkPreservesExistingQuery(t *testing.T) {
+	link, err := verifyLink("https://app.mitos.run/verify?ref=email", "tok-xyz")
+	if err != nil {
+		t.Fatalf("verify link: %v", err)
+	}
+	if !strings.Contains(link, "ref=email") || !strings.Contains(link, "token=tok-xyz") {
+		t.Fatalf("link dropped a query parameter: %q", link)
+	}
+}

--- a/internal/saas/orgprovision/orgprovision.go
+++ b/internal/saas/orgprovision/orgprovision.go
@@ -1,0 +1,76 @@
+// Package orgprovision implements the onboarding.OrgProvisioner seam over a
+// controller-runtime client: a verified signup creates the cluster-scoped Org
+// custom resource (api/v1.Org, name = org id), which the OrgReconciler turns into
+// a per-org isolation namespace (issue #288). It is the signup -> namespace
+// integration, gated by the same cluster-mode config that enables org tenancy.
+//
+// The provisioner is deliberately small and idempotent: an already-existing Org
+// is a success (a re-verify or a controller retry must not error), and only the
+// presentational DisplayName is reconciled on update. The org id, the namespace,
+// the quota, and the default-deny policy are all derived server-side by the
+// reconciler; this package never trusts client input for them.
+package orgprovision
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "mitos.run/mitos/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Provisioner creates and updates the tenant Org custom resource over a
+// controller-runtime client. It satisfies onboarding.OrgProvisioner.
+type Provisioner struct {
+	client client.Client
+}
+
+// New builds a Provisioner over c. c must have api/v1 registered in its scheme.
+func New(c client.Client) *Provisioner {
+	return &Provisioner{client: c}
+}
+
+// Provision ensures the cluster-scoped Org with metadata.name == orgID exists,
+// carrying displayName in its spec. It is idempotent:
+//
+//   - if the Org does not exist, it is created;
+//   - if it already exists, an AlreadyExists on create is treated as success, and
+//     the displayName is reconciled with an update only if it drifted.
+//
+// The orgID is the trusted server-derived id (the Personal org id minted at
+// signup); it is used verbatim as the resource name so NamespaceForOrg maps it to
+// mitos-org-<id>. Provision never returns an error for an existing org.
+func (p *Provisioner) Provision(ctx context.Context, orgID, displayName string) error {
+	if orgID == "" {
+		return fmt.Errorf("orgprovision: org id is required")
+	}
+
+	org := &v1.Org{
+		ObjectMeta: metav1.ObjectMeta{Name: orgID},
+		Spec:       v1.OrgSpec{DisplayName: displayName},
+	}
+	err := p.client.Create(ctx, org)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("orgprovision: create org %q: %w", orgID, err)
+	}
+
+	// Already exists: reconcile the display name only if it drifted, so a re-verify
+	// converges without thrashing the resourceVersion.
+	existing := &v1.Org{}
+	if gerr := p.client.Get(ctx, client.ObjectKey{Name: orgID}, existing); gerr != nil {
+		return fmt.Errorf("orgprovision: load existing org %q: %w", orgID, gerr)
+	}
+	if existing.Spec.DisplayName == displayName {
+		return nil
+	}
+	existing.Spec.DisplayName = displayName
+	if uerr := p.client.Update(ctx, existing); uerr != nil {
+		return fmt.Errorf("orgprovision: update org %q display name: %w", orgID, uerr)
+	}
+	return nil
+}

--- a/internal/saas/orgprovision/orgprovision_test.go
+++ b/internal/saas/orgprovision/orgprovision_test.go
@@ -1,0 +1,95 @@
+package orgprovision
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	v1 "mitos.run/mitos/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1.AddToScheme(s); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return s
+}
+
+// TestProvisionCreatesOrgCR asserts a fresh provision creates the cluster-scoped
+// Org with name == org id and the given display name.
+func TestProvisionCreatesOrgCR(t *testing.T) {
+	c := fakeclient.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	p := New(c)
+
+	if err := p.Provision(context.Background(), "org-abc", "Personal"); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	var got v1.Org
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "org-abc"}, &got); err != nil {
+		t.Fatalf("org not created: %v", err)
+	}
+	if got.Name != "org-abc" {
+		t.Fatalf("org name %q, want org-abc", got.Name)
+	}
+	if got.Spec.DisplayName != "Personal" {
+		t.Fatalf("display name %q, want Personal", got.Spec.DisplayName)
+	}
+}
+
+// TestProvisionIsIdempotentOnAlreadyExists asserts a second provision for the
+// same org id (AlreadyExists) succeeds rather than erroring.
+func TestProvisionIsIdempotentOnAlreadyExists(t *testing.T) {
+	c := fakeclient.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	p := New(c)
+	ctx := context.Background()
+
+	if err := p.Provision(ctx, "org-dup", "Personal"); err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	if err := p.Provision(ctx, "org-dup", "Personal"); err != nil {
+		t.Fatalf("second provision should be idempotent, got: %v", err)
+	}
+
+	var list v1.OrgList
+	if err := c.List(ctx, &list); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("got %d orgs, want exactly 1 (idempotent)", len(list.Items))
+	}
+}
+
+// TestProvisionReconcilesDisplayName asserts a provision with a changed display
+// name updates the existing Org rather than failing.
+func TestProvisionReconcilesDisplayName(t *testing.T) {
+	c := fakeclient.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	p := New(c)
+	ctx := context.Background()
+
+	if err := p.Provision(ctx, "org-rename", "Old Name"); err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	if err := p.Provision(ctx, "org-rename", "New Name"); err != nil {
+		t.Fatalf("rename provision: %v", err)
+	}
+	var got v1.Org
+	if err := c.Get(ctx, client.ObjectKey{Name: "org-rename"}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.DisplayName != "New Name" {
+		t.Fatalf("display name %q, want New Name", got.Spec.DisplayName)
+	}
+}
+
+func TestProvisionRejectsEmptyOrgID(t *testing.T) {
+	c := fakeclient.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	p := New(c)
+	if err := p.Provision(context.Background(), "", "x"); err == nil {
+		t.Fatal("expected error for empty org id")
+	}
+}


### PR DESCRIPTION
**Hosted SaaS campaign, Phase 6.** The signup funnel is real and closes the **signup -> tenant-provisioned** loop.

## What
- Public unauthenticated routes (`POST /onboarding/signup`, `POST|GET /onboarding/verify`) mount on the console **outside** the session middleware, gated by the server-controlled `console.signup` flag. SignUp normalizes the email, rejects unknown fields, and returns the **same** response whether or not the account exists (no user enumeration). Verify tokens are `crypto/rand` + sha256-at-rest, single-use, expiring.
- `internal/saas/onboarding/smtp.go`: real `EmailSender` over stdlib **net/smtp** (STARTTLS, PLAIN auth, configurable host/port/from). The email body carries only the one-time verify link; the SMTP password is never logged or in errors. Dev log-emailer fallback when `MITOS_SMTP_HOST` is unset, with a startup line naming the mode.
- `internal/saas/orgprovision`: on verified signup, after the account+org land in the durable store, it creates the `api/v1.Org` CR (name = org id) **idempotently**, triggering the OrgReconciler to stand up the per-org namespace. Missing k8s client skips with a warning (pure dev); a real provisioning error fails verify so the idempotent retry completes it. Gated by `MITOS_CONSOLE_ORG_TENANCY`. **This is the signup→namespace integration (the P1/P2 follow-up), placed where tenancy is actually created.**
- Chart: SMTP host/port/from as plain values, username/password via **secretKeyRef only**; console gets `orgs` get/create/update RBAC only when cluster onboarding is enabled. No new deps.

## Tests
Signup sends email + no-enumeration + normalization + single-use token; verify creates account+org+membership **and** the Org CR (fake client) + generic-fail on bad/expired/used token; SMTP addressing + password-never-leaked + dev fallback; org-CR idempotency + skip-without-client; chart secretKeyRef + conditional orgs RBAC. Build/vet/lint (both arches) clean.

Composes with #410 (tenancy) and #412 (Postgres). Shares chart/console files with #417/#418; will rebase as those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)