### PR TITLE
docs: wire Discord community into the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Roadmap
     url: https://github.com/mitos-run/mitos/blob/main/ROADMAP.md
     about: ROADMAP.md is the priority order for all work. Check it before requesting a feature.
+  - name: Discord community
+    url: https://discord.gg/zddgd2pgab
+    about: Usage questions, help, and general discussion. Use the support forums for how-do-I questions instead of opening an issue.

--- a/.github/workflows/discord-notify.yaml
+++ b/.github/workflows/discord-notify.yaml
@@ -1,0 +1,47 @@
+name: Discord notify
+
+# Posts release announcements and good-first-issue alerts to Discord via webhooks.
+# Webhook URLs are stored as repo secrets (DISCORD_WEBHOOK_ANNOUNCE,
+# DISCORD_WEBHOOK_GFI). User-controlled text (release name, issue title) is passed
+# through env vars rather than inline ${{ }} expansion to avoid script injection.
+
+on:
+  release:
+    types: [published]
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release to #announcements
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCE }}
+          NAME: ${{ github.event.release.name }}
+          TAG: ${{ github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then echo "DISCORD_WEBHOOK_ANNOUNCE not set, skipping"; exit 0; fi
+          title=":rocket: **${NAME:-$TAG}** is out"
+          jq -nc --arg t "$title" --arg u "$URL" '{content: ($t + "\n" + $u)}' \
+            | curl -sf -H "Content-Type: application/json" -d @- "$WEBHOOK"
+
+  good-first-issue:
+    if: github.event_name == 'issues' && github.event.label.name == 'good first issue'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post good first issue to #good-first-issues
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_GFI }}
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then echo "DISCORD_WEBHOOK_GFI not set, skipping"; exit 0; fi
+          jq -nc --arg t ":green_circle: **good first issue:** $TITLE" --arg u "$URL" \
+            '{content: ($t + "\n" + $u)}' \
+            | curl -sf -H "Content-Type: application/json" -d @- "$WEBHOOK"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,124 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, including the GitHub
+repositories and the Discord server, and also applies when an individual is
+officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+`conduct@mitos.run`. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction
+with the people involved, including unsolicited interaction with those enforcing
+the Code of Conduct, for a specified period of time. This includes avoiding
+interactions in community spaces as well as external channels like social media.
+Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+Community Impact: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards,
+including sustained inappropriate behavior, harassment of an individual, or
+aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 
 Thanks for your interest in contributing.
 
+## Talk to us
+
+Coordinate in the [Discord](https://discord.gg/zddgd2pgab) `#dev` channel:
+architecture questions, picking up an issue, or sanity-checking an approach
+before you open a PR. Bugs and feature requests still go through GitHub issues;
+design discussion can also live in GitHub Discussions.
+
 ## Build and test
 
 See the Commands section of [CLAUDE.md](CLAUDE.md) for the full list. The short version:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/mitos-run/mitos"><img alt="Go" src="https://img.shields.io/github/go-mod/go-version/mitos-run/mitos?label=go"></a>
   <a href="https://goreportcard.com/report/mitos.run/mitos"><img alt="Go Report Card" src="https://goreportcard.com/badge/mitos.run/mitos"></a>
   <a href="docs/"><img alt="Docs" src="https://img.shields.io/badge/docs-mitos-blue"></a>
+  <a href="https://discord.gg/zddgd2pgab"><img alt="Discord" src="https://img.shields.io/discord/1518722949295771759?label=discord&logo=discord&logoColor=white&color=5865F2"></a>
 </p>
 
 <p align="center">
@@ -28,7 +29,8 @@
   <a href="#features">Features</a> .
   <a href="#architecture">Architecture</a> .
   <a href="#comparison">Comparison</a> .
-  <a href="CONTRIBUTING.md">Contributing</a>
+  <a href="CONTRIBUTING.md">Contributing</a> .
+  <a href="https://discord.gg/zddgd2pgab">Community</a>
 </p>
 
 <p align="center">

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,16 @@
+# Getting help
+
+Pick the channel that matches what you need so the right people see it fast.
+
+| You want to | Go to |
+| --- | --- |
+| Ask how to do something (hosted or SDK) | Discord `#support` forum: https://discord.gg/zddgd2pgab |
+| Get help running Mitos on your own cluster | Discord `#self-hosting` forum |
+| Report a reproducible bug | [Open a bug report](https://github.com/mitos-run/mitos/issues/new?template=bug_report.yml) |
+| Request a feature | [Open a feature request](https://github.com/mitos-run/mitos/issues/new?template=feature_request.yml) |
+| Discuss a design or idea | [GitHub Discussions](https://github.com/mitos-run/mitos/discussions) |
+| Report a security vulnerability | Do not open a public issue. Follow [SECURITY.md](SECURITY.md). |
+
+For usage questions, the Discord support forums are faster than issues and the
+answers stay searchable for the next person. Please search existing forum posts
+and issues before opening a new one.


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs, and is built to grow an open-source contributor and user community.
> - This change touches repo-level community surfaces (README, issue templates, CONTRIBUTING, support and conduct docs, a CI workflow), not any runtime component.
> - Today the only community touchpoints are GitHub issues and Discussions; a Discord server now exists but nothing in the repo points to it, so users and contributors cannot find it.
> - Routing how-do-I questions to Discord and keeping bug reports on the tracker is standard open-source hygiene and keeps the issue tracker signal high.
> - This pull request wires the Discord server into the repo and automates release and good-first-issue announcements to it.
> - The benefit is a single discoverable community surface and an issue tracker that stays focused on actionable work.

## Linked Issues or Issue Description

No tracked issue. Problem: the repo exposes no path to the new Discord community, and release announcements are manual. This adds the links and a gated automation. Community work, no runtime behavior change.

## What Changed

- README: add a Discord badge to the badge row and a Community link to the nav row.
- `.github/ISSUE_TEMPLATE/config.yml`: add a Discord community contact link so usage questions route to chat instead of the tracker.
- CONTRIBUTING.md: add a "Talk to us" section pointing contributors to the Discord `#dev` channel.
- New SUPPORT.md: routing table (usage to Discord forums, bugs to issues, design to Discussions, security to SECURITY.md). GitHub renders this as the "Get help" banner.
- New CODE_OF_CONDUCT.md: Contributor Covenant 2.1, enforcement contact `conduct@mitos.run`.
- New `.github/workflows/discord-notify.yaml`: posts releases and good-first-issue items to Discord webhooks; user-controlled text is passed via env vars, not inline expansion, to avoid script injection.

## Verification

- [x] No Go or Python code paths changed, so go-test, go-lint, python-test, docker-build, and the e2e suites are unaffected.
- [x] The new workflow triggers only on `release: published` and `issues: labeled`; both jobs no-op when the `DISCORD_WEBHOOK_*` secrets are unset, so it cannot fail closed.
- [x] Markdown and YAML reviewed; no application logic involved.

## Risks

Low risk. Documentation and a secrets-gated notification workflow only. No runtime, security-surface, or hot-path change. Worst case is a missed or malformed Discord notification, which has no effect on the product.

## Model Used

Claude Opus 4.8 (model id `claude-opus-4-8`, 1M context), agentic mode in Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD) <!-- N/A: no behavior change, docs and CI only -->
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved <!-- N/A: surface unchanged -->
- [x] Benchmark run (bench/) included if the hot path was touched <!-- N/A: hot path untouched -->
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)
