### PR TITLE
chore(dependabot): cover Rust, Go SDK, console web, and Java SDK (#504)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,3 +66,69 @@ updates:
         update-types:
           - minor
           - patch
+  # Go SDK is its own module (github.com/mitos-run/mitos/sdk/go); the root gomod
+  # entry above does not see it.
+  - package-ecosystem: gomod
+    directory: /sdk/go
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    open-pull-requests-limit: 5
+    groups:
+      go-sdk-minor-patch:
+        update-types:
+          - minor
+          - patch
+  # Rust guest agent: PID 1 inside the VM and a security-sensitive path per
+  # docs/threat-model.md, so its crates must stay watched.
+  - package-ecosystem: cargo
+    directory: /guest/agent-rs
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    open-pull-requests-limit: 5
+    groups:
+      guest-agent-minor-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: cargo
+    directory: /sdk/rust
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    open-pull-requests-limit: 5
+    groups:
+      rust-sdk-minor-patch:
+        update-types:
+          - minor
+          - patch
+  # Console SPA pnpm workspace; the lockfile and workspace root are at /web, so
+  # this one entry covers web/app and web/packages/*.
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    open-pull-requests-limit: 5
+    groups:
+      console-web-minor-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: maven
+    directory: /sdk/java
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    open-pull-requests-limit: 5
+    groups:
+      java-sdk-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Thinking Path

> - Mitos ships a Go control plane plus six SDKs (Go, Python, TypeScript, Rust, Java, Ruby), a Rust guest agent, and a console web app, all in this monorepo.
> - This touches the supply-chain/CI surface: `.github/dependabot.yml`, which automates dependency update PRs.
> - The config was written before several SDKs and the console web app existed, so the Rust guest agent (PID 1, security-sensitive per docs/threat-model.md), the Rust SDK, the Go SDK module, the console pnpm workspace, and the Java SDK had no ecosystem watching them.
> - Unwatched dependencies silently rot; for the guest agent that is a security concern, and the supply-chain posture (cosign + SBOM in publish.yaml) deserves dependency hygiene to match.
> - This pull request adds cargo, gomod `/sdk/go`, npm `/web`, and maven `/sdk/java` entries, each grouped and capped.
> - The benefit is every first-party manifest now receives grouped weekly update PRs instead of drifting.

## Linked Issues or Issue Description

Closes #504.

## What Changed

- Add `cargo` for `/guest/agent-rs` (guest agent) and `/sdk/rust` (Rust SDK).
- Add `gomod` for `/sdk/go` (its own module, invisible to the root `gomod /` entry).
- Add `npm` for `/web` (console pnpm workspace root; covers web/app and web/packages/*).
- Add `maven` for `/sdk/java`.
- Each new entry keeps the weekly + `chore` prefix + grouped minor/patch pattern and adds `open-pull-requests-limit: 5` to cap the initial flood.

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses; 11 update entries total.
- [x] Every referenced directory exists in the repo (`sdk/go`, `guest/agent-rs`, `sdk/rust`, `web`, `sdk/java`).
- [x] No em or en dashes.

## Risks

Low risk. Config-only; no code, no runtime change. Worst case is a burst of dependency PRs on the next Dependabot run, bounded by `open-pull-requests-limit: 5` per ecosystem and grouped minor/patch. Two known follow-ups, both noted in #504: Ruby needs a `Gemfile` before a bundler entry works, and the repo-level "Dependabot version updates" Settings toggle must be confirmed on (a UI setting, not expressible here) or none of this config runs.

## Model Used

Claude Opus 4.8 (model id claude-opus-4-8, 1M context), extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [] Tests added: not applicable, declarative Dependabot config (validated by YAML parse + directory existence)
- [ ] Docs updated: not applicable
- [ ] Threat-model delta: not applicable, no runtime security surface change
- [ ] Benchmark run: not applicable, no hot-path change
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)