### PR TITLE
ci(release): pass --repo to the post-release publish dispatch so it stops failing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,4 +57,4 @@ jobs:
             exit 1
           fi
           echo "Release ${TAG} cut with GITHUB_TOKEN; dispatching the signed-image publish workflow for it."
-          gh workflow run publish.yaml -f tag="${TAG}" -f ref="${TAG}"
+          gh workflow run publish.yaml --repo "${{ github.repository }}" -f tag="${TAG}" -f ref="${TAG}"


### PR DESCRIPTION
## Thinking Path

> - The "Release Please" workflow failed on the latest main: its "Publish images for the new release" step died with `failed to run git: fatal: not a git repository`.
> - The job has no `actions/checkout`, and the step's `gh workflow run publish.yaml` call omits `--repo`, so `gh` falls back to resolving the repo from a local git remote that does not exist.
> - The release was tagged but the signed-image publish was never dispatched, reintroducing the tag-exists-but-no-images gap the step was added to prevent.
> - This pull request passes `--repo "${{ github.repository }}"` to the dispatch, matching the sibling `gh release list --repo ...` call two lines up.
> - The benefit is that release-please releases dispatch the image publish again (without needing RELEASE_PLEASE_TOKEN).

## Linked Issues or Issue Description

Fixes the `fatal: not a git repository` failure in the Release Please workflow's post-release publish dispatch.

## What Changed

- `.github/workflows/release-please.yml`: `gh workflow run publish.yaml` now passes `--repo "${{ github.repository }}"`.

## Verification

- [x] Root cause confirmed from the failing run log (`fatal: not a git repository`) and the workflow source (no checkout in the job; sibling `gh release list` already uses `--repo`).
- [x] `gh workflow run --repo OWNER/REPO` is the documented way to target a repo without a local checkout.

## Risks

Low. One-flag CI change, no runtime impact.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes (n/a; CI workflow one-liner)
- [x] Docs updated in the same PR (n/a)
- [x] No em or en dashes introduced anywhere
- [x] Every commit carries a `Signed-off-by` trailer
