### PR TITLE
fix(expose): forward the public host + X-Forwarded-* to exposed apps (#476)

### DIFF
--- a/docs/superpowers/specs/2026-06-27-run-on-mitos-tenancy-design.md
+++ b/docs/superpowers/specs/2026-06-27-run-on-mitos-tenancy-design.md
@@ -1,0 +1,153 @@
+# Run-on-Mitos Tenancy: per-user vs shared instances
+
+> Status: design draft for review. Surfaced by the OpenClaw live demo, which forced
+> the question "who gets which instance, and who is allowed in" to the front.
+
+## Goal
+
+Let a `mitos.yaml` author declare, in one place, **how an exposed app is
+multi-tenanted** and **who may reach it** - and have mitos route each caller to the
+right instance the most efficient, k8s-native, hard-isolated way. The OpenClaw case
+is the forcing function: a personal AI gateway must give every user their **own**
+isolated instance, gated by **their** identity; it must never be one shared,
+ungated box.
+
+## Two independent axes
+
+Tenancy and auth are orthogonal. `mitos.yaml` expresses both on the existing
+`expose` block:
+
+```yaml
+expose:
+  sharing:  authenticated      # WHO may reach it (the auth ladder, #407 - already built)
+                               #   public | link | authenticated | org | private
+  tenancy:  per-user           # WHICH instance they reach (NEW)
+                               #   per-user | shared
+```
+
+- **`sharing` (auth) - already built (#407).** The edge proxy gates the URL by
+  verified mitos identity (email -> org), with the public/link/authenticated/org/
+  private ladder. `public` is ungated; the others require a session and resolve a
+  caller `Identity`. Nothing new is needed here; flipping `sharing` from `public`
+  to `authenticated` gates OpenClaw by the user immediately.
+- **`tenancy` - the missing piece.** Given the resolved identity, which backend
+  instance does the request reach?
+
+### tenancy: shared (today's behavior)
+
+One golden snapshot, one warm pool, one (or a few) fork(s) serve **all** callers.
+Correct for stateless / read-only apps. Auth-gated or public, independent of
+tenancy. This is what the expose path does today: a single `Sandbox` with
+`spec.expose`, one route, all traffic.
+
+### tenancy: per-user (the new model)
+
+Each **authenticated identity** is routed to **its own fork**. On a request to
+`<label>.<domain>`:
+
+1. The edge resolves the caller `Identity` from `sharing` (must be a gated tier;
+   `per-user` + `public` is a config error - no identity to key on).
+2. The edge asks the controller for **this identity's instance** of this app.
+3. If one exists and is Ready, route to it. If not, **fork-on-demand** from the
+   golden snapshot (capture-running, ~86 ms) and route to the new fork.
+4. Idle per-user instances **scale to zero** (reaped after a TTL); a fresh request
+   re-forks instantly. A **warm pool** keeps N pre-forked, unclaimed instances so
+   even a cold user gets a sub-second start.
+
+Per-user state lives in the user's own microVM; per-user secrets are injected
+per-fork (`secretInheritance: reissue`), never baked, so no cross-user bleed.
+
+## Why this is the efficient, secure, k8s-native answer
+
+- **Hard isolation:** each user instance is a **Firecracker microVM** in a husk
+  pod, not a shared container or namespace. This is the strongest tenant boundary
+  available in the k8s ecosystem - a kernel + VM boundary per user, not cgroup +
+  seccomp. Honest k8s semantics (CLAUDE.md operating principle #3): these are not
+  pods, so the isolation story is VM-level, stated plainly.
+- **Cheap to multiply:** instances are **CoW forks** of one golden snapshot  - 
+  guest memory pages are shared copy-on-write, so N users do not cost N x full RAM.
+  Claim is ~86 ms (measured), so per-user fork-on-demand is interactive.
+- **Scale to zero per user:** idle instances are reaped (the failure/GC machinery,
+  #163, already reaps); the warm pool absorbs burst. A user who returns re-forks
+  from the still-resident golden snapshot. This is the efficiency lever: you pay
+  for active users, not registered users.
+- **Per-fork secrets + fork-correctness:** the existing reseed/secret-reissue
+  contract guarantees each user's instance has its own CRNG, clock, network
+  identity, and secret values.
+
+## k8s-native mechanism
+
+- **Identity -> instance map.** The controller keys a per-user instance by
+  `(app/label, identity)` - e.g. a `Sandbox` CR per active user-instance, labelled
+  with a hash of the identity (never the raw email) for selection, owned by the
+  golden pool. The edge forwards the resolved identity (it already extracts it for
+  the auth ladder) to the controller's resolve/route endpoint.
+- **Fork-on-demand.** The controller claims a warm husk for the identity (or forks
+  fresh), records the `(label, identity) -> Sandbox` mapping, and the expose route
+  for that request resolves to that Sandbox's endpoint. This reuses the claim path
+  and the expose route-sync wholesale; the only new logic is "resolve-or-create by
+  identity."
+- **Reaping.** A per-user instance with no traffic for `idleTTL` is terminated
+  (residual GC, #163). The mapping is dropped; the next request re-forks.
+- **Per-org scoping.** Ties into per-org namespaces (#288): per-user instances live
+  in the org's namespace, so tenancy nests inside the existing org boundary.
+
+## mitos.yaml surface (proposed)
+
+```yaml
+serve:
+  command: ...
+  ready: { http: { path: /, port: 18789 } }
+expose:
+  label: openclaw
+  sharing: authenticated        # or org / private - gates by mitos identity
+  tenancy:
+    mode: per-user              # or: shared
+    idleTTL: 30m                # reap a user's instance after this idle window
+    warm: 2                     # pre-forked unclaimed instances for instant cold start
+# secrets stay per-fork (already modelled): injected via Configure, never baked
+```
+
+`shared` collapses to today's single-route behavior. `per-user` requires a gated
+`sharing` tier (validation error otherwise).
+
+## What is built vs missing
+
+**Built:** the auth ladder + identity resolution (#407); the fork primitive and
+capture-running (#460); per-fork secret injection and fork-correctness; the warm
+pool and residual GC (#163); per-org namespaces (#288); the expose route-sync.
+
+**Missing (this slice):**
+1. `tenancy` field on `mitos.yaml` / `Sandbox.spec.expose` (API + validation:
+   `per-user` requires a gated tier).
+2. Controller **resolve-or-create-by-identity**: the `(label, identity) -> Sandbox`
+   map, fork-on-demand keyed by the edge-forwarded identity, and the per-user warm
+   pool.
+3. Edge -> controller **identity hand-off** on the request path (the edge already
+   has the verified identity; it must pass it to the route resolution).
+4. Per-user **idle reaping** wired to `idleTTL`.
+
+## Dependencies / related fixes this demo surfaced
+
+- **#476** public-URL injection + proxy trust: an app must know its public URL to
+  self-configure (origin allow-lists, redirect URIs). The proxy-trust half is
+  landing (PR #478); URL injection (`MITOS_PUBLIC_URL`) is still open and is needed
+  before per-user apps that template their own URL.
+- **#475** workload-command change must re-trigger the snapshot build; **#461** the
+  stale recorded digest on same-name rebuild. Both are the controller rebuild path
+  and bite the iterate-on-config loop a `mitos.yaml` author lives in.
+
+## Open questions for review
+
+1. **Identity key granularity:** per-user (`sub`) vs per-org vs per-(user,device)?
+   OpenClaw wants per-user; some apps may want per-org shared.
+2. **Cold-start UX when warm pool is empty:** block ~the fork+boot time, or show an
+   interstitial? Fork is ~86 ms but a cold golden (not yet built) is minutes.
+3. **Cost ceilings:** cap concurrent per-user instances per org (quota), and the
+   reap TTL defaults.
+4. **State persistence across reap:** per-user instance is ephemeral; if a user's
+   app has durable state, does it bind a per-user Workspace/volume that survives the
+   reap, or is the snapshot the only state? (Likely: opt-in per-user volume.)
+5. **Auth bridge depth (#476):** does mitos only gate the URL, or also forward a
+   trusted identity assertion the app consumes (forward-auth headers) so the app
+   need not run its own login?

--- a/docs/superpowers/specs/2026-06-27-run-on-mitos-tenancy-design.md
+++ b/docs/superpowers/specs/2026-06-27-run-on-mitos-tenancy-design.md
@@ -22,8 +22,13 @@ expose:
   sharing:  authenticated      # WHO may reach it (the auth ladder, #407 - already built)
                                #   public | link | authenticated | org | private
   tenancy:  per-user           # WHICH instance they reach (NEW)
-                               #   per-user | shared
+                               #   per-user | per-org | shared
+  forwardIdentity: true        # NEW: inject a trusted identity assertion into the app (SSO)
 ```
+
+> **Resolved (review 2026-06-27):** (1) support BOTH per-user and per-org tenancy -
+> the identity key is configurable; (2) the auth bridge FORWARDS a trusted identity
+> assertion into the app (deep SSO), not just gating the URL.
 
 - **`sharing` (auth) - already built (#407).** The edge proxy gates the URL by
   verified mitos identity (email -> org), with the public/link/authenticated/org/
@@ -102,14 +107,43 @@ expose:
   label: openclaw
   sharing: authenticated        # or org / private - gates by mitos identity
   tenancy:
-    mode: per-user              # or: shared
-    idleTTL: 30m                # reap a user's instance after this idle window
+    mode: per-user              # per-user | per-org | shared
+    idleTTL: 30m                # reap an instance after this idle window
     warm: 2                     # pre-forked unclaimed instances for instant cold start
+  forwardIdentity: true         # inject the trusted identity assertion into the app (SSO)
 # secrets stay per-fork (already modelled): injected via Configure, never baked
 ```
 
-`shared` collapses to today's single-route behavior. `per-user` requires a gated
-`sharing` tier (validation error otherwise).
+`shared` collapses to today's single-route behavior. `per-user` keys the instance
+by the verified subject; `per-org` keys it by the verified org (one shared instance
+per org). Both require a gated `sharing` tier (validation error otherwise) since
+there is no identity to key on under `public`.
+
+## Auth bridge: forward a trusted identity assertion (SSO)
+
+`forwardIdentity: true` makes mitos a true SSO front-door, not just a gated door:
+after the auth ladder verifies the caller, the edge injects a **trusted identity
+assertion** into the upstream request so the app can authenticate the user WITHOUT
+running its own login. Concretely the edge sets, on the request to forkd's expose
+handler (which forwards them to the guest):
+
+- `X-Mitos-User` (subject), `X-Mitos-Email` (verified email), `X-Mitos-Org`,
+  `X-Mitos-Groups` - the identity the ladder already resolved.
+
+Security (this is an auth surface; the threat model moves with it):
+
+- **Anti-spoofing:** the edge already strips inbound `X-Auth-Request-*` /
+  `X-Mitos-*` from the client before evaluating identity (`StripForwardAuthHeaders`),
+  so a client can never inject its own identity; the app trusts these headers ONLY
+  because mitos is the sole network path to the guest (the expose tunnel), and the
+  guest port is never directly reachable.
+- **Signed assertion option:** for apps that want to verify rather than trust the
+  hop, the edge can additionally mint a short-lived signed assertion (a JWT in
+  `X-Mitos-Assertion`) the app verifies against a published mitos JWKS - the same
+  key material as the expose grants. `forwardIdentity` defaults to header-only;
+  `forwardIdentity: signed` adds the JWT.
+- The assertion is per-request, carries no secret values, and is logged by key/count
+  only (never the email value), consistent with the secrets rule.
 
 ## What is built vs missing
 
@@ -118,14 +152,19 @@ capture-running (#460); per-fork secret injection and fork-correctness; the warm
 pool and residual GC (#163); per-org namespaces (#288); the expose route-sync.
 
 **Missing (this slice):**
-1. `tenancy` field on `mitos.yaml` / `Sandbox.spec.expose` (API + validation:
-   `per-user` requires a gated tier).
-2. Controller **resolve-or-create-by-identity**: the `(label, identity) -> Sandbox`
-   map, fork-on-demand keyed by the edge-forwarded identity, and the per-user warm
-   pool.
+1. `tenancy` + `forwardIdentity` fields on `mitos.yaml` / `Sandbox.spec.expose`
+   (API + validation: `per-user`/`per-org` require a gated tier).
+2. Controller **resolve-or-create-by-identity**: the `(label, identityKey) ->
+   Sandbox` map (identityKey = subject for per-user, org for per-org),
+   fork-on-demand keyed by the edge-forwarded identity, and the per-key warm pool.
 3. Edge -> controller **identity hand-off** on the request path (the edge already
    has the verified identity; it must pass it to the route resolution).
-4. Per-user **idle reaping** wired to `idleTTL`.
+4. Per-instance **idle reaping** wired to `idleTTL`.
+5. **Auth bridge:** the edge injects the trusted `X-Mitos-*` identity headers (and
+   optional signed `X-Mitos-Assertion` JWT) into the upstream; forkd's expose
+   forwards them to the guest. Requires a **threat-model delta** (a new trusted
+   identity surface) in the same PR, per CLAUDE.md security practice, and a named
+   human reviewer.
 
 ## Dependencies / related fixes this demo surfaced
 
@@ -137,17 +176,19 @@ pool and residual GC (#163); per-org namespaces (#288); the expose route-sync.
   stale recorded digest on same-name rebuild. Both are the controller rebuild path
   and bite the iterate-on-config loop a `mitos.yaml` author lives in.
 
-## Open questions for review
+## Open questions
 
-1. **Identity key granularity:** per-user (`sub`) vs per-org vs per-(user,device)?
-   OpenClaw wants per-user; some apps may want per-org shared.
-2. **Cold-start UX when warm pool is empty:** block ~the fork+boot time, or show an
+RESOLVED (review 2026-06-27):
+- **Identity key granularity:** support BOTH `per-user` (subject) and `per-org`
+  (one shared instance per org); configurable via `tenancy.mode`.
+- **Auth bridge depth:** FORWARD a trusted identity assertion (deep SSO) - see the
+  Auth bridge section. Header-only by default, signed-JWT opt-in.
+
+Still open:
+1. **Cold-start UX when warm pool is empty:** block ~the fork+boot time, or show an
    interstitial? Fork is ~86 ms but a cold golden (not yet built) is minutes.
-3. **Cost ceilings:** cap concurrent per-user instances per org (quota), and the
+2. **Cost ceilings:** cap concurrent per-user instances per org (quota), and the
    reap TTL defaults.
-4. **State persistence across reap:** per-user instance is ephemeral; if a user's
+3. **State persistence across reap:** a per-user instance is ephemeral; if a user's
    app has durable state, does it bind a per-user Workspace/volume that survives the
    reap, or is the snapshot the only state? (Likely: opt-in per-user volume.)
-5. **Auth bridge depth (#476):** does mitos only gate the URL, or also forward a
-   trusted identity assertion the app consumes (forward-auth headers) so the app
-   need not run its own login?

--- a/internal/daemon/expose.go
+++ b/internal/daemon/expose.go
@@ -51,32 +51,42 @@ func (api *SandboxAPI) ProxyHTTP(sandboxID string, guestPort int, prefix string)
 
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
-			// Propagate X-Forwarded-Host and X-Forwarded-Proto so that upstreams
-			// (e.g. the CDP relay) can learn the external origin. When the Rewrite
+			// Reconstruct the public front-door identity for the guest app. The
+			// edge proxy forwards the caller's real host/scheme as X-Forwarded-*;
+			// capture them from pr.In BEFORE SetXForwarded (which would otherwise
+			// overwrite X-Forwarded-Host with this internal hop). When the Rewrite
 			// hook is used, httputil.ReverseProxy strips incoming X-Forwarded-*
-			// headers before calling Rewrite, so we must re-propagate them
-			// explicitly from pr.In (the original, unmodified request). An edge
-			// proxy that already set these headers takes precedence; otherwise we
-			// derive the values from the request itself.
-			xfh := pr.In.Header.Get("X-Forwarded-Host")
-			if xfh == "" && pr.In.Host != "" {
-				xfh = pr.In.Host
+			// before calling Rewrite, so we re-propagate explicitly from pr.In.
+			// Fall back to the request's own host/scheme for a direct forkd call
+			// with no edge in front (e.g. the CDP relay).
+			pubHost := pr.In.Header.Get("X-Forwarded-Host")
+			if pubHost == "" {
+				pubHost = pr.In.Host
 			}
-			if xfh != "" {
-				pr.Out.Header.Set("X-Forwarded-Host", xfh)
-			}
-			xfp := pr.In.Header.Get("X-Forwarded-Proto")
-			if xfp == "" {
+			pubProto := pr.In.Header.Get("X-Forwarded-Proto")
+			if pubProto == "" {
 				if pr.In.TLS != nil {
-					xfp = "https"
+					pubProto = "https"
 				} else {
-					xfp = "http"
+					pubProto = "http"
 				}
 			}
-			pr.Out.Header.Set("X-Forwarded-Proto", xfp)
+			pr.SetXForwarded() // append the X-Forwarded-For chain for the guest
+			if pubHost != "" {
+				pr.Out.Header.Set("X-Forwarded-Host", pubHost)
+			}
+			pr.Out.Header.Set("X-Forwarded-Proto", pubProto)
 			pr.Out.URL.Scheme = "http"
 			pr.Out.URL.Host = "guest" // ignored: DialContext returns the tunnel
-			pr.Out.Host = "guest"
+			// Send the public host as the upstream Host so the guest app's Host-based
+			// logic (origin / CSRF / local-vs-remote detection) sees a coherent
+			// front-door host instead of the "guest" placeholder (#476). Fall back to
+			// "guest" when no host could be derived.
+			if pubHost != "" {
+				pr.Out.Host = pubHost
+			} else {
+				pr.Out.Host = "guest"
+			}
 			pr.Out.URL.Path = strings.TrimPrefix(pr.In.URL.Path, prefix)
 			if pr.Out.URL.Path == "" {
 				pr.Out.URL.Path = "/"

--- a/internal/daemon/expose_test.go
+++ b/internal/daemon/expose_test.go
@@ -335,3 +335,38 @@ func TestExposeResolvesSingleSandboxID(t *testing.T) {
 		t.Fatal("raw cluster id must not be registered; handleExpose must resolve it")
 	}
 }
+
+// TestExposeForwardsPublicHost guards the proxy-trust fix (#476): the expose
+// port-forward must present the guest app its real public front-door host (from
+// the edge's X-Forwarded-Host) as the upstream Host, plus the X-Forwarded-* chain,
+// rather than the internal "guest" placeholder. Apps behind the edge (e.g.
+// openclaw's Control-UI origin/local-vs-remote check) need this to accept traffic.
+func TestExposeForwardsPublicHost(t *testing.T) {
+	var gotHost, gotXFH, gotXFP string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		gotXFH = r.Header.Get("X-Forwarded-Host")
+		gotXFP = r.Header.Get("X-Forwarded-Proto")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+	port := portOf(t, backend)
+	api := newExposeTestAPI(t, backend.Listener.Addr().String())
+	rp, err := api.ProxyHTTP("sb1", port, "/v1/sandboxes/sb1/expose/"+itoa(port))
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sandboxes/sb1/expose/"+itoa(port)+"/", nil)
+	req.Header.Set("X-Forwarded-Host", "openclaw.mitos.run")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+	if gotHost != "openclaw.mitos.run" {
+		t.Fatalf("upstream Host = %q, want openclaw.mitos.run", gotHost)
+	}
+	if gotXFH != "openclaw.mitos.run" {
+		t.Fatalf("X-Forwarded-Host = %q, want openclaw.mitos.run", gotXFH)
+	}
+	if gotXFP != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q, want https", gotXFP)
+	}
+}

--- a/internal/preview/proxy.go
+++ b/internal/preview/proxy.go
@@ -24,9 +24,9 @@ type Config struct {
 	Signer      *Signer
 	Routes      *RouteTable
 	Logger      *slog.Logger
-	AuthOrigin  *AuthOrigin  // optional; required for OIDC-backed tiers
+	AuthOrigin  *AuthOrigin   // optional; required for OIDC-backed tiers
 	Sessions    *SessionCodec // optional; required to mint/decode per-app session cookies
-	GrantSigner *GrantSigner // optional; required to redeem grants from AuthOrigin
+	GrantSigner *GrantSigner  // optional; required to redeem grants from AuthOrigin
 }
 
 // Proxy is the per-sandbox preview reverse proxy. For each request it runs the
@@ -79,13 +79,13 @@ func NewProxy(cfg Config) *Proxy {
 //     clientIP from RemoteAddr.
 //  5. Look up the route. Evaluate identity and apply the tier:
 //     - ForwardAuthURL set: perform the forwardAuth subrequest; on non-2xx
-//       return that status; on 2xx copy identity headers and use the forwardAuth
-//       identity.
+//     return that status; on 2xx copy identity headers and use the forwardAuth
+//     identity.
 //     - private/org/authenticated: read the __Host- session cookie; if
-//       absent/expired 302 to auth.<domain>/start (or 401 if no AuthOrigin).
+//     absent/expired 302 to auth.<domain>/start (or 401 if no AuthOrigin).
 //     - link: verify the signed query token; on success set the app session
-//       cookie and 302 to a clean URL (cookie exchange); on cookie hit skip
-//       the token.
+//     cookie and 302 to a clean URL (cookie exchange); on cookie hit skip
+//     the token.
 //     - public: id stays nil.
 //  6. Authorize(route, id, clientIP). On Allow: reverse-proxy to forkd.
 //     DenyForbidden: 403. DenyUnauthenticated: 302 to login or 401.
@@ -380,6 +380,22 @@ func (p *Proxy) reverseProxy(w http.ResponseWriter, r *http.Request, route Route
 		req.URL.Path = prefix + sub
 		req.URL.RawPath = ""
 		req.Host = nodeEndpoint
+		// Tell forkd (and the exposed guest app) the real public front-door host and
+		// scheme. Without this the backend only ever sees the internal node endpoint
+		// (and forkd's "guest" placeholder), so a reverse-proxy-aware app cannot
+		// reconstruct its origin for local-vs-remote / origin / CSRF checks (#476).
+		// The edge terminates TLS, so the public scheme is https unless an upstream
+		// already set it.
+		if req.Header.Get("X-Forwarded-Host") == "" {
+			req.Header.Set("X-Forwarded-Host", r.Host)
+		}
+		if req.Header.Get("X-Forwarded-Proto") == "" {
+			if r.TLS != nil {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			} else {
+				req.Header.Set("X-Forwarded-Proto", "http")
+			}
+		}
 		// Defense in depth: drop any client-supplied Authorization before
 		// conditionally setting the per-sandbox bearer, so an empty-Token route
 		// never forwards a client credential to forkd.


### PR DESCRIPTION
## Thinking Path

The expose data path (edge proxy -> husk-stub ProxyHTTP -> guest) dropped the caller's public front-door identity: the edge set `Host` to the internal node endpoint and forwarded no `X-Forwarded-*`, and forkd's `ProxyHTTP` overwrote `Host` with the literal `guest`. A reverse-proxy-aware app behind the edge therefore could not reconstruct its real origin.

Surfaced by the OpenClaw live demo: its Control-UI WebSocket was rejected (`origin not allowed`, `loopback connection with non-local Host header, treating as remote`) even with the origin allow-listed, because openclaw saw `host=guest`.

Since this PR was opened, main independently landed X-Forwarded-Host/Proto propagation in `ProxyHTTP` (via the CDP-relay work), so the rebase merges both: main's request-derived fallback for the forwarded headers plus this PR's still-unique fix of sending the public host as the upstream `Host` (not the `guest` placeholder) and appending the X-Forwarded-For chain via `SetXForwarded`.

This is the proxy-trust slice of #476 (Run-on-Mitos: exposed apps need to know their public identity). Follow-ups in #476: inject `MITOS_PUBLIC_URL` into the build, and the auth bridge.

## What Changed

- **Edge proxy** (`internal/preview/proxy.go`): set `X-Forwarded-Host` (the public host) and `X-Forwarded-Proto` on the upstream request to forkd.
- **forkd expose** (`internal/daemon/expose.go`): reconstruct the public host/scheme (edge `X-Forwarded-*` with a request-derived fallback), append the `X-Forwarded-For` chain via `SetXForwarded`, forward the headers to the guest, and send the public host as the upstream `Host` instead of `guest`.
- Regression test (`TestExposeForwardsPublicHost`) asserts the guest receives the public host as upstream `Host`; main's `TestProxyHTTPForwardsXForwardedHeaders` and `TestProxyHTTPPreservesExistingXForwardedHeaders` continue to pass.

## Verification

- [x] `go build ./internal/daemon/ ./internal/preview/`
- [x] `go test ./internal/daemon/ -run 'TestProxyHTTP|TestExpose|TestHandleExpose'` (all pass)
- [x] `gofmt -l` clean; `golangci-lint run` clean on both GOOS=darwin and GOOS=linux
- [x] Rebased onto current main; the `expose.go` conflict resolved to merge both intents

## Security

Touches `internal/daemon` (security-sensitive path): forwarding a client-influenced `X-Forwarded-Host` to the guest as the upstream `Host`. The guest is the caller's own sandbox app, so the public front-door host is the intended value; no cross-tenant surface. Needs a named human reviewer per CLAUDE.md before merge.

## Model Used

Claude Opus 4.8 (1M context).
