### PR TITLE
test(e2b): assert preview-URL parity in the migration sample, fix stale get_host note (#317)

### DIFF
--- a/sdk/python/mitos/e2b.py
+++ b/sdk/python/mitos/e2b.py
@@ -28,7 +28,7 @@ E2B method -> mitos op (and whether it works TODAY against the standalone server
     sandbox.run_code(code)     -> DirectSandbox.run_code (rich MIME)  needs guest agent
     sandbox.set_timeout(s)     -> DirectSandbox.set_timeout (issue #218)  works today
     sandbox.kill()             -> DirectSandbox.terminate             works today
-    sandbox.get_host(port)     -> preview URLs (issue #126)           NOT AVAILABLE
+    sandbox.get_host(port)     -> preview URLs (issue #126)           works (proxy deployed)
 
 "works today" vs "needs guest agent": the create / connect / list / kill /
 set_timeout lifecycle answers on the bare mock-engine sandbox-server (no KVM).
@@ -36,10 +36,11 @@ exec / files / run_code need a real guest agent over vsock, so they are proven
 against a fake target in the unit tests and run end-to-end in the KVM CI job;
 this exactly mirrors the LangChain / OpenAI adapters (#203 / #204).
 
-``get_host`` is the ONE op with no honest mapping yet: it depends on preview
-URLs (issue #126), which are not built. Rather than fabricate a URL, it raises a
-clear typed ``AgentRunError`` (the #216 apierr envelope: stable ``code``, a
-``cause``, and actionable ``remediation``) naming the missing feature.
+``get_host`` delegates to the native ``DirectSandbox.get_host``: it returns a
+signed, expiring preview URL for the port, served by the per-sandbox preview
+reverse proxy (issue #126, now built). A server that does not expose the preview
+proxy returns a typed ``AgentRunError`` (the #216 apierr envelope: stable
+``code``, ``cause``, actionable ``remediation``) rather than a fabricated URL.
 
 NO hard dependency on the ``e2b`` package: this module imports it NEVER. The
 class and namespace shapes (``sandbox.commands.run``, ``sandbox.files.read``)

--- a/sdk/python/tests/test_e2b_compat.py
+++ b/sdk/python/tests/test_e2b_compat.py
@@ -166,6 +166,11 @@ def test_e2b_style_script_runs_unchanged(monkeypatch):
     deadline = sandbox.set_timeout(300)
     assert deadline > 0
 
+    # get_host(port) -> a signed preview URL for a guest port (the "Done when":
+    # a real E2B sample runs unchanged INCLUDING a preview URL).
+    host = sandbox.get_host(3000)
+    assert host.startswith("https://") and "port=3000" in host
+
     # kill -> terminate
     sandbox.kill()
     # --- end verbatim E2B surface ---


### PR DESCRIPTION
## Thinking Path

> - The E2B "change one import" shim (`mitos.e2b`) is the highest-leverage integration: anything that supports E2B works the moment the shim is at parity.
> - #317 asked to close the remaining gaps (get_host preview URL via #126, create/connect/list, set_timeout, kill) and prove a real E2B sample runs unchanged including a preview URL.
> - Auditing the code: create/connect/list/set_timeout/kill/run_code/commands/files all map, and get_host now delegates to DirectSandbox.get_host, which mints a signed preview URL via the sandbox-server `/v1/preview` endpoint (the preview proxy, #126, is now closed). The standalone server serves it, so self-hosted/air-gapped works.
> - Two loose ends predated #126 landing: the module header still said get_host was "NOT AVAILABLE", and the unchanged-import migration sample test covered every op except get_host.
> - This serves the "self-hosted E2B alternative" wedge (smolagents/deepagents/CrewAI/OpenHands) and the migration docs.
> - This pull request corrects the stale note and adds the preview-URL call to the migration sample.
> - The benefit is the drop-in parity is true and proven end to end in one sample.

## Linked Issues or Issue Description

Closes #317. (Depends on #126, closed.)

## What Changed

- `sdk/python/mitos/e2b.py`: correct the module header that still claimed `get_host` was "NOT AVAILABLE / not built" and raised an error; it now delegates to `DirectSandbox.get_host` (signed preview URL via the per-sandbox preview proxy, #126).
- `sdk/python/tests/test_e2b_compat.py`: add a `get_host(3000)` call to `test_e2b_style_script_runs_unchanged` so the unchanged-import sample exercises a preview URL too (the literal "Done when").

## Verification

- [x] `python3 -m pytest tests/test_e2b_compat.py` (13 passed), including the strengthened migration sample.
- [x] Confirmed `get_host` delegates to `DirectSandbox.get_host` (direct.py) which POSTs `/v1/preview`, and the standalone `sandbox-server` serves that endpoint (`cmd/sandbox-server/preview_test.go`).
- [x] `docs/migrating-from-e2b.md` support table shows every op green.

## Risks

Low risk. No production behavior change: `get_host` already worked and was unit-tested separately; this corrects a stale doc-comment and broadens one acceptance test.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (module header corrected; support table already green)
- [x] Threat-model delta included if the security surface moved (n/a)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
