### PR TITLE
fix(chart): stop fresh installs referencing a phantom pull secret (#399)

### DIFF
--- a/deploy/charts/charttest/imagepullsecret_test.go
+++ b/deploy/charts/charttest/imagepullsecret_test.go
@@ -1,0 +1,38 @@
+package charttest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNoImagePullSecretsByDefault asserts a default install attaches NO
+// imagePullSecrets to any workload pod. The published mitos-* images are public
+// on GHCR, so a fresh install pulls without a credential; referencing a
+// ghcr-pull secret that does not exist would only emit a confusing
+// "Unable to retrieve some image pull secrets" warning event on every pod.
+// Issue #399.
+func TestNoImagePullSecretsByDefault(t *testing.T) {
+	out := render(t)
+	if strings.Contains(out, "imagePullSecrets:") {
+		t.Fatalf("default render attaches imagePullSecrets, but the images are public; expected none\n%s", out)
+	}
+}
+
+// TestImagePullSecretsRenderWhenSet asserts the knob still works for a private
+// mirror: setting imagePullSecrets[0].name attaches that pull secret to the
+// workload pods. This is the only configuration that needs it.
+func TestImagePullSecretsRenderWhenSet(t *testing.T) {
+	out := render(t, "imagePullSecrets[0].name=ghcr-pull")
+	mustContain(t, out, "imagePullSecrets:")
+	mustContain(t, out, "- name: ghcr-pull")
+}
+
+// TestImagePullSecretNotRenderedByDefault asserts the chart does not render the
+// dockerconfigjson Secret by default (imagePullSecret.create=false): public
+// images need no credential.
+func TestImagePullSecretNotRenderedByDefault(t *testing.T) {
+	out := render(t)
+	if strings.Contains(out, "kubernetes.io/dockerconfigjson") {
+		t.Fatalf("default render created a dockerconfigjson pull Secret; public images need none\n%s", out)
+	}
+}

--- a/deploy/charts/mitos/README.md
+++ b/deploy/charts/mitos/README.md
@@ -14,7 +14,10 @@ It is a faithful translation of the kustomize manifests under `deploy/`.
   DaemonSets stay Pending until a matching node joins. PodSecurity admission must
   permit privileged pods in the install namespace; the chart sets
   `pod-security.kubernetes.io/enforce: privileged` on the namespace it creates.
-- A registry pull credential for the mitos-* images (see Image pull secret below).
+
+The published mitos-* images are public on GHCR, so no registry credential is
+needed for a default install. A pull secret is only required for a private mirror
+(see Image pull secret below).
 
 Label a KVM node:
 
@@ -78,20 +81,33 @@ CRDs and any data they own are left in place by design.
 
 ## Image pull secret
 
-The mitos-* images live in a private registry. By default the chart does NOT
-render a pull secret (`imagePullSecret.create=false`); create one out of band:
+The published mitos-* images on `ghcr.io/mitos-run` are public, so the default
+install pulls them with no credential and attaches no pull secret
+(`imagePullSecrets: []`). A release guard (`verify-public-images` in
+`.github/workflows/publish.yaml`) fails the release if any chart-referenced image
+is private or missing, so this stays true across releases.
+
+You only need a pull secret for a private mirror or a private re-publish of the
+images. In that case point `image.registry` at your mirror, then create the
+secret and reference it:
 
 ```
 kubectl create secret docker-registry ghcr-pull \
   --namespace mitos \
-  --docker-server=ghcr.io \
-  --docker-username=<github-username> \
-  --docker-password=<ghcr-read-packages-PAT>
+  --docker-server=<your-registry> \
+  --docker-username=<username> \
+  --docker-password=<read-packages-token>
+helm install mitos deploy/charts/mitos -n mitos --set namespace.create=false \
+  --set 'imagePullSecrets[0].name=ghcr-pull'
 ```
 
-Or set `imagePullSecret.create=true` and pass a real
-`imagePullSecret.dockerconfigjson`. Both the controller ServiceAccount and the
-forkd DaemonSet reference the secret named by `imagePullSecret.name`.
+Or let the chart render the secret: set `imagePullSecret.create=true`, pass a
+real base64 `imagePullSecret.dockerconfigjson`, and add `imagePullSecret.name` to
+`imagePullSecrets`.
+
+If a pod reports `ImagePullBackOff`, you are almost certainly on a private mirror
+without one of the above. The forkd DaemonSet's registry-credential mount is
+already optional, so a missing secret never blocks forkd from starting.
 
 ## Values
 
@@ -141,10 +157,10 @@ forkd DaemonSet reference the secret named by `imagePullSecret.name`.
 | `monitoring.prometheusRuleRelease` | `prometheus` | `release` label the Prometheus Operator selects on. |
 | `namespace.name` | `mitos` | Install namespace. |
 | `namespace.create` | `true` | Render the Namespace with PodSecurity labels. |
-| `imagePullSecret.create` | `false` | Render the pull-secret Secret. |
-| `imagePullSecret.name` | `ghcr-pull` | Pull-secret name referenced by the workloads. |
-| `imagePullSecret.dockerconfigjson` | `{"auths":{}}` base64 | Base64 dockerconfigjson value. |
-| `imagePullSecrets` | `[{name: ghcr-pull}]` | Pull-secret names attached to every workload pod. |
+| `imagePullSecret.create` | `false` | Render the dockerconfigjson Secret named below. Public images need none; set true only for a private mirror. |
+| `imagePullSecret.name` | `ghcr-pull` | Name of the Secret rendered when `create=true`. |
+| `imagePullSecret.dockerconfigjson` | `{"auths":{}}` base64 | Base64 dockerconfigjson value used when `create=true`. |
+| `imagePullSecrets` | `[]` | Pull-secret names attached to every workload pod. Empty by default (public images); populate for a private mirror. |
 | `commonLabels` | `{}` | Extra labels merged onto every resource. |
 
 ## Security notes

--- a/deploy/charts/mitos/templates/NOTES.txt
+++ b/deploy/charts/mitos/templates/NOTES.txt
@@ -22,18 +22,22 @@ kernel-stage DaemonSets stay Pending by design. Label a KVM-capable node:
 
   kubectl label node <node-name> mitos.run/kvm=true
 
-{{- if not .Values.imagePullSecret.create }}
+{{- if not .Values.imagePullSecrets }}
 
-The chart did NOT render the {{ .Values.imagePullSecret.name }} pull secret
-(imagePullSecret.create is false). Create it in the {{ include "mitos.namespace" . }}
-namespace before the images can pull, or set imagePullSecret.create=true with a
-real imagePullSecret.dockerconfigjson:
+The published mitos-* images on ghcr.io/mitos-run are public, so this install
+pulls them with no registry credential and attaches no pull secret.
 
-  kubectl create secret docker-registry {{ .Values.imagePullSecret.name }} \
+If you mirrored the images to a private registry, set image.registry to it and
+attach a pull secret. Otherwise an ImagePullBackOff here points at the registry,
+not a missing credential:
+
+  kubectl create secret docker-registry ghcr-pull \
     --namespace {{ include "mitos.namespace" . }} \
-    --docker-server=ghcr.io \
-    --docker-username=<github-username> \
-    --docker-password=<ghcr-read-packages-PAT>
+    --docker-server=<your-registry> \
+    --docker-username=<username> \
+    --docker-password=<read-packages-token>
+
+then reinstall with --set 'imagePullSecrets[0].name=ghcr-pull'.
 {{- end }}
 
 Verify the control plane:

--- a/deploy/charts/mitos/templates/serviceaccount.yaml
+++ b/deploy/charts/mitos/templates/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "mitos.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
-# The controller pulls its image from a private registry; the pull credential is
-# named here so every controller pod gets it without a manual patch.
+# The published images are public, so this renders nothing by default. For a
+# private mirror, set imagePullSecrets so every controller pod gets the credential
+# without a manual patch.
 {{- include "mitos.imagePullSecrets" . | nindent 0 }}

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -220,21 +220,28 @@ namespace:
   # admission labels (enforce=privileged) forkd and the device plugin require.
   create: true
 
-# Image pull secret for the mitos-* images.
+# Image pull secret for the mitos-* images. The published images on
+# ghcr.io/mitos-run are PUBLIC, so a default install needs no credential and the
+# knobs below stay off. They exist only for a private mirror or a private
+# re-publish of the images: point image.registry at your mirror, then either set
+# imagePullSecret.create=true with a real dockerconfigjson, or pre-create the
+# secret out of band and list it under imagePullSecrets below.
 imagePullSecret:
-  # When true, the chart renders the ghcr-pull dockerconfigjson Secret. When
-  # false, the Secret is assumed to already exist (create it out of band).
+  # When true, the chart renders the dockerconfigjson Secret named below. When
+  # false (the default), no Secret is rendered; public images need none.
   create: false
-  # The Secret name referenced by the workloads.
+  # The Secret name rendered when create=true. Add the same name to
+  # imagePullSecrets below for the workloads to use it.
   name: ghcr-pull
   # The base64-encoded dockerconfigjson value. Defaults to {"auths":{}}. Provide
-  # a real credential to enable image pulls.
+  # a real credential when create=true to enable pulls from a private mirror.
   dockerconfigjson: eyJhdXRocyI6e319
 
-# Image pull secret names referenced by every workload pod spec. Defaults to the
-# managed ghcr-pull secret name.
-imagePullSecrets:
-  - name: ghcr-pull
+# Image pull secret names attached to every workload pod spec. Empty by default:
+# the published images are public, so no secret is referenced and a fresh install
+# emits no "Unable to retrieve some image pull secrets" warning event. Populate
+# this only for a private mirror, for example: [{name: ghcr-pull}].
+imagePullSecrets: []
 
 # Extra labels merged onto every resource the chart renders.
 commonLabels: {}

--- a/deploy/imagepullsecret.yaml
+++ b/deploy/imagepullsecret.yaml
@@ -1,12 +1,14 @@
-# ghcr.io pull credential for the mitos-* images. This ships with an EMPTY
-# dockerconfigjson so the manifest is self-contained and apply-able; you MUST
-# populate it once with a real read:packages token before the images can pull:
+# Registry pull credential for the mitos-* images. The published images on
+# ghcr.io/mitos-run are PUBLIC, so the empty dockerconfigjson below is enough: the
+# kubelet falls back to an anonymous pull and the manifest stays self-contained
+# and apply-able. You only need to populate it for a private mirror or a private
+# re-publish of the images:
 #
 #   kubectl create secret docker-registry ghcr-pull \
 #     --namespace mitos \
-#     --docker-server=ghcr.io \
-#     --docker-username=<github-username> \
-#     --docker-password=<ghcr-read-packages-PAT> \
+#     --docker-server=<your-registry> \
+#     --docker-username=<username> \
+#     --docker-password=<read-packages-token> \
 #     --dry-run=client -o yaml | kubectl apply -f -
 #
 # The serviceaccounts reference it by name (deploy/rbac/serviceaccount.yaml and


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through the mitos.run CRDs and installed via the Helm chart under deploy/charts/mitos.
> - This touches the chart packaging surface (image pull credentials wired into every workload pod), not the runtime.
> - New GHCR packages default to private, so the original concern was a silent ImagePullBackOff on fresh installs. The published mitos-* images are now public (verified anonymously pullable for all 7 chart-referenced images at v1.5.0), and the verify-public-images release guard in publish.yaml keeps them that way.
> - With the images public, the leftover defects are honesty defects: the chart defaulted imagePullSecrets to a ghcr-pull secret that does not exist on a fresh install (so every pod emitted an "Unable to retrieve some image pull secrets" warning event), and the docs claimed the images "live in a private registry" with a pull credential as a prerequisite. This serves the no-unverified-claims operating principle and the clean fresh-install experience.
> - This pull request defaults imagePullSecrets to empty, keeps the knobs for a private mirror, and corrects every doc/comment to say the images are public and a pull secret is optional, with an ImagePullBackOff troubleshooting pointer.
> - The benefit is a fresh helm install pulls cleanly with no phantom-secret warning and no misleading documentation, while a private mirror is still a one-flag opt-in.

## Linked Issues or Issue Description

Closes #399.

## What Changed

- Default `imagePullSecrets` to `[]` in values.yaml (was `[{name: ghcr-pull}]`), so a fresh install references no secret and pulls public images cleanly.
- Reframe the `imagePullSecret`/`imagePullSecrets` values comments: images are public; the knobs are only for a private mirror or private re-publish.
- Rewrite the chart README "Image pull secret" section and prerequisites, fix the Values table defaults, and add an ImagePullBackOff troubleshooting pointer.
- Rewrite the NOTES.txt pull-secret block: gated on `not .Values.imagePullSecrets`, states the images are public and frames the credential as private-mirror-only.
- Correct the controller ServiceAccount comment and the kustomize deploy/imagepullsecret.yaml comment, both of which claimed a private registry / mandatory credential.
- Add charttest coverage in deploy/charts/charttest/imagepullsecret_test.go.

## Verification

- [x] `go test ./...` in deploy/charts/charttest passes (new TestNoImagePullSecretsByDefault, TestImagePullSecretsRenderWhenSet, TestImagePullSecretNotRenderedByDefault, plus the existing suite).
- [x] `helm lint deploy/charts/mitos` passes.
- [x] `helm template` default render attaches zero `imagePullSecrets:`; `--set 'imagePullSecrets[0].name=ghcr-pull'` attaches it to all 5 workload pods; forkd's optional docker-config mount is intact.
- [x] gofmt and go vet clean on the new test file.

## Risks

Low risk. The pull secret was never rendered by default (`imagePullSecret.create=false`), so no fresh install depended on it. forkd's registry-credential mount is already `optional: true`. A private-mirror operator who previously relied on the implicit `[{name: ghcr-pull}]` default must now set `imagePullSecrets[0].name` explicitly; this is documented in the README and NOTES.txt. No security surface change, so no threat-model delta. No hot-path change, so no benchmark.

## Model Used

Claude Opus 4.8 (model id claude-opus-4-8, 1M context), extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [ ] Threat-model delta: not applicable, no security surface change
- [ ] Benchmark run: not applicable, no hot-path change
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)