### PR TITLE
ci(krew): make krew publishing work (fix .krew.yaml indentation; drop ineffective GITHUB_REF override)

### DIFF
--- a/.github/workflows/krew.yaml
+++ b/.github/workflows/krew.yaml
@@ -91,10 +91,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Update the krew-index PR
-        # The bot reads GITHUB_REF and requires a tag ref. On a release event that
-        # is already refs/tags/<tag>; on a manual workflow_dispatch backfill it is
-        # refs/heads/<branch>, which the bot rejects, so synthesize the tag ref
-        # from the dispatch input.
-        env:
-          GITHUB_REF: refs/tags/${{ github.event.release.tag_name || github.event.inputs.tag }}
+        # The bot requires GITHUB_REF to be a tag ref. A release event already
+        # satisfies that; to backfill an existing tag, dispatch this workflow ON
+        # the tag ref so GITHUB_REF is refs/tags/<tag>:
+        #   gh workflow run krew.yaml --ref <tag> -f tag=<tag>
+        # A step-level env override does NOT work here: the runner injects the
+        # reserved GITHUB_REF into the container action with its own value.
         uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -19,33 +19,33 @@ spec:
       * a kubeconfig that can read Sandbox objects.
     See https://mitos.run for installation.
   platforms:
-    - selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-      {{ addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
-      bin: kubectl-mitos
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-      {{ addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
-      bin: kubectl-mitos
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-      {{ addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
-      bin: kubectl-mitos
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: arm64
-      {{ addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
-      bin: kubectl-mitos
-    - selector:
-        matchLabels:
-          os: windows
-          arch: amd64
-      {{ addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_windows_amd64.zip" .TagName }}
-      bin: kubectl-mitos.exe
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-mitos
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-mitos
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-mitos
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-mitos
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/mitos-run/mitos/releases/download/{{ .TagName }}/kubectl-mitos_{{ .TagName }}_windows_amd64.zip" .TagName }}
+    bin: kubectl-mitos.exe


### PR DESCRIPTION
## Thinking Path

> - A distribution audit found the kubectl plugin (krew) had never published past v0.13.0: the krew-release-bot failed every run.
> - Root cause 1 (the real bug): `.krew.yaml`'s `spec.platforms` block was indented two spaces deeper than the bot's contract. `addURIAndSha` emits its `sha256:` line at a fixed indent, so with the call placed at six spaces the rendered `uri:`/`sha256:` lines misaligned and the bot aborted with "failed to get plugin name from processed template / error converting YAML to JSON".
> - Root cause 2 (a wrong earlier fix, #480): a step-level `GITHUB_REF` env override cannot work for a Docker container action; the correct way to backfill an existing tag is to dispatch the workflow ON the tag ref.
> - This pull request fixes the `.krew.yaml` indentation to the canonical layout (verified against rajatjindal/kubectl-evict-pod) and removes the ineffective override, documenting the tag-ref dispatch instead.
> - The benefit is krew publishing works on every future release (and the v1.5.0 backfill once the fix is on a tag).

## Linked Issues or Issue Description

Distribution-channel backfill: makes the krew publish path actually work (it never has). Supersedes/corrects #480.

## What Changed

- `.krew.yaml`: re-indent `spec.platforms` to the canonical layout: `- selector:` at 2, `matchLabels:` at 6, `os/arch` at 8, `addURIAndSha` and `bin:` at 4. The rendered per-platform map (`selector`/`uri`/`sha256`/`bin` at column 4) is valid YAML.
- `.github/workflows/krew.yaml`: drop the no-op `GITHUB_REF` env override on the bot step; document the correct backfill (`gh workflow run krew.yaml --ref <tag> -f tag=<tag>`).

## Verification

- [x] Indentation matches the canonical bot template (fetched from rajatjindal/kubectl-evict-pod); the rendered output is valid YAML by construction.
- [x] Tag-ref dispatch confirmed to get past the `GITHUB_REF` requirement (it reached sha256 fetching before hitting this template bug).
- [ ] Full bot success verifies on the next release that carries this `.krew.yaml` (the v1.5.0 tag still holds the old template).

## Risks

Low. CI/template only; the release-event path uses the same corrected template.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] No em or en dashes introduced anywhere
- [x] Every commit carries a `Signed-off-by` trailer
