### PR TITLE
ci(krew): supply a tag-shaped GITHUB_REF for the krew backfill dispatch

### DIFF
--- a/.github/workflows/krew.yaml
+++ b/.github/workflows/krew.yaml
@@ -91,4 +91,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Update the krew-index PR
+        # The bot reads GITHUB_REF and requires a tag ref. On a release event that
+        # is already refs/tags/<tag>; on a manual workflow_dispatch backfill it is
+        # refs/heads/<branch>, which the bot rejects, so synthesize the tag ref
+        # from the dispatch input.
+        env:
+          GITHUB_REF: refs/tags/${{ github.event.release.tag_name || github.event.inputs.tag }}
         uses: rajatjindal/krew-release-bot@v0.0.46


### PR DESCRIPTION
## Thinking Path

> - Backfilling the kubectl plugin (krew) for v1.5.0 via `workflow_dispatch` failed: `krew-release-bot` reads `GITHUB_REF` and fatally rejects anything not in `refs/tags/<tag>` form.
> - On a `release: published` event `GITHUB_REF` is already the tag, but on a manual dispatch it is `refs/heads/<branch>`, so the bot aborted with `GITHUB_REF expected to be of format refs/tags/...`.
> - krew (and operator) are the channels that never published past v0.13.0 because release-please cut tags with the default GITHUB_TOKEN; now that RELEASE_PLEASE_TOKEN is set the release path works, but the v1.5.0 backfill still needs the dispatch path to function.
> - This pull request sets `GITHUB_REF` on the bot step from the dispatch tag input, leaving the release-event path unchanged.
> - The benefit is the krew manual backfill / re-cut path works.

## Linked Issues or Issue Description

Part of the distribution-channel backfill after wiring `RELEASE_PLEASE_TOKEN`. Fixes the `GITHUB_REF expected to be of format refs/tags/...` failure when backfilling krew for an existing tag.

## What Changed

- `.github/workflows/krew.yaml`: the `krew-release-bot` step gets `env: GITHUB_REF: refs/tags/${{ github.event.release.tag_name || github.event.inputs.tag }}`.

## Verification

- [x] On a `release: published` event, `github.event.release.tag_name` is set, so `GITHUB_REF` resolves to the same tag ref the bot already expects (no behavior change).
- [x] On `workflow_dispatch`, the required `tag` input synthesizes `refs/tags/<tag>`, satisfying the bot.

## Risks

Low. CI-only; the release-event path is unchanged and the publish still requires the tag's release assets to exist.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] No em or en dashes introduced anywhere
- [x] Every commit carries a `Signed-off-by` trailer
