### PR TITLE
fix(release): resolve publish tag from the latest release (auto-dispatch was a no-op)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,10 +46,14 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' && env.HAS_RP_TOKEN != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs['.--tag_name'] }}
         run: |
+          # Resolve the tag release-please just created from the latest release,
+          # rather than a release-please-action output whose key has varied across
+          # versions (a missing key silently skipped publishing). The latest
+          # release is the one release-please created on this run.
+          TAG="$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName')"
           if [ -z "${TAG}" ]; then
-            echo "release created but no tag name resolved; not dispatching publish" >&2
+            echo "release created but no tag resolved; not dispatching publish" >&2
             exit 1
           fi
           echo "Release ${TAG} cut with GITHUB_TOKEN; dispatching the signed-image publish workflow for it."


### PR DESCRIPTION
## Thinking Path
Cutting v1.4.0 created the tag and release but the auto-dispatch step failed: it read steps.release.outputs['.--tag_name'], which resolved empty on release-please-action v4, so the guard exited 1 and publish.yaml never ran (I dispatched v1.4.0 by hand). Make the tag resolution version-robust.

## Linked Issues or Issue Description
Follow-up to #450. Without this, the auto-publish cascade is a no-op on every release.

## What Changed
`release-please.yml`: resolve the tag from `gh release list --limit 1` (the release release-please just created) instead of a release-please-action output key, then dispatch publish.yaml with it.

## Verification
v1.4.0 images are publishing now via the manual dispatch (the same `gh workflow run publish.yaml -f tag=...` this step runs), confirming the dispatch path itself works; this only changes how the tag is resolved. actionlint runs in CI.

## Risks
Low. `gh release list --limit 1` returns the newest release, which is the one release-please created on the run. Guarded to fail loudly if no tag resolves.

## Model Used
Claude Opus 4.8 (1M context)

## Checklist
- [x] Verified the dispatch path works (v1.4.0 publishing)
- [x] No secret required
- [x] No em or en dashes