### PR TITLE
docs(integrations): MCP recipes for Vercel AI SDK, Pydantic AI, AutoGen, LlamaIndex (#321)

### DIFF
--- a/docs/integrations/mcp-frameworks.md
+++ b/docs/integrations/mcp-frameworks.md
@@ -1,0 +1,136 @@
+# Run code in a Mitos sandbox from any MCP framework
+
+Mitos ships a standard Model Context Protocol server, [`mitos-mcp`](../mcp.md),
+that exposes the sandbox lifecycle as MCP tools (`sandbox_create`,
+`sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_fork`,
+`sandbox_terminate`). Any agent framework with an MCP client can drive a Mitos
+sandbox with no Mitos-specific adapter code: point its MCP client at `mitos-mcp`
+and the tools appear to the agent.
+
+This page is the idiomatic MCP recipe for four common frameworks. Each snippet
+spawns `mitos-mcp` over stdio; configure where it runs and which credential it
+uses with two environment variables (see [docs/mcp.md](../mcp.md)):
+
+- `MITOS_BASE_URL`: the sandbox-server base URL (defaults to `https://mitos.run`;
+  set it to your self-hosted or local standalone server).
+- `MITOS_API_KEY`: the bearer token (or run `mitos auth login` once and omit it).
+
+Install the binary so it is on `PATH` (`go install mitos.run/mitos/cmd/mitos-mcp@latest`,
+or use the released binary). The framework MCP APIs below move between versions,
+so each recipe links the framework's own MCP docs as the source of truth.
+
+## Vercel AI SDK (TypeScript)
+
+Official docs: <https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools>. The MCP imports
+moved between AI SDK versions (`ai` / `ai/mcp-stdio` in v4, the dedicated
+`@ai-sdk/mcp` package in newer releases); use the import your installed version
+documents.
+
+```ts
+import { experimental_createMCPClient as createMCPClient } from "ai";
+import { Experimental_StdioMCPTransport } from "ai/mcp-stdio";
+import { generateText } from "ai";
+
+const mcp = await createMCPClient({
+  transport: new Experimental_StdioMCPTransport({
+    command: "mitos-mcp",
+    env: { MITOS_BASE_URL: process.env.MITOS_BASE_URL!, MITOS_API_KEY: process.env.MITOS_API_KEY! },
+  }),
+});
+
+try {
+  const tools = await mcp.tools(); // sandbox_create, sandbox_exec, ...
+  const { text } = await generateText({
+    model: yourModel,
+    tools,
+    prompt: "Create a python sandbox and run print(40+2).",
+  });
+  console.log(text);
+} finally {
+  await mcp.close();
+}
+```
+
+## Pydantic AI (Python)
+
+Official docs: <https://ai.pydantic.dev/mcp/client/>. Pydantic AI attaches an MCP
+server as a toolset; the stdio transport spawns the subprocess and is managed by
+`async with agent`.
+
+```python
+from fastmcp.client.transports import StdioTransport
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPToolset
+
+toolset = MCPToolset(
+    StdioTransport(
+        command="mitos-mcp",
+        env={"MITOS_BASE_URL": "http://localhost:8080", "MITOS_API_KEY": "..."},
+    )
+)
+agent = Agent("openai:gpt-4o", toolsets=[toolset])
+
+async def main():
+    async with agent:  # starts/stops the mitos-mcp subprocess
+        result = await agent.run("Create a python sandbox and run print(40+2).")
+        print(result.output)
+```
+
+## AutoGen (Python)
+
+Official docs: <https://microsoft.github.io/autogen/stable/> (`autogen_ext.tools.mcp`).
+`mcp_server_tools` adapts the MCP tools into AutoGen tools.
+
+```python
+import asyncio
+from autogen_ext.tools.mcp import StdioServerParams, mcp_server_tools
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.agents import AssistantAgent
+
+async def main():
+    params = StdioServerParams(
+        command="mitos-mcp",
+        env={"MITOS_BASE_URL": "http://localhost:8080", "MITOS_API_KEY": "..."},
+        read_timeout_seconds=60,
+    )
+    tools = await mcp_server_tools(params)  # sandbox_create, sandbox_exec, ...
+    agent = AssistantAgent(
+        name="assistant",
+        model_client=OpenAIChatCompletionClient(model="gpt-4o"),
+        tools=tools,
+    )
+    await agent.run(task="Create a python sandbox and run print(40+2).")
+
+asyncio.run(main())
+```
+
+## LlamaIndex (Python)
+
+Official docs: <https://docs.llamaindex.ai/en/stable/api_reference/tools/mcp/>
+(`pip install llama-index-tools-mcp`). `BasicMCPClient` spawns the stdio server;
+`McpToolSpec` turns its tools into LlamaIndex tools.
+
+```python
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+client = BasicMCPClient(
+    command_or_url="mitos-mcp",
+    args=[],
+    env={"MITOS_BASE_URL": "http://localhost:8080", "MITOS_API_KEY": "..."},
+)
+tools = McpToolSpec(client=client).to_tool_list()  # sandbox_create, sandbox_exec, ...
+
+agent = FunctionAgent(tools=tools, llm=OpenAI(model="gpt-4o"))
+# await agent.run("Create a python sandbox and run print(40+2).")
+```
+
+## Native SDK adapters (when you want code, not a tool server)
+
+For frameworks Mitos ships a first-class adapter for, prefer that over MCP:
+LangChain / deepagents (`mitos.integrations.langchain`), OpenAI Agents SDK
+(`mitos.integrations.openai_agents`), Claude Agent SDK
+(`mitos.integrations.claude_agent`), plus the E2B drop-in shim
+(`mitos.e2b`). The MCP recipes above cover the long tail without per-framework
+code.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -4,7 +4,9 @@
 Protocol](https://modelcontextprotocol.io) tools. Any MCP-speaking agent
 (Claude Desktop, an MCP client library, an agent framework with MCP support)
 can create sandboxes, run commands, read and write files, fork, and terminate,
-with no SDK integration.
+with no SDK integration. For copy-paste recipes wiring specific frameworks
+(Vercel AI SDK, Pydantic AI, AutoGen, LlamaIndex) to this server, see
+[integrations/mcp-frameworks.md](integrations/mcp-frameworks.md).
 
 It speaks MCP over a stdio JSON-RPC 2.0 transport: stdin and stdout are the
 protocol channel, and all logging goes to stderr. The protocol subset


### PR DESCRIPTION
## Thinking Path

> - Beyond the marquee integrations, a long tail of agent frameworks each plug in a sandbox as a tool; covering them widens the "works with the agent you already use" surface.
> - Mitos already ships a standard MCP stdio server (mitos-mcp) exposing the sandbox lifecycle as tools, so any MCP-capable framework can drive a sandbox with NO Mitos-specific adapter code.
> - All four named frameworks (Vercel AI SDK, Pydantic AI, AutoGen, LlamaIndex) have first-class MCP clients, so the idiomatic integration is a documented MCP recipe, not bespoke per-framework code.
> - The risk (the #319 deepagents lesson) is guessing each framework's MCP-client API; so each snippet was verified against the framework's current MCP docs, and each links that doc as the source of truth (these APIs move between versions).
> - This serves the integrations hub (D1) and the co-naming/adoption goal.
> - This pull request adds docs/integrations/mcp-frameworks.md with a verified recipe per framework and links it from docs/mcp.md.
> - The benefit is each framework has a working, documented way to run code in a Mitos sandbox.

## Linked Issues or Issue Description

Closes #321. (Relates: #203, #204, #205.)

## What Changed

- New `docs/integrations/mcp-frameworks.md`: the common `mitos-mcp` config (stdio, `MITOS_BASE_URL` + `MITOS_API_KEY`, the six tools) plus a per-framework copy-paste recipe:
  - Vercel AI SDK: `createMCPClient` + `Experimental_StdioMCPTransport` -> `tools()`.
  - Pydantic AI: `MCPToolset(StdioTransport(...))` on `Agent(toolsets=[...])` (the current FastMCP-based form, not the old `MCPServerStdio`).
  - AutoGen: `StdioServerParams` + `mcp_server_tools()` -> `AssistantAgent(tools=...)`.
  - LlamaIndex: `BasicMCPClient(command_or_url=...)` + `McpToolSpec().to_tool_list()`.
  - Cross-links the first-class native adapters (LangChain/deepagents, OpenAI Agents, Claude Agent, E2B shim) for when code beats a tool server.
- `docs/mcp.md` links the new recipe page.

## Verification

- [x] Each framework snippet was checked against that framework's current official MCP docs (fetched), not guessed; the page links each doc as the source of truth and flags version sensitivity (notably the Vercel AI SDK import path and the Pydantic AI API change).
- [x] No em/en dashes (the `no-dashes` gate).
- [x] The `mitos-mcp` config (command, `MITOS_BASE_URL`/`MITOS_API_KEY`, tool names) matches `cmd/mitos-mcp` and `docs/mcp.md`.

## Risks

Low risk. Docs only. Framework MCP APIs drift between versions, mitigated by linking each official doc as authoritative.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD) (n/a; docs)
- [x] Docs updated in the same PR
- [x] Threat-model delta included if the security surface moved (n/a)
- [x] Benchmark run included if the hot path was touched (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged (recipes use env-var placeholders for MITOS_API_KEY)
- [x] No internal/instance-local references
- [x] Every commit carries a `Signed-off-by` trailer
