### PR TITLE
docs(integrations): Claude Code, opencode, and OpenAI Agents SDK drop-in paths (#316, #318, #320)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,20 @@ Blocking `exec` works on the husk default. Streaming exec (`/v1/exec/stream`) an
 
 ### Integrations
 
-Drop a Mitos sandbox into the agent framework you already use. Each adapter is a thin shim over the same native ops (`exec`, `run_code`, `files`), with no hard dependency on the framework package.
+Drop a Mitos sandbox into the coding agent or agent framework you already use. Each adapter is a thin shim over the same native ops (`exec`, `run_code`, `files`, `fork`), with no hard dependency on the framework package. The [integrations hub](docs/integrations/README.md) indexes every path.
 
-| Framework | Import | Status |
+| Surface | How | Doc |
 |---|---|---|
-| LangChain / deepagents | `from mitos.integrations.langchain import MitosSandbox` | Planned |
-| OpenAI / Claude Agent SDK | `from mitos.integrations.openai_agents import MitosSandboxTools` | Planned |
-| VibeKit / ZenML | `from mitos.integrations.vibekit import MitosVibeKitProvider` | Planned |
+| Claude Code | MCP server + agent skill | [docs/integrations/claude-code.md](docs/integrations/claude-code.md) |
+| opencode | MCP server or harness-in-sandbox | [docs/integrations/opencode.md](docs/integrations/opencode.md) |
+| OpenAI Agents SDK | `from mitos.integrations.openai_agents import MitosSandboxTools` | [docs/integrations/openai-agents.md](docs/integrations/openai-agents.md) |
+| LangChain / deepagents | `from mitos.integrations.langchain import MitosSandbox` | [sdk/python/README.md](sdk/python/README.md) |
+| Claude Agent SDK | `from mitos.integrations.claude_agent import MitosSandboxTools` | [sdk/python/README.md](sdk/python/README.md) |
+| Vercel AI SDK / Pydantic AI / AutoGen / LlamaIndex | standard MCP server | [docs/integrations/mcp-frameworks.md](docs/integrations/mcp-frameworks.md) |
+| VibeKit / ZenML | `from mitos.integrations.vibekit import MitosVibeKitProvider` | [sdk/python/README.md](sdk/python/README.md) |
 | E2B (migration) | `from mitos.e2b import Sandbox` | [docs/migrating-from-e2b.md](docs/migrating-from-e2b.md) |
 
-The E2B shim is a "change one import" bridge for self-hosted, regulated, or air-gapped teams leaving E2B's cloud: it presents E2B's `Sandbox` surface over the standalone sandbox-server. `get_host(port)` returns a signed, expiring preview URL once the per-sandbox preview proxy is deployed.
+The Codex CLI is closed and its sandbox is not swappable; the supported path into the OpenAI ecosystem is the OpenAI Agents SDK above. The E2B shim is a "change one import" bridge for self-hosted, regulated, or air-gapped teams leaving E2B's cloud: it presents E2B's `Sandbox` surface over the standalone sandbox-server. `get_host(port)` returns a signed, expiring preview URL once the per-sandbox preview proxy is deployed.
 
 ### On a cluster
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,44 @@
+# Integrations
+
+Drop a Mitos snapshot-fork microVM into the coding agent or agent framework you
+already use. There are two shapes:
+
+- **Coding agents that run on a sandbox** (Claude Code, opencode): point the agent
+  at the Mitos MCP server, or host the agent harness inside a sandbox and reach it
+  over HTTP.
+- **Frameworks that use a sandbox as a tool** (OpenAI Agents SDK, LangChain /
+  deepagents, Vercel AI SDK, Pydantic AI, AutoGen, LlamaIndex): bind the sandbox
+  ops as tools, via a native adapter or the standard MCP server.
+
+Every path runs on your own infrastructure (the standalone `sandbox-server`, no
+Kubernetes, or a self-hosted cluster) or the hosted endpoint, and every path
+reaches the same native ops: `exec`, `run_code`, `files`, and `fork`.
+
+## Coding agents
+
+| Agent | How | Doc |
+|---|---|---|
+| Claude Code | MCP server (`claude mcp add`) + agent skill | [claude-code.md](claude-code.md) |
+| opencode | MCP server (`opencode.json`) or harness-in-sandbox | [opencode.md](opencode.md) |
+
+## Frameworks
+
+| Framework | How | Doc |
+|---|---|---|
+| OpenAI Agents SDK | native adapter `MitosSandboxTools` | [openai-agents.md](openai-agents.md) |
+| LangChain / deepagents | native adapter `from mitos.integrations.langchain import MitosSandbox` | [../../sdk/python/README.md](../../sdk/python/README.md) |
+| Vercel AI SDK, Pydantic AI, AutoGen, LlamaIndex | standard MCP server | [mcp-frameworks.md](mcp-frameworks.md) |
+| Any MCP client | standard MCP server `mitos-mcp` | [../mcp.md](../mcp.md) |
+
+## Migrating
+
+| From | How | Doc |
+|---|---|---|
+| E2B | one-import shim `from mitos.e2b import Sandbox` | [../migrating-from-e2b.md](../migrating-from-e2b.md) |
+
+## The honest Codex note
+
+The Codex CLI is closed and runs on OpenAI's own containers; its sandbox cannot
+be swapped for a Mitos one. The supported path into the OpenAI ecosystem is the
+OpenAI Agents SDK ([openai-agents.md](openai-agents.md)), which takes a Mitos
+sandbox as a tool.

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,133 @@
+# Give Claude Code a forkable computer (5 minutes)
+
+Claude Code's built-in sandbox is per-machine and OS-level. Mitos adds a
+Kubernetes-native, multi-tenant **microVM** with a fork primitive: Claude Code
+runs agent-generated code in a Firecracker microVM on your own cluster, and can
+fork a warm sandbox before a risky edit so a bad change is thrown away, not
+rolled back.
+
+Claude Code plugs in through the Mitos **MCP server** (`mitos-mcp`) and the Mitos
+**agent skill** (`skills/mitos/SKILL.md`). This walkthrough wires both.
+
+## Prerequisites
+
+- Claude Code installed (`claude`).
+- A Mitos sandbox backend, one of:
+  - the hosted endpoint `https://mitos.run` (set `MITOS_API_KEY`), or
+  - your self-hosted cluster's `sandbox-server` / gateway URL, or
+  - a local standalone `sandbox-server` for trying it out:
+    `go run ./cmd/sandbox-server --mock --addr :8080` (mock engine, no KVM), or a
+    real-mode server on a KVM host (`--kernel ... --rootfs ... --agent-bin ...`).
+- The `mitos-mcp` binary on your `PATH`:
+  `go install mitos.run/mitos/cmd/mitos-mcp@latest`.
+
+## 1. Add the Mitos MCP server to Claude Code
+
+`mitos-mcp` is a stdio MCP server: Claude Code launches it and talks JSON-RPC
+over stdin/stdout. Add it with `claude mcp add`, passing the backend URL and
+token as environment variables:
+
+```bash
+claude mcp add mitos \
+  --env MITOS_BASE_URL=https://mitos.run \
+  --env MITOS_API_KEY=your-scoped-token \
+  -- mitos-mcp
+```
+
+For a local standalone server, point it at `http://localhost:8080` and drop the
+token (the standalone server is tokenless):
+
+```bash
+claude mcp add mitos --env MITOS_BASE_URL=http://localhost:8080 -- mitos-mcp
+```
+
+> `mitos-mcp` speaks stdio, not HTTP; use the command form above (`-- mitos-mcp`),
+> not `--transport http`. Token resolution follows the SDK precedence: `--env
+> MITOS_API_KEY`, then `~/.config/mitos/credentials.json` from `mitos auth login`,
+> then tokenless.
+
+Confirm Claude Code connected to the server:
+
+```bash
+claude mcp get mitos     # Status: Connected
+claude mcp list          # mitos: mitos-mcp - Connected
+```
+
+Inside a session, `/mcp` lists the server and its tools.
+
+## 2. The tools Claude Code gets
+
+The server advertises the sandbox lifecycle as MCP tools:
+
+| Tool | Arguments | Purpose |
+|---|---|---|
+| `sandbox_create` | `pool` | Claim a sandbox from a pool / template; returns its id |
+| `sandbox_exec` | `sandbox`, `command`, `timeout_seconds?` | Run a shell command; returns `{exit_code, stdout, stderr}` |
+| `sandbox_read_file` | `sandbox`, `path` | Read a file |
+| `sandbox_write_file` | `sandbox`, `path`, `content` | Write a file |
+| `sandbox_fork` | `sandbox`, `replicas?` | Fork a live sandbox into isolated copies (cluster / forkd) |
+| `sandbox_terminate` | `sandbox` | Terminate a sandbox |
+
+Every failure is a structured envelope, `{code, cause, remediation}`, so the
+agent can branch on it instead of parsing prose.
+
+> The `pool` you pass to `sandbox_create` must already exist: a `SandboxPool` in
+> a cluster, or a template on the standalone server (`POST /v1/templates`). On the
+> standalone `sandbox-server` the fork primitive is pool to sandbox, so use
+> `sandbox_create` per attempt there; `sandbox_fork` forks a live sandbox on the
+> cluster / forkd path.
+
+## 3. Run agent-generated code in a microVM
+
+Ask Claude Code to use the sandbox. A prompt like:
+
+> Create a sandbox from the `python` pool, write a script that computes the 20th
+> Fibonacci number, run it, and show me the output. Then terminate the sandbox.
+
+drives `sandbox_create` -> `sandbox_write_file` -> `sandbox_exec` ->
+`sandbox_terminate`. The code never touches your laptop or the cluster host: it
+runs inside a Firecracker microVM with its own kernel.
+
+## 4. Fork before a risky edit
+
+The fork primitive is the reason to reach for Mitos over a local sandbox. On a
+cluster, ask Claude Code to fork the warm sandbox before a destructive change:
+
+> Fork this sandbox into 3 copies. In each, try a different refactor of
+> `app/handler.py`, run the tests, and tell me which fork passed. Keep that one
+> and terminate the others.
+
+Each fork is an independent microVM restored from the same warm snapshot in
+milliseconds (copy-on-write: you pay for the pages each fork dirties). A crash,
+a fork bomb, or an `rm -rf` in one fork cannot touch its siblings, the host, or
+the control plane, so it is safe to run code the model just wrote.
+
+## 5. The agent skill
+
+`skills/mitos/SKILL.md` teaches the workflow the tools enable: when to fork
+versus start fresh, the best-of-N loop, the microVM isolation guarantee, and the
+cost model (copy-on-write, discard losers promptly, capability budgets that bound
+a runaway fan-out). Install it as an
+[agent skill](https://docs.claude.com/en/docs/claude-code/skills) so Claude Code
+applies the fork-vs-fresh and cost reasoning, not just the raw tool calls.
+
+## What is verified
+
+This path was exercised end to end against a real Firecracker microVM (a
+standalone real-mode `sandbox-server` on a KVM host):
+
+- `claude mcp add` with the stdio command form registers the server, and
+  `claude mcp get` / `claude mcp list` report it **Connected** (Claude Code
+  completed the MCP `initialize` handshake against `mitos-mcp`).
+- Driving the advertised tools runs against the live VM: `sandbox_create` claims
+  a real microVM, `sandbox_exec` returns a real `{exit_code, stdout}`,
+  `sandbox_write_file` then `sandbox_read_file` round-trips file content, and
+  `sandbox_terminate` reaps it.
+- The agent skill's examples were corrected to match the current SDK surface
+  (direct `mitos.create` for the hosted / standalone loop; the `AgentRun`
+  cluster surface for durable-workspace commit).
+
+The model-driving step (Claude Code choosing the tools from a prompt) uses your
+Claude Code session. The MCP server's protocol conformance and the real-microVM
+exec path are gated in CI (the MCP conformance test and the `firecracker-test`
+job).

--- a/docs/integrations/openai-agents.md
+++ b/docs/integrations/openai-agents.md
@@ -1,0 +1,112 @@
+# Give the OpenAI Agents SDK a Mitos sandbox
+
+The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) (the
+`openai-agents` package) lets an agent call tools you define as function tools.
+Mitos ships a native adapter, `MitosSandboxTools`, that binds four sandbox tools
+(`run_command`, `read_file`, `write_file`, `run_code`) to a Mitos snapshot-fork
+microVM, so any Agents SDK agent can run and edit code inside a hardware-isolated
+sandbox on your own infrastructure.
+
+This is an adapter over the existing SDK ops (`exec`, `files`, `run_code`); it
+needs no Kubernetes (it runs against the standalone `sandbox-server` or the
+hosted control plane) and it imports `openai-agents` lazily, so the rest of your
+code works whether or not the SDK is installed.
+
+## Install
+
+```bash
+pip install "mitos-run[openai-agents]"
+```
+
+The `[openai-agents]` extra pulls in the `openai-agents` package. The base
+`mitos-run` install already carries the adapter module; only the
+`as_function_tools()` conversion needs the SDK.
+
+## Quickstart
+
+Point the adapter at a sandbox backend with `MITOS_BASE_URL` (a standalone
+`sandbox-server`, for example `http://localhost:8080`, or the hosted
+`https://mitos.run`) and `MITOS_API_KEY` (or run `mitos auth login` once; the
+standalone server runs tokenless).
+
+```python
+from agents import Agent, Runner
+from mitos.integrations.openai_agents import MitosSandboxTools
+
+# Build a READY sandbox and bind the four tools to it (no Kubernetes).
+tools = MitosSandboxTools.create("python", base_url="http://localhost:8080")
+
+agent = Agent(
+    name="coder",
+    instructions=(
+        "You run and edit code inside a sandbox. Use run_command for shell, "
+        "run_code for snippets, and read_file / write_file for files."
+    ),
+    tools=tools.as_function_tools(),
+)
+
+result = Runner.run_sync(agent, "Write hello.py that prints 42, then run it.")
+print(result.final_output)
+
+tools.close()  # terminate the sandbox
+```
+
+`MitosSandboxTools` is also a context manager (`with MitosSandboxTools.create(...)
+as tools:`) and exposes the underlying `DirectSandbox` as `tools.sandbox` for the
+Mitos-only operations (`fork`, `pause`/`resume`, PTY, preview URLs).
+
+The four tools map to native sandbox ops:
+
+| Tool | Maps to | Returns |
+|---|---|---|
+| `run_command(command, timeout=30)` | `sandbox.exec` | `{stdout, stderr, exit_code, exec_time_ms}` |
+| `read_file(path)` | `sandbox.files.read` | file contents (string) |
+| `write_file(path, content)` | `sandbox.files.write` | `{path, written}` |
+| `run_code(code, language="python")` | `sandbox.run_code` | flattened `Execution` (text, logs, rich results, error) |
+
+`run_code` needs a language kernel in the sandbox image; against a minimal image
+it returns a fail-closed `KernelUnavailable` until the kernel ships in the base
+image. `run_command` / `read_file` / `write_file` work on any image with a shell.
+
+## Why fork
+
+Because each sandbox is a Firecracker microVM, you can fork a warm one into N
+isolated attempts and let the agent explore in parallel (best-of-N), then keep
+the winner. Reach the fork primitive through the underlying handle:
+
+```python
+tools = MitosSandboxTools.create("python", base_url="http://localhost:8080")
+children = tools.sandbox.fork(4)        # 4 isolated microVMs from the warm base
+# give each child its own agent / attempt, score them, keep the winner
+```
+
+See the [Mitos agent skill](../../skills/mitos/SKILL.md) for the full
+fork-vs-fresh and best-of-N workflow.
+
+## Codex: the honest path
+
+The **Codex CLI** is closed and runs the agent on OpenAI's own containers; its
+sandbox is not swappable. There is no supported way to point the Codex CLI at a
+Mitos sandbox, and we do not document a workaround that does not exist.
+
+The real path into the OpenAI ecosystem is the **OpenAI Agents SDK** shown above
+(it is open and takes a Mitos sandbox as a tool). If you are using a Codex model,
+drive it through the Agents SDK with these tools rather than the CLI.
+
+## What is verified
+
+The adapter's tool layer is exercised end to end against a real Firecracker
+microVM (a standalone real-mode `sandbox-server` on a KVM host):
+
+- `MitosSandboxTools.create(...)` builds a ready sandbox; `function_tools()` and
+  `as_function_tools()` return the four tools, and `as_function_tools()`
+  constructs real `agents.FunctionTool` objects when `openai-agents` is
+  installed.
+- Invoking the tool callables runs against the live VM: `write_file` then
+  `read_file` round-trips file content, and `run_command` returns real stdout
+  and a real exit code.
+
+The model-driving step (an `Agent` actually selecting and calling these tools)
+uses your own OpenAI credentials, exactly as the Agents SDK documents. The adapter
+unit tests live in `sdk/python/tests/test_openai_agents_integration.py` and run in
+CI; the real-microVM exec path is gated by the `firecracker-test` job.

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,0 +1,103 @@
+# Run opencode against a Mitos sandbox
+
+[opencode](https://opencode.ai) is an open-source terminal coding agent. There
+are two ways to combine it with Mitos:
+
+1. **Give opencode a Mitos sandbox as a tool** (MCP): opencode runs on your
+   machine and reaches into a Mitos microVM to create sandboxes, exec, fork, and
+   move files.
+2. **Host the opencode harness inside a sandbox** and drive it over HTTP: opencode
+   itself runs inside a Mitos microVM, one per agent, reachable over an
+   authenticated URL.
+
+## 1. Mitos sandbox as an MCP tool
+
+opencode is an MCP client. Point it at the Mitos MCP server, `mitos-mcp`, and the
+sandbox lifecycle appears to the agent as tools (`sandbox_create`,
+`sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_fork`,
+`sandbox_terminate`).
+
+Install the server so it is on `PATH`
+(`go install mitos.run/mitos/cmd/mitos-mcp@latest`), then add a local MCP server
+to your `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "mitos": {
+      "type": "local",
+      "command": ["mitos-mcp"],
+      "environment": {
+        "MITOS_BASE_URL": "https://mitos.run",
+        "MITOS_API_KEY": "your-scoped-token"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+For a local standalone server, set `MITOS_BASE_URL` to `http://localhost:8080`
+and drop the token (the standalone `sandbox-server` is tokenless). `mitos-mcp`
+resolves its credential the same way every Mitos surface does: `MITOS_API_KEY`,
+then `~/.config/mitos/credentials.json` from `mitos auth login`, then tokenless.
+
+Confirm opencode connected and loaded the tools:
+
+```bash
+opencode mcp list
+#  ✓ mitos  connected
+```
+
+Now in an opencode session the agent can claim a microVM, run the code it
+writes, and (on a cluster) fork it for best-of-N. The `pool` passed to
+`sandbox_create` must already exist (a `SandboxPool` on a cluster, or a template
+on the standalone server via `POST /v1/templates`).
+
+## 2. Host the opencode harness inside a sandbox
+
+opencode ships a headless server (`opencode serve`) that exposes its HTTP API.
+You can run that server inside a Mitos microVM and drive it over HTTP, one
+isolated opencode per agent. This builds on the
+[agent-harness recipe](../recipes/agent-harness.md); the sandbox side is
+identical, with `opencode serve` as the daemon.
+
+Start the daemon inside the guest and open a host forward to it:
+
+```bash
+# Start opencode's headless server inside the sandbox (port 4096 by default).
+curl -fsS -X POST localhost:8080/v1/exec \
+  -d '{"sandbox":"sbx-1","command":"nohup opencode serve --hostname 0.0.0.0 --port 4096 >/tmp/oc.log 2>&1 &"}'
+
+# Open a host TCP forward to the guest port and dial the opencode API.
+curl -fsS -X POST localhost:8080/v1/sandboxes/sbx-1/forward -d '{"guest_port":4096}'
+# -> {"host":"127.0.0.1:NNNNN","guest_port":4096}
+curl http://127.0.0.1:NNNNN/    # reaches opencode inside the guest
+```
+
+To fan out, warm one base sandbox, fork it, and give each fork its own
+authenticated URL with Mitos Expose, so each agent gets a fresh, isolated
+opencode:
+
+```bash
+mitos workspace serve harness --pool opencode --as agent-1 --port 4096 \
+  --expose-domain mitos.app
+# -> https://agent-1.mitos.app/
+```
+
+See the [agent-harness recipe](../recipes/agent-harness.md) for the full
+host-forward, Mitos Expose, and fork-fan-out patterns (authenticated URLs, the
+private / link / authenticated / public sharing tiers, and the SDK `serve()`
+handles).
+
+## What is verified
+
+opencode 1.x connects to the Mitos MCP server with the `opencode.json` above:
+`opencode mcp list` reports `mitos connected`, meaning opencode completed the MCP
+`initialize` handshake and imported the sandbox tools. The tools themselves are
+exercised end to end against a real Firecracker microVM (a standalone real-mode
+`sandbox-server` on a KVM host): `sandbox_create` claims a real VM,
+`sandbox_exec` returns a real `{exit_code, stdout}`, and `sandbox_write_file` /
+`sandbox_read_file` round-trip file content. The model-driving step uses the LLM
+provider you configure in opencode.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -4,9 +4,11 @@
 Protocol](https://modelcontextprotocol.io) tools. Any MCP-speaking agent
 (Claude Desktop, an MCP client library, an agent framework with MCP support)
 can create sandboxes, run commands, read and write files, fork, and terminate,
-with no SDK integration. For copy-paste recipes wiring specific frameworks
-(Vercel AI SDK, Pydantic AI, AutoGen, LlamaIndex) to this server, see
-[integrations/mcp-frameworks.md](integrations/mcp-frameworks.md).
+with no SDK integration. For copy-paste recipes wiring specific surfaces to this
+server, see the [integrations hub](integrations/README.md):
+[Claude Code](integrations/claude-code.md), [opencode](integrations/opencode.md),
+and the [framework MCP recipes](integrations/mcp-frameworks.md) (Vercel AI SDK,
+Pydantic AI, AutoGen, LlamaIndex).
 
 It speaks MCP over a stdio JSON-RPC 2.0 transport: stdin and stdout are the
 protocol channel, and all logging goes to stderr. The protocol subset

--- a/skills/mitos/SKILL.md
+++ b/skills/mitos/SKILL.md
@@ -49,22 +49,18 @@ Warm one base, fan out, run attempts in parallel, keep the winner, discard the r
 ```python
 import mitos
 
-# Warm base, bound to a durable workspace so the winner can be committed.
-base = mitos.create("python", workspace="refactor-task")
+# Warm one base sandbox (hosted endpoint or a standalone sandbox-server;
+# resolves MITOS_BASE_URL and the credential file).
+base = mitos.create("python")
 
-# Fan out 8 independent attempts. Each child is a full microVM that must
-# activate; raise the timeout for a wide fan-out (each child is ~10-15s).
-children = base.fork(8, timeout=180)
+# Fan out 8 independent attempts. Each child is a full microVM restored from
+# the base snapshot, isolated from its siblings.
+children = base.fork(8)
 
 # Run one attempt per child IN PARALLEL (threads/async), then score them.
 # Each child is isolated: a crash or rm -rf in one cannot touch the others.
 results = run_attempts_in_parallel(children)   # your scoring
 winner = pick_best(results)
-
-# Commit the winner: terminating a workspace-bound sandbox dehydrates
-# /workspace into a new committed revision. checkpoint=True also snapshots VM
-# memory for a resumable head. It returns the workspace name.
-winner.terminate(checkpoint=True)
 
 # Discard the losers. You only paid for the pages each one dirtied.
 for c in children:
@@ -75,13 +71,37 @@ for c in children:
 The same shape works over MCP: `sandbox_create` -> `sandbox_fork` ->
 `sandbox_exec`/`sandbox_read_file` per child -> `sandbox_terminate`.
 
-## Lineage and workspaces
+## Lineage and workspaces (Kubernetes cluster mode)
 
-A Workspace is the durable, forkable filesystem behind sandboxes. Each commit is
-a revision; revisions form a lineage you can inspect (`workspace.log()`) and
-resume from (start a new sandbox `from_revision`). Use a workspace when work must
-survive the sandbox: the best-of-N winner above is kept because the base was
-bound to one. Ephemeral, throwaway exploration needs no workspace.
+A Workspace is the durable, forkable filesystem behind sandboxes: bind a base to
+one so the best-of-N winner is committed instead of discarded. Workspaces are a
+Kubernetes cluster feature, driven by the `AgentRun` surface (not the direct
+`mitos.create` one):
+
+```python
+import mitos
+
+run = mitos.AgentRun(namespace="default")           # k8s mode
+
+# Bind the base to a durable workspace by name.
+base = run.create("python", workspace="refactor-task")
+children = base.fork(8, timeout=180)                 # seconds to activate
+
+results = run_attempts_in_parallel(children)
+winner = pick_best(results)
+
+# Commit the winner: terminating a workspace-bound sandbox dehydrates
+# /workspace into a new committed revision. checkpoint=True also snapshots VM
+# memory for a resumable head. It returns the workspace name.
+winner.terminate(checkpoint=True)
+for c in children:
+    if c is not winner:
+        c.terminate()
+```
+
+Each commit is a revision; revisions form a lineage you can inspect
+(`run.workspace("refactor-task").log()`) and resume from. Ephemeral, throwaway
+exploration needs no workspace; use the direct `mitos.create` loop above.
 
 ## Cost-awareness
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed to agents through the mitos-mcp server and the language SDKs.
> - Epic #323 ("be the sandbox every agent plugs into") is the category's top growth lever: being co-named with the agents and frameworks developers already use.
> - Three sub-issues remained open (#316 opencode, #318 Claude Code, #320 Codex / OpenAI Agents SDK). The plumbing for each already shipped; what was missing was a verified, copy-paste drop-in path, plus the honest Codex-CLI-not-swappable note.
> - It needs to be addressed now because the closed sub-issues (#317 E2B shim, #319 deepagents, #321 MCP frameworks) already landed and this finishes the epic; it serves the integrations workstream.
> - This pull request documents and verifies the three remaining paths against a real Firecracker microVM, and fixes an API-drift bug in the agent skill found during verification.
> - The benefit is that "point your agent at a Mitos sandbox on your own cluster" now works in one go, with every claim backed by a real-microVM run.

## Linked Issues or Issue Description

Closes #316
Closes #318
Closes #320
Related: #323

## What Changed

- `docs/integrations/openai-agents.md` (#320): the OpenAI Agents SDK adapter (`MitosSandboxTools`) with a runnable example, the tool-to-op mapping, fork-for-best-of-N, and the honest note that the Codex CLI sandbox is not swappable (the supported OpenAI path is the Agents SDK).
- `docs/integrations/claude-code.md` (#318): a 5 minute walkthrough to give Claude Code a forkable microVM via `claude mcp add` (the stdio command form, since `mitos-mcp` is stdio, not `--transport http`) plus the agent skill, with the fork-before-a-risky-edit flow.
- `docs/integrations/opencode.md` (#316): point opencode at the Mitos MCP server via `opencode.json`, plus hosting the opencode harness inside a sandbox over HTTP (builds on `docs/recipes/agent-harness.md`).
- `docs/integrations/README.md`: an integrations hub indexing coding agents, frameworks, and the E2B migration.
- `skills/mitos/SKILL.md`: fix the best-of-N example, which called cluster-only kwargs (`workspace=`, `fork(timeout=)`, `terminate(checkpoint=)`) on the direct-mode `mitos.create` entry. Split into a runnable direct/hosted loop and a clearly labeled cluster-mode `AgentRun` durable-workspace variant.
- `README.md`, `docs/mcp.md`: refresh the integrations table (shipped, not "Planned") and cross-link the new docs.

## Verification

All paths were exercised end to end against a real Firecracker microVM: a standalone real-mode `sandbox-server` (current source, freshly built guest agent) on a bare-metal KVM host, tunneled locally.

- [x] Python SDK `create` / `exec` / `files.write+read` / `fork(2)` / `terminate` against the live VM (fork in ~341 ms).
- [x] `MitosSandboxTools` function tools execute against the live VM (`write_file` then `read_file` round-trips; `run_command` returns real exit code + stdout); `as_function_tools()` builds real `agents.FunctionTool` objects with `openai-agents` 0.17.7.
- [x] `mitos-mcp` driven over stdio (the exact JSON-RPC Claude Code uses): `initialize`, `tools/list` (6 tools), and `tools/call` for `sandbox_create` / `sandbox_exec` / `sandbox_write_file` / `sandbox_read_file` / `sandbox_terminate` against the live VM.
- [x] `claude mcp add mitos --env MITOS_BASE_URL=... -- mitos-mcp` then `claude mcp get` reports **Connected**.
- [x] `opencode mcp list` reports the `mitos` server **connected** (opencode 1.17.11).
- [x] The corrected direct best-of-N example (fork 4, parallel exec, keep winner, terminate losers) runs on the live VM.
- [x] `cd sdk/python && PYTHONPATH=. python3 -m pytest tests/test_openai_agents_integration.py` -> 12 passed.
- [x] No em or en dashes in the changed files.

The model-driving step of each integration (the LLM actually selecting the tools) uses the reader's own provider credentials, exactly as each framework documents; that boundary is stated in each doc.

## Risks

Low risk: docs plus one agent-skill markdown example fix. No Go, controller, forkd, or guest-agent code changed, so no runtime, security-surface, or hot-path impact; no threat-model or bench delta needed. The skill fix corrects an example that would have raised `TypeError` as written.

## Model Used

- Claude Opus 4.8 (1M context), model id `claude-opus-4-8[1m]`, extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (docs)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD): no behavior change; existing adapter tests stay green
- [x] Docs updated in the same PR
- [x] Threat-model delta included if the security surface moved: not applicable
- [x] Benchmark run included if the hot path was touched: not applicable
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
