### PR TITLE
feat(sdk): fork(n) ergonomics across the TypeScript SDK and CLI (#311)

### DIFF
--- a/internal/agentcli/cli.go
+++ b/internal/agentcli/cli.go
@@ -15,7 +15,9 @@ Usage:
   mitos sandbox create [--pool P]                create a sandbox, print its id
   mitos sandbox ls [-n namespace] [-A]           list sandboxes
   mitos sandbox exec <id> <command...>           run a command in a sandbox
-  mitos sandbox fork <id> [--replicas N]         fork a sandbox, print new ids
+  mitos fork <id> [--count N]                    fork a running sandbox into N
+                                                    live children, print new ids
+  mitos sandbox fork <id> [--count N]            alias of the above
   mitos sandbox terminate <id>                   destroy a sandbox
   mitos ws create|ls|log|diff|fork|revert|rm     workspace lifecycle (git verbs)
   mitos ws bind <id> <workspace>                 bind a sandbox to a workspace
@@ -34,7 +36,7 @@ Flags:
   --timeout int      exec timeout in seconds (0 = backend default)
   -n string          namespace (ls)
   -A                 all namespaces (ls)
-  --replicas int     number of forks (fork)
+  --count int        number of children to fork (fork; alias --replicas)
   -h, --help         print this help
 `
 
@@ -62,6 +64,10 @@ func Run(ctx context.Context, args []string, backend Backend, out, errw io.Write
 		return cmdRun(ctx, args[1:], backend, out, errw)
 	case "sandbox":
 		return cmdSandbox(ctx, args[1:], backend, out, errw)
+	case "fork":
+		// Top-level alias for `sandbox fork` so the homepage one-liner
+		// `mitos fork <id> --count N` works verbatim (#311).
+		return cmdSandboxFork(ctx, args[1:], backend, out, errw)
 	case "ws":
 		if backend == nil || backend.Workspace() == nil {
 			fmt.Fprint(errw, "ws: this backend does not support workspaces\n")

--- a/internal/agentcli/cli_test.go
+++ b/internal/agentcli/cli_test.go
@@ -183,6 +183,37 @@ func TestSandboxForkDispatch(t *testing.T) {
 	}
 }
 
+func TestSandboxForkCountFlag(t *testing.T) {
+	// --count is the documented flag name (#311); it forks that many children.
+	fb := NewFakeBackend()
+	fb.ForkIDs = []string{"f1", "f2"}
+	code, _, _ := runCLI(t, fb, "sandbox", "fork", "sbx-1", "--count", "2")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	calls := fb.RecordedCalls()
+	if calls[0].Method != "fork" || calls[0].SandboxID != "sbx-1" || calls[0].Replicas != 2 {
+		t.Fatalf("calls = %v, want fork sbx-1 x2 via --count", calls)
+	}
+}
+
+func TestTopLevelForkDispatch(t *testing.T) {
+	// `mitos fork <id> --count N` is the homepage one-liner (#311).
+	fb := NewFakeBackend()
+	fb.ForkIDs = []string{"f1", "f2", "f3"}
+	code, out, _ := runCLI(t, fb, "fork", "sbx-1", "--count", "3")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	calls := fb.RecordedCalls()
+	if calls[0].Method != "fork" || calls[0].SandboxID != "sbx-1" || calls[0].Replicas != 3 {
+		t.Fatalf("calls = %v, want fork sbx-1 x3 via top-level fork", calls)
+	}
+	if !strings.Contains(out.String(), "f1") {
+		t.Fatalf("fork output = %q, want it to contain the child ids", out.String())
+	}
+}
+
 func TestSandboxTerminateDispatch(t *testing.T) {
 	fb := NewFakeBackend()
 	code, _, _ := runCLI(t, fb, "sandbox", "terminate", "sbx-1")

--- a/internal/agentcli/commands.go
+++ b/internal/agentcli/commands.go
@@ -150,6 +150,9 @@ func cmdSandboxFork(ctx context.Context, args []string, backend Backend, out, er
 	// flag parser stops at the first non-flag token, so split the id out first.
 	id, rest := splitFirstPositional(args)
 	fs := newFlagSet("sandbox fork", errw)
+	// --count is the documented flag (#311); --replicas is kept as a back-compat
+	// alias. --count wins when set (default 0 means "not set, use --replicas").
+	count := fs.Int("count", 0, "number of forks (alias of --replicas)")
 	replicas := fs.Int("replicas", 1, "number of forks")
 	if err := fs.Parse(rest); err != nil {
 		fmt.Fprint(errw, usage)
@@ -162,7 +165,11 @@ func cmdSandboxFork(ctx context.Context, args []string, backend Backend, out, er
 		fmt.Fprintf(errw, "sandbox fork: a sandbox id is required\n\n%s", usage)
 		return 2
 	}
-	ids, err := backend.Fork(ctx, id, *replicas)
+	n := *replicas
+	if *count > 0 {
+		n = *count
+	}
+	ids, err := backend.Fork(ctx, id, n)
 	if err != nil {
 		fmt.Fprintf(errw, "fork: %v\n", err)
 		return 1

--- a/sdk/python/mitos/aio.py
+++ b/sdk/python/mitos/aio.py
@@ -367,7 +367,21 @@ class AsyncSandbox:
                 group=API_GROUP, version=API_VERSION, namespace=self.namespace,
                 plural="sandboxes", name=fork_name,
             )
-            ready = [f for f in obj.get("status", {}).get("children", []) if f.get("phase") == "Ready"]
+            status = obj.get("status", {})
+            # A refused fork (secret inheritance, capacity, budget) is terminal:
+            # surface the Rejected condition as an LLM-legible error (#311).
+            for c in status.get("conditions", []) or []:
+                if c.get("type") == "Rejected" and c.get("status") == "True":
+                    raise AgentRunError(
+                        f"fork {fork_name} was rejected",
+                        code="fork_rejected",
+                        cause=c.get("reason", "Rejected"),
+                        remediation=c.get(
+                            "message",
+                            "Inspect the fork's Rejected condition and adjust the request.",
+                        ),
+                    )
+            ready = [f for f in status.get("children", []) if f.get("phase") == "Ready"]
             if len(ready) >= n:
                 out = []
                 for f in ready:

--- a/sdk/python/mitos/sandbox.py
+++ b/sdk/python/mitos/sandbox.py
@@ -714,6 +714,22 @@ class Sandbox:
                 name=fork_name,
             )
             status = obj.get("status", {})
+
+            # A refused fork (secret inheritance, capacity, budget) is terminal:
+            # the controller sets a Rejected condition rather than ever producing
+            # children. Surface it as an LLM-legible error instead of timing out.
+            for c in status.get("conditions", []) or []:
+                if c.get("type") == "Rejected" and c.get("status") == "True":
+                    raise AgentRunError(
+                        f"fork {fork_name} was rejected",
+                        code="fork_rejected",
+                        cause=c.get("reason", "Rejected"),
+                        remediation=c.get(
+                            "message",
+                            "Inspect the fork's Rejected condition and adjust the request.",
+                        ),
+                    )
+
             forks = status.get("children", [])
 
             ready = [f for f in forks if f.get("phase") == "Ready"]

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -136,6 +136,28 @@ def test_sandbox_fork_creates_cr(ready_sandbox, mock_api):
     assert forks[1]._sandbox_id == "f2"
 
 
+def test_sandbox_fork_rejected_is_legible(ready_sandbox, mock_api):
+    # A refused fork (secret inheritance, capacity, budget) is terminal: the
+    # controller sets a Rejected condition. fork() must surface it as an
+    # LLM-legible error instead of waiting out the timeout (#311).
+    mock_api.get_namespaced_custom_object.return_value = {
+        "status": {
+            "conditions": [
+                {
+                    "type": "Rejected",
+                    "status": "True",
+                    "reason": "SecretInheritanceDenied",
+                    "message": "source sandbox holds secrets; recreate the fork with spec.secretInheritance=inherit to permit it",
+                },
+            ],
+        },
+    }
+    with pytest.raises(AgentRunError) as ei:
+        ready_sandbox.fork(2, timeout=0.5)
+    assert ei.value.code == "fork_rejected"
+    assert ei.value.cause == "SecretInheritanceDenied"
+
+
 def test_sandbox_fork_threads_timeout(ready_sandbox):
     """fork(timeout=...) must thread the value into _wait_forks so a wide
     single-node fan-out is not capped at the 30.0s default."""

--- a/sdk/typescript/examples/cluster.ts
+++ b/sdk/typescript/examples/cluster.ts
@@ -44,6 +44,14 @@ async function main(): Promise<void> {
   const content = await sandbox.files.read("/tmp/data.txt");
   console.log("file content:", content.trim());
 
+  // Live fork-to-many: one call returns N independent copy-on-write children.
+  // Each child shares the parent's memory pages until it writes, so it lands in
+  // a warm, Ready environment. Branch one agent into many parallel attempts.
+  const [a, b] = await sandbox.fork(2);
+  await a.exec("echo conservative > /workspace/a.txt");
+  await b.exec("echo aggressive  > /workspace/a.txt");
+  console.log("forked children:", a.id, b.id);
+
   // List all sandboxes in the namespace, optionally filtered by pool.
   const all = await client.list("my-pool");
   console.log("active sandboxes:", all.map((s) => s.name));

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -7,7 +7,7 @@
 import { AgentRunError } from "./errors.js";
 import type { CustomObject, K8sApi } from "./k8s.js";
 import { Sandbox, toBaseUrl } from "./sandbox.js";
-import type { TerminateOptions } from "./sandbox.js";
+import type { ForkOptions, Forker, TerminateOptions } from "./sandbox.js";
 import type { SandboxInfo, SandboxPhase } from "./types.js";
 import { Workspace } from "./workspace.js";
 
@@ -86,6 +86,14 @@ function randomName(): string {
   globalThis.crypto.getRandomValues(bytes);
   const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
   return `sandbox-${hex}`;
+}
+
+// Short random hex suffix (6 chars) for fork object names; mirrors the Python
+// SDK's uuid4().hex[:6].
+function randomSuffix(): string {
+  const bytes = new Uint8Array(3);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 function defaultSleep(ms: number): Promise<void> {
@@ -171,6 +179,7 @@ export class AgentRun {
       endpoint: toBaseUrl(endpoint),
       token,
       terminator: this.makeTerminator(name),
+      forker: this.makeForker(name),
     });
   }
 
@@ -295,7 +304,98 @@ export class AgentRun {
       endpoint: toBaseUrl(resolved),
       token,
       terminator: this.makeTerminator(name),
+      forker: this.makeForker(name),
     });
+  }
+
+  /**
+   * Builds the fork capability for a sandbox: fork(n) creates a Sandbox with
+   * spec.source.fromSandbox + replicas=n (the controller fans out n indexed
+   * copy-on-write children), waits for all n to reach Ready, and returns each as
+   * a bound Sandbox (with its own token and a forker of its own). Mirrors the
+   * Python SDK Sandbox.fork. The live fork-to-many primitive, #311.
+   */
+  private makeForker(sourceName: string): Forker {
+    return async (n = 1, opts?: ForkOptions): Promise<Sandbox[]> => {
+      const forkName = `${sourceName}-fork-${randomSuffix()}`;
+      const forkObj: CustomObject = {
+        apiVersion: `${API_GROUP}/${API_VERSION}`,
+        kind: "Sandbox",
+        metadata: { name: forkName, namespace: this.namespace },
+        spec: {
+          source: { fromSandbox: { name: sourceName, pauseSource: opts?.pauseSource ?? false } },
+          replicas: n,
+        },
+      };
+      await this.k8s.createClaim(this.namespace, forkObj);
+      return this.waitForks(forkName, n, opts?.timeoutMs ?? this.pollTimeoutMs);
+    };
+  }
+
+  /**
+   * Polls a fork object's status.children until at least `expected` are Ready,
+   * then binds each to a Sandbox (reading its own per-child token Secret; the
+   * source's token does not open a child). LLM-legible on timeout.
+   */
+  private async waitForks(forkName: string, expected: number, timeoutMs: number): Promise<Sandbox[]> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const obj = await this.k8s.getClaim(this.namespace, forkName);
+      const status = obj.status ?? {};
+      // A refused fork (secret inheritance, capacity, budget) is terminal: the
+      // controller sets a Rejected condition rather than ever producing children.
+      // Surface it as an LLM-legible error instead of waiting out the timeout.
+      const conditions = (status["conditions"] as Array<Record<string, unknown>>) ?? [];
+      const rejected = conditions.find(
+        (c) => c["type"] === "Rejected" && c["status"] === "True",
+      );
+      if (rejected) {
+        throw new AgentRunError(`fork ${forkName} was rejected`, {
+          code: "fork_rejected",
+          cause: (rejected["reason"] as string) || "Rejected",
+          remediation:
+            (rejected["message"] as string) ||
+            "Inspect the fork's Rejected condition and adjust the request.",
+        });
+      }
+      const children = (status["children"] as Array<Record<string, unknown>>) ?? [];
+      const ready = children.filter((c) => c["phase"] === "Ready");
+      if (ready.length >= expected) {
+        const out: Sandbox[] = [];
+        for (const c of ready) {
+          const childName = (c["name"] as string) ?? "";
+          const childEndpoint = (c["endpoint"] as string) ?? "";
+          let token: string | undefined;
+          let secretEndpoint = "";
+          try {
+            const secret = await this.k8s.readSecret(this.namespace, childName + TOKEN_SECRET_SUFFIX);
+            token = secret["token"] || undefined;
+            secretEndpoint = secret["endpoint"] ?? "";
+          } catch {
+            // No token Secret for this child yet; proceed tokenless.
+          }
+          out.push(
+            new Sandbox({
+              id: childName,
+              endpoint: toBaseUrl(childEndpoint || secretEndpoint),
+              token,
+              terminator: this.makeTerminator(childName),
+              forker: this.makeForker(childName),
+            }),
+          );
+        }
+        return out;
+      }
+      if (Date.now() >= deadline) {
+        throw new AgentRunError(`forks not ready after ${timeoutMs}ms`, {
+          code: "ready_timeout",
+          cause: `fork ${forkName} did not produce ${expected} Ready children within ${timeoutMs}ms`,
+          remediation:
+            "Raise the timeout, or check the source is Ready and the pool/node has capacity.",
+        });
+      }
+      await this.sleep(POLL_INTERVAL_MS);
+    }
   }
 
   /**

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -43,6 +43,8 @@ export { ConnectClient } from "./connect.js";
 export type {
   SandboxOptions,
   Terminator,
+  Forker,
+  ForkOptions,
   TerminateOptions,
   TerminateOutput,
   RunCodeCallbacks,

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -44,6 +44,21 @@ export interface TerminateOptions {
  */
 export type Terminator = (opts?: TerminateOptions) => Promise<string | undefined>;
 
+/** Options for fork(n). */
+export interface ForkOptions {
+  /** Pause the source VM during the fork checkpoint. Default false. */
+  pauseSource?: boolean;
+  /** Override the readiness poll timeout in ms. Defaults to the client's. */
+  timeoutMs?: number;
+}
+
+/**
+ * Forks the sandbox into n independent copy-on-write children and resolves once
+ * all are Ready. Supplied by the cluster client; a bare/server-mode Sandbox has
+ * none and fork() throws.
+ */
+export type Forker = (n: number, opts?: ForkOptions) => Promise<Sandbox[]>;
+
 export interface SandboxOptions {
   id: string;
   endpoint: string;
@@ -53,6 +68,8 @@ export interface SandboxOptions {
   /** Custom teardown. When omitted, terminate() is a no-op for the bare
    * Sandbox (the owning client supplies one). */
   terminator?: Terminator;
+  /** Fork capability. When omitted, fork() throws (server-mode/bare Sandbox). */
+  forker?: Forker;
 }
 
 // Proto-JSON wire shapes for the Connect sandbox.v1.Sandbox file RPCs. The
@@ -170,6 +187,7 @@ export class Sandbox {
   // (set_timeout, pause, resume) and the PTY WebSocket stay on http/ws.
   private readonly connect: ConnectClient;
   private readonly terminator?: Terminator;
+  private readonly forker?: Forker;
   // Retained so createPty can authenticate the WebSocket upgrade; the PTY
   // endpoint is gated by the same per-sandbox bearer token as the HTTP API.
   // Never logged.
@@ -193,6 +211,7 @@ export class Sandbox {
     // legacy /v1/* routes did (the endpoint is the server's own address).
     this.connect = new ConnectClient(toBaseUrl(opts.endpoint), opts.id, opts.token);
     this.terminator = opts.terminator;
+    this.forker = opts.forker;
     this.files = new SandboxFiles(this, this.connect);
   }
 
@@ -471,6 +490,29 @@ export class Sandbox {
       return this.terminator(opts);
     }
     return undefined;
+  }
+
+  /**
+   * Fork this running sandbox into n independent copy-on-write children and
+   * resolve once all are Ready. Children share the parent's memory pages until
+   * they write, so each lands in a warm, ready environment (the live fork-to-many
+   * primitive, #311). Returns the n child Sandboxes; each can fork again.
+   *
+   * Available on a cluster-bound Sandbox (one returned by the AgentRun cluster
+   * client). A bare or server-mode Sandbox has no fork capability and throws an
+   * LLM-legible error.
+   */
+  async fork(n = 1, opts?: ForkOptions): Promise<Sandbox[]> {
+    if (!this.forker) {
+      throw new AgentRunError("fork is not available on this sandbox", {
+        code: "fork_unsupported",
+        cause:
+          "this Sandbox was not created by the cluster client, so it carries no fork capability",
+        remediation:
+          "Create the sandbox via the cluster AgentRun client to use fork(n).",
+      });
+    }
+    return this.forker(n, opts);
   }
 }
 

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -182,6 +182,83 @@ describe("AgentRun.create", () => {
     expect(sandbox.endpoint).toBe("http://10.0.0.5:9091");
   });
 
+  it("fork(n) creates a fork Sandbox with replicas=n and returns n Ready children (#311)", async () => {
+    const fake = new FakeK8s({
+      getResponses: [
+        // create() waitReady for the source sandbox.
+        { phase: "Ready", endpoint: "10.0.0.5:9091", sandboxID: "sbx-src" },
+        // fork() poll: the fork object's status.children, all Ready.
+        {
+          children: [
+            { name: "sbx-1-fork-aa-0", phase: "Ready", endpoint: "10.0.0.6:9091", sandboxID: "c0" },
+            { name: "sbx-1-fork-aa-1", phase: "Ready", endpoint: "10.0.0.7:9091", sandboxID: "c1" },
+          ],
+        },
+      ],
+      secret: { token: "tok", endpoint: "10.0.0.5:9091" },
+    });
+    const run = new AgentRun({ k8s: fake, namespace: "team-a", sleep: noSleep });
+    const sb = await run.create("python-pool", { name: "sbx-1" });
+
+    const children = await sb.fork(2);
+
+    // Returns N live children.
+    expect(children).toHaveLength(2);
+    expect(children.map((c) => c.endpoint).sort()).toEqual([
+      "http://10.0.0.6:9091",
+      "http://10.0.0.7:9091",
+    ]);
+
+    // The fork object is a Sandbox with replicas=2 and source.fromSandbox.
+    const forkClaim = fake.createdClaims[1];
+    expect(forkClaim.kind).toBe("Sandbox");
+    const spec = forkClaim.spec as Record<string, unknown>;
+    expect(spec["replicas"]).toBe(2);
+    expect(spec["source"]).toEqual({ fromSandbox: { name: "sbx-1", pauseSource: false } });
+
+    // Children can fork again (the forker is injected into each child).
+    expect(typeof children[0].fork).toBe("function");
+  });
+
+  it("fork(n) raises an LLM-legible error when children are not ready in time (#311)", async () => {
+    const fake = new FakeK8s({
+      getResponses: [
+        { phase: "Ready", endpoint: "10.0.0.5:9091" },
+        { children: [] }, // never enough Ready children
+      ],
+      secret: { token: "tok" },
+    });
+    const run = new AgentRun({ k8s: fake, pollTimeoutMs: 5, sleep: noSleep });
+    const sb = await run.create("p", { name: "sbx-1" });
+    await expect(sb.fork(2)).rejects.toMatchObject({ code: "ready_timeout" });
+  });
+
+  it("fork(n) surfaces a rejected fork as an LLM-legible error, not a timeout (#311)", async () => {
+    const fake = new FakeK8s({
+      getResponses: [
+        { phase: "Ready", endpoint: "10.0.0.5:9091" },
+        {
+          conditions: [
+            {
+              type: "Rejected",
+              status: "True",
+              reason: "SecretInheritanceDenied",
+              message:
+                "source sandbox holds secrets; recreate the fork with spec.secretInheritance=inherit to permit it",
+            },
+          ],
+        },
+      ],
+      secret: { token: "tok" },
+    });
+    const run = new AgentRun({ k8s: fake, pollTimeoutMs: 50, sleep: noSleep });
+    const sb = await run.create("p", { name: "sbx-1" });
+    await expect(sb.fork(2)).rejects.toMatchObject({
+      code: "fork_rejected",
+      errorCause: "SecretInheritanceDenied",
+    });
+  });
+
   it("times out with a clear error when the sandbox never becomes Ready", async () => {
     const fake = new FakeK8s({ getResponses: [{ phase: "Pending" }] });
     const run = new AgentRun({ k8s: fake, pollTimeoutMs: 5, sleep: noSleep });


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and live-forks a running VM into many isolated children (best-of-N, tree-of-thought, RL fan-out); that is the flagship, category-defining demo.
> - The DX that sells it is one call returning N live children, exposed identically across the SDKs and CLI.
> - The Python SDK and the k8s API already did this (Sandbox.fork(n) -> list, spec.replicas + source.fromSandbox), but the TypeScript SDK had no cluster fork and the CLI flag/command did not match the documented one-liner.
> - Refused forks (secret inheritance, capacity, budget) only timed out, so the real reason was not surfaced; the issue requires LLM-legible {code, cause, remediation} on refusal.
> - This serves the homepage/use-case DX (ROADMAP api/dx; relates #22, #24) where the snippet must run verbatim.
> - This pull request adds TypeScript cluster fork(n), the `mitos fork <id> --count N` one-liner, and fork_rejected errors across all SDK waiters.
> - The benefit is fork-to-many is a true one-liner with the same shape and error legibility in every surface.

## Linked Issues or Issue Description

Closes #311.

## What Changed

- **TypeScript cluster SDK**: `Sandbox.fork(n, opts?)` creates a Sandbox with `spec.source.fromSandbox` + `replicas=n`, waits for all n children to reach Ready, and returns each as a bound `Sandbox` (own token, own forker). Injected like the existing `terminator`; a bare/server-mode Sandbox throws a clear `fork_unsupported` error. New `Forker`/`ForkOptions` types exported.
- **CLI**: top-level `mitos fork <id> --count N` (alias of `mitos sandbox fork`); `--count` is the documented flag, `--replicas` kept as a back-compat alias.
- **LLM-legible refusals**: a refused fork is terminal with a `Rejected` condition; the cluster fork waiters now raise a `fork_rejected` `AgentRunError` carrying the condition reason + message instead of timing out. Applied to the TS waiter and the Python sync and async waiters.
- **Docs**: the TS cluster example shows `fork(2)`; the README Python hero snippet already runs verbatim.

## Verification

- [x] TS: `npm test` (109 passed) incl. new fork(n) success, timeout, and rejection tests; `npm run build` and `npm run check:examples` clean (the fork example compiles).
- [x] Python: `python3 -m pytest` full suite (298 passed) incl. the new `fork_rejected` test; sync + async waiters covered.
- [x] CLI: `go test ./internal/agentcli/` incl. new `--count` and top-level `fork` dispatch tests; `go build`/`go vet`/`gofmt` clean.
- [ ] Returns N Ready children on a real KVM cluster: the maintainer's gated KVM e2e (cannot run from CI here).

## Risks

Low risk. Additive: new TS method + new CLI flag/command + a new terminal-state branch in the fork waiters. Existing `--replicas` and Python fork(n) behavior unchanged.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (TS example)
- [x] Threat-model delta included if the security surface moved (n/a)
- [x] Benchmark run included if the hot path was touched (n/a; control-plane fan-out, not the engine hot path)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged (per-child tokens read into memory only)
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
