### PR TITLE
docs(releasing): document the release cascade, required secrets, and manual backfill

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,7 +15,9 @@ skips with a clear log.
 | Artifact | Registry | Workflow | Trigger |
 | --- | --- | --- | --- |
 | Container images (controller, forkd, husk-stub, kvm-device-plugin) | ghcr.io/mitos-run, cosign-signed, SBOM-attested | `.github/workflows/publish.yaml` | `v*` tag push, or manual dispatch with a tag input |
-| CLI (`mitos`): binaries, archives, checksums, deb/rpm, Homebrew cask | GitHub Releases plus the Homebrew tap | `.github/workflows/release.yaml` (goreleaser) | `v*` tag push |
+| CLI (`mitos`): binaries, archives, checksums, deb/rpm, Homebrew cask | GitHub Releases plus the Homebrew tap | `.github/workflows/release.yaml` (goreleaser) | `v*` tag push, or manual dispatch with a `ref` input |
+| kubectl plugin (`kubectl mitos`) | krew-index | `.github/workflows/krew.yaml` (`.krew.yaml` template) | `release: published`, or manual dispatch ON the tag ref |
+| OLM operator bundle | OperatorHub.io (`k8s-operatorhub/community-operators`) | `.github/workflows/operator-release.yaml` | `release: published`, or manual dispatch with `version`/`previous` inputs |
 | Python SDK (dist `mitos-run`, import `mitos`) | PyPI | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/python/pyproject.toml` merged to main |
 | TypeScript SDK (`@mitos/sdk`) | npm | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/typescript/package.json` merged to main |
 | Ruby SDK (`mitos`) | RubyGems | `.github/workflows/publish-sdks.yaml` | version bump in `sdk/ruby/lib/mitos/version.rb` merged to main |
@@ -148,18 +150,59 @@ a short-lived token (its `token` output is passed to `cargo publish` via
 `CARGO_REGISTRY_TOKEN`) and revokes it after the job. No `CARGO_REGISTRY_TOKEN`
 secret is stored.
 
-## Cutting an image or CLI release
+## Cutting a release (images, CLI, krew, operator)
 
-Image and CLI releases follow the release-please flow:
+release-please opens and lands a `chore(main): release X` PR, then tags the
+commit `vX` and publishes a GitHub release for it. From there the four
+release-driven channels publish.
 
-1. release-please opens and lands a `chore(main): release X` PR and tags the
-   commit `vX`.
-2. The `v*` tag drives `release.yaml` (goreleaser builds the CLI binaries,
-   archives, checksums, deb/rpm, and, when `HOMEBREW_TAP_TOKEN` is present, the
-   Homebrew cask).
-3. The signed images are published by dispatching `publish.yaml` with the tag
-   input (the release-please tag push does not auto-trigger `on: push: tags`).
+### The `RELEASE_PLEASE_TOKEN` is what makes the cascade work
 
-The image and CLI maintainer setup (the `HOMEBREW_TAP_TOKEN` and the GHCR write
-token) is documented inline in those two workflows and in
-[docs/install.md](install.md).
+GitHub deliberately blocks events created with the default `GITHUB_TOKEN` (a tag
+push, a published release) from triggering other workflows, to avoid recursive
+runs. release-please uses whatever token it is given:
+
+- With `RELEASE_PLEASE_TOKEN` set (a PAT or GitHub App token with `contents:write`
+  and `workflow`), the tag and release events release-please creates DO cascade,
+  so `publish.yaml` (images, on the `v*` tag), `release.yaml` (CLI, on the `v*`
+  tag), `krew.yaml` and `operator-release.yaml` (both on `release: published`) all
+  fire automatically. This is the intended path.
+- Without it, release-please falls back to `GITHUB_TOKEN`, none of those
+  downstream workflows fire on their own, and only the explicit dispatch step
+  inside `release-please.yml` publishes the images. The CLI, krew, and operator
+  then never publish until dispatched by hand. Set the token.
+
+### Required release secrets
+
+| Secret | Needed for | Scopes / notes |
+| --- | --- | --- |
+| `RELEASE_PLEASE_TOKEN` | the whole release cascade (images, CLI, krew, operator) | classic PAT `repo` + `workflow`, or a GitHub App token with `contents:write` + `workflow`. Without it nothing downstream auto-publishes. |
+| `COMMUNITY_OPERATORS_TOKEN` | the OperatorHub PR to `k8s-operatorhub/community-operators` | classic PAT `repo` AND `workflow`. The `workflow` scope is REQUIRED: the PR branch is based on community-operators `main`, which carries `.github/workflows/*`, and GitHub refuses a PAT push touching workflow files without it. The token's account owns the fork the PR comes from. |
+| `HOMEBREW_TAP_TOKEN` | the Homebrew cask in `release.yaml` | token scoped to `mitos-run/homebrew-tap`. Optional: when absent the CLI release still succeeds and skips the cask. |
+| GHCR write token | image push in `publish.yaml` | documented inline in that workflow; falls back to `GITHUB_TOKEN`. |
+
+OperatorHub also needs a one-time fork of `k8s-operatorhub/community-operators`
+under the `COMMUNITY_OPERATORS_TOKEN` account; the workflow creates it on first
+run. New images push to GHCR private by default, so making each new image package
+public is a one-time manual step. See [docs/distribution.md](distribution.md),
+[docs/operatorhub.md](operatorhub.md), and [docs/krew.md](krew.md) for the
+per-channel runbooks, and [docs/install.md](install.md) for the install side.
+
+### Manual backfill
+
+When a release was cut before a channel was wired up (or a channel run failed),
+backfill an existing tag with these dispatches:
+
+| Channel | Command |
+| --- | --- |
+| Images | `gh workflow run publish.yaml -f tag=vX.Y.Z -f ref=vX.Y.Z` |
+| CLI | `gh workflow run release.yaml -f ref=vX.Y.Z` |
+| krew | `gh workflow run krew.yaml --ref vX.Y.Z -f tag=vX.Y.Z` |
+| OperatorHub | `gh workflow run operator-release.yaml -f version=X.Y.Z -f previous=<last published>` |
+
+The krew backfill MUST dispatch ON the tag ref (`--ref vX.Y.Z`), not just pass the
+tag input: the krew-release-bot reads `GITHUB_REF` and requires a `refs/tags/...`
+ref, and a step-level env override does not reach the container action. Because
+the bot reads `.krew.yaml` from the dispatched ref, a krew template fix only takes
+effect for tags that carry it; krew-index tracks the latest version, so an older
+tag that cannot be backfilled is superseded by the next release.


### PR DESCRIPTION
## Thinking Path

> - A distribution audit found releases were tagged but images/CLI/krew/operator never published, because release-please cut tags with the default GITHUB_TOKEN (which cannot trigger downstream workflows) and RELEASE_PLEASE_TOKEN was unset.
> - Fixing it surfaced several non-obvious facts the release doc never captured: the cascade depends on RELEASE_PLEASE_TOKEN; OperatorHub needs COMMUNITY_OPERATORS_TOKEN with both repo AND workflow scope (the PR branch carries workflow files); krew backfill must dispatch ON the tag ref.
> - This pull request records all of that in docs/releasing.md so it is not rediscovered the hard way.
> - The benefit is a single place that explains what makes the release cascade fire, the required secrets and their exact scopes, and the manual backfill commands.

## Linked Issues or Issue Description

Documents the release cascade and required secrets after wiring RELEASE_PLEASE_TOKEN and COMMUNITY_OPERATORS_TOKEN and fixing the publish/CLI/krew workflows.

## What Changed

- `docs/releasing.md`: add krew and OperatorHub to the "what ships" table; add a "Cutting a release" section explaining the GITHUB_TOKEN cascade limitation and RELEASE_PLEASE_TOKEN; a required-secrets table (RELEASE_PLEASE_TOKEN, COMMUNITY_OPERATORS_TOKEN with the repo+workflow gotcha, HOMEBREW_TAP_TOKEN, GHCR write); and a manual-backfill table with the per-channel dispatch commands (incl. krew `--ref <tag>`).

## Verification

- [x] Matches the workflows as they exist on main (publish.yaml, release.yaml, krew.yaml, operator-release.yaml) and the behavior verified live during the v1.5.0 backfill.
- [x] No em or en dashes.

## Risks

None. Docs only.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] No em or en dashes introduced anywhere
- [x] Every commit carries a `Signed-off-by` trailer
