### PR TITLE
fix(cas): unpin deleted templates and drive periodic CAS GC (#464)

### DIFF
--- a/cmd/forkd/main.go
+++ b/cmd/forkd/main.go
@@ -18,6 +18,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"mitos.run/mitos/internal/casgc"
 	"mitos.run/mitos/internal/daemon"
 	"mitos.run/mitos/internal/dnsproxy"
 	"mitos.run/mitos/internal/fork"
@@ -64,6 +65,9 @@ func main() {
 		maxExecTimeoutSecs   int
 		casListen            string
 		allowInsecureGRPC    bool
+		casGCInterval        time.Duration
+		casDiskHigh          float64
+		casDiskLow           float64
 	)
 	// peerToken is read from the environment, NOT a flag: a flag is visible in
 	// /proc/<pid>/cmdline, and the token is a credential. The controller already
@@ -84,6 +88,9 @@ func main() {
 	flag.StringVar(&chrootBase, "chroot-base", "/srv/jailer", "Jailer chroot base directory; must share a filesystem with --data-dir")
 	flag.StringVar(&uidRange, "uid-range", "64000-64999", "Inclusive uid/gid range for per-VM jailer users, formatted low-high")
 	flag.StringVar(&casDir, "cas-dir", "", "Content-addressed store directory for snapshot integrity and transfer. Empty means <data-dir>/cas")
+	flag.DurationVar(&casGCInterval, "cas-gc-interval", 5*time.Minute, "How often forkd evicts unpinned CAS chunks when the data-dir filesystem crosses --cas-disk-high-watermark; 0 disables CAS GC. Pinned (active-template) chunks are never evicted (#464)")
+	flag.Float64Var(&casDiskHigh, "cas-disk-high-watermark", 0.85, "Data-dir filesystem used fraction at or above which CAS GC evicts; prevents un-GC'd CAS from tripping node DiskPressure (#464)")
+	flag.Float64Var(&casDiskLow, "cas-disk-low-watermark", 0.70, "Data-dir filesystem used fraction the CAS GC evicts down toward when triggered")
 	flag.BoolVar(&allowUnverified, "allow-unverified-snapshots", false, "Allow forking snapshots that fail or skip integrity verification (development only; refused by default)")
 	flag.BoolVar(&allowIncompatible, "allow-incompatible-snapshots", false, "Allow forking snapshots whose recorded environment (Firecracker version, CPU model, or snapshot format) is incompatible with this host (development only; refused by default)")
 	flag.BoolVar(&enableNet, "enable-networking", false, "Enable per-sandbox guest networking (tap device, egress nftables, NIC attach). Default false until proven on KVM CI")
@@ -158,6 +165,9 @@ func main() {
 	// template distribution. Set only on the real engine when mTLS and a peer
 	// token are both configured. Nil leaves the HTTP server plaintext as before.
 	var casServing *daemon.CASServing
+	// casGCStore is the real engine's CAS store, captured for the periodic GC
+	// (#464). nil in mock mode (no real CAS to evict).
+	var casGCStore casgc.Store
 
 	if mockMode {
 		fmt.Println("forkd: running in mock mode")
@@ -290,6 +300,7 @@ func main() {
 			os.Exit(1)
 		}
 		engine = real
+		casGCStore = real.CASStore()
 
 		// Raw-forkd multi-tenant gate (security blocker 5): the raw-forkd engine
 		// path (this non-husk forkd DaemonSet) runs the daemon privileged and, when
@@ -367,6 +378,16 @@ func main() {
 	metricsCtx, metricsCancel := context.WithCancel(context.Background())
 	defer metricsCancel()
 	go server.SampleMetrics(metricsCtx, 0)
+
+	// Periodic CAS garbage collection (#464): the content-addressed store evicts
+	// unpinned (deleted-template) chunks down to a low watermark whenever the
+	// data-dir filesystem crosses the high watermark, so orphaned chunks cannot
+	// grow unbounded and trip node DiskPressure. Pinned active-template chunks are
+	// never evicted. Cancelled on shutdown via metricsCtx.
+	if casGCStore != nil && casGCInterval > 0 {
+		go casgc.Run(metricsCtx, casGCStore, dataDir, casGCInterval, casDiskHigh, casDiskLow, casgc.DiskUsage,
+			func(format string, args ...any) { fmt.Fprintf(os.Stderr, "forkd: "+format+"\n", args...) })
+	}
 
 	// Start the controlled DNS resolver (node-level Runnable) when enabled. It
 	// binds the resolver IP on port 53 (udp + tcp); a listen failure is fatal

--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -146,6 +146,31 @@ missed left the VM's backing files behind after the VM itself was reaped.
 - Proving test: `TestGCSweepsOrphanVolumes` (volume orphan past grace reclaimed;
   backed and fresh backings left alone).
 
+### CAS disk exhaustion: orphaned chunks are evicted before DiskPressure
+
+forkd's content-addressed store evicts least-recently-used UNPINNED chunks so a
+node's data dir cannot fill with debris from deleted templates and trip the
+kubelet's DiskPressure eviction (the capacity-exhaustion answer for forkd's local
+disk, #464). Two pieces close the loop the eviction primitive previously lacked:
+
+- `DeleteTemplate` now unpins the template's CAS manifest
+  (`internal/fork/engine.go`), so a deleted template's chunks stop being pinned
+  and become eligible for eviction. Previously they stayed pinned forever and the
+  CAS grew unbounded (observed: 13 GB with zero active pools).
+- A periodic GC (`internal/casgc`, started in `cmd/forkd`) checks the data-dir
+  filesystem each `--cas-gc-interval` and, when usage crosses
+  `--cas-disk-high-watermark`, calls `cas.EvictToFit` to bring the CAS down toward
+  `--cas-disk-low-watermark`. Pinned (active-template) chunks are never evicted,
+  so a node fills back off via the capacity heartbeat rather than losing data it
+  still needs.
+
+- Bound: with GC enabled, unpinned CAS bytes are reclaimed within one
+  `--cas-gc-interval` once the data-dir filesystem crosses the high watermark.
+- Proving tests: `casgc.TestTarget` and `TestTickEvictsOnlyAboveWatermark` (the
+  watermark math and trigger), `fork.TestDeleteTemplateUnpinsManifest` (delete
+  unpins), and the existing `cas.TestEvictToFitRespectsPinAndLRU` (pinned chunks
+  protected, LRU order).
+
 ### Controller-restart reconciliation: desired state is rebuilt from CRDs
 
 The GC holds no in-memory desired state. Each pass rebuilds the desired-alive and

--- a/internal/cas/evict.go
+++ b/internal/cas/evict.go
@@ -29,6 +29,25 @@ func (s *Store) pinPath(d Digest) string {
 	return filepath.Join(s.root, "pins", string(d))
 }
 
+// IsPinned reports whether a manifest currently has a pin marker.
+func (s *Store) IsPinned(manifestDigest Digest) (bool, error) {
+	_, err := os.Stat(s.pinPath(manifestDigest))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat pin %s: %w", manifestDigest, err)
+}
+
+// TotalBytes returns the total on-disk size of all chunks in the store. It is
+// the exported accessor the periodic GC (internal/casgc) uses to decide how far
+// to evict.
+func (s *Store) TotalBytes() (int64, error) {
+	return s.totalChunkBytes()
+}
+
 // pinnedChunks returns the union of all chunk digests referenced by any
 // currently pinned manifest. A chunk in this set is never evicted.
 func (s *Store) pinnedChunks() (map[Digest]struct{}, error) {

--- a/internal/casgc/casgc.go
+++ b/internal/casgc/casgc.go
@@ -1,0 +1,86 @@
+// Package casgc drives the content-addressed store's eviction (cas.EvictToFit)
+// so orphaned chunks do not grow unbounded and trip node DiskPressure (#464).
+// The CAS already evicts least-recently-used UNPINNED chunks and never touches a
+// pinned (active-template) manifest; this package is the missing trigger: a
+// periodic loop that evicts when the data-dir filesystem crosses a high
+// watermark, down to a low watermark.
+package casgc
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the slice of cas.Store this package needs (cas.Store satisfies it).
+type Store interface {
+	TotalBytes() (int64, error)
+	EvictToFit(maxBytes int64) (int64, error)
+}
+
+// DiskUsageFunc reports the used and total bytes of the filesystem holding path.
+type DiskUsageFunc func(path string) (used, total int64, err error)
+
+// Target computes the CAS byte budget to evict down to. When the filesystem is
+// below the high watermark it returns evict=false (nothing to do). Otherwise it
+// returns the CAS size that, once evicted to, brings the filesystem to the low
+// watermark, clamped to >= 0 (0 means evict every unpinned chunk). Pinned chunks
+// are protected by EvictToFit regardless, so an active template is never evicted.
+func Target(usedBytes, totalBytes, casBytes int64, high, low float64) (maxBytes int64, evict bool) {
+	if totalBytes <= 0 || casBytes <= 0 {
+		return 0, false
+	}
+	if float64(usedBytes) < high*float64(totalBytes) {
+		return 0, false
+	}
+	target := int64(low * float64(totalBytes)) // desired used bytes after GC
+	toFree := usedBytes - target
+	if toFree <= 0 {
+		return 0, false
+	}
+	maxCAS := casBytes - toFree
+	if maxCAS < 0 {
+		maxCAS = 0
+	}
+	return maxCAS, true
+}
+
+// tick runs one GC evaluation. Exposed for tests.
+func tick(store Store, dataDir string, high, low float64, usage DiskUsageFunc, logf func(string, ...any)) {
+	used, total, err := usage(dataDir)
+	if err != nil {
+		logf("cas gc: read disk usage of %s: %v", dataDir, err)
+		return
+	}
+	casBytes, err := store.TotalBytes()
+	if err != nil {
+		logf("cas gc: read cas size: %v", err)
+		return
+	}
+	maxBytes, evict := Target(used, total, casBytes, high, low)
+	if !evict {
+		return
+	}
+	freed, err := store.EvictToFit(maxBytes)
+	if err != nil {
+		logf("cas gc: evict to %d bytes: %v", maxBytes, err)
+		return
+	}
+	if freed > 0 {
+		logf("cas gc: freed %d bytes (disk used %d/%d, cas target %d)", freed, used, total, maxBytes)
+	}
+}
+
+// Run drives tick on interval until ctx is cancelled. It is the trigger the CAS
+// eviction primitive lacked (#464). logf is the (non-secret) log sink.
+func Run(ctx context.Context, store Store, dataDir string, interval time.Duration, high, low float64, usage DiskUsageFunc, logf func(string, ...any)) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			tick(store, dataDir, high, low, usage, logf)
+		}
+	}
+}

--- a/internal/casgc/casgc_test.go
+++ b/internal/casgc/casgc_test.go
@@ -1,0 +1,76 @@
+package casgc
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTarget(t *testing.T) {
+	cases := []struct {
+		name             string
+		used, total, cas int64
+		high, low        float64
+		wantMax          int64
+		wantEvict        bool
+	}{
+		{name: "below high watermark: no evict", used: 50, total: 100, cas: 30, high: 0.85, low: 0.70, wantEvict: false},
+		{name: "above high: evict cas down to bring fs to low", used: 90, total: 100, cas: 30, high: 0.85, low: 0.70, wantMax: 10, wantEvict: true}, // free 20 -> cas 30-20=10
+		{name: "need to free more than cas holds: evict all", used: 95, total: 100, cas: 10, high: 0.85, low: 0.70, wantMax: 0, wantEvict: true},    // free 25 > cas 10 -> 0
+		{name: "empty cas: nothing to do", used: 95, total: 100, cas: 0, high: 0.85, low: 0.70, wantEvict: false},
+		{name: "zero total: nothing to do", used: 0, total: 0, cas: 10, high: 0.85, low: 0.70, wantEvict: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotMax, gotEvict := Target(c.used, c.total, c.cas, c.high, c.low)
+			if gotEvict != c.wantEvict {
+				t.Fatalf("evict = %v, want %v", gotEvict, c.wantEvict)
+			}
+			if gotEvict && gotMax != c.wantMax {
+				t.Fatalf("maxBytes = %d, want %d", gotMax, c.wantMax)
+			}
+		})
+	}
+}
+
+type fakeStore struct {
+	cas        int64
+	evictedTo  int64
+	evictCalls int
+}
+
+func (f *fakeStore) TotalBytes() (int64, error) { return f.cas, nil }
+func (f *fakeStore) EvictToFit(maxBytes int64) (int64, error) {
+	f.evictCalls++
+	f.evictedTo = maxBytes
+	freed := f.cas - maxBytes
+	if freed < 0 {
+		freed = 0
+	}
+	return freed, nil
+}
+
+func TestTickEvictsOnlyAboveWatermark(t *testing.T) {
+	logf := func(string, ...any) {}
+
+	// Below high watermark: no eviction.
+	below := &fakeStore{cas: 30}
+	tick(below, "/data", 0.85, 0.70, func(string) (int64, int64, error) { return 50, 100, nil }, logf)
+	if below.evictCalls != 0 {
+		t.Fatalf("evicted below the watermark (%d calls)", below.evictCalls)
+	}
+
+	// Above high watermark: evict down to the computed target (free 20 of cas 30 -> 10).
+	above := &fakeStore{cas: 30}
+	tick(above, "/data", 0.85, 0.70, func(string) (int64, int64, error) { return 90, 100, nil }, logf)
+	if above.evictCalls != 1 || above.evictedTo != 10 {
+		t.Fatalf("evict calls=%d to=%d, want 1 to=10", above.evictCalls, above.evictedTo)
+	}
+}
+
+func TestTickToleratesDiskError(t *testing.T) {
+	s := &fakeStore{cas: 100}
+	tick(s, "/data", 0.85, 0.70, func(string) (int64, int64, error) { return 0, 0, errors.New("statfs boom") }, func(string, ...any) {})
+	if s.evictCalls != 0 {
+		t.Fatal("evicted despite a disk-usage error")
+	}
+}

--- a/internal/casgc/disk_unix.go
+++ b/internal/casgc/disk_unix.go
@@ -1,0 +1,20 @@
+//go:build linux || darwin
+
+package casgc
+
+import "syscall"
+
+// DiskUsage reports the used and total bytes of the filesystem containing path,
+// via statfs. Bsize differs in type across linux/darwin, so it is widened to
+// uint64 before multiplying.
+func DiskUsage(path string) (used, total int64, err error) {
+	var st syscall.Statfs_t
+	if serr := syscall.Statfs(path, &st); serr != nil {
+		return 0, 0, serr
+	}
+	bsize := uint64(st.Bsize)
+	total = int64(uint64(st.Blocks) * bsize)
+	avail := int64(uint64(st.Bavail) * bsize)
+	used = total - avail
+	return used, total, nil
+}

--- a/internal/fork/deletetemplate_test.go
+++ b/internal/fork/deletetemplate_test.go
@@ -1,0 +1,44 @@
+package fork
+
+import (
+	"path/filepath"
+	"testing"
+
+	"mitos.run/mitos/internal/cas"
+	"mitos.run/mitos/internal/firecracker"
+)
+
+// TestDeleteTemplateUnpinsManifest proves DeleteTemplate unpins the template's
+// CAS manifest so its chunks become eligible for eviction (#464). Before this,
+// DeleteTemplate only removed the snapshot dir and left the manifest pinned
+// forever, so deleted templates' chunks grew the CAS unbounded.
+func TestDeleteTemplateUnpinsManifest(t *testing.T) {
+	dd := t.TempDir()
+	store, err := cas.New(filepath.Join(dd, "cas"))
+	if err != nil {
+		t.Fatalf("cas.New: %v", err)
+	}
+	d := cas.Digest("sha256:00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+	if err := store.Pin(d); err != nil {
+		t.Fatalf("Pin: %v", err)
+	}
+
+	e := &Engine{
+		dataDir:         dd,
+		casStore:        store,
+		templateMgr:     firecracker.NewTemplateManager("firecracker", "vmlinux", dd, firecracker.JailerConfig{}),
+		templateDigests: map[string]cas.Digest{"t1": d},
+	}
+
+	if err := e.DeleteTemplate("t1"); err != nil {
+		t.Fatalf("DeleteTemplate: %v", err)
+	}
+
+	pinned, err := store.IsPinned(d)
+	if err != nil {
+		t.Fatalf("IsPinned: %v", err)
+	}
+	if pinned {
+		t.Fatal("DeleteTemplate left the manifest pinned; deleted-template chunks would leak (#464)")
+	}
+}

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -2169,6 +2169,26 @@ func (e *Engine) DeleteTemplate(id string) error {
 			return err
 		}
 	}
+	// Unpin the template's CAS manifest so its chunks become eligible for
+	// eviction by the GC; otherwise a deleted template's chunks stay pinned
+	// forever and the CAS grows unbounded (#464). Prefer the in-memory digest,
+	// fall back to the persisted digest file so a post-restart delete still
+	// unpins. Best-effort: a failed unpin must not block the delete.
+	if e.casStore != nil {
+		e.mu.Lock()
+		d, ok := e.templateDigests[id]
+		e.mu.Unlock()
+		if !ok {
+			if fileD, ferr := readDigestFile(e.dataDir, id); ferr == nil {
+				d, ok = fileD, true
+			}
+		}
+		if ok {
+			if err := e.casStore.Unpin(d); err != nil {
+				fmt.Fprintf(os.Stderr, "forkd: WARNING unpin template %s manifest for GC: %v\n", id, err)
+			}
+		}
+	}
 	if err := e.templateMgr.DeleteTemplate(id); err != nil {
 		return fmt.Errorf("delete template %s: %w", id, err)
 	}


### PR DESCRIPTION
## Thinking Path

> - forkd's content-addressed store (internal/cas) dedups and serves template snapshot chunks on each node's local disk.
> - It already had EvictToFit (LRU eviction of unpinned chunks) and Unpin, but NOTHING called them: EvictToFit was dead code and DeleteTemplate only RemoveAll'd the snapshot dir without unpinning.
> - So a deleted template's chunks stayed pinned forever; orphaned chunks grew unbounded (observed live: 13 GB CAS with zero active pools), crossed the kubelet DiskPressure threshold, and took forkd down.
> - This violates CLAUDE.md #4 (boring failure behavior: a component must define what happens on capacity exhaustion).
> - This pull request wires the existing primitive to a trigger: DeleteTemplate unpins, and a periodic GC evicts when the data-dir filesystem crosses a watermark.
> - The benefit is the CAS cannot grow unbounded; a node fills back off via the capacity heartbeat instead of losing forkd to DiskPressure.

## Linked Issues or Issue Description

Closes #464. (Part of the DiskPressure-cascade trio with #463 (merged) and #469.)

## What Changed

- `DeleteTemplate` (internal/fork/engine.go) now unpins the template's CAS manifest (in-memory digest, falling back to the persisted digest file so a post-restart delete still unpins), so its chunks become eligible for eviction. Best-effort; never blocks the delete.
- New `internal/casgc` periodic GC, started in `cmd/forkd`: each `--cas-gc-interval` (default 5m) it reads the data-dir filesystem usage and, when it crosses `--cas-disk-high-watermark` (0.85), calls `cas.EvictToFit` to bring the CAS toward `--cas-disk-low-watermark` (0.70). EvictToFit only evicts UNPINNED, LRU chunks, so active-template chunks are never touched.
- `cas.TotalBytes` / `cas.IsPinned` exported accessors.
- `docs/failure-gc.md` records the disk-exhaustion guarantee.

## Verification

- [x] `casgc.TestTarget` (watermark math) and `TestTickEvictsOnlyAboveWatermark` / `TestTickToleratesDiskError` (trigger + fault tolerance).
- [x] `fork.TestDeleteTemplateUnpinsManifest` (RED before the fix, GREEN after).
- [x] Existing `cas.TestEvictToFitRespectsPinAndLRU` still passes (pinned chunks protected, LRU order).
- [x] `go build ./cmd/forkd/` clean on darwin and `GOOS=linux`; gofmt clean.

## Risks

Low risk. EvictToFit never touches pinned (active) chunks, so an in-use template cannot be evicted. GC is disabled with `--cas-gc-interval=0`. The unpin is best-effort and cannot fail a delete.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (failure-gc.md)
- [x] Threat-model delta included if the security surface moved (n/a; no new surface)
- [x] Benchmark run included if the hot path was touched (n/a; GC is off the fork hot path)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
