### PR TITLE
fix(release): auto-publish signed images on release and track the version in the chart

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,21 +7,50 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # actions:write lets the cascade step below dispatch publish.yaml when a
+  # release is cut without a PAT configured.
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      # When RELEASE_PLEASE_TOKEN (a PAT or GitHub App token) is set, the tag
+      # release-please pushes triggers publish.yaml naturally, so the explicit
+      # dispatch below is skipped to avoid a duplicate publish run.
+      HAS_RP_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           # A release or tag created with the default GITHUB_TOKEN does NOT
           # trigger other workflows (GitHub blocks recursive token-driven runs),
-          # so the tag/release that release-please cuts would never start
-          # publish.yaml (images) or operator-release.yaml (OperatorHub bundle).
-          # Set the RELEASE_PLEASE_TOKEN secret to a PAT or GitHub App token with
-          # contents:write and workflow scope so the release event cascades to
-          # those workflows. It falls back to GITHUB_TOKEN when unset, which keeps
-          # today's behavior (the release PR still lands, downstream stays manual).
+          # so the tag release-please cuts would not start publish.yaml (images)
+          # on its own. Two ways to make releases publish automatically:
+          #   1. Set the RELEASE_PLEASE_TOKEN secret to a PAT or GitHub App token
+          #      with contents:write and workflow scope; the release event then
+          #      cascades to every downstream workflow naturally.
+          #   2. Leave it unset (the default): the cascade step below dispatches
+          #      publish.yaml explicitly. workflow_dispatch IS allowed under
+          #      GITHUB_TOKEN (unlike push/tag/release events), so no secret is
+          #      needed and images still publish on every release.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Publish the signed images for the new release. Without this, a release cut
+      # with the default GITHUB_TOKEN would tag the repo but never build or push
+      # images, leaving users unable to pull the new version (the v1.3.0 gap).
+      # Skipped when a PAT is configured, since the tag push already cascades.
+      - name: Publish images for the new release
+        if: ${{ steps.release.outputs.releases_created == 'true' && env.HAS_RP_TOKEN != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs['.--tag_name'] }}
+        run: |
+          if [ -z "${TAG}" ]; then
+            echo "release created but no tag name resolved; not dispatching publish" >&2
+            exit 1
+          fi
+          echo "Release ${TAG} cut with GITHUB_TOKEN; dispatching the signed-image publish workflow for it."
+          gh workflow run publish.yaml -f tag="${TAG}" -f ref="${TAG}"

--- a/deploy/charts/mitos/Chart.yaml
+++ b/deploy/charts/mitos/Chart.yaml
@@ -5,8 +5,8 @@ name: mitos
 # lifecycle through the mitos.run CRDs.
 description: Snapshot-fork sandboxes for AI agents on Kubernetes.
 type: application
-version: 0.4.1
-appVersion: "v0.13.0"
+version: 0.4.1 # x-release-please-version
+appVersion: "v0.13.0" # x-release-please-version
 kubeVersion: ">=1.29.0-0"
 keywords:
   - sandbox

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -23,7 +23,7 @@ controller:
     # Image repository for the controller (appended to image.registry).
     repository: mitos-controller
     # Image tag for the controller. Defaults to the chart appVersion.
-    tag: v0.13.0
+    tag: ""
     # Image pull policy for the controller container.
     pullPolicy: IfNotPresent
   # Number of controller replicas. Multiple replicas run HA with leader election.
@@ -91,7 +91,7 @@ controller:
 huskStub:
   image:
     repository: mitos-husk-stub
-    tag: v0.13.0
+    tag: ""
     pullPolicy: IfNotPresent
 
 # forkd (DaemonSet): the per-node privileged snapshot builder. Schedules only on
@@ -99,7 +99,7 @@ huskStub:
 forkd:
   image:
     repository: mitos-forkd
-    tag: v0.13.0
+    tag: ""
     pullPolicy: IfNotPresent
   # forkd container resource requests and limits. mitos.run/kvm is the device
   # plugin resource that injects /dev/kvm and /dev/net/tun; it REPLACES
@@ -136,7 +136,7 @@ devicePlugin:
   enabled: true
   image:
     repository: mitos-kvm-device-plugin
-    tag: v0.13.0
+    tag: ""
     pullPolicy: IfNotPresent
 
 # Kernel provisioner (DaemonSet): stages the guest kernel into the node hostPath
@@ -184,7 +184,7 @@ facade:
   enabled: false
   image:
     repository: mitos-facade
-    tag: v0.13.0
+    tag: ""
     pullPolicy: IfNotPresent
   # The mitos.run pool a Sandbox binds to when it carries no bridge annotation.
   defaultPool: default
@@ -277,7 +277,7 @@ console:
   edition: community
   image:
     repository: mitos-console
-    tag: v0.13.0
+    tag: ""
     pullPolicy: IfNotPresent
   # Console replicas. The OIDC login flow keeps session and OIDC-state per-pod in
   # memory with no shared backing, so multiple replicas behind one Service break
@@ -402,7 +402,7 @@ gateway:
   enabled: true
   image:
     repository: mitos-gateway
-    tag: v0.13.0
+    tag: ""
     pullPolicy: IfNotPresent
   replicas: 2
   # Abuse-control enforcement (quotas, rate limits, and the kill-switch). Default

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,9 @@
         { "type": "ci", "section": "CI", "hidden": true },
         { "type": "test", "section": "Tests", "hidden": true },
         { "type": "refactor", "section": "Refactoring", "hidden": true }
+      ],
+      "extra-files": [
+        { "type": "generic", "path": "deploy/charts/mitos/Chart.yaml" }
       ]
     }
   }


### PR DESCRIPTION
## Thinking Path
Real-world verification on box2 surfaced the root cause: box2 runs v0.13.0 because newer releases never published images. The pipeline is architected correctly (release-please + publish.yaml with the right inputs) but the GITHUB_TOKEN-cut tag does not trigger publish.yaml, and the chart is frozen at v0.13.0. Fixed both so releases land for users with no manual steps and no required secret.

## Linked Issues or Issue Description
Production-ready release pipeline (the v1.3.0-never-published gap). Unblocks deploying the merged Run with Mitos code (#442, #443, #447) to real clusters.

## What Changed
- `release-please.yml`: dispatch `publish.yaml` for the new tag when a release is cut and no PAT is configured (workflow_dispatch is the documented exception that fires under GITHUB_TOKEN); `actions: write` added for the dispatch.
- `release-please-config.json`: `extra-files` generic updater for `deploy/charts/mitos/Chart.yaml`.
- `Chart.yaml`: annotate `version` and `appVersion` so release-please bumps them in lockstep (appVersion keeps its `v` prefix to match published image tags).
- `values.yaml`: empty the seven hardcoded mitos component tags so they fall back to `.Chart.AppVersion` (the existing preview-proxy pattern).

## Verification
`helm template` (kube 1.31) renders all seven images at the current `v0.13.0` via the appVersion fallback (behavior preserved now, tracks the release going forward); `helm lint` clean; `release-please-config.json` valid JSON; no em or en dashes. actionlint runs in CI.

## Risks
Low. Chart version moves to lockstep with the app version on the next release (0.4.1 -> the release version); chart-releaser publishes the new version so users receive it. No token needed; a PAT remains optional and is respected.

## Model Used
Claude Opus 4.8 (1M context)

## Checklist
- [x] Verified with helm template + lint
- [x] No secret required (works with GITHUB_TOKEN)
- [x] No em or en dashes