### PR TITLE
chore(ci): add agentic PR/issue templates and a PR-policy gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,21 +2,66 @@ name: Bug report
 description: Report a defect in the sandbox system
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this report. Keep every answer concise, reproducible, and grounded in observed evidence.
+        Do not speculate or infer beyond the evidence. If a section cannot be answered from what you observed, respond with exactly `NOT_ENOUGH_INFO`.
+
+        Please report one defect per submission. Break multiple issues into separate reports.
+  - type: dropdown
+    id: bug_type
+    attributes:
+      label: Bug type
+      description: Choose the category that best matches this report.
+      options:
+        - Regression (worked before, now fails)
+        - Crash or hang (process exits, deadlocks, or wedges)
+        - Correctness (wrong output or state without a crash)
+        - Fork-correctness hazard (RNG, clocks, secret inheritance; see docs/fork-correctness.md)
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component is at fault, as best you can tell.
+      options:
+        - controller
+        - forkd
+        - guest agent
+        - sandbox-server
+        - Python SDK
+        - Other SDK
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Fork engine
+      description: Real Firecracker engine (needs KVM) or the mock engine (kind e2e, envtest).
+      options:
+        - KVM (real Firecracker)
+        - Mock
+        - Not applicable
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
       label: Description
-      description: What happened, and what did you expect instead?
+      description: One or two sentences on what is broken, based only on observed evidence. If the evidence is insufficient, respond with exactly `NOT_ENOUGH_INFO`.
     validations:
       required: true
   - type: textarea
     id: reproduction
     attributes:
       label: Reproduction steps
-      description: Minimal steps to reproduce the behavior (manifests, SDK calls, commands).
+      description: Shortest deterministic repro supported by direct observation (manifests, SDK calls, commands). If it cannot be grounded, respond with exactly `NOT_ENOUGH_INFO`.
       placeholder: |
         1. Apply this SandboxPool ...
-        2. Create this SandboxClaim ...
+        2. Create this Sandbox ...
         3. Observe ...
     validations:
       required: true
@@ -24,18 +69,26 @@ body:
     id: expected
     attributes:
       label: Expected behavior
+      description: State the expected result using a concrete reference (prior observed behavior, a known-good version, the docs). If no grounded reference exists, respond with exactly `NOT_ENOUGH_INFO`.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Describe only the observed result, including user-visible errors and cited evidence. If it cannot be grounded, respond with exactly `NOT_ENOUGH_INFO`.
     validations:
       required: true
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Kubernetes version, KVM or mock engine, deployment method (make install, kind, bare metal), component versions.
+      description: Kubernetes version, deployment method (make install, kind, bare metal), and component versions.
       placeholder: |
         - Kubernetes version:
-        - Engine: KVM / mock
         - Deployment method:
         - Component versions (controller, forkd, SDK):
+        - Node OS / kernel (for KVM issues):
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
     url: https://github.com/mitos-run/mitos/blob/main/SECURITY.md
-    about: Do not file public issues for vulnerabilities; use private reporting as described in SECURITY.md.
+    about: Do not file public issues for exploitable vulnerabilities; use private reporting as described in SECURITY.md.
+  - name: Roadmap
+    url: https://github.com/mitos-run/mitos/blob/main/ROADMAP.md
+    about: ROADMAP.md is the priority order for all work. Check it before requesting a feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,18 +2,22 @@ name: Feature request
 description: Propose a new capability or improvement
 labels: ["enhancement"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us evaluate this with concrete use cases and tradeoffs. ROADMAP.md is the priority order for all work; check it before filing.
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: What problem are you trying to solve? What is impossible or painful today?
+      description: What problem are you trying to solve? What is impossible or painful today? Ground this in a real use case, not a hypothetical.
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
       label: Proposed solution
-      description: How should it work? Sketch API shapes or CLI flags if relevant.
+      description: How should it work? Sketch API shapes, CRD fields, or CLI flags if relevant.
     validations:
       required: true
   - type: textarea
@@ -23,6 +27,13 @@ body:
       description: Other approaches you considered and why they fall short.
     validations:
       required: false
+  - type: textarea
+    id: breaking
+    attributes:
+      label: Breaking changes
+      description: Does this change any CRD field, API shape, or output that users or agents rely on? Describe what changes and how compatibility is kept. Write "None" only if you are certain.
+    validations:
+      required: true
   - type: textarea
     id: roadmap-fit
     attributes:

--- a/.github/ISSUE_TEMPLATE/security_finding.yml
+++ b/.github/ISSUE_TEMPLATE/security_finding.yml
@@ -1,0 +1,56 @@
+name: Security finding (non-sensitive)
+description: Track a known security surface, threat-model gap, or hardening task. NOT for exploitable vulnerabilities.
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## STOP if this is an exploitable vulnerability
+
+        If you can demonstrate an exploit, a privilege escalation, a sandbox escape, secret disclosure, or any other directly exploitable weakness, do NOT file it here.
+        Report it privately as described in [SECURITY.md](https://github.com/mitos-run/mitos/blob/main/SECURITY.md).
+
+        Use this form only for non-sensitive security work: a stale or missing row in docs/threat-model.md, a documented surface that lacks a control, a hardening task, or a fork-correctness hazard (docs/fork-correctness.md) that is not directly exploitable.
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: This is NOT an exploitable vulnerability. I understand exploitable issues must be reported privately per SECURITY.md.
+          required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - internal/fork (snapshot/restore, CoW)
+        - internal/firecracker (VM lifecycle)
+        - internal/daemon (forkd gRPC and HTTP)
+        - guest/agent-rs (PID 1, vsock)
+        - Token / attenuation / auth
+        - Network / egress filtering
+        - Expose subsystem
+        - Other / cross-cutting
+    validations:
+      required: true
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What is the security surface or gap? Ground it in code, the threat model, or observed behavior. If you cannot ground it, respond with exactly `NOT_ENOUGH_INFO`.
+    validations:
+      required: true
+  - type: textarea
+    id: threat_model
+    attributes:
+      label: Threat-model delta
+      description: Which row of docs/threat-model.md does this touch, and how should its status change? Per the operating principles, a surface change and its threat-model update land in the same PR.
+    validations:
+      required: true
+  - type: textarea
+    id: remediation
+    attributes:
+      label: Proposed remediation
+      description: How should this be controlled or closed? Note any feature work it should block.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,89 @@
-## Summary
+<!--
+Required PR title: conventional commit form, e.g.
+  feat(controller): confine sandbox placement to tainted KVM pool
+  fix(husk): tear down the tap on partial egress-filter failure
+Types: feat, fix, docs, ci, chore, refactor, test.
+Describe the user-visible change, not the implementation detail.
+-->
 
-<!-- What does this PR change and why? -->
+## Thinking Path
 
-## Test plan
+<!--
+Required. Trace your reasoning from the top of the project down to this change,
+so a reviewer (or a future agent) can reconstruct WHY this exists, not just what
+it does. Blockquote style, 5-8 steps. End with the change and its benefit.
+-->
 
-- [ ] <!-- How was this verified? List the commands run and suites passed. -->
+> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
+> - [Which component or subsystem is involved: controller, forkd, guest agent, sandbox-server, SDK]
+> - [What problem, gap, or hazard exists today]
+> - [Why it needs to be addressed now, and which ROADMAP.md section it serves]
+> - This pull request ...
+> - The benefit is ...
+
+## Linked Issues or Issue Description
+
+<!--
+Required. Pick ONE path:
+
+(A) An issue exists: tag it with `Closes #NNN`, `Fixes #NNN`, or `Related: #NNN`.
+(B) No issue exists: describe the problem here following the relevant issue form
+    fields (.github/ISSUE_TEMPLATE/bug_report.yml or feature_request.yml).
+
+Only reference PUBLIC github.com/mitos-run/mitos issues and PRs. Do NOT paste
+internal or instance-local references that other contributors cannot open:
+Paperclip ticket ids (PAP-123 / PAPA-123), `agent://` links, or
+localhost/tailnet URLs. See CONTRIBUTING.md, "No internal references".
+-->
+
+-
+
+## What Changed
+
+<!-- Bullet list of concrete changes, one bullet per logical unit. -->
+
+-
+
+## Verification
+
+<!--
+Required. How can a reviewer confirm this works? List the exact commands run and
+suites passed. Per the no-unverified-claims rule, every public number must be
+reproducible from bench/.
+-->
+
+- [ ] <!-- e.g. make test-unit, make test-controller, golangci-lint run (both GOOS) -->
+
+## Risks
+
+<!-- What could go wrong: crash, node loss, slow etcd, capacity exhaustion,
+migration safety, breaking change. Or "Low risk" if genuinely minor. -->
+
+-
+
+## Model Used
+
+<!--
+Required. Which AI model produced or assisted this change? Include:
+  - Provider and model name (e.g. Claude Opus, GPT, Gemini)
+  - Exact model id or version (e.g. claude-opus-4-8)
+  - Context window if relevant (e.g. 1M context)
+  - Reasoning/thinking mode if applicable
+If no AI model was used, write "None, human-authored".
+-->
+
+-
 
 ## Checklist
 
-- [ ] Tests added for behavior changes
+- [ ] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
+- [ ] Thinking Path traces from project context to this change
+- [ ] Model Used is filled in (with version and capability details)
+- [ ] Tests added for behavior changes, in the same commit (TDD)
 - [ ] Docs updated in the same PR
 - [ ] Threat-model delta (docs/threat-model.md) included if the security surface moved
-- [ ] No em or en dashes introduced
-- [ ] Secret values never logged
+- [ ] Benchmark run (bench/) included if the hot path was touched
+- [ ] No em or en dashes introduced anywhere
+- [ ] Secret values never logged, in errors, in condition messages, or on host paths
+- [ ] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
+- [ ] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

--- a/.github/workflows/pr-policy.yaml
+++ b/.github/workflows/pr-policy.yaml
@@ -11,6 +11,9 @@ name: PR policy
 on:
   pull_request:
     branches: [main]
+    # Include `edited` so the title and body checks re-run when a contributor
+    # fixes the PR title or body, instead of leaving a stale failure.
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-policy.yaml
+++ b/.github/workflows/pr-policy.yaml
@@ -1,0 +1,130 @@
+name: PR policy
+
+# Enforce the contribution guardrails that templates alone cannot: no em/en
+# dashes in the diff (CLAUDE.md punctuation rule), a conventional-commit PR
+# title, the agentic PR-body sections (Thinking Path, Model Used, Verification),
+# and no internal/instance-local references leaking into a public PR. These are
+# lightweight in-repo checks, matching the DCO workflow: no external app setup.
+# PR body and title are passed through env vars, never interpolated into a shell
+# script, to avoid template injection.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-dashes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Reject em and en dashes in added lines
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Only scan lines this PR ADDS, so pre-existing content never fails a PR.
+          # Exclude vendored and binary-ish paths the punctuation rule does not govern.
+          added=$(git diff --unified=0 "${BASE_SHA}...${HEAD_SHA}" -- \
+            ':(exclude)vendor/**' \
+            ':(exclude)**/*.svg' \
+            ':(exclude)**/*.png' \
+            ':(exclude)**/*.jpg' \
+            ':(exclude)go.sum' \
+            ':(exclude)**/pnpm-lock.yaml' \
+            | grep -E '^\+' | grep -v '^\+\+\+' || true)
+          if printf '%s' "${added}" | grep -nP '[\x{2014}\x{2013}]' >/dev/null 2>&1; then
+            echo "FAIL: an added line contains an em (U+2014) or en (U+2013) dash."
+            echo "CLAUDE.md bans them everywhere: source, comments, Markdown, YAML, CRDs, commit messages."
+            echo "Offending added lines:"
+            printf '%s\n' "${added}" | grep -nP '[\x{2014}\x{2013}]' || true
+            echo "Use only . , ; : as connectors. ASCII hyphen-minus (-) is fine for ranges."
+            exit 1
+          fi
+          echo "ok: no em or en dashes in added lines."
+
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a conventional-commit PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          pattern='^(feat|fix|docs|ci|chore|refactor|test)(\([a-z0-9,_/.-]+\))?!?: .+'
+          if printf '%s' "${TITLE}" | grep -qE "${pattern}"; then
+            echo "ok: \"${TITLE}\""
+          else
+            echo "FAIL: PR title is not a conventional commit."
+            echo "Got: \"${TITLE}\""
+            echo "Expected: type(scope): description"
+            echo "Types: feat, fix, docs, ci, chore, refactor, test. Scope optional."
+            exit 1
+          fi
+
+  body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require agentic PR sections and reject internal references
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          # Skip bot-authored PRs (dependabot, release-please): they use their own
+          # body. Done inside the step, not as a job-level `if`, so this required
+          # check always reports a conclusion instead of leaving the context
+          # pending and blocking merge.
+          # Brackets are escaped: in a case pattern, [bot] is a character class,
+          # not a literal, so an unescaped dependabot[bot] would never match.
+          case "${AUTHOR}" in
+            dependabot\[bot\]|github-actions\[bot\]|release-please\[bot\])
+              echo "ok: skipping body policy for bot author ${AUTHOR}."
+              exit 0
+              ;;
+          esac
+          python3 - <<'PY'
+          import os, re, sys
+
+          body = os.environ.get("BODY") or ""
+          # Drop HTML comments so template guidance does not count as filled content.
+          stripped = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+
+          fail = []
+
+          for header in ("## Thinking Path", "## Verification", "## Model Used"):
+              if header not in body:
+                  fail.append(f"missing required section: {header}")
+
+          # Model Used must carry real content, not an empty bullet.
+          m = re.search(r"## Model Used\s*(.*?)(?:\n## |\Z)", stripped, flags=re.DOTALL)
+          section = (m.group(1).strip() if m else "")
+          meaningful = [ln for ln in section.splitlines()
+                        if ln.strip() and ln.strip() not in ("-", "*")]
+          if not meaningful:
+              fail.append("Model Used is empty: name the AI model used, or write 'None, human-authored'.")
+
+          # No internal/instance-local references in a public PR.
+          patterns = {
+              r"\bPAPA?-\d+\b": "Paperclip ticket id (PAP-/PAPA-)",
+              r"agent://": "agent:// link",
+              r"https?://localhost": "localhost URL",
+              r"https?://[\w.-]+\.ts\.net": "tailnet URL",
+          }
+          for pat, label in patterns.items():
+              if re.search(pat, body, flags=re.IGNORECASE):
+                  fail.append(f"internal reference found ({label}); use only public #NNN or mitos-run/mitos URLs")
+
+          if fail:
+              print("FAIL: PR body policy violations:")
+              for f in fail:
+                  print(f"  - {f}")
+              print("See .github/pull_request_template.md and CONTRIBUTING.md.")
+              sys.exit(1)
+          print("ok: PR body sections present and clean.")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,34 @@ the disclosure process in [SECURITY.md](SECURITY.md).
 
 ## Pull requests
 
+Substantial portions of this codebase are AI-assisted, and AI agents may open
+PRs on a contributor's behalf. The template is required; fill every section. The
+agentic-specific sections exist so a reviewer or a future agent can reconstruct
+why a change exists, not just what it does:
+
+- **Thinking Path**: trace your reasoning from project context down to this
+  change (5 to 8 steps, blockquote style).
+- **Model Used**: the AI model that produced or assisted the change (provider,
+  exact model id, context window, reasoning mode), or "None, human-authored".
+  CI rejects an empty Model Used section.
+- **No internal references**: reference only public `mitos-run/mitos` issues and
+  PRs. Do not paste internal or instance-local references that others cannot
+  open: Paperclip ticket ids (`PAP-123` / `PAPA-123`), `agent://` links, or
+  localhost/tailnet URLs. CI rejects these in the PR body.
+
+Every PR also needs:
+
+- A conventional-commit PR title (`type(scope): description`), enforced in CI.
 - Tests for every behavior change, in the same commit.
 - Docs updated in the same PR.
 - If the security surface moved, include the threat-model delta (docs/threat-model.md) in the same PR.
-- All six CI checks must be green: go-test, go-lint, python-test, docker-build, kind-e2e, firecracker-test.
+- A benchmark run (bench/) if the hot path was touched.
+
+The PR-policy check (`.github/workflows/pr-policy.yaml`) enforces the title
+format, the required PR sections, the no-internal-references rule, and the
+no-dashes rule on added lines. All required CI checks must be green, including
+go-test, go-lint, python-test, docker-build, the kind-e2e suites, and
+firecracker-test.
 
 ## Where to start
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via CoW snapshots, exposed through CRDs, and much of the contribution flow is now agent-driven.
> - The contribution surface (issue forms, PR template, CONTRIBUTING) is where an agent or human first states intent, evidence, and provenance.
> - Today the PR template is thin and nothing enforces the punctuation rule, the conventional-title convention, or keeps internal/instance-local references out of public PRs.
> - openclaw/openclaw and paperclipai/paperclip already solved adjacent problems: evidence-grounded issue forms and an agent-aware PR template (Thinking Path, Model Used).
> - This pull request ports those patterns, adapts them to Mitos semantics, and backs the agentic sections with a lightweight CI gate.
> - The benefit is that every contribution, including agent-authored ones, arrives grounded, attributable, and machine-checkable, without any external GitHub App.

## What Changed

- PR template: Thinking Path, Model Used, internal-reference ban, plus the existing threat-model, bench, no-dashes, and secrets checklist.
- bug_report: NOT_ENOUGH_INFO grounding and Bug-type, Component, and Fork-engine dropdowns.
- feature_request: grounding and a required Breaking-changes field; Roadmap-fit kept.
- New security_finding form for non-sensitive threat-model and hardening work, with a hard redirect of exploitable issues to private reporting.
- config: blank issues disabled, roadmap linked.
- New `.github/workflows/pr-policy.yaml`: rejects em/en dashes in added lines, requires a conventional-commit title, requires the Thinking Path/Verification/Model Used sections plus a filled Model Used, and rejects internal references. Body and title are read via env, never interpolated into the shell.
- CONTRIBUTING.md updated in place.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on all changed YAML: parses.
- Title regex unit-checked: passes `feat(controller):`, `docs(api/v2):`, `chore(main): release`; rejects `Add a thing`, `feature:`.
- Dash gate unit-checked: flags an added em-dash line, ignores ASCII hyphens and `+++` headers, only scans added lines, excludes vendored/binary paths.
- Body gate unit-checked against three fixtures: good body passes; empty Model Used fails; missing section plus an internal-style reference (ticket id or instance-local link) fails. Bot authors are skipped inside the step (escaped brackets) so the required check always reports.
- Self-check: no em/en dashes in any added file.
- This PR body is itself the first real run of the new gate.

## Risks

- Low risk: no production code paths touched. The gate runs only on `pull_request` to `main`.
- The gate is not a required check until added in branch protection; doing that is a follow-up step on this same change.

## Model Used

- Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking. Agent-driven, human-reviewed.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] No behavior change in product code (tooling/templates only); validated via the unit checks above
- [x] Docs updated in the same PR (CONTRIBUTING.md)
- [ ] Threat-model delta: not applicable, no security surface moved
- [ ] Benchmark run: not applicable, hot path untouched
- [x] No em or en dashes introduced
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer
