### PR TITLE
fix(forkd): grant CAP_DAC_OVERRIDE so the builder can rebuild its own rootfs (#426)

### DIFF
--- a/cmd/forkd/jailer.go
+++ b/cmd/forkd/jailer.go
@@ -47,11 +47,23 @@ func jailerRequiredCapabilities() []string {
 // NET_ADMIN, so the jailer list stays the minimal authority for the jail and
 // NET_ADMIN is the single, documented builder extra. NET_ADMIN is scoped to
 // forkd's own pod netns (forkd is not hostNetwork), exactly like the husk pod's
-// NET_ADMIN; it cannot reach the host netns. This is the single source of truth
-// the DaemonSet securityContext.capabilities.add must match
+// NET_ADMIN; it cannot reach the host netns.
+//
+// It also includes CAP_DAC_OVERRIDE: the builder copies and finalizes the
+// template rootfs.ext4 under <dataDir>/templates, and that file becomes owned by
+// a per-VM jailed uid (the jailer hard-links the rootfs into the chroot and
+// chowns the shared inode to the per-VM uid). On a subsequent build forkd (root,
+// but subject to normal DAC checks without this cap) otherwise cannot reopen its
+// own template rootfs for write and the snapshot build fails with EACCES (#426).
+// DAC_OVERRIDE is negligible marginal authority next to the CAP_SYS_ADMIN the
+// builder already holds, and like the rest of the set it is scoped to forkd's
+// own pod, not the host.
+//
+// This is the single source of truth the DaemonSet
+// securityContext.capabilities.add must match
 // (cmd/forkd/manifest_conformance_test.go). Widening it is a threat-model change.
 func forkdRequiredCapabilities() []string {
-	return append(jailerRequiredCapabilities(), "CAP_NET_ADMIN")
+	return append(jailerRequiredCapabilities(), "CAP_NET_ADMIN", "CAP_DAC_OVERRIDE")
 }
 
 // parseUIDRange parses the --uid-range flag, "low-high" inclusive.

--- a/cmd/forkd/jailer_test.go
+++ b/cmd/forkd/jailer_test.go
@@ -137,13 +137,14 @@ func TestJailerRequiredCapabilities(t *testing.T) {
 
 // TestForkdRequiredCapabilities pins the FULL capability set the forkd CONTAINER
 // runs with after dropping privileged: true. It is the jailer set
-// (jailerRequiredCapabilities) PLUS CAP_NET_ADMIN, which the BUILDER needs to
-// create the per-template placeholder tap host-side (internal/fork/engine.go,
-// `ip tuntap add`) when networking is enabled; the jailer itself does not need
-// NET_ADMIN, so the two sets are kept distinct. This list is the authority the
-// DaemonSet securityContext.capabilities.add must agree with
-// (manifest_conformance_test.go). NET_ADMIN is scoped to forkd's own pod netns
-// (forkd is not hostNetwork), exactly as the husk pod's NET_ADMIN is.
+// (jailerRequiredCapabilities) PLUS two BUILDER extras the jailer itself does not
+// need: CAP_NET_ADMIN to create the per-template placeholder tap host-side
+// (internal/fork/engine.go, `ip tuntap add`) when networking is enabled, and
+// CAP_DAC_OVERRIDE so the builder can reopen the template rootfs.ext4 it wrote
+// after the jailer chowned the shared inode to the per-VM uid (#426). The jailer
+// and builder sets are kept distinct. This list is the authority the DaemonSet
+// securityContext.capabilities.add must agree with (manifest_conformance_test.go).
+// Both extras are scoped to forkd's own pod, not the host.
 func TestForkdRequiredCapabilities(t *testing.T) {
 	want := []string{
 		"CAP_SYS_ADMIN",
@@ -151,7 +152,8 @@ func TestForkdRequiredCapabilities(t *testing.T) {
 		"CAP_SETUID",
 		"CAP_SETGID",
 		"CAP_MKNOD",
-		"CAP_NET_ADMIN", // build-time placeholder tap (NOT a jailer requirement)
+		"CAP_NET_ADMIN",    // build-time placeholder tap (NOT a jailer requirement)
+		"CAP_DAC_OVERRIDE", // reopen the builder's own rootfs after the jailer chown (#426)
 	}
 	got := forkdRequiredCapabilities()
 	if len(got) != len(want) {
@@ -165,21 +167,25 @@ func TestForkdRequiredCapabilities(t *testing.T) {
 }
 
 // TestForkdRequiredCapabilitiesExtendsJailerSet asserts forkd's container set is
-// exactly the jailer set plus NET_ADMIN, so the jailer set stays the minimal
-// authority for the jail and NET_ADMIN is the single, documented builder extra.
+// exactly the jailer set followed by the documented builder extras (NET_ADMIN,
+// DAC_OVERRIDE), so the jailer set stays the minimal authority for the jail and
+// every builder addition is explicit and ordered.
 func TestForkdRequiredCapabilitiesExtendsJailerSet(t *testing.T) {
 	jailer := jailerRequiredCapabilities()
 	forkd := forkdRequiredCapabilities()
-	if len(forkd) != len(jailer)+1 {
-		t.Fatalf("forkd set %v should be the jailer set %v plus exactly one capability", forkd, jailer)
+	builderExtras := []string{"CAP_NET_ADMIN", "CAP_DAC_OVERRIDE"}
+	if len(forkd) != len(jailer)+len(builderExtras) {
+		t.Fatalf("forkd set %v should be the jailer set %v plus the builder extras %v", forkd, jailer, builderExtras)
 	}
 	for i := range jailer {
 		if forkd[i] != jailer[i] {
 			t.Fatalf("forkd set must start with the jailer set in order: forkd[%d]=%q, jailer[%d]=%q", i, forkd[i], i, jailer[i])
 		}
 	}
-	if forkd[len(forkd)-1] != "CAP_NET_ADMIN" {
-		t.Fatalf("the one builder extra must be CAP_NET_ADMIN, got %q", forkd[len(forkd)-1])
+	for j, extra := range builderExtras {
+		if forkd[len(jailer)+j] != extra {
+			t.Fatalf("builder extra[%d] = %q, want %q", j, forkd[len(jailer)+j], extra)
+		}
 	}
 }
 

--- a/deploy/charts/mitos/templates/forkd-daemonset.yaml
+++ b/deploy/charts/mitos/templates/forkd-daemonset.yaml
@@ -88,7 +88,9 @@ spec:
           # cgroup/namespace setup; CHOWN to hand the chroot to the jailed uid;
           # SETUID/SETGID to drop to it; MKNOD for the in-chroot device nodes;
           # NET_ADMIN for the BUILD-time placeholder tap (`ip tuntap add`,
-          # --enable-networking), scoped to forkd's own pod netns).
+          # --enable-networking), scoped to forkd's own pod netns; DAC_OVERRIDE so
+          # the builder can reopen the template rootfs.ext4 it wrote after the
+          # jailer chowned the shared inode to the per-VM uid, #426).
           # /dev/kvm and /dev/net/tun come from the device plugin (mitos.run/kvm),
           # not a privileged hostPath. allowPrivilegeEscalation: false and
           # seccompProfile RuntimeDefault complete the hardening. See
@@ -106,6 +108,7 @@ spec:
                 - SETGID
                 - MKNOD
                 - NET_ADMIN
+                - DAC_OVERRIDE
             seccompProfile:
               type: RuntimeDefault
           resources:

--- a/deploy/daemon/daemonset.yaml
+++ b/deploy/daemon/daemonset.yaml
@@ -115,9 +115,10 @@ spec:
               containerPort: 9092
           # NOT privileged. forkd is the privileged BUILDER concentrated to the
           # explicit builder capability set, not a privileged-and-long-lived
-          # daemon: it drops ALL capabilities and adds back ONLY the six the
+          # daemon: it drops ALL capabilities and adds back ONLY the seven the
           # builder needs (cmd/forkd/jailer.go forkdRequiredCapabilities, the
-          # single source of truth: the five jailer caps plus NET_ADMIN):
+          # single source of truth: the five jailer caps plus NET_ADMIN and
+          # DAC_OVERRIDE):
           #   - SYS_ADMIN: mount(2) for the chroot-base pivot setup, plus the
           #     jailer's cgroup and namespace setup;
           #   - CHOWN:     hand the per-VM chroot files to the jailed uid/gid;
@@ -126,6 +127,9 @@ spec:
           #   - NET_ADMIN: create the per-template placeholder tap at BUILD time
           #     (`ip tuntap add`, --enable-networking); scoped to forkd's own pod
           #     netns (forkd is not hostNetwork), like the husk pod's NET_ADMIN.
+          #   - DAC_OVERRIDE: reopen the template rootfs.ext4 the builder itself
+          #     wrote, after the jailer chowned the shared inode to the per-VM
+          #     uid, so a rebuild does not fail with EACCES (#426).
           # /dev/kvm and /dev/net/tun come from the device plugin (mitos.run/kvm),
           # NOT a privileged hostPath, so the device cgroup is scoped by the
           # kubelet. allowPrivilegeEscalation: false and seccompProfile
@@ -144,6 +148,7 @@ spec:
                 - SETGID
                 - MKNOD
                 - NET_ADMIN
+                - DAC_OVERRIDE
             seccompProfile:
               type: RuntimeDefault
           resources:

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -113,7 +113,7 @@ open, with a severity on the review rows) is preserved throughout.
 | Guest agent - Rust (`guest/agent-rs`) | PID 1 in guest; the SOLE production agent since Phase E (#310). Baked as `/init` by `guest/rootfs/build.sh` and `kvm-test.yaml`. Serves ONLY gRPC on vsock port 53 (AgentGRPCPort); all host callers speak gRPC (SP1.5 merged, Go agent and legacy JSON protocol removed). SECURITY-SENSITIVE: requires named human reviewer; see `docs/security-review-policy.md`. | nothing | forkd / husk stub (gRPC, port 53) |
 | husk pod stub (`cmd/husk-stub`), the DEFAULT runner | unprivileged pod, `/dev/kvm` via device plugin (not `privileged`), drop ALL caps and add only `NET_ADMIN` (in-pod egress firewall, scoped to the pod netns), `seccomp: RuntimeDefault`, read-only snapshot mount; the long-lived husk-stub container is NOT privileged | controller (mTLS control channel) | controller |
 | husk `enable-ip-forward` init container (name-egress pools only) | short-lived PRIVILEGED init container on the husk pod; writes `net.ipv4.ip_forward=1` in the shared pod netns and exits BEFORE the workload runs; added only when name-based egress is configured (`--husk-dns-upstream` set) | controller (it is part of the pod spec) | controller |
-| forkd (`cmd/forkd`), the snapshot BUILDER and the raw-forkd fallback | NON-privileged DaemonSet pod (uid 0, `privileged: false`, `allowPrivilegeEscalation: false`, `seccomp: RuntimeDefault`): drops ALL capabilities and adds back ONLY the explicit builder set (`SYS_ADMIN`, `CHOWN`, `SETUID`, `SETGID`, `MKNOD` for the jailer, plus `NET_ADMIN` for the build-time placeholder tap; `cmd/forkd/jailer.go` `forkdRequiredCapabilities`). The per-VM jailer is ENABLED in the shipped DaemonSet (`deploy/daemon/daemonset.yaml`: `--jailer`/`--chroot-base`/`--uid-range`), so every build/raw-forkd VM runs under a dedicated uid/gid in a per-VM chroot. `/dev/kvm` and `/dev/net/tun` come from the device plugin (`mitos.run/kvm`), NOT a privileged hostPath. (#352) | controller | controller, nodes |
+| forkd (`cmd/forkd`), the snapshot BUILDER and the raw-forkd fallback | NON-privileged DaemonSet pod (uid 0, `privileged: false`, `allowPrivilegeEscalation: false`, `seccomp: RuntimeDefault`): drops ALL capabilities and adds back ONLY the explicit builder set (`SYS_ADMIN`, `CHOWN`, `SETUID`, `SETGID`, `MKNOD` for the jailer, plus `NET_ADMIN` for the build-time placeholder tap and `DAC_OVERRIDE` so the builder can reopen the template `rootfs.ext4` it wrote after the jailer chowned the shared inode to the per-VM uid, #426; `cmd/forkd/jailer.go` `forkdRequiredCapabilities`). `DAC_OVERRIDE` is negligible marginal authority next to the `CAP_SYS_ADMIN` the builder already holds. The per-VM jailer is ENABLED in the shipped DaemonSet (`deploy/daemon/daemonset.yaml`: `--jailer`/`--chroot-base`/`--uid-range`), so every build/raw-forkd VM runs under a dedicated uid/gid in a per-VM chroot. `/dev/kvm` and `/dev/net/tun` come from the device plugin (`mitos.run/kvm`), NOT a privileged hostPath. (#352) | controller | controller, nodes |
 | controller (`cmd/controller`) | cluster Deployment, CRD + Secrets RBAC | kube-apiserver | forkd, husk pods |
 | Snapshot artifacts | files under `/var/lib/mitos` on each node | - | forkd builds them; husk pods mount and execute them as memory images |
 
@@ -162,8 +162,10 @@ privileged process and RUN many times by unprivileged pods.
   per-node BUILDER and the raw-forkd fallback: building a snapshot runs the
   jailer, which needs `CAP_SYS_ADMIN` (chroot-base mount setup, cgroup, and
   namespace setup), `CAP_CHOWN`/`CAP_SETUID`/`CAP_SETGID` (hand and drop to the
-  per-VM uid), `CAP_MKNOD` (in-chroot `/dev/kvm` and `/dev/net/tun` nodes), and
-  `CAP_NET_ADMIN` (the build-time placeholder tap). forkd runs with EXACTLY that
+  per-VM uid), `CAP_MKNOD` (in-chroot `/dev/kvm` and `/dev/net/tun` nodes),
+  `CAP_NET_ADMIN` (the build-time placeholder tap), and `CAP_DAC_OVERRIDE` (reopen
+  the template `rootfs.ext4` the builder wrote after the jailer chowned the shared
+  inode to the per-VM uid, #426). forkd runs with EXACTLY that
   set (`drop: [ALL]`, `privileged: false`, `allowPrivilegeEscalation: false`,
   `seccompProfile: RuntimeDefault`), and `/dev/kvm`/`/dev/net/tun` come from the
   device plugin (`mitos.run/kvm`), not a privileged hostPath. Status: mitigated.


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; forkd is the non-privileged per-node snapshot builder (uid 0, drop ALL caps, explicit add list, #352).
> - Building a template snapshot copies the template `rootfs.ext4`, and the jailer hard-links that rootfs into each per-VM chroot and chowns the shared inode to the per-VM jailed uid.
> - forkd's add list did not include `DAC_OVERRIDE`, so on a subsequent build root-as-other could not reopen its own template rootfs for write.
> - Every snapshot build then failed with `copy rootfs: open .../rootfs.ext4: permission denied`, so no pool got a snapshot (found deploying to single-node k3s; the maintainer confirmed a kubectl patch adding the cap unblocks it).
> - This serves ROADMAP section 0 and the first-prod-QA install path.
> - This pull request adds `DAC_OVERRIDE` as a builder extra in the single source of truth and both shipped manifests, and records the surface delta.
> - The benefit is forkd can rebuild its own template rootfs and pools get snapshots.

## Linked Issues or Issue Description

Fixes #426.

## What Changed

- Add `CAP_DAC_OVERRIDE` to `forkdRequiredCapabilities` (single source of truth) as a builder extra alongside `NET_ADMIN`; the jailer set stays minimal.
- Add it to `deploy/daemon/daemonset.yaml` and the Helm chart `forkd-daemonset.yaml`.
- Update the cap unit tests and the manifest conformance test to pin the new exact 7-cap set.
- `docs/threat-model.md`: record the surface delta (negligible next to the `CAP_SYS_ADMIN` the builder already holds).

## Verification

- [x] TDD: added the cap to the source of truth first, watched `TestShippedDaemonSetHasExactJailerCapabilities` fail, then updated the manifests to green.
- [x] `go test ./cmd/forkd/` passes; `gofmt` clean.

## Risks

Low risk. Runtime EACCES resolution requires the KVM cluster (the maintainer validated the equivalent kubectl patch); CI verifies the manifest/cap contract.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta included (security surface moved)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
