### PR TITLE
ci: pin scorecard-action to v2.4.3 (retracted v2 tag)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The **OpenSSF Scorecard** workflow has failed on every push to main (incl. the v1.3.0 release push) with:

> Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`

Confirmed via the GitHub API that `ossf/scorecard-action` no longer has a `refs/tags/v2` (the floating major tag was retracted); the latest concrete tag is **v2.4.3**. Pin to it, matching this repo's tag-pinning convention for the other actions (`actions/checkout@v6`, `actions/setup-go@v5`, ...).

Note: the Scorecard workflow only triggers on `push: branches: [main]` + schedule, so it does not run on this PR; it validates on the post-merge push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)