### PR TITLE
fix(chart): default console.replicas to 1 so OIDC login works (#427)

### DIFF
--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -279,8 +279,12 @@ console:
     repository: mitos-console
     tag: v0.13.0
     pullPolicy: IfNotPresent
-  # Console replicas. The BFF is stateless; run more than one for HA.
-  replicas: 2
+  # Console replicas. The OIDC login flow keeps session and OIDC-state per-pod in
+  # memory with no shared backing, so multiple replicas behind one Service break
+  # login: /auth/login and /auth/callback can land on different pods and the state
+  # no longer matches (#427). Default to 1; running more than one for HA requires a
+  # shared session store first (sticky sessions or a backed store).
+  replicas: 1
   resources:
     requests:
       memory: "64Mi"


### PR DESCRIPTION
## Thinking Path

> - Mitos ships a web console (BFF plus SPA) installed by the Helm chart, with OIDC login for self-host and hosted editions.
> - The console BFF keeps session and OIDC-state per-pod in memory with no shared backing store.
> - The chart default ran the console at `replicas: 2` behind a single Service.
> - So `/auth/login` and `/auth/callback` could land on different pods, the OIDC state did not match, and login failed silently (the SPA shows console unavailable / 401 on `/console/capabilities`; found deploying with Dex on k3s).
> - This serves ROADMAP section 0 and the first-prod-QA install path (a self-host operator cannot log into the console).
> - This pull request defaults `console.replicas` to 1, the working configuration, and documents that HA needs a shared session store first.
> - The benefit is OIDC console login works out of the box.

## Linked Issues or Issue Description

Fixes #427.

## What Changed

- Default `console.replicas` to `1` in `deploy/charts/mitos/values.yaml`; the Deployment template already reads the value directly.
- Document in the value comment that HA requires a shared session store (sticky sessions or a backed store) as a follow-up.

## Verification

- [x] `helm template --kube-version 1.31.0` renders the console Deployment with `replicas: 1` (controller stays `2`); `helm-lint` covers it in CI.

## Risks

Low risk. Single console replica has no HA; the comment records that and the shared-session-store follow-up.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD) (n/a; chart default)
- [x] Docs updated in the same PR (value comment)
- [x] Threat-model delta included if the security surface moved (n/a)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
