### PR TITLE
chore(branding): make every distribution listing consistent and world-class

### DIFF
--- a/Dockerfile.console
+++ b/Dockerfile.console
@@ -32,5 +32,13 @@ RUN CGO_ENABLED=0 go build -o console ./cmd/console/
 
 # 3) Minimal runtime.
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="mitos-console" \
+      org.opencontainers.image.description="Mitos console: the web dashboard for Mitos." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /build/console /console
 ENTRYPOINT ["/console"]

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -8,5 +8,13 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o controller ./cmd/controller/
 
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="mitos-controller" \
+      org.opencontainers.image.description="Mitos controller: reconciles the SandboxPool, Sandbox, Workspace, and WorkspaceRevision CRDs and selects nodes." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /build/controller /controller
 ENTRYPOINT ["/controller"]

--- a/Dockerfile.facade
+++ b/Dockerfile.facade
@@ -8,5 +8,13 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o facade ./cmd/facade/
 
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="mitos-facade" \
+      org.opencontainers.image.description="Mitos facade: the agents.x-k8s.io conformance API in front of Mitos sandboxes." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /build/facade /facade
 ENTRYPOINT ["/facade"]

--- a/Dockerfile.forkd
+++ b/Dockerfile.forkd
@@ -33,6 +33,14 @@ RUN rustup target add x86_64-unknown-linux-musl && \
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.title="mitos-forkd" \
+      org.opencontainers.image.description="Mitos forkd: per-node daemon that boots and copy-on-write forks Firecracker microVM sandboxes." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -8,5 +8,13 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o gateway ./cmd/gateway/
 
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="mitos-gateway" \
+      org.opencontainers.image.description="Mitos gateway: the hosted API gateway for Mitos." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /build/gateway /gateway
 ENTRYPOINT ["/gateway"]

--- a/Dockerfile.husk-stub
+++ b/Dockerfile.husk-stub
@@ -11,6 +11,14 @@ RUN CGO_ENABLED=0 go build -o husk-stub ./cmd/husk-stub/
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.title="mitos-husk-stub" \
+      org.opencontainers.image.description="Mitos husk-stub: pod-native warm sandbox runner." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/Dockerfile.kvm-device-plugin
+++ b/Dockerfile.kvm-device-plugin
@@ -8,5 +8,13 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o kvm-device-plugin ./cmd/kvm-device-plugin/
 
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="mitos-kvm-device-plugin" \
+      org.opencontainers.image.description="Mitos KVM device plugin: advertises /dev/kvm to sandbox nodes." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /build/kvm-device-plugin /kvm-device-plugin
 ENTRYPOINT ["/kvm-device-plugin"]

--- a/Dockerfile.preview-proxy
+++ b/Dockerfile.preview-proxy
@@ -10,5 +10,13 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o preview-proxy ./cmd/preview-proxy/
 
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="preview-proxy" \
+      org.opencontainers.image.description="Mitos expose edge proxy: authenticated named URLs to a sandbox port." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /build/preview-proxy /preview-proxy
 ENTRYPOINT ["/preview-proxy"]

--- a/deploy/charts/mitos/Chart.yaml
+++ b/deploy/charts/mitos/Chart.yaml
@@ -21,7 +21,8 @@ icon: https://raw.githubusercontent.com/mitos-run/mitos/main/docs/assets/mitos-m
 sources:
   - https://github.com/mitos-run/mitos
 maintainers:
-  - name: mitos-run
+  - name: Mitos maintainers
+    email: maintainers@mitos.run
     url: https://mitos.run
 # Artifact Hub metadata. home, the maintainer url, and the links below all point
 # at https://mitos.run so the listing backlinks to the canonical domain.
@@ -42,19 +43,19 @@ annotations:
       url: https://github.com/mitos-run/mitos/issues
   artifacthub.io/images: |
     - name: controller
-      image: ghcr.io/mitos-run/mitos-controller:v0.13.0
+      image: ghcr.io/mitos-run/mitos-controller:v1.5.0 # x-release-please-version
     - name: forkd
-      image: ghcr.io/mitos-run/mitos-forkd:v0.13.0
+      image: ghcr.io/mitos-run/mitos-forkd:v1.5.0 # x-release-please-version
     - name: husk-stub
-      image: ghcr.io/mitos-run/mitos-husk-stub:v0.13.0
+      image: ghcr.io/mitos-run/mitos-husk-stub:v1.5.0 # x-release-please-version
     - name: kvm-device-plugin
-      image: ghcr.io/mitos-run/mitos-kvm-device-plugin:v0.13.0
+      image: ghcr.io/mitos-run/mitos-kvm-device-plugin:v1.5.0 # x-release-please-version
     - name: facade
-      image: ghcr.io/mitos-run/mitos-facade:v0.13.0
+      image: ghcr.io/mitos-run/mitos-facade:v1.5.0 # x-release-please-version
     - name: console
-      image: ghcr.io/mitos-run/mitos-console:v0.13.0
+      image: ghcr.io/mitos-run/mitos-console:v1.5.0 # x-release-please-version
     - name: gateway
-      image: ghcr.io/mitos-run/mitos-gateway:v0.13.0
+      image: ghcr.io/mitos-run/mitos-gateway:v1.5.0 # x-release-please-version
   artifacthub.io/crds: |
     - kind: SandboxPool
       version: v1

--- a/deploy/olm/bundle/manifests/mitos.clusterserviceversion.yaml
+++ b/deploy/olm/bundle/manifests/mitos.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     support: mitos
     createdAt: "2026-06-22T00:00:00Z"
     description: >-
-      Snapshot-fork microVM sandboxes for AI agents on Kubernetes. mitos boots
+      Snapshot-fork microVM sandboxes for AI agents on Kubernetes. Mitos boots
       Firecracker microVMs, forks them via copy-on-write snapshots, and exposes
       the whole lifecycle through declarative CRDs.
     alm-examples: |-
@@ -123,17 +123,17 @@ metadata:
         }
       ]
 spec:
-  displayName: mitos
+  displayName: Mitos
   description: |-
-    ## mitos
+    ## Mitos
 
-    Snapshot-fork microVM sandboxes for AI agents on Kubernetes. mitos boots
+    Snapshot-fork microVM sandboxes for AI agents on Kubernetes. Mitos boots
     Firecracker microVMs, forks them via copy-on-write snapshots, and exposes
     the whole lifecycle through declarative custom resources in the API group
     `mitos.run`.
 
     Agent harnesses need fast, isolated environments where agents can read and
-    write files, install packages, and run untrusted code. mitos gives each
+    write files, install packages, and run untrusted code. Mitos gives each
     agent an isolated, forkable computer: a Firecracker microVM that restores
     from a memory snapshot, forks into parallel attempts via copy-on-write, and
     can persist a durable workspace. You drive the whole lifecycle through
@@ -141,8 +141,8 @@ spec:
 
     ### What this operator installs
 
-    This operator deploys the mitos **controller**, a Deployment that reconciles
-    the mitos custom resources and selects nodes for sandbox placement. The
+    This operator deploys the Mitos **controller**, a Deployment that reconciles
+    the Mitos custom resources and selects nodes for sandbox placement. The
     controller, once running, deploys and drives the per-node components it needs
     (the privileged `forkd` DaemonSet and, on the husk pod-native default, warm
     husk pods). Those node-level components are managed by the controller and are
@@ -162,7 +162,7 @@ spec:
 
     ### Requirements (read before installing)
 
-    mitos runs real virtual machines. It requires:
+    Mitos runs real virtual machines. It requires:
 
     - Cluster nodes with **KVM / hardware virtualization** available to the
       `forkd` DaemonSet (nested virtualization if running on a virtualized
@@ -171,32 +171,29 @@ spec:
       host paths on those nodes.
     - Bare metal is the reference platform (Hetzner plus Talos). Managed control
       planes and locked-down platforms may not permit the privilege and device
-      access mitos needs; verify before relying on it.
+      access Mitos needs; verify before relying on it.
 
-    The controller image referenced by this bundle is
-    `ghcr.io/mitos-run/mitos-controller:v0.13.0`. NOTE: the project is migrating
-    its image registry; the controller and the node images
-    (`mitos-forkd`, `mitos-husk-stub`, `mitos-kvm-device-plugin`, `mitos-facade`)
-    must be present under `ghcr.io/mitos-run` before this bundle can install and
-    run. Until then the images are published under `ghcr.io/paperclipinc`.
+    The controller and the node images (`mitos-forkd`, `mitos-husk-stub`,
+    `mitos-kvm-device-plugin`, `mitos-facade`) are published as signed, multi-arch
+    images under `ghcr.io/mitos-run`.
 
     Project website: https://mitos.run
     Documentation: https://mitos.run/docs
     Source: https://github.com/mitos-run/mitos
   version: 0.13.0
   maturity: alpha
-  minKubeVersion: 1.28.0
+  minKubeVersion: 1.29.0
   keywords:
     - sandbox
     - firecracker
     - microvm
-    - ai-agents
-    - fork
     - snapshot
+    - fork
+    - ai-agents
     - kvm
-    - agents
+    - operator
   provider:
-    name: mitos
+    name: Mitos
     url: https://mitos.run
   maintainers:
     - name: mitos maintainers

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -110,7 +110,7 @@ Value types:
 
 ## Streaming exec
 
-`Exec` runs over the Connect `sandbox.v1.Sandbox` runtime protocol (issue #24) and
+`Exec` runs over the Connect `sandbox.v1.Sandbox` runtime protocol and
 returns the buffered result. For live output, `ExecStream` yields stdout/stderr
 chunks as they are produced. The Go SDK speaks Connect over the standard library
 alone (no gRPC runtime, no codegen), so it stays dependency-free.
@@ -276,7 +276,7 @@ of this module: the files API (`/v1/files/*`), interactive PTY (`/v1/pty`),
 Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) ships in Python,
-TypeScript, and Go today and is planned for the rest, for full parity (#296).
+TypeScript, and Go today and is planned for the rest, for full parity.
 
 | Language | Install | Covers |
 | --- | --- | --- |

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -254,7 +254,7 @@ can drive the sandbox HTTP API directly.
 Mitos ships native clients in six languages. All of them share the same
 direct-mode surface (create a template, fork, exec, terminate), so the API maps
 1:1 across languages; cluster mode (driving the Kubernetes CRDs) ships in Python,
-TypeScript, and Java, for full parity (#296).
+TypeScript, and Java, for full parity.
 
 | Language | Install | Covers |
 | --- | --- | --- |

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -9,7 +9,7 @@
   <version>0.1.0</version>
   <packaging>jar</packaging>
 
-  <name>mitos Java SDK</name>
+  <name>Mitos Java SDK</name>
   <description>A thin, dependency-free Java client for Mitos snapshot-fork sandboxes. Direct mode talks to the standalone and hosted sandbox-server REST API (create templates, fork sandboxes, run exec, terminate); cluster mode (AgentRun) drives the mitos.run/v1 Kubernetes CRDs (SandboxPool, Sandbox, Workspace) with in-cluster or kubeconfig auth. Built on the JDK standard library alone, with no runtime dependencies.</description>
   <url>https://mitos.run</url>
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -86,7 +86,7 @@ asyncio.run(main())
 `mitos.create` / `Sandbox.create` returns a `DirectSandbox`.
 
 The runtime calls (exec, run_code, files) ride the Connect `sandbox.v1.Sandbox`
-service at `/sandbox.v1.Sandbox/<Method>` (issue #24); the control-plane calls
+service at `/sandbox.v1.Sandbox/<Method>`; the control-plane calls
 (templates, fork, sandboxes) and the interactive PTY keep their `/v1/*`
 transports. The sandbox is addressed by id via the `X-Sandbox-Id` header.
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,10 +7,23 @@
 [project]
 name = "mitos-run"
 version = "0.1.0"
-description = "Python SDK for mitos: sub-millisecond sandbox forking on Kubernetes"
+description = "Python SDK for Mitos: snapshot-fork sandboxes for AI agents on Kubernetes."
 keywords = ["sandbox", "firecracker", "microvm", "ai-agents", "kubernetes", "code-interpreter", "mitos"]
 readme = "README.md"
 license = {text = "Apache-2.0"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Distributed Computing",
+]
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.27.0",

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -20,6 +20,9 @@ Direct mode uses `net/http`, `json`, `uri`, and `securerandom`; cluster mode add
 
 ## Install
 
+The gem is not yet on RubyGems; until then, vendor it from source (clone the
+repo and point your Gemfile at `sdk/ruby`). Once published:
+
 ```bash
 gem install mitos
 ```

--- a/sdk/ruby/mitos.gemspec
+++ b/sdk/ruby/mitos.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/mitos/version"
 Gem::Specification.new do |spec|
   spec.name = "mitos"
   spec.version = Mitos::VERSION
-  spec.authors = ["mitos"]
-  spec.summary = "Ruby SDK for mitos snapshot-fork sandboxes (direct and Kubernetes cluster mode)."
+  spec.authors = ["Mitos maintainers"]
+  spec.summary = "Ruby SDK for Mitos: snapshot-fork sandboxes for AI agents on Kubernetes."
   spec.description =
     "A thin, dependency-free Ruby client for mitos. Direct mode talks to the " \
     "standalone and hosted sandbox-server REST API (create templates, fork " \

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -3,13 +3,13 @@ name = "mitos"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.74"
-description = "Thin direct-mode Rust client for the mitos standalone and hosted sandbox-server REST API."
+description = "Rust SDK for Mitos: snapshot-fork sandboxes for AI agents on Kubernetes (direct and cluster modes)."
 license = "Apache-2.0"
 homepage = "https://mitos.run"
 documentation = "https://mitos.run/docs"
 repository = "https://github.com/mitos-run/mitos"
 readme = "README.md"
-keywords = ["mitos", "sandbox", "firecracker", "agents"]
+keywords = ["mitos", "sandbox", "firecracker", "microvm", "ai-agents"]
 categories = ["api-bindings"]
 
 [dependencies]

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@mitos/sdk",
   "version": "0.1.0",
-  "description": "TypeScript SDK for the mitos sandbox runtime: direct sandbox-server mode and Kubernetes cluster mode.",
+  "description": "TypeScript SDK for Mitos: snapshot-fork sandboxes for AI agents on Kubernetes (direct and cluster modes).",
+  "author": "Mitos maintainers <maintainers@mitos.run>",
   "homepage": "https://mitos.run",
   "repository": { "type": "git", "url": "git+https://github.com/mitos-run/mitos.git", "directory": "sdk/typescript" },
   "bugs": { "url": "https://github.com/mitos-run/mitos/issues" },


### PR DESCRIPTION
## Thinking Path

> - A branding audit of every distribution channel (in-repo metadata plus live registries) found drift, stale data, and a leak: the public OperatorHub listing contained an internal "migrating to ... ghcr.io/paperclipinc" note, image tags on Artifact Hub were stale at v0.13.0, container images had zero OCI labels, the Python PyPI description was an unverifiable "sub-millisecond" claim, SDK descriptions had five different phrasings, and READMEs leaked internal issue refs.
> - The goal is one consistent, current, complete brand across all channels.
> - This pull request fixes the source metadata for every channel.
> - The benefit is world-class, honest listings; most refresh on the next release, OperatorHub via a re-dispatch (see below).

## Linked Issues or Issue Description

Branding/consistency pass across all distribution channels following the distribution-pipeline fixes.

## What Changed

- OperatorHub CSV: remove the `ghcr.io/paperclipinc` migration leak; "mitos" -> "Mitos" display/provider/prose; minKubeVersion 1.29.0; aligned keywords.
- Helm chart: image tags v0.13.0 -> v1.5.0 with `x-release-please-version` markers (auto-bump henceforth); maintainer email for Artifact Hub rendering.
- All 8 Dockerfiles: add `org.opencontainers.image.*` labels (title/description/source/url/documentation/vendor/licenses).
- SDKs: unified canonical one-line description (Python/Rust/TS/Ruby/Java); fixed the off-brand Python "sub-millisecond" claim; PyPI classifiers; Rust keyword alignment; TS author; "Mitos" casing in Ruby/Java metadata.
- READMEs: strip internal issue refs (#296, #24); honest Ruby install (not yet on RubyGems).
- krew homepage intentionally left as the GitHub repo (so krew-index shows the star count).

## Verification

- [x] `package.json` parses (JSON); CSV + Chart parse (YAML).
- [x] No em or en dashes in any touched file.
- [x] `preview-proxy` deliberately NOT added to the chart images (its GHCR package is not public, would 404 the Artifact Hub scan).
- [x] Live image tags confirmed: `mitos-controller:v1.5.0` is public (HTTP 200).

## Notes on when listings refresh

Source-only change. Listings update when each channel re-publishes: the chart on its next release, PyPI/crates on the next SDK version bump, image OCI labels on the next image build. OperatorHub PR #8526 is open with the old (leaked) CSV; after this merges I will re-dispatch `operator-release.yaml` so it carries the cleaned bundle.

## Risks

Low. Metadata, Dockerfile labels, and docs only; no application code paths touched.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Docs updated in the same PR
- [x] No em or en dashes introduced anywhere
- [x] Every commit carries a `Signed-off-by` trailer
