### PR TITLE
ci(release): allow manual CLI release backfill via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,13 @@ on:
   push:
     tags:
       - "v*"
+  # Manual backfill: (re)build the CLI assets for an existing tag, for example
+  # when a release was cut before the publish cascade was wired up.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Existing release tag to (re)build CLI assets for (for example v1.5.0)"
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +31,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # On a manual backfill, check out the requested tag so goreleaser
+          # computes that release version; on a tag push this resolves to the
+          # pushed tag ref.
+          ref: ${{ github.event.inputs.ref || github.ref }}
           # goreleaser needs full history and tags to compute the version and
           # changelog context.
           fetch-depth: 0


### PR DESCRIPTION
## Thinking Path

> - During a distribution audit we found `release.yaml` (goreleaser/CLI) had never run: it triggers only on `v*` tag push, but release-please cut its tags with the default GITHUB_TOKEN (no RELEASE_PLEASE_TOKEN), and GitHub blocks token-created tag events from triggering other workflows.
> - Result: v1.4.0 and v1.5.0 GitHub releases have zero CLI assets (no binaries, archives, deb/rpm, Homebrew).
> - RELEASE_PLEASE_TOKEN is now configured, so future releases will cascade; but the already-cut v1.5.0 needs a manual backfill, which this workflow had no way to do.
> - This pull request adds a workflow_dispatch with a `ref` input so the CLI assets can be (re)built for an existing tag.
> - The benefit is a manual CLI backfill path and a general manual re-cut for any tag.

## What Changed

- `.github/workflows/release.yaml`: add `workflow_dispatch` with a required `ref` input; the checkout step uses `${{ github.event.inputs.ref || github.ref }}` so goreleaser computes the requested release version. The tag-push path is unchanged.

## Verification

- [x] Tag-push path unchanged (`ref` falls back to `github.ref`).
- [x] On dispatch, goreleaser checks out the requested tag, so `release` mode sees a tagged HEAD.

## Risks

Low. CI-only; the publish still requires a real tag to exist.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] No em or en dashes introduced anywhere
- [x] Every commit carries a `Signed-off-by` trailer
