### PR TITLE
fix(husk): tear down the tap on partial egress-filter failure (#428)

### DIFF
--- a/internal/husk/netfilter.go
+++ b/internal/husk/netfilter.go
@@ -57,7 +57,7 @@ type netfilterRunner func(ctx context.Context, argv []string, stdin string) erro
 // assign the host IP, bring it up, apply the idempotent shared table, then this
 // VM's per-tap chain. A malformed allowlist fails the whole call (fail-closed:
 // a VM never comes up with a half-applied filter).
-func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwarding func() error, cfg NetfilterConfig) error {
+func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwarding func() error, cfg NetfilterConfig) (err error) {
 	enforceable, _, err := netconf.SplitAllowList(cfg.Allow)
 	if err != nil {
 		return fmt.Errorf("husk netfilter: parse allowlist: %w", err)
@@ -78,6 +78,21 @@ func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwardin
 	if err := run(ctx, netconf.TapAddArgs(cfg.Tap), ""); err != nil {
 		return fmt.Errorf("husk netfilter: create tap %s: %w", cfg.Tap, err)
 	}
+	// The tap now exists. Its name is deterministic per template, so if ANY step
+	// below fails we MUST remove the tap (and any partial chain state) or the next
+	// activation attempt fails right here at tap creation with EBUSY (Device or
+	// resource busy), which masks the real first-attempt error and permanently
+	// poisons the warm pod (issue #428). Tear down idempotently on every error
+	// path; the original error is preserved as the named return so the true
+	// root-cause step error is surfaced, not the EBUSY of a later retry.
+	defer func() {
+		if err != nil {
+			// Detached from ctx so cleanup still runs when the failure was a
+			// context cancellation or deadline (otherwise the same canceled ctx
+			// would fail the teardown commands and re-leak the tap).
+			_ = teardownEgressFilter(context.WithoutCancel(ctx), run, cfg.Tap)
+		}
+	}()
 	if err := run(ctx, netconf.AddrAddArgs(cfg.HostIP, cfg.Tap), ""); err != nil {
 		return fmt.Errorf("husk netfilter: assign host ip to tap %s: %w", cfg.Tap, err)
 	}

--- a/internal/husk/netfilter_test.go
+++ b/internal/husk/netfilter_test.go
@@ -2,6 +2,7 @@ package husk
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -20,6 +21,33 @@ type recordingRunner struct{ calls []recordedCall }
 func (r *recordingRunner) run(_ context.Context, argv []string, stdin string) error {
 	r.calls = append(r.calls, recordedCall{argv: argv, stdin: stdin})
 	return nil
+}
+
+// failingRunner records calls and returns err on the call at index failAt, so a
+// test can simulate a step failing AFTER the tap is created.
+type failingRunner struct {
+	calls  []recordedCall
+	failAt int
+	err    error
+}
+
+func (r *failingRunner) run(_ context.Context, argv []string, stdin string) error {
+	idx := len(r.calls)
+	r.calls = append(r.calls, recordedCall{argv: argv, stdin: stdin})
+	if r.err != nil && idx == r.failAt {
+		return r.err
+	}
+	return nil
+}
+
+func sawTapDelete(calls []recordedCall, tap string) bool {
+	want := strings.Join(netconf.LinkDelArgs(tap), " ")
+	for _, c := range calls {
+		if strings.Join(c.argv, " ") == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestApplyEgressFilterRendersDenyChainWithMetadataBlock(t *testing.T) {
@@ -137,5 +165,53 @@ func TestApplyEgressFilterRejectsMalformedAllow(t *testing.T) {
 	}
 	if err := applyEgressFilter(context.Background(), rr.run, nil, cfg); err == nil {
 		t.Fatal("expected error on malformed allow entry, got nil")
+	}
+}
+
+// TestApplyEgressFilterTearsDownTapOnPartialFailure proves that when a step
+// after tap creation fails, applyEgressFilter removes the tap it created (issue
+// #428). The tap name is deterministic per template, so a leaked tap makes every
+// retry fail at tap creation with EBUSY and masks the real first-attempt error.
+func TestApplyEgressFilterTearsDownTapOnPartialFailure(t *testing.T) {
+	stepErr := errors.New("RTNETLINK answers: operation not permitted")
+	// Call index 0 is the tap add; index 1 is the host-IP assignment, the first
+	// step after the tap exists. Fail there.
+	rr := &failingRunner{failAt: 1, err: stepErr}
+	cfg := NetfilterConfig{
+		Tap:     "sbtapdeadbeef",
+		GuestIP: net.ParseIP("10.200.0.2"),
+		HostIP:  net.ParseIP("10.200.0.1"),
+		Egress:  v1.EgressDeny,
+	}
+	err := applyEgressFilter(context.Background(), rr.run, nil, cfg)
+	if err == nil {
+		t.Fatal("expected an error from the failing step, got nil")
+	}
+	// The real step error is surfaced (wrapped), not masked by a later EBUSY.
+	if !errors.Is(err, stepErr) {
+		t.Fatalf("want the underlying step error wrapped, got: %v", err)
+	}
+	// The tap was torn down: a link delete for this exact tap was issued on the
+	// failure path, so a retry will not hit EBUSY.
+	if !sawTapDelete(rr.calls, cfg.Tap) {
+		t.Fatalf("applyEgressFilter leaked tap %q on failure (no link del); calls: %+v", cfg.Tap, rr.calls)
+	}
+}
+
+// TestApplyEgressFilterDoesNotTearDownOnSuccess proves the happy path leaves the
+// tap in place (teardown is the stub's job on Close, not apply's on success).
+func TestApplyEgressFilterDoesNotTearDownOnSuccess(t *testing.T) {
+	rr := &recordingRunner{}
+	cfg := NetfilterConfig{
+		Tap:     "sbtap0",
+		GuestIP: net.ParseIP("10.200.0.2"),
+		HostIP:  net.ParseIP("10.200.0.1"),
+		Egress:  v1.EgressDeny,
+	}
+	if err := applyEgressFilter(context.Background(), rr.run, nil, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if sawTapDelete(rr.calls, cfg.Tap) {
+		t.Fatalf("applyEgressFilter tore down the tap on success; calls: %+v", rr.calls)
 	}
 }


### PR DESCRIPTION
Fixes the tap-leak + error-masking half of #428.

## Problem
`internal/husk/netfilter.go applyEgressFilter` creates the tap, then assigns the host IP, brings it up, and installs the nft egress/input chains. If any step **after tap creation** failed, the tap was left behind. Because the tap name is deterministic per template, every subsequent activation then failed at the FIRST step:

> `husk: apply in-pod egress filter: husk netfilter: create tap <name>: ip tuntap add <name> mode tap: ioctl(TUNSETIFF): Device or resource busy`

So (1) the real first-attempt failure was masked by EBUSY on retries, and (2) the warm pod was permanently poisoned (on single-node k3s the pool reaches Ready but no sandbox starts).

## Fix
- Once the tap exists, `defer teardownEgressFilter` on any error path (idempotent), so partial state is removed and a retry does not hit EBUSY.
- Teardown runs on a `context.WithoutCancel` copy so cleanup still fires when the failure was a context cancellation/deadline.
- `applyEgressFilter` now uses a **named return** so the ORIGINAL step error is surfaced instead of the masking EBUSY.
- Success path unchanged (the stub still tears down on `Close`).

## Security
No enforcement-semantics change: on failure the datapath is torn down toward nothing, still fail-closed (no half-open path), so the threat-model husk-egress row is unaffected. (Touches the husk egress path, so flagging for your review per the security-path rule.)

## Tests
- `TestApplyEgressFilterTearsDownTapOnPartialFailure`: a step failing after tap creation surfaces the real wrapped error AND issues a `link del` for that exact tap (no leak).
- `TestApplyEgressFilterDoesNotTearDownOnSuccess`: the happy path issues no teardown.
Build/vet/lint (both arches) clean.

## Leaves #428 open
The underlying k3s egress-setup step root-cause (why the IP/nft step fails on stock single-node k3s) is separate and was only diagnosable once the true error stopped being masked. Redeploy with this fix and the real step error will surface in the husk log; #428 stays open to track that root-cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)