### PR TITLE
fix(controller): issue the husk TLS leaf in the controller namespace too (#414)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -993,7 +993,16 @@ per-pool/template assurance FLOOR, both shipped here:
   husk server key, never the CA signing key and never the shared forkd key.
   Scope: the cluster-wide secrets grant is the enabling privilege for writing
   ca.crt into pool namespaces; a namespaced grant scoped to pool namespaces is a
-  follow-up once pool namespaces are enumerable at install time.
+  follow-up once pool namespaces are enumerable at install time. This
+  pool-namespace-holds-no-CA-signing-key property holds for MULTI-namespace
+  deployments. In the single-namespace self-host topology (a pool created in the
+  controller's own namespace, now supported so husk pods start, #414) the pool IS
+  the controller namespace and therefore naturally holds ca.key: the
+  cross-namespace isolation boundary does not exist there because there is no
+  second namespace. This is an accepted simplicity/isolation tradeoff for
+  single-tenant self-host; multi-tenant deployments MUST give each pool (tenant)
+  its own namespace distinct from the controller's, where the property above
+  applies.
 - Husk activation target authenticity (warm-slot impersonation). Activation
   delivers the claim's resolved secrets plus the per-sandbox bearer token to the
   husk pod's self-reported PodIP over the mTLS control channel. So if pod

--- a/internal/controller/husk_tls.go
+++ b/internal/controller/husk_tls.go
@@ -33,13 +33,13 @@ const HuskTLSSecretName = "mitos-husk-tls"
 // namespace (where ca.key lives and never leaves) and issues/heals a
 // husk.<poolNamespace>.mitos leaf into a namespace-local mitos-husk-tls Secret
 // the husk pod mounts. Reuses the same ensureCA/ensureLeaf primitives as
-// EnsurePKI, so it is race-safe and self-healing. A pool that runs in the
-// controller namespace itself needs nothing extra (mitos-forkd-tls is already
-// there), so that case is a no-op.
+// EnsurePKI, so it is race-safe and self-healing. This holds for a pool that
+// runs in the controller namespace itself (the natural single-namespace
+// self-host install): the husk pod always mounts mitos-husk-tls regardless of
+// namespace, so the leaf must be issued there too, not skipped (#414). The husk
+// secret (mitos-husk-tls) is distinct from forkd's (mitos-forkd-tls), so there
+// is no collision when both live in the controller namespace.
 func EnsureHuskTLS(ctx context.Context, c client.Client, controllerNamespace, poolNamespace string) error {
-	if poolNamespace == controllerNamespace {
-		return nil
-	}
 	ca, err := ensureCA(ctx, c, controllerNamespace)
 	if err != nil {
 		return fmt.Errorf("load CA to issue husk leaf for %s: %w", poolNamespace, err)

--- a/internal/controller/husk_tls_test.go
+++ b/internal/controller/husk_tls_test.go
@@ -112,3 +112,30 @@ func TestEnsureHuskTLSIsIdempotent(t *testing.T) {
 		t.Error("husk tls leaf changed on a second EnsureHuskTLS call; it must be idempotent")
 	}
 }
+
+// TestEnsureHuskTLSWritesLeafInControllerNamespace proves a pool that shares the
+// controller namespace (the natural single-namespace self-host install: controller
+// and pool both in "mitos") still gets a mitos-husk-tls Secret. The husk pod
+// always mounts that Secret, so skipping it for the controller namespace left
+// husk pods stuck in ContainerCreating forever (#414).
+func TestEnsureHuskTLSWritesLeafInControllerNamespace(t *testing.T) {
+	c := newCoreClient(t)
+	ns := newPKINamespace(t, c)
+	if _, err := controller.EnsurePKI(ctx, c, ns); err != nil {
+		t.Fatalf("EnsurePKI: %v", err)
+	}
+
+	// Pool namespace == controller namespace.
+	if err := controller.EnsureHuskTLS(ctx, c, ns, ns); err != nil {
+		t.Fatalf("EnsureHuskTLS: %v", err)
+	}
+
+	sec := getSecret(t, c, ns, controller.HuskTLSSecretName)
+	for _, key := range []string{"tls.crt", "tls.key"} {
+		if len(sec.Data[key]) == 0 {
+			t.Fatalf("husk tls secret missing key %s in the controller namespace", key)
+		}
+	}
+	ca := getSecret(t, c, ns, controller.CASecretName)
+	verifyLeaf(t, sec.Data["tls.crt"], ca.Data["ca.crt"], pki.HuskServerName(ns), x509.ExtKeyUsageServerAuth)
+}


### PR DESCRIPTION
## Thinking Path

> - Mitos runs husk pods (the default sandbox runner) that mount a per-namespace `mitos-husk-tls` Secret to serve the mTLS husk control channel.
> - The controller's `EnsureHuskTLS` issues that leaf per pool namespace, signed by the control-plane CA in the controller namespace.
> - It early-returned when `poolNamespace == controllerNamespace`, on the false assumption that the controller namespace needs nothing extra.
> - But the husk pod ALWAYS mounts `mitos-husk-tls`, so in the natural single-namespace self-host layout (controller and pool both in `mitos`) husk pods hung forever in `ContainerCreating` (secret not found; found deploying to single-node k3s).
> - This serves ROADMAP section 0 and the first-prod-QA install path (the first thing a self-host user does is create a pool next to the controller).
> - This pull request removes the early-return so the leaf is issued in the controller namespace too, and documents the different isolation posture of that topology.
> - The benefit is single-namespace installs start husk pods.

## Linked Issues or Issue Description

Fixes #414.

## What Changed

- Remove the `poolNamespace == controllerNamespace` early-return in `EnsureHuskTLS`; the function already issues into `poolNamespace`, which simply equals the controller namespace here. No collision: husk and forkd secrets have different names.
- Fix the now-false doc comment.
- `docs/threat-model.md`: note that the single-namespace topology naturally holds `ca.key`, so the cross-namespace isolation property applies only to multi-namespace deployments; multi-tenant deployments must give each pool its own namespace.

## Verification

- [x] TDD: added `TestEnsureHuskTLSWritesLeafInControllerNamespace` (pool ns == controller ns), watched it fail (secret not created), then pass. Existing per-namespace and rotation tests still pass.
- [x] `go test ./internal/controller/ -run TestEnsureHuskTLS` green (envtest); `gofmt` clean.

## Risks

Low risk. Only adds a Secret in the controller namespace for the single-namespace case; multi-namespace behavior is unchanged.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta included (security surface moved: single-namespace topology)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
