### PR TITLE
feat(runmanifest): mitos.yaml -> golden pool + per-fork provisioner (Run with Mitos, slices 1-2)

### DIFF
--- a/internal/runmanifest/manifest.go
+++ b/internal/runmanifest/manifest.go
@@ -1,0 +1,155 @@
+// Package runmanifest parses and validates the mitos.yaml "Run with Mitos"
+// manifest (schema v1) and maps it to the mitos primitives: a golden SandboxPool
+// to fork from, plus the run, preview, secret, egress, workspace, and auto-update
+// (track) intent the provisioner and the auto-update reconciler consume.
+//
+// This is the foundation slice of the Run with Mitos feature (issue #340, the
+// production funnel #440). It does pure parsing, validation, and mapping; it holds
+// no cluster, no I/O, and no secret values (secret VALUES are supplied per-fork at
+// run time, never in the manifest, never in the golden snapshot).
+package runmanifest
+
+// SchemaVersion is the only manifest schema version this package understands.
+const SchemaVersion = 1
+
+// Manifest is a parsed mitos.yaml. Every field maps to a step in the click ->
+// fork -> serve flow; see the package doc and docs/superpowers/specs for the
+// full design.
+type Manifest struct {
+	// Version is the manifest schema version; only SchemaVersion is accepted.
+	// Zero is treated as SchemaVersion for forward-friendly minimal manifests.
+	Version int `json:"version,omitempty"`
+
+	// Name is the DNS-label identity of the app (pool name, URL label).
+	Name string `json:"name"`
+	// Title and Icon are presentation only (the consent screen, the badge).
+	Title string `json:"title,omitempty"`
+	Icon  string `json:"icon,omitempty"`
+
+	// Source is where the golden template comes from (image or build) and how it
+	// tracks upstream for auto-update.
+	Source Source `json:"source"`
+
+	// Run is the workload baked into the golden snapshot.
+	Run Run `json:"run"`
+
+	// Preview is the interactable surface that becomes the live URL.
+	Preview Preview `json:"preview"`
+
+	// Secrets are prompted at click and injected per-fork; never baked into the
+	// golden (fork-correctness secret non-inheritance).
+	Secrets []Secret `json:"secrets,omitempty"`
+
+	// Egress is the default-deny outbound allowlist for the sandbox.
+	Egress Egress `json:"egress,omitempty"`
+
+	// Workspace is the durable, versioned path that survives updates and rebases.
+	Workspace *Workspace `json:"workspace,omitempty"`
+
+	// Resources sizes each forked instance.
+	Resources Resources `json:"resources,omitempty"`
+}
+
+// Source declares the golden's origin and its auto-update tracking.
+type Source struct {
+	// Image is the OCI image the golden is built from. Mutually exclusive with
+	// Build; exactly one must be set.
+	Image string `json:"image,omitempty"`
+	// Build builds the golden from a repo when no published image exists.
+	Build *Build `json:"build,omitempty"`
+	// Track watches upstream and re-snapshots the golden on a new release.
+	Track *Track `json:"track,omitempty"`
+}
+
+// Build builds the golden from source.
+type Build struct {
+	Repo       string `json:"repo"`
+	Dockerfile string `json:"dockerfile,omitempty"`
+}
+
+// Track is the auto-update policy.
+type Track struct {
+	// Watch is the image or repo to watch for new releases.
+	Watch string `json:"watch"`
+	// Channel is the tag, semver range, or branch to follow.
+	Channel string `json:"channel,omitempty"`
+	// OnNewRelease is the action on a new release. The conservative default is
+	// resnapshot+offer-rebase (re-snapshot the golden, offer instances a rebase).
+	OnNewRelease OnNewRelease `json:"on_new_release,omitempty"`
+}
+
+// OnNewRelease is the auto-update action.
+type OnNewRelease string
+
+const (
+	// ResnapshotOfferRebase re-snapshots the golden and offers running instances a
+	// one-click rebase (the safe default).
+	ResnapshotOfferRebase OnNewRelease = "resnapshot+offer-rebase"
+	// ResnapshotAutoRebase re-snapshots and auto-rebases instances (opt-in).
+	ResnapshotAutoRebase OnNewRelease = "resnapshot+auto-rebase"
+	// ResnapshotOnly re-snapshots the golden but leaves running instances alone.
+	ResnapshotOnly OnNewRelease = "resnapshot"
+)
+
+// Run is the workload the golden runs.
+type Run struct {
+	// Command overrides the image entrypoint. Empty inherits the image CMD.
+	Command []string `json:"command,omitempty"`
+	// Workdir runs the command from this directory.
+	Workdir string `json:"workdir,omitempty"`
+	// Env are NON-secret environment variables baked into the golden. Secret
+	// values come from Secrets, injected per-fork.
+	Env map[string]string `json:"env,omitempty"`
+	// Ready gates when the golden is snapshotted, so every fork boots serving.
+	Ready *Ready `json:"ready,omitempty"`
+}
+
+// Ready is the snapshot-after-serving gate.
+type Ready struct {
+	HTTP    *HTTPReady `json:"http,omitempty"`
+	Timeout string     `json:"timeout,omitempty"`
+}
+
+// HTTPReady is an HTTP health gate.
+type HTTPReady struct {
+	Port   int    `json:"port"`
+	Path   string `json:"path,omitempty"`
+	Expect int    `json:"expect,omitempty"`
+}
+
+// Preview is the interactable port and its auth posture.
+type Preview struct {
+	Port int `json:"port"`
+	// Auth is the expose auth posture; "ladder" is the private-by-default default.
+	Auth string `json:"auth,omitempty"`
+}
+
+// Secret is a secret the clicker supplies. Only its SHAPE lives here; the VALUE
+// is collected at run time and injected per-fork.
+type Secret struct {
+	Name     string `json:"name"`
+	Label    string `json:"label,omitempty"`
+	Required bool   `json:"required,omitempty"`
+	// Generate, when > 0, lets mitos mint a random secret of this byte length if
+	// the clicker leaves it blank.
+	Generate int `json:"generate,omitempty"`
+}
+
+// Egress is the default-deny outbound allowlist.
+type Egress struct {
+	Allow []string `json:"allow,omitempty"`
+}
+
+// Workspace is the durable, versioned path.
+type Workspace struct {
+	Path    string `json:"path"`
+	Persist bool   `json:"persist,omitempty"`
+}
+
+// Resources sizes each forked instance.
+type Resources struct {
+	Pool     string `json:"pool,omitempty"`
+	CPU      string `json:"cpu,omitempty"`
+	Memory   string `json:"memory,omitempty"`
+	Lifetime string `json:"lifetime,omitempty"`
+}

--- a/internal/runmanifest/manifest_test.go
+++ b/internal/runmanifest/manifest_test.go
@@ -1,0 +1,150 @@
+package runmanifest
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func mustRead(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return b
+}
+
+// TestParseExamples asserts every shipped example manifest parses and validates.
+func TestParseExamples(t *testing.T) {
+	for _, f := range []string{"openclaw.yaml", "deerflow.yaml", "hermes.yaml"} {
+		if _, err := Parse(mustRead(t, f)); err != nil {
+			t.Errorf("%s: Parse: %v", f, err)
+		}
+	}
+}
+
+// TestGoldenPoolOpenClaw asserts the image-based manifest maps to a golden pool
+// with the workdir-wrapped command, non-secret env, resources, the ready snapshot
+// trigger, and a warm floor.
+func TestGoldenPoolOpenClaw(t *testing.T) {
+	m, err := Parse(mustRead(t, "openclaw.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	pool, err := m.GoldenPool("sandboxes")
+	if err != nil {
+		t.Fatalf("GoldenPool: %v", err)
+	}
+	if pool.Name != "openclaw" || pool.Namespace != "sandboxes" {
+		t.Fatalf("pool identity = %s/%s, want openclaw/sandboxes", pool.Namespace, pool.Name)
+	}
+	tpl := pool.Spec.Template
+	if tpl == nil {
+		t.Fatal("template is nil")
+	}
+	if tpl.Image != "ghcr.io/openclaw/openclaw:latest" {
+		t.Errorf("image = %q", tpl.Image)
+	}
+	// workdir set -> command wrapped in sh -c with cd and exec.
+	if len(tpl.Command) != 3 || tpl.Command[0] != "sh" || tpl.Command[1] != "-c" {
+		t.Fatalf("command not shell-wrapped: %v", tpl.Command)
+	}
+	if !strings.Contains(tpl.Command[2], "cd '/app' && exec 'node' 'openclaw.mjs'") {
+		t.Errorf("wrapped command = %q", tpl.Command[2])
+	}
+	if tpl.Resources.CPU.String() != "2" || tpl.Resources.Memory.String() != "2Gi" {
+		t.Errorf("resources = %s/%s", tpl.Resources.CPU.String(), tpl.Resources.Memory.String())
+	}
+	if pool.Spec.Snapshots == nil || pool.Spec.Snapshots.SnapshotAfter != "Ready" {
+		t.Errorf("snapshot trigger = %+v", pool.Spec.Snapshots)
+	}
+	if pool.Spec.Warm == nil || pool.Spec.Warm.Min != 1 {
+		t.Errorf("warm = %+v", pool.Spec.Warm)
+	}
+	// Non-secret env carries HOME but never a secret name.
+	var sawHome bool
+	for _, e := range tpl.Env {
+		if e.Name == "HOME" && e.Value == "/home/node" {
+			sawHome = true
+		}
+	}
+	if !sawHome {
+		t.Error("non-secret env HOME missing from golden")
+	}
+}
+
+// TestSecretValuesNeverInGolden is the load-bearing security property: declared
+// secrets must NOT appear in the golden snapshot's env (they are injected
+// per-fork). The golden is shareable precisely because it holds no clicker keys.
+func TestSecretValuesNeverInGolden(t *testing.T) {
+	m, err := Parse(mustRead(t, "openclaw.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	pool, err := m.GoldenPool("sandboxes")
+	if err != nil {
+		t.Fatalf("GoldenPool: %v", err)
+	}
+	secretNames := map[string]bool{}
+	for _, s := range m.Secrets {
+		secretNames[s.Name] = true
+	}
+	if len(secretNames) == 0 {
+		t.Fatal("fixture has no secrets to check")
+	}
+	for _, e := range pool.Spec.Template.Env {
+		if secretNames[e.Name] {
+			t.Errorf("secret %q leaked into the golden snapshot env", e.Name)
+		}
+	}
+	// And the required-secret set is what the consent screen would prompt for.
+	if got := m.RequiredSecretNames(); len(got) != 1 || got[0] != "ANTHROPIC_API_KEY" {
+		t.Errorf("required secrets = %v, want [ANTHROPIC_API_KEY]", got)
+	}
+}
+
+// TestGoldenPoolBuildNotYet asserts a build-from-source manifest parses but
+// GoldenPool fails loudly until that slice lands (no silent half-mapping).
+func TestGoldenPoolBuildNotYet(t *testing.T) {
+	m, err := Parse(mustRead(t, "deerflow.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if _, err := m.GoldenPool("sandboxes"); err == nil {
+		t.Fatal("GoldenPool on a build-from-source manifest should error until that slice lands")
+	} else if !strings.Contains(err.Error(), "source.image") {
+		t.Errorf("error should name source.image, got: %v", err)
+	}
+}
+
+// TestValidateErrors covers the actionable failure modes.
+func TestValidateErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"missing name", "source: {image: x}\npreview: {port: 80}", "name is required"},
+		{"bad name", "name: Bad_Name\nsource: {image: x}\npreview: {port: 80}", "DNS label"},
+		{"image and build", "name: a\nsource: {image: x, build: {repo: r}}\npreview: {port: 80}", "exactly one of image or build"},
+		{"no source", "name: a\nsource: {}\npreview: {port: 80}", "requires an image"},
+		{"no preview port", "name: a\nsource: {image: x}\npreview: {}", "preview.port is required"},
+		{"bad preview auth", "name: a\nsource: {image: x}\npreview: {port: 80, auth: open}", "preview.auth"},
+		{"dup secret", "name: a\nsource: {image: x}\npreview: {port: 80}\nsecrets: [{name: K}, {name: K}]", "more than once"},
+		{"bad cpu", "name: a\nsource: {image: x}\npreview: {port: 80}\nresources: {cpu: two}", "resources.cpu"},
+		{"bad track action", "name: a\nsource: {image: x, track: {watch: w, on_new_release: yolo}}\npreview: {port: 80}", "on_new_release"},
+		{"unknown field", "name: a\nsource: {image: x}\npreview: {port: 80}\nbogus: 1", "parse"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse([]byte(c.yaml))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error = %q, want substring %q", err.Error(), c.want)
+			}
+		})
+	}
+}

--- a/internal/runmanifest/parse.go
+++ b/internal/runmanifest/parse.go
@@ -1,0 +1,150 @@
+package runmanifest
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/yaml"
+)
+
+// dnsLabel matches a Kubernetes DNS label: lowercase alphanumerics and hyphens,
+// not starting or ending with a hyphen, at most 63 characters. The name becomes a
+// pool name and a URL label, so it must be a valid DNS label.
+var dnsLabel = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+
+// envName matches a POSIX-ish environment variable name (the shape a secret or
+// env key must take).
+var envName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// Parse decodes a mitos.yaml manifest and validates it. It rejects unknown fields
+// (strict) so a typo fails loudly with an actionable error rather than silently
+// dropping config. The returned Manifest is safe to map with GoldenPool.
+func Parse(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := yaml.UnmarshalStrict(data, &m); err != nil {
+		return nil, fmt.Errorf("mitos.yaml: parse: %w", err)
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Validate checks the manifest is internally consistent and complete enough to
+// provision. Errors carry the field and an actionable remediation, per the API v2
+// LLM-legible error rule (#28).
+func (m *Manifest) Validate() error {
+	if m.Version != 0 && m.Version != SchemaVersion {
+		return fmt.Errorf("mitos.yaml: unsupported version %d; this build understands version %d", m.Version, SchemaVersion)
+	}
+	if m.Name == "" {
+		return fmt.Errorf("mitos.yaml: name is required (a DNS label, for example \"openclaw\")")
+	}
+	if !dnsLabel.MatchString(m.Name) {
+		return fmt.Errorf("mitos.yaml: name %q must be a DNS label (lowercase alphanumerics and hyphens, no leading or trailing hyphen, max 63 chars)", m.Name)
+	}
+
+	// Source: exactly one of image or build.
+	hasImage := m.Source.Image != ""
+	hasBuild := m.Source.Build != nil
+	switch {
+	case hasImage && hasBuild:
+		return fmt.Errorf("mitos.yaml: source must set exactly one of image or build, not both")
+	case !hasImage && !hasBuild:
+		return fmt.Errorf("mitos.yaml: source requires an image (for example ghcr.io/org/app:latest) or a build block")
+	}
+	if hasBuild && m.Source.Build.Repo == "" {
+		return fmt.Errorf("mitos.yaml: source.build.repo is required when building from source")
+	}
+	if t := m.Source.Track; t != nil {
+		if t.Watch == "" {
+			return fmt.Errorf("mitos.yaml: source.track.watch is required (the image or repo to watch for releases)")
+		}
+		switch t.OnNewRelease {
+		case "", ResnapshotOfferRebase, ResnapshotAutoRebase, ResnapshotOnly:
+		default:
+			return fmt.Errorf("mitos.yaml: source.track.on_new_release %q is not one of resnapshot+offer-rebase, resnapshot+auto-rebase, resnapshot", t.OnNewRelease)
+		}
+	}
+
+	// Run.
+	for k := range m.Run.Env {
+		if !envName.MatchString(k) {
+			return fmt.Errorf("mitos.yaml: run.env key %q is not a valid environment variable name", k)
+		}
+	}
+	if r := m.Run.Ready; r != nil {
+		if r.HTTP == nil {
+			return fmt.Errorf("mitos.yaml: run.ready needs an http gate (run.ready.http.port)")
+		}
+		if r.HTTP.Port <= 0 || r.HTTP.Port > 65535 {
+			return fmt.Errorf("mitos.yaml: run.ready.http.port %d is out of range 1-65535", r.HTTP.Port)
+		}
+		if r.Timeout != "" {
+			if _, err := time.ParseDuration(r.Timeout); err != nil {
+				return fmt.Errorf("mitos.yaml: run.ready.timeout %q is not a duration (for example 90s): %w", r.Timeout, err)
+			}
+		}
+	}
+
+	// Preview.
+	if m.Preview.Port <= 0 || m.Preview.Port > 65535 {
+		return fmt.Errorf("mitos.yaml: preview.port is required and must be 1-65535 (the port your live surface serves on)")
+	}
+	switch m.Preview.Auth {
+	case "", "ladder", "required":
+	default:
+		return fmt.Errorf("mitos.yaml: preview.auth %q is not one of ladder, required", m.Preview.Auth)
+	}
+
+	// Secrets.
+	seen := map[string]bool{}
+	for i, s := range m.Secrets {
+		if s.Name == "" {
+			return fmt.Errorf("mitos.yaml: secrets[%d].name is required", i)
+		}
+		if !envName.MatchString(s.Name) {
+			return fmt.Errorf("mitos.yaml: secrets[%d].name %q is not a valid environment variable name", i, s.Name)
+		}
+		if seen[s.Name] {
+			return fmt.Errorf("mitos.yaml: secret %q is declared more than once", s.Name)
+		}
+		seen[s.Name] = true
+		if s.Generate < 0 {
+			return fmt.Errorf("mitos.yaml: secrets[%d].generate must be >= 0", i)
+		}
+	}
+
+	// Egress.
+	for i, a := range m.Egress.Allow {
+		if strings.TrimSpace(a) == "" {
+			return fmt.Errorf("mitos.yaml: egress.allow[%d] is empty", i)
+		}
+	}
+
+	// Workspace.
+	if m.Workspace != nil && m.Workspace.Path == "" {
+		return fmt.Errorf("mitos.yaml: workspace.path is required when a workspace is declared")
+	}
+
+	// Resources.
+	if m.Resources.CPU != "" {
+		if _, err := resource.ParseQuantity(m.Resources.CPU); err != nil {
+			return fmt.Errorf("mitos.yaml: resources.cpu %q is not a quantity (for example \"2\"): %w", m.Resources.CPU, err)
+		}
+	}
+	if m.Resources.Memory != "" {
+		if _, err := resource.ParseQuantity(m.Resources.Memory); err != nil {
+			return fmt.Errorf("mitos.yaml: resources.memory %q is not a quantity (for example \"2Gi\"): %w", m.Resources.Memory, err)
+		}
+	}
+	switch m.Resources.Lifetime {
+	case "", "persistent", "ephemeral":
+	default:
+		return fmt.Errorf("mitos.yaml: resources.lifetime %q is not one of persistent, ephemeral", m.Resources.Lifetime)
+	}
+	return nil
+}

--- a/internal/runmanifest/plan.go
+++ b/internal/runmanifest/plan.go
@@ -55,6 +55,7 @@ func (m *Manifest) GoldenPool(namespace string) (*v1.SandboxPool, error) {
 				Command:   m.effectiveCommand(),
 				Env:       m.nonSecretEnv(),
 				Resources: res,
+				Network:   m.egressPolicy(),
 			},
 			Snapshots: &v1.PoolSnapshots{
 				ReplicasPerNode: 1,
@@ -120,6 +121,20 @@ func (m *Manifest) sandboxResources() (v1.SandboxResources, error) {
 		r.Memory = q
 	}
 	return r, nil
+}
+
+// egressPolicy turns the manifest egress allowlist into a default-deny pool
+// network policy: deny everything, allow only the declared destinations. An empty
+// allowlist leaves the pool default in place (nil) rather than block all egress,
+// since some apps declare egress per-fork; the provisioner can still tighten it.
+func (m *Manifest) egressPolicy() *v1.NetworkPolicy {
+	if len(m.Egress.Allow) == 0 {
+		return nil
+	}
+	return &v1.NetworkPolicy{
+		Egress: v1.EgressDeny,
+		Allow:  append([]string(nil), m.Egress.Allow...),
+	}
 }
 
 // RequiredSecretNames returns the names of secrets the clicker must supply (those

--- a/internal/runmanifest/plan.go
+++ b/internal/runmanifest/plan.go
@@ -1,0 +1,141 @@
+package runmanifest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// PoolName is the SandboxPool name for this manifest (resources.pool override, or
+// the manifest name).
+func (m *Manifest) PoolName() string {
+	if m.Resources.Pool != "" {
+		return m.Resources.Pool
+	}
+	return m.Name
+}
+
+// GoldenPool maps the manifest to the golden v1.SandboxPool that instances fork
+// from. It bakes only NON-secret config: the image, the (workdir-wrapped) command,
+// non-secret env, and resources. Secret values are injected per-fork by the
+// provisioner and never appear here, so the golden snapshot is shareable without
+// leaking any clicker's keys (fork-correctness secret non-inheritance).
+//
+// Build-from-source goldens (source.build) resolve to a built image in a later
+// slice; until then GoldenPool requires source.image and returns an actionable
+// error otherwise. The HTTP ready gate is preserved on the manifest for the
+// snapshot-after-serving slice; this mapping uses the existing SnapshotAfterReady
+// trigger.
+func (m *Manifest) GoldenPool(namespace string) (*v1.SandboxPool, error) {
+	if m.Source.Image == "" {
+		return nil, fmt.Errorf("mitos.yaml %q: GoldenPool needs source.image; build-from-source golden resolution is a later slice", m.Name)
+	}
+	res, err := m.sandboxResources()
+	if err != nil {
+		return nil, err
+	}
+	pool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.PoolName(),
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "run-with-mitos",
+				"mitos.run/run-manifest":       m.Name,
+			},
+		},
+		Spec: v1.SandboxPoolSpec{
+			Template: &v1.PoolTemplateSpec{
+				Image:     m.Source.Image,
+				Command:   m.effectiveCommand(),
+				Env:       m.nonSecretEnv(),
+				Resources: res,
+			},
+			Snapshots: &v1.PoolSnapshots{
+				ReplicasPerNode: 1,
+				SnapshotAfter:   v1.SnapshotAfterReady,
+			},
+			Warm: &v1.PoolWarm{Min: 1},
+		},
+	}
+	return pool, nil
+}
+
+// effectiveCommand returns the command to run in the guest, honoring run.workdir by
+// wrapping in a shell when a workdir is set. With no command the image entrypoint
+// is inherited (nil).
+func (m *Manifest) effectiveCommand() []string {
+	if len(m.Run.Command) == 0 {
+		return nil
+	}
+	if m.Run.Workdir == "" {
+		return append([]string(nil), m.Run.Command...)
+	}
+	quoted := make([]string, len(m.Run.Command))
+	for i, c := range m.Run.Command {
+		quoted[i] = shellQuote(c)
+	}
+	return []string{"sh", "-c", fmt.Sprintf("cd %s && exec %s", shellQuote(m.Run.Workdir), strings.Join(quoted, " "))}
+}
+
+// nonSecretEnv maps run.env to a deterministically ordered []corev1.EnvVar. Secret
+// values are NOT here; they are injected per-fork.
+func (m *Manifest) nonSecretEnv() []corev1.EnvVar {
+	if len(m.Run.Env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m.Run.Env))
+	for k := range m.Run.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]corev1.EnvVar, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, corev1.EnvVar{Name: k, Value: m.Run.Env[k]})
+	}
+	return out
+}
+
+// sandboxResources parses the manifest CPU and memory into a SandboxResources.
+// Validation already verified they parse; this re-parses to build the typed value.
+func (m *Manifest) sandboxResources() (v1.SandboxResources, error) {
+	var r v1.SandboxResources
+	if m.Resources.CPU != "" {
+		q, err := resource.ParseQuantity(m.Resources.CPU)
+		if err != nil {
+			return r, fmt.Errorf("mitos.yaml %q: resources.cpu: %w", m.Name, err)
+		}
+		r.CPU = q
+	}
+	if m.Resources.Memory != "" {
+		q, err := resource.ParseQuantity(m.Resources.Memory)
+		if err != nil {
+			return r, fmt.Errorf("mitos.yaml %q: resources.memory: %w", m.Name, err)
+		}
+		r.Memory = q
+	}
+	return r, nil
+}
+
+// RequiredSecretNames returns the names of secrets the clicker must supply (those
+// not mintable via generate). The provisioner uses this to drive the consent
+// screen and to fail closed when a required secret is missing.
+func (m *Manifest) RequiredSecretNames() []string {
+	var out []string
+	for _, s := range m.Secrets {
+		if s.Required {
+			out = append(out, s.Name)
+		}
+	}
+	return out
+}
+
+// shellQuote single-quotes a string for safe use inside an sh -c command.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/runmanifest/provision.go
+++ b/internal/runmanifest/provision.go
@@ -1,0 +1,128 @@
+package runmanifest
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// ProvisionResult is what one click produces: a per-fork Secret holding the
+// clicker's values, and the Sandbox that forks the golden and consumes them. The
+// caller applies both. Secret VALUES live only in Result.Secret.Data; this package
+// never logs them.
+type ProvisionResult struct {
+	Secret  *corev1.Secret
+	Sandbox *v1.Sandbox
+}
+
+// randSource is the entropy used for generated secrets; overridable in tests.
+var randSource = rand.Read
+
+// Provision maps a manifest plus the clicker-supplied secret values into a
+// per-fork Sandbox (forking the golden pool) and the Secret that backs it.
+//
+// instanceLabel is the single DNS label for this instance: the expose subdomain
+// (label.<expose-domain>), the Secret/Sandbox/Workspace names. Required secrets
+// that are neither supplied nor mintable fail closed. Mintable secrets
+// (generate > 0) left blank are minted from crypto/rand. SecretInheritance is set
+// to reissue so a fork never inherits the golden's in-memory secrets.
+func Provision(m *Manifest, supplied map[string]string, namespace, instanceLabel string) (*ProvisionResult, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	if !dnsLabel.MatchString(instanceLabel) {
+		return nil, fmt.Errorf("instance label %q must be a DNS label", instanceLabel)
+	}
+
+	values := map[string][]byte{}
+	var mounts []v1.SecretMount
+	secretName := instanceLabel + "-secrets"
+	for _, s := range m.Secrets {
+		v, ok := supplied[s.Name]
+		switch {
+		case ok && v != "":
+			values[s.Name] = []byte(v)
+		case s.Generate > 0:
+			minted, err := generateSecret(s.Generate)
+			if err != nil {
+				return nil, fmt.Errorf("mint secret %q: %w", s.Name, err)
+			}
+			values[s.Name] = []byte(minted)
+		case s.Required:
+			return nil, fmt.Errorf("secret %q is required but was not provided", s.Name)
+		default:
+			continue // optional, not supplied: skip it.
+		}
+		mounts = append(mounts, v1.SecretMount{
+			Name:      s.Name,
+			SecretRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: secretName}, Key: s.Name},
+			EnvVar:    s.Name,
+		})
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "run-with-mitos",
+				"mitos.run/run-manifest":       m.Name,
+				"mitos.run/instance":           instanceLabel,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: values,
+	}
+
+	sandbox := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceLabel,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "run-with-mitos",
+				"mitos.run/run-manifest":       m.Name,
+				"mitos.run/instance":           instanceLabel,
+			},
+		},
+		Spec: v1.SandboxSpec{
+			Source:            v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: m.PoolName()}},
+			Secrets:           mounts,
+			SecretInheritance: v1.SecretReissue,
+			Expose: &v1.SandboxExpose{
+				Port:    int32(m.Preview.Port),
+				Label:   instanceLabel,
+				Sharing: exposeSharing(m.Preview.Auth),
+			},
+		},
+	}
+	if m.Workspace != nil && m.Workspace.Persist {
+		sandbox.Spec.WorkspaceRef = &v1.LocalObjectReference{Name: instanceLabel + "-workspace"}
+	}
+
+	return &ProvisionResult{Secret: secret, Sandbox: sandbox}, nil
+}
+
+// exposeSharing maps the manifest preview.auth to the expose sharing tier. The
+// auth ladder requires a verified identity; the default is owner-private.
+func exposeSharing(auth string) string {
+	switch auth {
+	case "ladder", "required":
+		return "authenticated"
+	default:
+		return "private"
+	}
+}
+
+// generateSecret returns a hex string carrying n bytes of entropy.
+func generateSecret(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := randSource(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/runmanifest/provision_test.go
+++ b/internal/runmanifest/provision_test.go
@@ -1,0 +1,125 @@
+package runmanifest
+
+import (
+	"strings"
+	"testing"
+
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// TestGoldenPoolEgress asserts the manifest egress allowlist becomes a default-deny
+// pool network policy.
+func TestGoldenPoolEgress(t *testing.T) {
+	m, err := Parse(mustRead(t, "openclaw.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	pool, err := m.GoldenPool("sandboxes")
+	if err != nil {
+		t.Fatalf("GoldenPool: %v", err)
+	}
+	np := pool.Spec.Template.Network
+	if np == nil {
+		t.Fatal("expected a default-deny network policy from egress")
+	}
+	if np.Egress != v1.EgressDeny {
+		t.Errorf("egress = %q, want deny", np.Egress)
+	}
+	if len(np.Allow) != 2 || np.Allow[0] != "api.anthropic.com" {
+		t.Errorf("allow = %v", np.Allow)
+	}
+}
+
+// TestProvisionOpenClaw is the core of slice 2: clicker supplies one key, the
+// mintable token is generated, and the result is a fork of the golden with the
+// secret mounted, expose configured, workspace bound, and non-inheritance set.
+func TestProvisionOpenClaw(t *testing.T) {
+	m, err := Parse(mustRead(t, "openclaw.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "sk-real"}, "tenant-jannes", "jannes-openclaw")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Secret holds the supplied value and a minted token (32 bytes -> 64 hex chars).
+	if got := string(res.Secret.Data["ANTHROPIC_API_KEY"]); got != "sk-real" {
+		t.Errorf("supplied secret = %q", got)
+	}
+	tok := string(res.Secret.Data["OPENCLAW_GATEWAY_TOKEN"])
+	if len(tok) != 64 {
+		t.Errorf("minted token len = %d, want 64 hex chars", len(tok))
+	}
+
+	sb := res.Sandbox
+	if sb.Spec.Source.PoolRef == nil || sb.Spec.Source.PoolRef.Name != "openclaw" {
+		t.Errorf("poolRef = %+v, want openclaw", sb.Spec.Source.PoolRef)
+	}
+	if sb.Spec.SecretInheritance != v1.SecretReissue {
+		t.Errorf("secretInheritance = %q, want reissue (non-inheritance)", sb.Spec.SecretInheritance)
+	}
+	if len(sb.Spec.Secrets) != 2 {
+		t.Fatalf("secret mounts = %d, want 2", len(sb.Spec.Secrets))
+	}
+	for _, mt := range sb.Spec.Secrets {
+		if mt.SecretRef.Name != "jannes-openclaw-secrets" {
+			t.Errorf("mount %s references %q, want jannes-openclaw-secrets", mt.Name, mt.SecretRef.Name)
+		}
+	}
+	if sb.Spec.Expose == nil || sb.Spec.Expose.Port != 18789 || sb.Spec.Expose.Label != "jannes-openclaw" {
+		t.Errorf("expose = %+v", sb.Spec.Expose)
+	}
+	if sb.Spec.Expose.Sharing != "authenticated" {
+		t.Errorf("sharing = %q, want authenticated (auth ladder)", sb.Spec.Expose.Sharing)
+	}
+	if sb.Spec.WorkspaceRef == nil || sb.Spec.WorkspaceRef.Name != "jannes-openclaw-workspace" {
+		t.Errorf("workspaceRef = %+v", sb.Spec.WorkspaceRef)
+	}
+}
+
+// TestProvisionSecretValuesOnlyInSecret asserts secret VALUES live only in the
+// Secret, never inlined into the Sandbox spec.
+func TestProvisionSecretValuesOnlyInSecret(t *testing.T) {
+	m, _ := Parse(mustRead(t, "openclaw.yaml"))
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "sk-leak-canary"}, "ns", "inst")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	for _, mt := range res.Sandbox.Spec.Secrets {
+		// A SecretMount carries only a reference, never the value.
+		if strings.Contains(mt.SecretRef.Name, "sk-leak-canary") || mt.EnvVar == "sk-leak-canary" {
+			t.Error("secret value leaked into the Sandbox spec")
+		}
+	}
+}
+
+// TestProvisionRequiredMissing fails closed when a required secret is absent.
+func TestProvisionRequiredMissing(t *testing.T) {
+	m, _ := Parse(mustRead(t, "openclaw.yaml"))
+	_, err := Provision(m, map[string]string{}, "ns", "inst")
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected required-secret error, got: %v", err)
+	}
+}
+
+// TestProvisionDeterministicMint stubs entropy to assert minting is wired and the
+// minted value lands in the Secret.
+func TestProvisionDeterministicMint(t *testing.T) {
+	orig := randSource
+	t.Cleanup(func() { randSource = orig })
+	randSource = func(b []byte) (int, error) {
+		for i := range b {
+			b[i] = 0xAB
+		}
+		return len(b), nil
+	}
+	m, _ := Parse(mustRead(t, "openclaw.yaml"))
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", "inst")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got := string(res.Secret.Data["OPENCLAW_GATEWAY_TOKEN"]); got != strings.Repeat("ab", 32) {
+		t.Errorf("minted token = %q", got)
+	}
+}

--- a/internal/runmanifest/testdata/deerflow.yaml
+++ b/internal/runmanifest/testdata/deerflow.yaml
@@ -1,0 +1,27 @@
+name: deerflow
+title: DeerFlow . multi-agent research harness
+source:
+  build:
+    repo: github.com/bytedance/deer-flow
+  track:
+    watch: github.com/bytedance/deer-flow
+    channel: main
+run:
+  command: ["make", "docker-start"]
+  ready:
+    http: { port: 2026, path: /, expect: 200 }
+    timeout: 180s
+preview:
+  port: 2026
+  auth: ladder
+secrets:
+  - { name: ANTHROPIC_API_KEY, label: Model key, required: true }
+  - { name: TAVILY_API_KEY, label: Web search key, required: false }
+egress:
+  allow: [api.anthropic.com, api.tavily.com]
+workspace:
+  path: /app/data
+  persist: true
+resources:
+  cpu: "4"
+  memory: 4Gi

--- a/internal/runmanifest/testdata/hermes.yaml
+++ b/internal/runmanifest/testdata/hermes.yaml
@@ -1,0 +1,25 @@
+name: hermes-agent
+title: Hermes . self-improving AI agent
+source:
+  image: docker.io/nousresearch/hermes-agent:latest
+  track:
+    watch: docker.io/nousresearch/hermes-agent
+    channel: latest
+    on_new_release: resnapshot+offer-rebase
+run:
+  command: ["gateway", "run"]
+  ready:
+    http: { port: 8642, path: /health, expect: 200 }
+preview:
+  port: 8787
+  auth: ladder
+secrets:
+  - { name: OPENAI_API_KEY, label: Model key, required: true }
+egress:
+  allow: [api.openai.com, api.anthropic.com]
+workspace:
+  path: /opt/data
+  persist: true
+resources:
+  cpu: "2"
+  memory: 2Gi

--- a/internal/runmanifest/testdata/openclaw.yaml
+++ b/internal/runmanifest/testdata/openclaw.yaml
@@ -1,0 +1,32 @@
+name: openclaw
+title: OpenClaw . your personal AI assistant
+source:
+  image: ghcr.io/openclaw/openclaw:latest
+  track:
+    watch: ghcr.io/openclaw/openclaw
+    channel: latest
+    on_new_release: resnapshot+offer-rebase
+run:
+  workdir: /app
+  command: ["node", "openclaw.mjs", "gateway", "--bind", "lan", "--port", "18789"]
+  env:
+    HOME: /home/node
+  ready:
+    http: { port: 18789, path: /healthz, expect: 200 }
+    timeout: 90s
+preview:
+  port: 18789
+  auth: ladder
+secrets:
+  - { name: OPENCLAW_GATEWAY_TOKEN, label: Gateway token, generate: 32 }
+  - { name: ANTHROPIC_API_KEY, label: Claude API key, required: true }
+egress:
+  allow: [api.anthropic.com, api.telegram.org]
+workspace:
+  path: /home/node/.openclaw
+  persist: true
+resources:
+  pool: openclaw
+  cpu: "2"
+  memory: 2Gi
+  lifetime: persistent


### PR DESCRIPTION
## Thinking Path
Run with Mitos (#340, funnel #440) needs a foundation mapping a repo's mitos.yaml to the mitos primitives. Built as pure, cluster-free Go so it is unit-true on its own, with secret isolation encoded as tests, not prose.

## Linked Issues or Issue Description
#340 (button + mitos.yaml), #440 (production funnel). Public arbitrary-repo path stays gated on #341.

## What Changed
`internal/runmanifest`: parse + validate mitos.yaml (schema v1, strict, actionable errors) and map it to the golden `v1.SandboxPool`; the provisioner maps a manifest plus clicker secrets to a per-fork `Sandbox` and `Secret`. Secrets are injected per-fork, never baked into the golden. Egress becomes a default-deny pool policy. Fixtures for openclaw, deerflow, hermes.

## Verification
`go test ./internal/runmanifest/` green; gofmt and go vet clean. `TestSecretValuesNeverInGolden` and `TestProvisionSecretValuesOnlyInSecret` assert secret values never enter the golden snapshot or the Sandbox spec; required-secret fail-closed and validation errors are covered.

## Risks
Pure mapping code, no cluster I/O. Build-from-source goldens and the HTTP ready-gate trigger are preserved on the manifest for later slices and fail loudly until implemented.

## Model Used
Claude Opus 4.8 (1M context)

## Checklist
- [x] Tests added and green
- [x] No secret values logged
- [x] No em or en dashes