### PR TITLE
feat(kubectl-mitos): label guest ps with claim/pool/workspace from the Sandbox CRD (#164)

### DIFF
--- a/cmd/kubectl-mitos/ps_guest.go
+++ b/cmd/kubectl-mitos/ps_guest.go
@@ -11,8 +11,11 @@ import (
 	"time"
 
 	connect "connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "mitos.run/mitos/api/v1"
 	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
 	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // This file is the kubectl mitos ps consumer of the Layer 3 guest telemetry
@@ -40,11 +43,12 @@ type guestVitals struct {
 	Processes          []guestProcess
 }
 
-// labeledVitals is the guest snapshot the ps consumer renders, plus the host's
+// labeledVitals is the guest snapshot the ps consumer renders, plus the
 // claim/pool/workspace labels. The numeric sample (steal, memory vs balloon)
 // comes from the Connect Vitals RPC and the per-process table from the Connect
-// Processes RPC. The claim/pool/workspace labels are not carried by either RPC,
-// so they render empty until a future labeled RPC fills them.
+// Processes RPC. The claim/pool/workspace labels are Kubernetes control-plane
+// metadata the guest cannot know, so they are resolved from the Sandbox object
+// (sandboxLabels), not over the guest RPCs (#164 item 1).
 type labeledVitals struct {
 	Claim     string
 	Pool      string
@@ -151,6 +155,11 @@ func runPsProcesses(namespace, name string) error {
 	if err == nil && endpoint != "" {
 		v, ferr := fetchGuestVitals(ctx, http.DefaultClient, endpoint, token, ref)
 		if ferr == nil {
+			// Claim/pool/workspace are control-plane metadata on the Sandbox
+			// object; the guest cannot know them, so they are resolved from the
+			// CRD here rather than over the guest vitals RPC (#164 item 1).
+			v.Namespace = namespace
+			v.Claim, v.Pool, v.Workspace = sandboxLabels(ctx, c, namespace, name)
 			fmt.Print(renderGuestProcesses(v))
 			return nil
 		}
@@ -159,6 +168,27 @@ func runPsProcesses(namespace, name string) error {
 		fmt.Fprintf(os.Stderr, "note: %v; falling back to fork sandbox listing\n", err)
 	}
 	return runPs(namespace, false, name)
+}
+
+// sandboxLabels resolves the claim/pool/workspace labels for a sandbox from its
+// Sandbox object. These are Kubernetes control-plane metadata the guest cannot
+// know (the guest is just a VM), so they are read from the CRD here rather than
+// carried over the guest vitals RPC (#164 item 1). Best-effort: on a read error
+// the claim degrades to the requested name with empty pool/workspace, so the ps
+// table still renders something honest.
+func sandboxLabels(ctx context.Context, c client.Client, namespace, name string) (claim, pool, workspace string) {
+	claim = name
+	var sb v1.Sandbox
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sb); err != nil {
+		return claim, "", ""
+	}
+	if sb.Spec.Source.PoolRef != nil {
+		pool = sb.Spec.Source.PoolRef.Name
+	}
+	if sb.Spec.WorkspaceRef != nil {
+		workspace = sb.Spec.WorkspaceRef.Name
+	}
+	return claim, pool, workspace
 }
 
 // renderGuestProcesses formats the real in-guest process table as a column table

--- a/cmd/kubectl-mitos/ps_guest_test.go
+++ b/cmd/kubectl-mitos/ps_guest_test.go
@@ -7,8 +7,44 @@ import (
 	"testing"
 
 	connect "connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "mitos.run/mitos/api/v1"
 	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// TestSandboxLabelsFromCRD proves the claim/pool/workspace labels rendered by
+// `kubectl mitos ps --processes` come from the Sandbox object (control-plane
+// metadata the guest cannot know), not from the guest vitals RPC (#164 item 1).
+func TestSandboxLabelsFromCRD(t *testing.T) {
+	scheme := execScheme(t)
+	sandbox := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "team-a"},
+		Spec: v1.SandboxSpec{
+			Source:       v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "python-pool"}},
+			WorkspaceRef: &v1.LocalObjectReference{Name: "ws-1"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox).Build()
+
+	claim, pool, ws := sandboxLabels(context.Background(), c, "team-a", "sbx")
+	if claim != "sbx" || pool != "python-pool" || ws != "ws-1" {
+		t.Fatalf("got claim=%q pool=%q workspace=%q, want sbx/python-pool/ws-1", claim, pool, ws)
+	}
+}
+
+// TestSandboxLabelsMissingObjectDegrades proves the labels degrade gracefully
+// (claim = the requested name, empty pool/workspace) when the Sandbox object is
+// not readable, so the ps table still renders honestly.
+func TestSandboxLabelsMissingObjectDegrades(t *testing.T) {
+	scheme := execScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	claim, pool, ws := sandboxLabels(context.Background(), c, "default", "ghost")
+	if claim != "ghost" || pool != "" || ws != "" {
+		t.Fatalf("got claim=%q pool=%q workspace=%q, want ghost//", claim, pool, ws)
+	}
+}
 
 // TestFetchGuestVitals_FirstSampleAndProcesses verifies the ps --processes path
 // builds the snapshot from TWO Connect calls: it takes the FIRST GuestVitals


### PR DESCRIPTION
## Thinking Path

> - Mitos exposes per-sandbox observability; `kubectl mitos ps --processes` shows the REAL in-guest process table over the Connect Vitals/Processes RPCs (Layer 3 of #164).
> - The rendered header has claim/pool/workspace columns, but they came out empty: the code expected them from a "future labeled RPC".
> - That is the wrong design: claim/pool/workspace are Kubernetes control-plane metadata; the guest is just a VM and cannot know them. The controller even ships them to forkd (ForkRequest.vitals_labels), but forkd never reads them.
> - The plugin already has cluster access and fetches the Sandbox object to resolve the endpoint and token, so the labels are one field-read away.
> - This serves #164 Layer 3 (the last user-visible gap) and the agent-facing observability surface.
> - This pull request resolves the labels from the Sandbox CRD in the plugin, with no guest agent or proto change.
> - The benefit is `ps --processes` shows accurate claim/pool/workspace next to real guest processes.

## Linked Issues or Issue Description

Part of #164 (observability Layer 3). Closes the last user-visible gap of the guest telemetry bridge; the remaining #164 items are being rescoped separately.

## What Changed

- Add `sandboxLabels(ctx, c, namespace, name)` deriving claim (the sandbox name), pool (`spec.source.poolRef`), and workspace (`spec.workspaceRef`) from the Sandbox object. Best-effort: degrades to the name with empty pool/workspace on a read error so the table still renders honestly.
- Populate the labels in `runPsProcesses` before rendering. No guest agent or proto change.
- Update the now-stale comment that said labels render empty "until a future labeled RPC fills them".

## Verification

- [x] TDD: added `TestSandboxLabelsFromCRD` (fake client with poolRef + workspaceRef) and `TestSandboxLabelsMissingObjectDegrades`, watched the build fail on the undefined symbol, then pass.
- [x] `go test ./cmd/kubectl-mitos/` green; `gofmt`/`go vet` clean.

## Risks

Low risk. CLI-only; one extra lightweight Get on an interactive command; degrades gracefully when the object is unreadable.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (stale comment corrected)
- [x] Threat-model delta included if the security surface moved (n/a; read-only CLI)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
