### PR TITLE
fix(build): add the preview-proxy Dockerfile + publish it (expose proxy was never buildable)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,8 @@ jobs:
             dockerfile: Dockerfile.kvm-device-plugin
           - name: mitos-facade
             dockerfile: Dockerfile.facade
+          - name: preview-proxy
+            dockerfile: Dockerfile.preview-proxy
           - name: mitos-console
             dockerfile: Dockerfile.console
           - name: mitos-gateway

--- a/Dockerfile.preview-proxy
+++ b/Dockerfile.preview-proxy
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+# The Mitos Expose edge proxy (cmd/preview-proxy): terminates TLS for the
+# wildcard sandbox preview subdomains and proxies to the right sandbox guest
+# port. Built and published like the other components (publish.yaml matrix).
+FROM golang:1.26-bookworm AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o preview-proxy ./cmd/preview-proxy/
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /build/preview-proxy /preview-proxy
+ENTRYPOINT ["/preview-proxy"]


### PR DESCRIPTION
## Thinking Path
Deploying v1.4.0 and enabling expose on a real cluster, the preview-proxy hit ImagePullBackOff: ghcr.io/mitos-run/preview-proxy never existed because there was no Dockerfile.preview-proxy and publish.yaml never built it. So the entire Mitos Expose subsystem has never been deployable, despite the controller code, chart, and CRD field being merged.

## Linked Issues or Issue Description
Makes the expose subsystem actually shippable. Companion to the chart CRD sync (#454) which restored the Sandbox.spec.expose field.

## What Changed
- Add Dockerfile.preview-proxy (same golang:1.26 builder + distroless pattern as Dockerfile.controller).
- Add the preview-proxy entry to publish.yaml's image matrix so the signed image is built and pushed on every release.

## Verification
go build ./cmd/preview-proxy/ compiles; built the image from this Dockerfile on a real node and the proxy starts, loads its TLS cert, and serves :8443/:8080. Built and imported to verify the expose proxy comes up.

## Risks
Low; adds one image to the publish matrix and a standard Dockerfile.

## Model Used
Claude Opus 4.8 (1M context)

## Checklist
- [x] preview-proxy compiles and runs from this image
- [x] Added to the publish matrix
- [x] No em or en dashes