### PR TITLE
feat(runservice): click-to-provision run service + HTTP endpoints (Run with Mitos, slice 4)

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -136,8 +136,12 @@ func main() {
 		// binary serves the BFF and the UI. The login flow and the middleware share
 		// ONE session store so a session issued at /auth/callback resolves here.
 		sessions := saas.NewSessionService(sessionStore, accounts)
-		mux.Handle("/console/", console.SessionMiddleware(sessions)(con))
+		sessionMW := console.SessionMiddleware(sessions)
+		mux.Handle("/console/", sessionMW(con))
 		mux.Handle("/", spa.Handler())
+		// Run with Mitos endpoints sit behind the same session auth so each call
+		// carries the verified org. Opt-in via MITOS_CONSOLE_RUN_WITH_MITOS.
+		mountRunWithMitos(mux, sessionMW, logger)
 		if issuer := os.Getenv("MITOS_CONSOLE_OIDC_ISSUER"); issuer != "" {
 			mountAuth(mux, logger, accounts, sessionStore, issuer)
 		} else {

--- a/cmd/console/run.go
+++ b/cmd/console/run.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"mitos.run/mitos/internal/runservice"
+	"mitos.run/mitos/internal/saas/console"
+	"mitos.run/mitos/internal/tenant"
+)
+
+// mountRunWithMitos mounts the Run with Mitos endpoints (GET /run/describe, POST
+// /run) behind the session middleware so each call carries the verified org from
+// the OIDC session (never a client header). It is OPT-IN via
+// MITOS_CONSOLE_RUN_WITH_MITOS and currently UNVERIFIED AT RUNTIME: the
+// unit-tested runservice core is wired to the console's ambient kube client, the
+// verified-org session context, and the per-org namespace map (#410), but it has
+// not yet been exercised against a live cluster end to end.
+//
+// This mounts the FIRST-PARTY flagship path for signed-in tenants. The public
+// arbitrary-repo path stays gated on #341 and is not enabled here.
+func mountRunWithMitos(mux *http.ServeMux, authMiddleware func(http.Handler) http.Handler, logger *slog.Logger) {
+	if os.Getenv("MITOS_CONSOLE_RUN_WITH_MITOS") == "" {
+		return
+	}
+	domain := strings.TrimSpace(os.Getenv("MITOS_EXPOSE_DOMAIN"))
+	if domain == "" {
+		logger.Warn("run-with-mitos requested but MITOS_EXPOSE_DOMAIN is empty; not mounting")
+		return
+	}
+	kc, err := kubeClient()
+	if err != nil {
+		logger.Error("run-with-mitos: kube client unavailable; not mounting", "err", err)
+		return
+	}
+	svc := runservice.New(&runservice.GitHubFetcher{}, &runservice.K8sApplier{Client: kc}, domain)
+	resolver := &runservice.ContextResolver{
+		OrgFromRequest:  func(r *http.Request) (string, bool) { return console.OrgFromContext(r.Context()) },
+		NamespaceForOrg: tenant.NamespaceForOrg,
+	}
+	runMux := http.NewServeMux()
+	runservice.NewHandler(svc, resolver).Routes(runMux)
+	// Both "/run" (POST) and "/run/describe" (GET) route through the sub-mux behind
+	// the session middleware.
+	mux.Handle("/run", authMiddleware(runMux))
+	mux.Handle("/run/", authMiddleware(runMux))
+	logger.Info("run-with-mitos endpoints mounted behind session auth", "exposeDomain", domain)
+}

--- a/internal/runservice/adapters_test.go
+++ b/internal/runservice/adapters_test.go
@@ -129,6 +129,25 @@ func TestTenantResolve(t *testing.T) {
 	}
 }
 
+func TestContextResolver(t *testing.T) {
+	cr := &ContextResolver{
+		OrgFromRequest:  func(*http.Request) (string, bool) { return "org-abc", true },
+		NamespaceForOrg: func(orgID string) string { return "tenant-" + orgID },
+	}
+	id, err := cr.Resolve(httptest.NewRequest("POST", "/run", nil), "github.com/openclaw/openclaw")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if id.Namespace != "tenant-org-abc" || !strings.HasPrefix(id.InstanceLabel, "openclaw-") {
+		t.Errorf("identity = %+v", id)
+	}
+	// Unauthenticated -> fail closed.
+	cr.OrgFromRequest = func(*http.Request) (string, bool) { return "", false }
+	if _, err := cr.Resolve(httptest.NewRequest("POST", "/run", nil), "github.com/o/r"); err == nil {
+		t.Fatal("unauthenticated request should fail closed")
+	}
+}
+
 func TestTenantResolveNotSignedIn(t *testing.T) {
 	tr := &TenantResolver{
 		CurrentEmail:    func(_ *http.Request) (string, error) { return "", errors.New("no session") },

--- a/internal/runservice/adapters_test.go
+++ b/internal/runservice/adapters_test.go
@@ -1,0 +1,141 @@
+package runservice
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/runmanifest"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// TestK8sApplierCreateThenUpdate proves the upsert is idempotent: a second run of
+// the same app reuses (updates) the golden pool rather than failing on conflict.
+func TestK8sApplierCreateThenUpdate(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	ap := &K8sApplier{Client: c}
+
+	m, err := runmanifest.Parse([]byte(openclawYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := m.GoldenPool("ns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ap.Apply(context.Background(), pool); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// A fresh object (no resourceVersion), as a second run would build, must update
+	// in place, not error.
+	pool2, _ := m.GoldenPool("ns")
+	if err := ap.Apply(context.Background(), pool2); err != nil {
+		t.Fatalf("second apply (update): %v", err)
+	}
+
+	var got v1.SandboxPool
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "openclaw"}, &got); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if got.Spec.Template == nil || got.Spec.Template.Image != "ghcr.io/openclaw/openclaw:latest" {
+		t.Errorf("pool not applied correctly: %+v", got.Spec.Template)
+	}
+}
+
+func TestK8sApplierAppliesSecretAndSandbox(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	ap := &K8sApplier{Client: c}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}, Data: map[string][]byte{"K": []byte("v")}}
+	sandbox := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns"}}
+	if err := ap.Apply(context.Background(), secret, sandbox); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "inst"}, &v1.Sandbox{}); err != nil {
+		t.Errorf("sandbox not applied: %v", err)
+	}
+}
+
+func TestInstanceLabel(t *testing.T) {
+	a, err := instanceLabel("github.com/openclaw/openclaw", "org-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deterministic for the same (src, org).
+	b, _ := instanceLabel("github.com/openclaw/openclaw", "org-123")
+	if a != b {
+		t.Errorf("label not deterministic: %q vs %q", a, b)
+	}
+	// Different org -> different label (global subdomain uniqueness).
+	d, _ := instanceLabel("github.com/openclaw/openclaw", "org-999")
+	if a == d {
+		t.Error("different orgs produced the same label")
+	}
+	if !strings.HasPrefix(a, "openclaw-") {
+		t.Errorf("label %q should start with the repo name", a)
+	}
+	// Must be a valid manifest DNS label (Provision will accept it).
+	if _, err := runmanifest.Provision(mustManifest(t, openclawYAML), map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", a); err != nil {
+		t.Errorf("instance label not provisionable: %v", err)
+	}
+}
+
+type fakeAccounts struct {
+	org string
+	err error
+}
+
+func (f fakeAccounts) OrgForEmail(context.Context, string) (string, error) {
+	return f.org, f.err
+}
+
+func TestTenantResolve(t *testing.T) {
+	tr := &TenantResolver{
+		CurrentEmail:    func(_ *http.Request) (string, error) { return "jannes@mitos.run", nil },
+		Accounts:        fakeAccounts{org: "org-abc"},
+		NamespaceForOrg: func(orgID string) string { return "tenant-" + orgID },
+	}
+	id, err := tr.Resolve(httptest.NewRequest("POST", "/run", nil), "github.com/openclaw/openclaw")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if id.Namespace != "tenant-org-abc" {
+		t.Errorf("namespace = %q", id.Namespace)
+	}
+	if !strings.HasPrefix(id.InstanceLabel, "openclaw-") {
+		t.Errorf("label = %q", id.InstanceLabel)
+	}
+}
+
+func TestTenantResolveNotSignedIn(t *testing.T) {
+	tr := &TenantResolver{
+		CurrentEmail:    func(_ *http.Request) (string, error) { return "", errors.New("no session") },
+		Accounts:        fakeAccounts{},
+		NamespaceForOrg: func(string) string { return "ns" },
+	}
+	if _, err := tr.Resolve(httptest.NewRequest("POST", "/run", nil), "github.com/o/r"); err == nil {
+		t.Fatal("expected not-signed-in error")
+	}
+}

--- a/internal/runservice/applier.go
+++ b/internal/runservice/applier.go
@@ -1,0 +1,40 @@
+package runservice
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// K8sApplier is the production Applier: it upserts objects through a
+// controller-runtime client. Create-or-update keeps a repeat run idempotent: the
+// shared golden pool is reused, and re-running an instance reconciles it in place.
+type K8sApplier struct {
+	Client client.Client
+}
+
+// Apply creates each object, or updates it in place if it already exists. Objects
+// are applied in the order given (golden pool, then Secret, then Sandbox) so a
+// fork never references a pool or secret that is not yet present.
+func (a *K8sApplier) Apply(ctx context.Context, objs ...client.Object) error {
+	for _, o := range objs {
+		if err := a.Client.Create(ctx, o); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("apply %T %s/%s: %w", o, o.GetNamespace(), o.GetName(), err)
+			}
+			// Already there: carry the live resourceVersion onto the desired
+			// object and update it in place.
+			existing := o.DeepCopyObject().(client.Object)
+			if err := a.Client.Get(ctx, client.ObjectKeyFromObject(o), existing); err != nil {
+				return fmt.Errorf("apply %T %s/%s: get existing: %w", o, o.GetNamespace(), o.GetName(), err)
+			}
+			o.SetResourceVersion(existing.GetResourceVersion())
+			if err := a.Client.Update(ctx, o); err != nil {
+				return fmt.Errorf("apply %T %s/%s: update: %w", o, o.GetNamespace(), o.GetName(), err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/runservice/fetch.go
+++ b/internal/runservice/fetch.go
@@ -30,9 +30,9 @@ func (g *GitHubFetcher) base() string {
 	return "https://raw.githubusercontent.com"
 }
 
-// manifestURL builds the raw mitos.yaml URL for a src like
-// "github.com/owner/repo" (a leading scheme and a trailing .git are tolerated).
-func manifestURL(base, src string) (string, error) {
+// splitRepo parses a src like "github.com/owner/repo" into owner and repo,
+// tolerating a leading scheme, a "github.com/" prefix, and a trailing ".git".
+func splitRepo(src string) (owner, repo string, err error) {
 	s := strings.TrimSpace(src)
 	for _, p := range []string{"https://", "http://", "github.com/"} {
 		s = strings.TrimPrefix(s, p)
@@ -41,9 +41,18 @@ func manifestURL(base, src string) (string, error) {
 	s = strings.Trim(s, "/")
 	parts := strings.Split(s, "/")
 	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return "", fmt.Errorf("src %q must look like github.com/owner/repo", src)
+		return "", "", fmt.Errorf("src %q must look like github.com/owner/repo", src)
 	}
-	return fmt.Sprintf("%s/%s/%s/HEAD/mitos.yaml", base, parts[0], parts[1]), nil
+	return parts[0], parts[1], nil
+}
+
+// manifestURL builds the raw mitos.yaml URL for a src.
+func manifestURL(base, src string) (string, error) {
+	owner, repo, err := splitRepo(src)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s/%s/HEAD/mitos.yaml", base, owner, repo), nil
 }
 
 // Fetch retrieves and parses the repo's mitos.yaml.

--- a/internal/runservice/fetch.go
+++ b/internal/runservice/fetch.go
@@ -1,0 +1,80 @@
+package runservice
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"mitos.run/mitos/internal/runmanifest"
+)
+
+// maxManifestBytes caps a fetched manifest so a hostile or runaway source cannot
+// stream unbounded data into the parser.
+const maxManifestBytes = 1 << 20 // 1 MiB
+
+// GitHubFetcher fetches mitos.yaml from a GitHub repo's default branch via
+// raw.githubusercontent.com.
+type GitHubFetcher struct {
+	// Client is the HTTP client; nil uses http.DefaultClient.
+	Client *http.Client
+	// baseURL overrides the raw host (tests point it at an httptest server).
+	baseURL string
+}
+
+func (g *GitHubFetcher) base() string {
+	if g.baseURL != "" {
+		return g.baseURL
+	}
+	return "https://raw.githubusercontent.com"
+}
+
+// manifestURL builds the raw mitos.yaml URL for a src like
+// "github.com/owner/repo" (a leading scheme and a trailing .git are tolerated).
+func manifestURL(base, src string) (string, error) {
+	s := strings.TrimSpace(src)
+	for _, p := range []string{"https://", "http://", "github.com/"} {
+		s = strings.TrimPrefix(s, p)
+	}
+	s = strings.TrimSuffix(s, ".git")
+	s = strings.Trim(s, "/")
+	parts := strings.Split(s, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("src %q must look like github.com/owner/repo", src)
+	}
+	return fmt.Sprintf("%s/%s/%s/HEAD/mitos.yaml", base, parts[0], parts[1]), nil
+}
+
+// Fetch retrieves and parses the repo's mitos.yaml.
+func (g *GitHubFetcher) Fetch(ctx context.Context, src string) (*runmanifest.Manifest, error) {
+	u, err := manifestURL(g.base(), src)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c := g.Client
+	if c == nil {
+		c = http.DefaultClient
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", u, err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("no mitos.yaml at %s; add one to the repo root to make it runnable", u)
+	default:
+		return nil, fmt.Errorf("fetch %s: unexpected status %d", u, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", u, err)
+	}
+	return runmanifest.Parse(body)
+}

--- a/internal/runservice/fetch_test.go
+++ b/internal/runservice/fetch_test.go
@@ -1,0 +1,66 @@
+package runservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestManifestURL(t *testing.T) {
+	const base = "https://raw.githubusercontent.com"
+	cases := []struct {
+		src  string
+		want string
+		ok   bool
+	}{
+		{"github.com/openclaw/openclaw", base + "/openclaw/openclaw/HEAD/mitos.yaml", true},
+		{"https://github.com/bytedance/deer-flow.git", base + "/bytedance/deer-flow/HEAD/mitos.yaml", true},
+		{"openclaw/openclaw", base + "/openclaw/openclaw/HEAD/mitos.yaml", true},
+		{"github.com/onlyowner", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, err := manifestURL(base, c.src)
+		if c.ok && (err != nil || got != c.want) {
+			t.Errorf("manifestURL(%q) = %q, %v; want %q", c.src, got, err, c.want)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("manifestURL(%q) should error", c.src)
+		}
+	}
+}
+
+func TestFetchOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/openclaw/openclaw/HEAD/mitos.yaml") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(openclawYAML))
+	}))
+	defer srv.Close()
+
+	g := &GitHubFetcher{baseURL: srv.URL}
+	m, err := g.Fetch(context.Background(), "github.com/openclaw/openclaw")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if m.Name != "openclaw" {
+		t.Errorf("manifest name = %q", m.Name)
+	}
+}
+
+func TestFetchNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	g := &GitHubFetcher{baseURL: srv.URL}
+	_, err := g.Fetch(context.Background(), "github.com/no/such")
+	if err == nil || !strings.Contains(err.Error(), "no mitos.yaml") {
+		t.Fatalf("want not-found error, got %v", err)
+	}
+}

--- a/internal/runservice/http.go
+++ b/internal/runservice/http.go
@@ -1,0 +1,93 @@
+package runservice
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// maxRequestBytes caps the run request body (a small JSON of src plus secrets).
+const maxRequestBytes = 256 << 10
+
+// IdentityResolver maps an authenticated request plus the source repo to the
+// tenant namespace and the instance label. The production resolver reads the
+// signed-in user (the OIDC session), maps to the org namespace (#410), and builds
+// a per-user-per-app label; an unauthenticated request fails so the funnel routes
+// it to signup first.
+type IdentityResolver interface {
+	Resolve(r *http.Request, src string) (Identity, error)
+}
+
+// Handler serves the run endpoints.
+type Handler struct {
+	svc      *Service
+	identity IdentityResolver
+}
+
+// NewHandler wires a Service and an identity resolver into HTTP handlers.
+func NewHandler(svc *Service, id IdentityResolver) *Handler {
+	return &Handler{svc: svc, identity: id}
+}
+
+// Routes registers GET /run/describe and POST /run on mux.
+func (h *Handler) Routes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /run/describe", h.describe)
+	mux.HandleFunc("POST /run", h.run)
+}
+
+// describe returns the consent contract for a source repo (no auth required: it is
+// the public preview the badge links to).
+func (h *Handler) describe(w http.ResponseWriter, r *http.Request) {
+	src := r.URL.Query().Get("src")
+	if src == "" {
+		writeError(w, http.StatusBadRequest, "src query parameter is required")
+		return
+	}
+	d, err := h.svc.Describe(r.Context(), src)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, d)
+}
+
+type runRequest struct {
+	Src     string            `json:"src"`
+	Secrets map[string]string `json:"secrets,omitempty"`
+}
+
+// run provisions an instance for the signed-in user.
+func (h *Handler) run(w http.ResponseWriter, r *http.Request) {
+	var req runRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBytes)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Src == "" {
+		writeError(w, http.StatusBadRequest, "src is required")
+		return
+	}
+	id, err := h.identity.Resolve(r, req.Src)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "sign in to run this: "+err.Error())
+		return
+	}
+	res, err := h.svc.Run(r.Context(), req.Src, id, req.Secrets)
+	if err != nil {
+		// Provisioning errors are actionable (for example a missing required
+		// secret) and never contain secret values.
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/runservice/http_test.go
+++ b/internal/runservice/http_test.go
@@ -1,0 +1,96 @@
+package runservice
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeIdentity struct {
+	id  Identity
+	err error
+}
+
+func (f fakeIdentity) Resolve(*http.Request, string) (Identity, error) {
+	return f.id, f.err
+}
+
+func newTestServer(t *testing.T, idr IdentityResolver) *httptest.Server {
+	t.Helper()
+	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, &fakeApplier{}, "mitos.run")
+	mux := http.NewServeMux()
+	NewHandler(svc, idr).Routes(mux)
+	return httptest.NewServer(mux)
+}
+
+func TestDescribeHandler(t *testing.T) {
+	srv := newTestServer(t, fakeIdentity{})
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/run/describe?src=github.com/openclaw/openclaw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestDescribeHandlerMissingSrc(t *testing.T) {
+	srv := newTestServer(t, fakeIdentity{})
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/run/describe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestRunHandler(t *testing.T) {
+	idr := fakeIdentity{id: Identity{Namespace: "tenant-jannes", InstanceLabel: "jannes-openclaw"}}
+	srv := newTestServer(t, idr)
+	defer srv.Close()
+	body := `{"src":"github.com/openclaw/openclaw","secrets":{"ANTHROPIC_API_KEY":"sk-real"}}`
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestRunHandlerUnauthorized(t *testing.T) {
+	srv := newTestServer(t, fakeIdentity{err: errors.New("no session")})
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+"/run", "application/json",
+		strings.NewReader(`{"src":"github.com/openclaw/openclaw"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestRunHandlerMissingRequiredSecret(t *testing.T) {
+	idr := fakeIdentity{id: Identity{Namespace: "ns", InstanceLabel: "inst"}}
+	srv := newTestServer(t, idr)
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+"/run", "application/json",
+		strings.NewReader(`{"src":"github.com/openclaw/openclaw"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+}

--- a/internal/runservice/identity.go
+++ b/internal/runservice/identity.go
@@ -1,0 +1,88 @@
+package runservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// AccountLookup maps a verified email to the org the instance is isolated and
+// billed under. The production implementation adapts internal/saas AccountService
+// (FindOrCreateByEmail then the account's personal org).
+type AccountLookup interface {
+	OrgForEmail(ctx context.Context, email string) (orgID string, err error)
+}
+
+// TenantResolver is the production IdentityResolver. It maps a signed-in request
+// to the tenant namespace and a deterministic, globally unique instance label.
+type TenantResolver struct {
+	// CurrentEmail returns the verified email of the signed-in user, or an error
+	// when the request is not authenticated (the funnel then routes to signup).
+	CurrentEmail func(r *http.Request) (string, error)
+	// Accounts maps an email to its org.
+	Accounts AccountLookup
+	// NamespaceForOrg maps an org id to its namespace (orgprovision, #410).
+	NamespaceForOrg func(orgID string) string
+}
+
+// Resolve implements IdentityResolver.
+func (t *TenantResolver) Resolve(r *http.Request, src string) (Identity, error) {
+	email, err := t.CurrentEmail(r)
+	if err != nil {
+		return Identity{}, err
+	}
+	if strings.TrimSpace(email) == "" {
+		return Identity{}, fmt.Errorf("not signed in")
+	}
+	orgID, err := t.Accounts.OrgForEmail(r.Context(), email)
+	if err != nil {
+		return Identity{}, fmt.Errorf("resolve org: %w", err)
+	}
+	ns := t.NamespaceForOrg(orgID)
+	if ns == "" {
+		return Identity{}, fmt.Errorf("no namespace provisioned for org %q", orgID)
+	}
+	label, err := instanceLabel(src, orgID)
+	if err != nil {
+		return Identity{}, err
+	}
+	return Identity{Namespace: ns, InstanceLabel: label}, nil
+}
+
+// instanceLabel builds a deterministic, globally unique DNS label: the repo name
+// plus a short hash of the org id. Deterministic so a repeat run reconciles the
+// same instance; the org-scoped hash means labels never collide across tenants
+// (the label is a global subdomain).
+func instanceLabel(src, orgID string) (string, error) {
+	_, repo, err := splitRepo(src)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(orgID))
+	short := hex.EncodeToString(sum[:])[:10]
+	label := sanitizeLabel(repo) + "-" + short
+	if len(label) > 63 {
+		label = label[:63]
+	}
+	return label, nil
+}
+
+// sanitizeLabel lowercases and reduces a string to DNS-label-safe characters.
+func sanitizeLabel(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		out = "app"
+	}
+	return out
+}

--- a/internal/runservice/identity.go
+++ b/internal/runservice/identity.go
@@ -52,6 +52,35 @@ func (t *TenantResolver) Resolve(r *http.Request, src string) (Identity, error) 
 	return Identity{Namespace: ns, InstanceLabel: label}, nil
 }
 
+// ContextResolver resolves identity from a verified org already attached to the
+// request context by an upstream session middleware (the console/gateway pattern,
+// where org and account come from a verified session, never a client header). It
+// is the resolver the console mounts.
+type ContextResolver struct {
+	// OrgFromRequest returns the verified org id for the request, or ok=false when
+	// the request is unauthenticated.
+	OrgFromRequest func(r *http.Request) (orgID string, ok bool)
+	// NamespaceForOrg maps an org id to its provisioned namespace (orgprovision).
+	NamespaceForOrg func(orgID string) string
+}
+
+// Resolve implements IdentityResolver.
+func (c *ContextResolver) Resolve(r *http.Request, src string) (Identity, error) {
+	orgID, ok := c.OrgFromRequest(r)
+	if !ok || strings.TrimSpace(orgID) == "" {
+		return Identity{}, fmt.Errorf("not signed in")
+	}
+	ns := c.NamespaceForOrg(orgID)
+	if ns == "" {
+		return Identity{}, fmt.Errorf("no namespace provisioned for org %q", orgID)
+	}
+	label, err := instanceLabel(src, orgID)
+	if err != nil {
+		return Identity{}, err
+	}
+	return Identity{Namespace: ns, InstanceLabel: label}, nil
+}
+
 // instanceLabel builds a deterministic, globally unique DNS label: the repo name
 // plus a short hash of the org id. Deterministic so a repeat run reconciles the
 // same instance; the org-scoped hash means labels never collide across tenants

--- a/internal/runservice/service.go
+++ b/internal/runservice/service.go
@@ -1,0 +1,130 @@
+// Package runservice turns a "Run with Mitos" click into a provisioned instance:
+// it fetches a repo's mitos.yaml, ensures the golden SandboxPool, provisions the
+// per-fork Sandbox and its Secret, applies them, and returns the live URL.
+//
+// It is the seam between the front door (the run HTTP endpoint, the badge) and the
+// cluster. Dependencies (manifest fetch, object apply, tenant identity) are
+// injected so the core is unit-testable without a cluster or network. Secret
+// VALUES flow through Run into the applied Secret only; they are never logged or
+// returned.
+//
+// Tenancy: the golden pool lands in the caller's tenant namespace (isolation-first,
+// per the per-org namespace model #410), so a fork shares pages copy-on-write with
+// the tenant's own golden. A cross-tenant shared-golden cost tier is a deliberate
+// later decision (it trades namespace isolation for wider CoW sharing) and is out
+// of scope here.
+package runservice
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"mitos.run/mitos/internal/runmanifest"
+)
+
+// ManifestFetcher fetches and parses a repo's mitos.yaml for a source reference
+// such as "github.com/openclaw/openclaw".
+type ManifestFetcher interface {
+	Fetch(ctx context.Context, src string) (*runmanifest.Manifest, error)
+}
+
+// Applier upserts cluster objects (the golden pool, the per-fork Secret, the
+// Sandbox). Implementations make it idempotent so re-running an app reuses the
+// existing golden pool rather than failing on conflict.
+type Applier interface {
+	Apply(ctx context.Context, objs ...client.Object) error
+}
+
+// Identity is the resolved tenant for one click: the namespace the instance lands
+// in and the unique DNS label that becomes its subdomain. The real resolver maps
+// the signed-in user to their org namespace (#410) and a per-user-per-app label.
+type Identity struct {
+	Namespace     string
+	InstanceLabel string
+}
+
+// RunDescription is the consent contract shown before provisioning: what forks,
+// what it needs, where it may egress. It carries NO secret values.
+type RunDescription struct {
+	Name    string         `json:"name"`
+	Title   string         `json:"title,omitempty"`
+	Image   string         `json:"image,omitempty"`
+	Secrets []SecretPrompt `json:"secrets,omitempty"`
+	Egress  []string       `json:"egress,omitempty"`
+}
+
+// SecretPrompt is one secret the clicker is asked for.
+type SecretPrompt struct {
+	Name     string `json:"name"`
+	Label    string `json:"label,omitempty"`
+	Required bool   `json:"required"`
+	Generate bool   `json:"generate"`
+}
+
+// RunResult is the outcome of a successful run.
+type RunResult struct {
+	Instance string `json:"instance"`
+	URL      string `json:"url"`
+}
+
+// Service provisions instances from manifests.
+type Service struct {
+	fetch        ManifestFetcher
+	apply        Applier
+	exposeDomain string
+}
+
+// New builds a Service. exposeDomain is the cluster's expose domain (for example
+// "mitos.run"); the live URL is "<instanceLabel>.<exposeDomain>".
+func New(f ManifestFetcher, a Applier, exposeDomain string) *Service {
+	return &Service{fetch: f, apply: a, exposeDomain: exposeDomain}
+}
+
+// Describe fetches the manifest and returns the consent contract for src.
+func (s *Service) Describe(ctx context.Context, src string) (*RunDescription, error) {
+	m, err := s.fetch.Fetch(ctx, src)
+	if err != nil {
+		return nil, fmt.Errorf("describe %q: %w", src, err)
+	}
+	d := &RunDescription{Name: m.Name, Title: m.Title, Image: m.Source.Image, Egress: m.Egress.Allow}
+	for _, sec := range m.Secrets {
+		d.Secrets = append(d.Secrets, SecretPrompt{
+			Name:     sec.Name,
+			Label:    sec.Label,
+			Required: sec.Required,
+			Generate: sec.Generate > 0,
+		})
+	}
+	return d, nil
+}
+
+// Run provisions an instance of src for the given identity and supplied secrets:
+// ensure the golden pool, provision the per-fork objects, apply them, and return
+// the live URL. The golden pool, the Secret, and the Sandbox are applied together;
+// the Applier upserts so a repeat run reuses the existing golden.
+func (s *Service) Run(ctx context.Context, src string, id Identity, secrets map[string]string) (*RunResult, error) {
+	if id.Namespace == "" || id.InstanceLabel == "" {
+		return nil, fmt.Errorf("run: identity needs a namespace and an instance label")
+	}
+	m, err := s.fetch.Fetch(ctx, src)
+	if err != nil {
+		return nil, fmt.Errorf("run %q: %w", src, err)
+	}
+	pool, err := m.GoldenPool(id.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("run %q: golden pool: %w", src, err)
+	}
+	res, err := runmanifest.Provision(m, secrets, id.Namespace, id.InstanceLabel)
+	if err != nil {
+		return nil, fmt.Errorf("run %q: provision: %w", src, err)
+	}
+	if err := s.apply.Apply(ctx, pool, res.Secret, res.Sandbox); err != nil {
+		return nil, fmt.Errorf("run %q: apply: %w", src, err)
+	}
+	return &RunResult{
+		Instance: id.InstanceLabel,
+		URL:      fmt.Sprintf("https://%s.%s", id.InstanceLabel, s.exposeDomain),
+	}, nil
+}

--- a/internal/runservice/service_test.go
+++ b/internal/runservice/service_test.go
@@ -1,0 +1,166 @@
+package runservice
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/runmanifest"
+)
+
+const openclawYAML = `
+name: openclaw
+title: OpenClaw
+source:
+  image: ghcr.io/openclaw/openclaw:latest
+run:
+  command: ["node", "openclaw.mjs"]
+preview:
+  port: 18789
+  auth: ladder
+secrets:
+  - { name: OPENCLAW_GATEWAY_TOKEN, label: Gateway token, generate: 32 }
+  - { name: ANTHROPIC_API_KEY, label: Claude API key, required: true }
+egress:
+  allow: [api.anthropic.com]
+workspace:
+  path: /home/node/.openclaw
+  persist: true
+`
+
+func mustManifest(t *testing.T, y string) *runmanifest.Manifest {
+	t.Helper()
+	m, err := runmanifest.Parse([]byte(y))
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return m
+}
+
+type fakeFetcher struct {
+	m   *runmanifest.Manifest
+	err error
+}
+
+func (f *fakeFetcher) Fetch(context.Context, string) (*runmanifest.Manifest, error) {
+	return f.m, f.err
+}
+
+type fakeApplier struct {
+	applied []client.Object
+	err     error
+}
+
+func (f *fakeApplier) Apply(_ context.Context, objs ...client.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.applied = append(f.applied, objs...)
+	return nil
+}
+
+func TestDescribe(t *testing.T) {
+	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, &fakeApplier{}, "mitos.run")
+	d, err := svc.Describe(context.Background(), "github.com/openclaw/openclaw")
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if d.Name != "openclaw" || d.Image != "ghcr.io/openclaw/openclaw:latest" {
+		t.Errorf("description = %+v", d)
+	}
+	if len(d.Secrets) != 2 {
+		t.Fatalf("secrets = %d, want 2", len(d.Secrets))
+	}
+	// The consent contract carries prompts and flags, never values.
+	var req, gen bool
+	for _, s := range d.Secrets {
+		if s.Name == "ANTHROPIC_API_KEY" && s.Required {
+			req = true
+		}
+		if s.Name == "OPENCLAW_GATEWAY_TOKEN" && s.Generate {
+			gen = true
+		}
+	}
+	if !req || !gen {
+		t.Errorf("expected required+generate flags surfaced: %+v", d.Secrets)
+	}
+	if len(d.Egress) != 1 || d.Egress[0] != "api.anthropic.com" {
+		t.Errorf("egress = %v", d.Egress)
+	}
+}
+
+func TestRunProvisionsAndApplies(t *testing.T) {
+	ap := &fakeApplier{}
+	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, ap, "mitos.run")
+	res, err := svc.Run(context.Background(), "github.com/openclaw/openclaw",
+		Identity{Namespace: "tenant-jannes", InstanceLabel: "jannes-openclaw"},
+		map[string]string{"ANTHROPIC_API_KEY": "sk-real"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.URL != "https://jannes-openclaw.mitos.run" {
+		t.Errorf("URL = %q", res.URL)
+	}
+
+	// The golden pool, the Secret, and the Sandbox are all applied, into the
+	// tenant namespace.
+	if len(ap.applied) != 3 {
+		t.Fatalf("applied %d objects, want 3", len(ap.applied))
+	}
+	var pool, secret, sandbox bool
+	for _, o := range ap.applied {
+		if o.GetNamespace() != "tenant-jannes" {
+			t.Errorf("object %T in namespace %q, want tenant-jannes", o, o.GetNamespace())
+		}
+		switch obj := o.(type) {
+		case *v1.SandboxPool:
+			pool = true
+		case *corev1.Secret:
+			secret = true
+			if string(obj.Data["ANTHROPIC_API_KEY"]) != "sk-real" {
+				t.Error("supplied secret missing from applied Secret")
+			}
+		case *v1.Sandbox:
+			sandbox = true
+			if obj.Spec.Source.PoolRef == nil || obj.Spec.Source.PoolRef.Name != "openclaw" {
+				t.Error("sandbox does not fork the golden pool")
+			}
+		}
+	}
+	if !pool || !secret || !sandbox {
+		t.Errorf("applied set incomplete: pool=%v secret=%v sandbox=%v", pool, secret, sandbox)
+	}
+}
+
+func TestRunRequiredSecretMissing(t *testing.T) {
+	ap := &fakeApplier{}
+	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, ap, "mitos.run")
+	_, err := svc.Run(context.Background(), "x",
+		Identity{Namespace: "ns", InstanceLabel: "inst"}, map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("want required-secret error, got %v", err)
+	}
+	if len(ap.applied) != 0 {
+		t.Error("nothing should be applied when provisioning fails")
+	}
+}
+
+func TestRunNeedsIdentity(t *testing.T) {
+	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, &fakeApplier{}, "mitos.run")
+	if _, err := svc.Run(context.Background(), "x", Identity{}, nil); err == nil {
+		t.Fatal("Run without identity should fail")
+	}
+}
+
+func TestRunFetchError(t *testing.T) {
+	svc := New(&fakeFetcher{err: errors.New("boom")}, &fakeApplier{}, "mitos.run")
+	if _, err := svc.Run(context.Background(), "x",
+		Identity{Namespace: "ns", InstanceLabel: "inst"}, nil); err == nil {
+		t.Fatal("fetch error should propagate")
+	}
+}


### PR DESCRIPTION
## Thinking Path
With the manifest and provisioner in place (#442), the next piece is the click-to-provision core: fetch a repo manifest, ensure the golden, provision the fork, return a live URL. Dependency-injected so it is unit-testable without a cluster, then wired to the real console behind session auth.

## Linked Issues or Issue Description
#340, #440. Stacked on #442 (base is the manifest branch). Public arbitrary-repo path stays gated on #341.

## What Changed
`internal/runservice`: fetch (GitHub raw, 1 MiB cap) plus ensure-golden plus provision plus apply, returning the live URL; `GET /run/describe` (public consent contract, no secret values) and `POST /run` (auth-gated). `K8sApplier` upserts idempotently; `TenantResolver`/`ContextResolver` map a signed-in request to the org namespace (#410) and a deterministic, globally unique instance label. Mounted on the console behind the session middleware, opt-in via `MITOS_CONSOLE_RUN_WITH_MITOS`.

## Verification
`go test ./internal/runservice/` green; the console binary compiles against the real seams (`SessionMiddleware`, `OrgFromContext`, `tenant.NamespaceForOrg`, `kubeClient`); gofmt and go vet clean. The console mount is unverified at runtime (no live cluster), labeled as such in the commit.

## Risks
The console mount is gated off by default. Golden pool lands in the tenant namespace (isolation-first); a shared-golden cost tier is a documented later decision.

## Model Used
Claude Opus 4.8 (1M context)

## Checklist
- [x] Tests added and green
- [x] No secret values logged
- [x] No em or en dashes