### PR TITLE
fix(ociroot): tolerate unreadable subtrees when measuring rootfs size (#415)

### DIFF
--- a/internal/ociroot/ext4.go
+++ b/internal/ociroot/ext4.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"math"
 	"os/exec"
 	"path/filepath"
@@ -80,6 +81,9 @@ func DirSizeMB(dir string) (int, error) {
 			// Such dirs are near-empty, and the headroom multiplier plus the
 			// minRootfsMB floor below absorb the small undercount.
 			if errors.Is(err, fs.ErrPermission) {
+				// Leave a trail so a later undercount is diagnosable without a re-run
+				// (matches the extract.go skip logging style).
+				log.Printf("ociroot: skipping unreadable path %q during size measurement: %v", path, err)
 				return nil
 			}
 			return err

--- a/internal/ociroot/ext4.go
+++ b/internal/ociroot/ext4.go
@@ -1,6 +1,7 @@
 package ociroot
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -71,6 +72,16 @@ func DirSizeMB(dir string) (int, error) {
 	var total int64
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			// Tolerate a subtree the walker cannot read. apt-based images
+			// (debian/ubuntu/python-slim) ship root-only dirs such as
+			// /var/cache/apt/archives/partial (mode 0700, owned by _apt); a
+			// non-root forkd cannot traverse them, and the size measurement must
+			// not abort the whole template build over a cache/staging dir (#415).
+			// Such dirs are near-empty, and the headroom multiplier plus the
+			// minRootfsMB floor below absorb the small undercount.
+			if errors.Is(err, fs.ErrPermission) {
+				return nil
+			}
 			return err
 		}
 		if d.Type().IsRegular() {

--- a/internal/ociroot/ext4_test.go
+++ b/internal/ociroot/ext4_test.go
@@ -95,3 +95,32 @@ func TestDirSizeMBHasHeadroomAndFloor(t *testing.T) {
 		t.Errorf("size = %d, want at least 280 (content*1.4)", size)
 	}
 }
+
+// TestDirSizeMBToleratesUnreadableSubdir reproduces #415: apt-based images
+// (debian/ubuntu/python-slim) contain root-only dirs such as
+// /var/cache/apt/archives/partial (mode 0700, owned by _apt). When forkd is
+// non-root it cannot traverse them, so the size walk must skip the unreadable
+// subtree and still return a usable size instead of aborting the whole build.
+func TestDirSizeMBToleratesUnreadableSubdir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks; cannot exercise EACCES")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "f"), make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(root, "partial")
+	if err := os.Mkdir(sub, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore perms so the test temp dir can be cleaned up.
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+
+	size, err := DirSizeMB(root)
+	if err != nil {
+		t.Fatalf("DirSizeMB returned an error on an unreadable subdir (#415): %v", err)
+	}
+	if size < minRootfsMB {
+		t.Fatalf("size = %d, want at least the floor %d", size, minRootfsMB)
+	}
+}


### PR DESCRIPTION
## Thinking Path

> - Mitos builds pool template rootfs images from OCI refs; `internal/ociroot` extracts the image and measures its size to pick the ext4 size.
> - `DirSizeMB` walked the extracted tree summing file sizes and returned any walk error.
> - apt-based images (debian/ubuntu/python:3.12-slim/node) ship root-only dirs such as `/var/cache/apt/archives/partial` (mode 0700, owned by `_apt`).
> - When forkd is non-root it cannot traverse them, so the walk aborted and the whole template build failed; only Alpine worked (found deploying to single-node k3s).
> - This serves ROADMAP section 0 and the first-prod-QA install path (most real base images are apt-based).
> - This pull request makes the size walk tolerate unreadable subtrees and log them, instead of aborting.
> - The benefit is a pool can be built from a standard `python:3.12-slim` image.

## Linked Issues or Issue Description

Fixes #415.

## What Changed

- `DirSizeMB` skips a subtree it cannot read (`fs.ErrPermission`) and continues; non-permission errors still fail hard.
- The 1.4x headroom and `minRootfsMB` floor absorb the small undercount (these dirs are caches/staging, near-empty).
- Log the skipped path so a later undercount is diagnosable without a re-run (matches the extract.go skip-logging style).
- Robust regardless of whether forkd runs as root (composes with #426).

## Verification

- [x] TDD: added `TestDirSizeMBToleratesUnreadableSubdir` (mode-0000 subdir mirroring apt's `partial`), watched it fail with `permission denied`, then pass. Guarded to skip under euid 0.
- [x] `go test ./internal/ociroot/` passes; `gofmt` clean.

## Risks

Low risk. A genuinely large unreadable dir would undercount the rootfs size; in practice these are caches and the headroom/floor cover them, and the skip is now logged.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (n/a)
- [x] Threat-model delta included if the security surface moved (n/a)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
