### PR TITLE
feat(computer-use): headless Chromium + CDP browser-automation template (#314)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,6 +303,31 @@ jobs:
       - run: docker build -f Dockerfile.facade -t mitos-facade:ci .
       - run: docker build -f Dockerfile.console -t mitos-console:ci .
       - run: docker build -f Dockerfile.gateway -t mitos-gateway:ci .
+      # The computer-use template image (headless Chromium + CDP relay, issue
+      # #314). Build context is the repository root because the relay is compiled
+      # from source. Smoke that the multi-stage build works, the launcher brings
+      # up Chromium, and the relay answers CDP on the published port (curl's
+      # Host: localhost:9222 also exercises the relay's host-header rewrite). This
+      # is the cheap proportional check; the warm-fork snapshot and the named-URL
+      # relay path are verified on real KVM
+      # (docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md), not
+      # in this container-only job.
+      - name: Build the computer-use image and smoke CDP
+        run: |
+          set -euo pipefail
+          docker build -f images/computer-use/Dockerfile -t mitos-computer-use:ci .
+          docker run -d -p 9222:9222 --name cu \
+            --entrypoint /usr/local/bin/start-chromium.sh mitos-computer-use:ci
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9222/json/version 2>/dev/null | grep -q webSocketDebuggerUrl; then
+              ok=1; echo "CDP answered after ${i}s"; break
+            fi
+            sleep 1
+          done
+          docker logs cu 2>&1 | tail -5 || true
+          docker rm -f cu >/dev/null 2>&1 || true
+          [ "$ok" = 1 ] || { echo "FAIL: CDP /json/version did not return webSocketDebuggerUrl"; exit 1; }
       # Trivy scans each locally built image for known OS/library CVEs (CVE
       # pipeline, issue #35). Installed directly from a pinned release (the
       # marketplace action's binary installer proved flaky in CI). Phased in as
@@ -324,7 +349,7 @@ jobs:
             exit 0
           fi
           trivy --version || { echo "::warning::Trivy not runnable; skipping advisory image scan"; exit 0; }
-          for img in mitos-controller:ci mitos-forkd:ci mitos-husk-stub:ci mitos-kvm-device-plugin:ci mitos-facade:ci mitos-console:ci mitos-gateway:ci; do
+          for img in mitos-controller:ci mitos-forkd:ci mitos-husk-stub:ci mitos-kvm-device-plugin:ci mitos-facade:ci mitos-console:ci mitos-gateway:ci mitos-computer-use:ci; do
             echo "=== Trivy scan ${img} (HIGH,CRITICAL, fixable) ==="
             trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
               --ignorefile .trivyignore "${img}" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -307,7 +307,7 @@ jobs:
       # #314). Build context is the repository root because the relay is compiled
       # from source. Smoke that the multi-stage build works, the launcher brings
       # up Chromium, and the relay answers CDP on the published port (curl's
-      # Host: localhost:9222 also exercises the relay's host-header rewrite). This
+      # Host: 127.0.0.1:9222 also exercises the relay's host-header path). This
       # is the cheap proportional check; the warm-fork snapshot and the named-URL
       # relay path are verified on real KVM
       # (docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md), not

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,6 +48,8 @@ jobs:
             dockerfile: Dockerfile.console
           - name: mitos-gateway
             dockerfile: Dockerfile.gateway
+          - name: mitos-computer-use
+            dockerfile: images/computer-use/Dockerfile
     env:
       REGISTRY: ghcr.io
       IMAGE: ghcr.io/mitos-run/${{ matrix.name }}

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Per-topic docs live in [`docs/`](docs/). Start with the [quickstart](docs/quicks
 | `mitos` CLI, MCP server, Agent Skill | [docs/cli.md](docs/cli.md), [docs/mcp.md](docs/mcp.md), [skills/mitos/SKILL.md](skills/mitos/SKILL.md) |
 | Guest port forwarding | [docs/ports.md](docs/ports.md) |
 | Recipe: host an agent harness over HTTP | [docs/recipes/agent-harness.md](docs/recipes/agent-harness.md) |
+| Recipe: headless Chromium / CDP for browser-automation agents | [docs/recipes/browser-automation.md](docs/recipes/browser-automation.md) |
 | Migrating from E2B | [docs/migrating-from-e2b.md](docs/migrating-from-e2b.md) |
 | Talos + Hetzner reference platform | [docs/platforms/talos-hetzner.md](docs/platforms/talos-hetzner.md) |
 | Target API surface (v2 spec) | [docs/api/v2-spec.md](docs/api/v2-spec.md) |

--- a/cmd/cdp-relay/main.go
+++ b/cmd/cdp-relay/main.go
@@ -1,0 +1,20 @@
+// cmd/cdp-relay/main.go
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+)
+
+func main() {
+	listen := flag.String("listen", ":9222", "address the relay listens on")
+	upstream := flag.String("upstream", "127.0.0.1:9223", "Chromium CDP address (host:port)")
+	flag.Parse()
+
+	h := newRelayHandler(*upstream)
+	log.Printf("cdp-relay: listening on %s, forwarding to %s", *listen, *upstream)
+	if err := http.ListenAndServe(*listen, h); err != nil {
+		log.Fatalf("cdp-relay: %v", err)
+	}
+}

--- a/cmd/cdp-relay/relay.go
+++ b/cmd/cdp-relay/relay.go
@@ -52,8 +52,13 @@ func newRelayHandler(upstream string) http.Handler {
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
-			// Chromium rejects any Host that is not an IP or "localhost".
-			pr.Out.Host = "localhost"
+			// Chromium rejects any Host that is not an IP literal or "localhost".
+			// Send the upstream host:port (an IP literal like 127.0.0.1:9223): it
+			// passes the check AND is reflected verbatim into the discovery
+			// webSocketDebuggerUrl, so rewriteDiscovery can match and rewrite it.
+			// "localhost" alone would be reflected portless (ws://localhost/...),
+			// which the port-qualified rewrite would miss.
+			pr.Out.Host = upstream
 			// The ReverseProxy strips incoming X-Forwarded-* headers before
 			// calling Rewrite when the Rewrite hook is used. Re-propagate them
 			// from pr.In (the original, unmodified request) so ModifyResponse

--- a/cmd/cdp-relay/relay.go
+++ b/cmd/cdp-relay/relay.go
@@ -60,10 +60,19 @@ func newRelayHandler(upstream string) http.Handler {
 			// which the port-qualified rewrite would miss.
 			pr.Out.Host = upstream
 			// The ReverseProxy strips incoming X-Forwarded-* headers before
-			// calling Rewrite when the Rewrite hook is used. Re-propagate them
-			// from pr.In (the original, unmodified request) so ModifyResponse
-			// can read them from resp.Request.Header.
-			if xfh := pr.In.Header.Get("X-Forwarded-Host"); xfh != "" {
+			// calling Rewrite when the Rewrite hook is used, and it rewrites the
+			// outbound Host above, so resp.Request in ModifyResponse no longer
+			// carries the client's origin. Re-propagate it. Prefer an
+			// edge-proxy-set X-Forwarded-Host; otherwise fall back to the client's
+			// own Host, which is the reachable origin on the direct host-forward
+			// path (Chromium's internal upstream port is not reachable by the
+			// client). This is what makes the discovery URL point somewhere the
+			// client can actually connect to.
+			xfh := pr.In.Header.Get("X-Forwarded-Host")
+			if xfh == "" {
+				xfh = pr.In.Host
+			}
+			if xfh != "" {
 				pr.Out.Header.Set("X-Forwarded-Host", xfh)
 			}
 			if xfp := pr.In.Header.Get("X-Forwarded-Proto"); xfp != "" {

--- a/cmd/cdp-relay/relay.go
+++ b/cmd/cdp-relay/relay.go
@@ -37,9 +37,11 @@ func rewriteDiscovery(body []byte, upstreamHostPort, scheme, externalHost string
 }
 
 // newRelayHandler returns an http.Handler that reverse-proxies all traffic to
-// the Chromium CDP endpoint at upstream (e.g. "127.0.0.1:9223"), setting
-// Host: localhost on every upstream request so Chromium's DevTools host-header
-// check passes. For /json* paths it rewrites webSocketDebuggerUrl and
+// the Chromium CDP endpoint at upstream (e.g. "127.0.0.1:9223"), setting the
+// upstream host:port as the Host on every upstream request so Chromium's
+// DevTools host-header check passes (it accepts an IP literal) and the host it
+// reflects into the discovery URL is one rewriteDiscovery can match. For /json*
+// paths it rewrites webSocketDebuggerUrl and
 // devtoolsFrontendUrl in the response body from the loopback address to the
 // external origin (read from X-Forwarded-Host and X-Forwarded-Proto). WebSocket
 // upgrade requests on /devtools/... are proxied transparently by

--- a/cmd/cdp-relay/relay.go
+++ b/cmd/cdp-relay/relay.go
@@ -1,0 +1,103 @@
+// cmd/cdp-relay/relay.go
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// rewriteDiscovery rewrites the upstream-loopback ws host in a CDP /json body
+// to the external origin. upstreamHostPort is e.g. "127.0.0.1:9223".
+// It replaces both the IP form (ws://127.0.0.1:PORT) and the localhost form
+// (ws://localhost:PORT) that Chromium may emit. The SCHEME+HOST+PORT prefix is
+// replaced; the /devtools/... path suffix is preserved.
+func rewriteDiscovery(body []byte, upstreamHostPort, scheme, externalHost string) []byte {
+	// Extract port for the localhost variant (ws://localhost:PORT).
+	port := ""
+	if idx := strings.LastIndex(upstreamHostPort, ":"); idx >= 0 {
+		port = upstreamHostPort[idx+1:]
+	}
+	replacement := scheme + "://" + externalHost
+	s := string(body)
+	// Replace the IP form.
+	s = strings.ReplaceAll(s, "ws://"+upstreamHostPort, replacement)
+	s = strings.ReplaceAll(s, "wss://"+upstreamHostPort, replacement)
+	// Replace the localhost form.
+	if port != "" {
+		s = strings.ReplaceAll(s, "ws://localhost:"+port, replacement)
+		s = strings.ReplaceAll(s, "wss://localhost:"+port, replacement)
+	}
+	return []byte(s)
+}
+
+// newRelayHandler returns an http.Handler that reverse-proxies all traffic to
+// the Chromium CDP endpoint at upstream (e.g. "127.0.0.1:9223"), setting
+// Host: localhost on every upstream request so Chromium's DevTools host-header
+// check passes. For /json* paths it rewrites webSocketDebuggerUrl and
+// devtoolsFrontendUrl in the response body from the loopback address to the
+// external origin (read from X-Forwarded-Host and X-Forwarded-Proto). WebSocket
+// upgrade requests on /devtools/... are proxied transparently by
+// httputil.ReverseProxy; the rewritten Host applies to the upgrade too.
+func newRelayHandler(upstream string) http.Handler {
+	target := &url.URL{
+		Scheme: "http",
+		Host:   upstream,
+	}
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			// Chromium rejects any Host that is not an IP or "localhost".
+			pr.Out.Host = "localhost"
+			// The ReverseProxy strips incoming X-Forwarded-* headers before
+			// calling Rewrite when the Rewrite hook is used. Re-propagate them
+			// from pr.In (the original, unmodified request) so ModifyResponse
+			// can read them from resp.Request.Header.
+			if xfh := pr.In.Header.Get("X-Forwarded-Host"); xfh != "" {
+				pr.Out.Header.Set("X-Forwarded-Host", xfh)
+			}
+			if xfp := pr.In.Header.Get("X-Forwarded-Proto"); xfp != "" {
+				pr.Out.Header.Set("X-Forwarded-Proto", xfp)
+			}
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			// Only rewrite /json* discovery endpoints; leave all other paths alone.
+			if !strings.HasPrefix(resp.Request.URL.Path, "/json") {
+				return nil
+			}
+			body, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				return fmt.Errorf("read CDP discovery body: %w", err)
+			}
+			// Determine external ws scheme from forwarding headers preserved above.
+			scheme := "ws"
+			if resp.Request.Header.Get("X-Forwarded-Proto") == "https" {
+				scheme = "wss"
+			}
+			externalHost := resp.Request.Header.Get("X-Forwarded-Host")
+			if externalHost == "" {
+				// Fallback: no forwarding header means the relay is accessed
+				// directly. Use the upstream address so the body is at least
+				// syntactically valid (local loopback relay mode).
+				externalHost = upstream
+			}
+			rewritten := rewriteDiscovery(body, upstream, scheme, externalHost)
+			resp.Body = io.NopCloser(bytes.NewReader(rewritten))
+			resp.ContentLength = int64(len(rewritten))
+			resp.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
+			return nil
+		},
+		// FlushInterval is left at the default (0) so that httputil.ReverseProxy
+		// can handle WebSocket upgrades transparently. A positive value would
+		// buffer non-streaming responses; -1 would flush immediately after each
+		// write. CDP WebSocket sessions use the upgrade path regardless, so the
+		// default is correct.
+	}
+	return rp
+}

--- a/cmd/cdp-relay/relay_test.go
+++ b/cmd/cdp-relay/relay_test.go
@@ -104,3 +104,43 @@ func TestRelayEndToEnd(t *testing.T) {
 		t.Errorf("body: got %q, want it to contain %q", body, want)
 	}
 }
+
+// TestRelayDirectForwardUsesRequestHost proves the host-forward path: with no
+// X-Forwarded-Host (a raw TCP forward sets none), the relay rewrites the
+// discovery URL to the client's own request Host, which is the reachable origin.
+// Without this the body would keep the guest-internal upstream port, unreachable
+// to the client.
+func TestRelayDirectForwardUsesRequestHost(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, port, _ := net.SplitHostPort(listener.Addr().String())
+	upstreamHostPort := "127.0.0.1:" + port
+
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/json/version" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"webSocketDebuggerUrl":"ws://`+upstreamHostPort+`/devtools/browser/ABC"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	upstream.Listener = listener
+	upstream.Start()
+	defer upstream.Close()
+
+	handler := newRelayHandler(upstreamHostPort)
+	req := httptest.NewRequest(http.MethodGet, "/json/version", nil)
+	req.Host = "127.0.0.1:42999" // the client's forward address; no X-Forwarded-Host
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200\nbody: %s", rec.Code, rec.Body.String())
+	}
+	want := "ws://127.0.0.1:42999/devtools/browser/ABC"
+	if body := rec.Body.String(); !strings.Contains(body, want) {
+		t.Errorf("body: got %q, want it to contain %q", body, want)
+	}
+}

--- a/cmd/cdp-relay/relay_test.go
+++ b/cmd/cdp-relay/relay_test.go
@@ -47,8 +47,9 @@ func TestRewriteDiscoveryDevtoolsFrontendUrl(t *testing.T) {
 }
 
 // TestRelayEndToEnd proves two things in a single httptest pass:
-//  1. The relay sets Host: localhost on the upstream request (the fake
-//     upstream returns 403 for any other Host, so a 200 proves the rewrite).
+//  1. The relay sets a Host the Chromium DevTools check accepts (an IP literal
+//     or localhost) on the upstream request. The fake upstream mimics that check
+//     and returns 403 for any other Host, so a 200 proves the rewrite.
 //  2. The relay rewrites webSocketDebuggerUrl in /json* responses from the
 //     upstream loopback address to the external origin from X-Forwarded-Host.
 func TestRelayEndToEnd(t *testing.T) {
@@ -62,8 +63,14 @@ func TestRelayEndToEnd(t *testing.T) {
 	upstreamHostPort := "127.0.0.1:" + port
 
 	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Reject any Host that is not "localhost" to prove the relay sets it.
-		if r.Host != "localhost" {
+		// Mimic Chromium's DevTools host-header check: accept only an IP-literal
+		// or localhost host-part. This proves the relay sends such a Host (it
+		// sends the upstream host:port, e.g. 127.0.0.1:PORT).
+		host := r.Host
+		if h, _, err := net.SplitHostPort(r.Host); err == nil {
+			host = h
+		}
+		if host != "localhost" && net.ParseIP(host) == nil {
 			http.Error(w, "forbidden: bad Host "+r.Host, http.StatusForbidden)
 			return
 		}

--- a/cmd/cdp-relay/relay_test.go
+++ b/cmd/cdp-relay/relay_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRewriteDiscoveryWS127 covers the ws://127.0.0.1:PORT form.
+func TestRewriteDiscoveryWS127(t *testing.T) {
+	body := []byte(`{"webSocketDebuggerUrl":"ws://127.0.0.1:9223/devtools/browser/ABC"}`)
+	got := rewriteDiscovery(body, "127.0.0.1:9223", "wss", "example.test")
+	want := "wss://example.test/devtools/browser/ABC"
+	if !strings.Contains(string(got), want) {
+		t.Errorf("rewriteDiscovery: got %q, want substring %q", got, want)
+	}
+	if strings.Contains(string(got), "127.0.0.1:9223") {
+		t.Errorf("rewriteDiscovery: output still contains original host: %q", got)
+	}
+}
+
+// TestRewriteDiscoveryWSLocalhost covers the ws://localhost:PORT form that
+// Chromium sometimes emits instead of the IP form.
+func TestRewriteDiscoveryWSLocalhost(t *testing.T) {
+	body := []byte(`{"webSocketDebuggerUrl":"ws://localhost:9223/devtools/browser/ABC"}`)
+	got := rewriteDiscovery(body, "127.0.0.1:9223", "wss", "example.test")
+	want := "wss://example.test/devtools/browser/ABC"
+	if !strings.Contains(string(got), want) {
+		t.Errorf("rewriteDiscovery: got %q, want substring %q", got, want)
+	}
+	if strings.Contains(string(got), "localhost:9223") {
+		t.Errorf("rewriteDiscovery: output still contains original host: %q", got)
+	}
+}
+
+// TestRewriteDiscoveryDevtoolsFrontendUrl covers devtoolsFrontendUrl fields.
+func TestRewriteDiscoveryDevtoolsFrontendUrl(t *testing.T) {
+	body := []byte(`{"devtoolsFrontendUrl":"ws://127.0.0.1:9223/devtools/inspector.html"}`)
+	got := rewriteDiscovery(body, "127.0.0.1:9223", "ws", "example.test")
+	want := "ws://example.test/devtools/inspector.html"
+	if !strings.Contains(string(got), want) {
+		t.Errorf("rewriteDiscovery: got %q, want substring %q", got, want)
+	}
+}
+
+// TestRelayEndToEnd proves two things in a single httptest pass:
+//  1. The relay sets Host: localhost on the upstream request (the fake
+//     upstream returns 403 for any other Host, so a 200 proves the rewrite).
+//  2. The relay rewrites webSocketDebuggerUrl in /json* responses from the
+//     upstream loopback address to the external origin from X-Forwarded-Host.
+func TestRelayEndToEnd(t *testing.T) {
+	// Obtain a free port before starting the server so the body template can
+	// reference the actual host:port without a data race.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, port, _ := net.SplitHostPort(listener.Addr().String())
+	upstreamHostPort := "127.0.0.1:" + port
+
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject any Host that is not "localhost" to prove the relay sets it.
+		if r.Host != "localhost" {
+			http.Error(w, "forbidden: bad Host "+r.Host, http.StatusForbidden)
+			return
+		}
+		if r.URL.Path == "/json/version" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"webSocketDebuggerUrl":"ws://`+upstreamHostPort+`/devtools/browser/ABC"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	upstream.Listener = listener
+	upstream.Start()
+	defer upstream.Close()
+
+	handler := newRelayHandler(upstreamHostPort)
+
+	req := httptest.NewRequest(http.MethodGet, "/json/version", nil)
+	req.Header.Set("X-Forwarded-Host", "example.test")
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (upstream rejected the Host header or proxy failed)\nbody: %s",
+			rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	want := "wss://example.test/devtools/browser/ABC"
+	if !strings.Contains(body, want) {
+		t.Errorf("body: got %q, want it to contain %q", body, want)
+	}
+}

--- a/cmd/sandbox-server/main.go
+++ b/cmd/sandbox-server/main.go
@@ -411,10 +411,62 @@ type networkConfig struct {
 	InboundCIDRs []string `json:"inbound_cidrs,omitempty"`
 }
 
+type workloadReadyReq struct {
+	Port           uint32 `json:"port"`
+	Path           string `json:"path,omitempty"`
+	Expect         uint32 `json:"expect,omitempty"`
+	TimeoutSeconds uint32 `json:"timeout_seconds,omitempty"`
+}
+
+type workloadReq struct {
+	Command []string          `json:"command,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	Ready   *workloadReadyReq `json:"ready,omitempty"`
+}
+
+type resourcesReq struct {
+	VcpuCount  int32 `json:"vcpu_count,omitempty"`
+	MemSizeMib int64 `json:"mem_size_mib,omitempty"`
+}
+
 type createTemplateReq struct {
 	ID           string         `json:"id"`
 	InitWaitSecs int            `json:"init_wait_seconds"`
 	Network      *networkConfig `json:"network,omitempty"`
+	// Workload starts a long-running process during template build so the
+	// snapshot captures it already serving and a fork wakes warm (issue #460).
+	// The engine already supports this; the cluster path wires it via forkd.
+	Workload *workloadReq `json:"workload,omitempty"`
+	// Resources sizes the build VM. Omitted leaves the engine default (512 MiB,
+	// 1 vCPU); a Chromium template needs more.
+	Resources *resourcesReq `json:"resources,omitempty"`
+}
+
+// workloadFromReq maps the JSON workload to the engine's firecracker.WorkloadSpec.
+// nil maps to nil so the engine keeps its no-workload default.
+func workloadFromReq(w *workloadReq) *firecracker.WorkloadSpec {
+	if w == nil || len(w.Command) == 0 {
+		return nil
+	}
+	spec := &firecracker.WorkloadSpec{Command: w.Command, Env: w.Env}
+	if w.Ready != nil {
+		spec.Ready = &firecracker.WorkloadHTTPReady{
+			Port:           w.Ready.Port,
+			Path:           w.Ready.Path,
+			Expect:         w.Ready.Expect,
+			TimeoutSeconds: w.Ready.TimeoutSeconds,
+		}
+	}
+	return spec
+}
+
+// vmResFromReq maps the JSON resources to the engine's firecracker.VMResources.
+// nil maps to nil so the engine keeps its default sizing.
+func vmResFromReq(r *resourcesReq) *firecracker.VMResources {
+	if r == nil || (r.VcpuCount == 0 && r.MemSizeMib == 0) {
+		return nil
+	}
+	return &firecracker.VMResources{VcpuCount: r.VcpuCount, MemSizeMib: r.MemSizeMib}
 }
 
 func (s *server) handleCreateTemplate(w http.ResponseWriter, r *http.Request) {
@@ -473,7 +525,7 @@ func (s *server) handleCreateTemplate(w http.ResponseWriter, r *http.Request) {
 		// and appends init=/init to the boot args, which the prior
 		// TemplateManager-direct path did not, so an agent-at-/init rootfs no
 		// longer panics with "no working init found".
-		if err := s.engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, nil, nil); err != nil {
+		if err := s.engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, workloadFromReq(req.Workload), vmResFromReq(req.Resources)); err != nil {
 			s.releaseIdempotent(idemKey)
 			errResp(w, fmt.Sprintf("create template: %v", err), 500)
 			return

--- a/cmd/sandbox-server/main_test.go
+++ b/cmd/sandbox-server/main_test.go
@@ -474,3 +474,50 @@ func TestIdempotencyReleaseAllowsRetryAfterFailure(t *testing.T) {
 		t.Fatalf("after release a retry must proceed, not stay in-flight, got %v", st)
 	}
 }
+
+func TestWorkloadFromReq(t *testing.T) {
+	if got := workloadFromReq(nil); got != nil {
+		t.Fatalf("nil req should map to nil, got %v", got)
+	}
+	w := &workloadReq{
+		Command: []string{"/usr/local/bin/start-chromium.sh"},
+		Env:     map[string]string{"FOO": "bar"},
+		Ready:   &workloadReadyReq{Port: 9222, Path: "/json/version", Expect: 200, TimeoutSeconds: 90},
+	}
+	got := workloadFromReq(w)
+	if got == nil || len(got.Command) != 1 || got.Command[0] != "/usr/local/bin/start-chromium.sh" {
+		t.Fatalf("command not mapped: %+v", got)
+	}
+	if got.Env["FOO"] != "bar" {
+		t.Fatalf("env not mapped: %+v", got.Env)
+	}
+	if got.Ready == nil || got.Ready.Port != 9222 || got.Ready.Path != "/json/version" || got.Ready.Expect != 200 || got.Ready.TimeoutSeconds != 90 {
+		t.Fatalf("ready not mapped: %+v", got.Ready)
+	}
+}
+
+func TestVMResFromReq(t *testing.T) {
+	if got := vmResFromReq(nil); got != nil {
+		t.Fatalf("nil req should map to nil, got %v", got)
+	}
+	got := vmResFromReq(&resourcesReq{VcpuCount: 2, MemSizeMib: 1024})
+	if got == nil || got.VcpuCount != 2 || got.MemSizeMib != 1024 {
+		t.Fatalf("resources not mapped: %+v", got)
+	}
+}
+
+func TestCreateTemplateReqDecodesWorkloadAndResources(t *testing.T) {
+	body := `{"id":"chrome","workload":{"command":["/usr/local/bin/start-chromium.sh"],` +
+		`"ready":{"port":9222,"path":"/json/version","expect":200,"timeout_seconds":90}},` +
+		`"resources":{"vcpu_count":2,"mem_size_mib":1024}}`
+	var req createTemplateReq
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if req.Workload == nil || len(req.Workload.Command) != 1 {
+		t.Fatalf("workload not decoded: %+v", req.Workload)
+	}
+	if req.Resources == nil || req.Resources.MemSizeMib != 1024 {
+		t.Fatalf("resources not decoded: %+v", req.Resources)
+	}
+}

--- a/docs/recipes/browser-automation.md
+++ b/docs/recipes/browser-automation.md
@@ -70,7 +70,8 @@ CDP is HTTP plus a WebSocket upgrade. Two ways to reach guest port 9222:
   against any standalone server with no extra setup.
 - **Named URL over the preview proxy** (authenticated, shareable): the in-image
   CDP relay makes this work. Chromium's DevTools server rejects any `Host` that is
-  not an IP or `localhost`, so the relay sends `Host: localhost` upstream and
+  not an IP literal or `localhost`, so the relay sends the upstream `host:port`
+  (an IP literal Chromium accepts) as the Host upstream and
   rewrites the discovery `webSocketDebuggerUrl` to the external origin (from the
   `X-Forwarded-Host` the expose proxy now sets). Reach it with
   `sandbox.get_host(9222)` (a signed, expiring URL) and point your CDP client at

--- a/docs/recipes/browser-automation.md
+++ b/docs/recipes/browser-automation.md
@@ -1,0 +1,119 @@
+# Headless Chromium / CDP for browser-automation agents
+
+Give an agent a forkable, hardware-isolated browser. This recipe boots headless
+Chromium with a Chrome DevTools Protocol (CDP) endpoint inside a Mitos microVM,
+snapshots it already listening so a fork wakes a warm browser in milliseconds, and
+exposes CDP so Playwright, Stagehand, browser-use, or any CDP client drives it.
+
+Why Mitos for this, versus a SaaS browser cloud: your cookies, sessions, and
+scraped data stay on your own infrastructure; a hostile page is contained in a
+Firecracker microVM, not a shared-kernel container; and you can fork one warm
+browser into N isolated attempts at fork(2) speed (best-of-N browsing).
+
+## The image
+
+`images/computer-use` is a debian-slim image with Chromium, the CDP relay, and a
+launcher. The launcher starts Chromium headless on an internal loopback port and
+the relay on the exposed port 9222. Build and publish it (the build context is the
+repository root, because the relay is compiled from source):
+
+```bash
+docker build -f images/computer-use/Dockerfile -t ghcr.io/mitos-run/mitos-computer-use:dev .
+```
+
+Chromium runs with `--no-sandbox`: the microVM is the isolation boundary, not
+Chromium's own sandbox (the same posture as E2B Desktop and Browserbase). See
+[the threat model](../threat-model.md).
+
+## On a Kubernetes cluster
+
+A `SandboxPool` whose template runs Chromium as a serving workload, so the pool
+snapshots it already listening on CDP and every claim or fork wakes warm:
+
+```yaml
+apiVersion: mitos.run/v1
+kind: SandboxPool
+metadata:
+  name: browser
+spec:
+  template:
+    image: ghcr.io/mitos-run/mitos-computer-use:dev
+    resources: { cpu: "2", memory: "1536Mi" }   # Chromium needs more than 512Mi
+    workload:
+      command: ["/usr/local/bin/start-chromium.sh"]
+      ready: { port: 9222, path: /json/version, expect: 200, timeoutSeconds: 90 }
+```
+
+## On the standalone sandbox-server (no Kubernetes)
+
+Run a real-mode `sandbox-server` against the computer-use rootfs, then create a
+warm template with the workload and resources (the standalone template endpoint
+accepts both):
+
+```bash
+curl -fsS -X POST localhost:8080/v1/templates -H 'Content-Type: application/json' -d '{
+  "id": "browser",
+  "workload": {"command": ["/usr/local/bin/start-chromium.sh"],
+               "ready": {"port": 9222, "path": "/json/version", "expect": 200, "timeout_seconds": 90}},
+  "resources": {"vcpu_count": 2, "mem_size_mib": 1536}
+}'
+```
+
+The SDK accepts the same fields: `mitos.create("browser", workload=..., resources=...)`.
+
+## Reaching CDP
+
+CDP is HTTP plus a WebSocket upgrade. Two ways to reach guest port 9222:
+
+- **Loopback host-forward** (local and SDK): open a forward and connect a CDP
+  client to the returned `host:port`. This is what the example uses and works
+  against any standalone server with no extra setup.
+- **Named URL over the preview proxy** (authenticated, shareable): the in-image
+  CDP relay makes this work. Chromium's DevTools server rejects any `Host` that is
+  not an IP or `localhost`, so the relay sends `Host: localhost` upstream and
+  rewrites the discovery `webSocketDebuggerUrl` to the external origin (from the
+  `X-Forwarded-Host` the expose proxy now sets). Reach it with
+  `sandbox.get_host(9222)` (a signed, expiring URL) and point your CDP client at
+  it. Keep this endpoint private; CDP is full remote control of the browser.
+
+Drive it with Playwright (the same shape works for Stagehand and browser-use):
+
+```python
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp(cdp_url)   # forward host:port or get_host URL
+    page = browser.new_page()
+    page.goto("https://example.com")
+    page.screenshot(path="shot.png")
+    browser.close()
+```
+
+The runnable end-to-end example is
+[`sdk/python/examples/browser_cdp.py`](../../sdk/python/examples/browser_cdp.py).
+
+## Fork to many: best-of-N browsing
+
+Warm one browser, fork it into N isolated microVMs, give each its own attempt:
+
+```python
+base = mitos.create("browser", workload=..., resources={"vcpu_count": 2, "mem_size_mib": 1536})
+children = base.fork(8)   # 8 warm browsers, each restored from the snapshot
+# drive each child's CDP independently; a crash or hostile page in one cannot
+# reach its siblings, the host, or the control plane.
+```
+
+In-flight pages do not transfer across a fork (a child resumes snapshot state, not
+live CDP connections); connect fresh and open a new page or context after a fork.
+
+## Which path runs this, honestly
+
+- The warm-fork model needs the serving workload, which runs on a cluster
+  `SandboxPool` and on the standalone sandbox-server (both wire the `workload` and
+  `resources` fields). Chromium needs roughly 1.5 to 2 GiB; 512 MiB is too small.
+- CDP is exposed over WebSocket. A full graphical desktop for vision computer-use
+  agents (Anthropic Computer Use, OpenAI CUA) over VNC / noVNC is a separate,
+  heavier surface and is not part of this template.
+- Verified on real KVM: a Chromium serving workload reaches Ready and snapshots
+  live; a fork wakes a warm browser in about 2.7 seconds; Playwright drives it
+  over CDP on both the host-forward and the relay paths (navigate, click,
+  screenshot). See `docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md`.

--- a/docs/superpowers/plans/2026-06-27-computer-use-cdp-template.md
+++ b/docs/superpowers/plans/2026-06-27-computer-use-cdp-template.md
@@ -1,0 +1,648 @@
+# Computer-use headless Chromium + CDP template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a first-party, CI-verified template that boots headless Chromium with a CDP endpoint inside a Mitos microVM, snapshotted live so a fork yields warm browsers, reachable over the existing authenticated expose proxy, with a runnable example and recipe.
+
+**Architecture:** A debian-slim + Chromium OCI image whose launcher starts headless Chromium on guest loopback with `--remote-debugging-port=9222`. The serving-workload primitive (#460) snapshots it already listening; a fork restores N warm browsers. CDP (HTTP + WebSocket) rides the existing expose reverse proxy. The standalone `sandbox-server` template endpoint is extended to accept the `workload` and `resources` the engine already supports, so the warm-fork model runs on the no-Kubernetes path and is end-to-end verifiable on a single KVM host.
+
+**Tech Stack:** Go (cmd/sandbox-server, internal/firecracker), Python SDK (sdk/python/mitos), Docker (image build), Firecracker microVM, Playwright (example/verification), GHCR.
+
+## Global Constraints
+
+- Punctuation: never use em (U+2014) or en (U+2013) dashes anywhere (source, comments, docs, YAML, commit messages, PR text). Use `.` `,` `;` `:` and ASCII hyphen-minus only.
+- Go: error wrapping `fmt.Errorf("context: %w", err)`; octal as `0o644`; gofmt + golangci-lint clean is a merge gate; run BOTH `golangci-lint run --timeout=5m` and `GOOS=linux golangci-lint run --timeout=5m`.
+- DCO: every commit carries `Signed-off-by` (`git commit -s`).
+- Conventional commits: feat, fix, docs, ci, chore, refactor, test. Branch already `feat/computer-use-cdp-template`.
+- Secrets: never log secret values; errors carry actionable remediation.
+- TDD: failing test first, in the same commit as the behavior change.
+- Stage explicit paths only; never `git add -A`.
+- No unverified claims: every number/behavior the docs state must be reproducible (box1 run or a test).
+- Box access: `ssh -F /Users/jannesstubbemann/repos/mitos-run/mitos/.superpowers/ssh_config box1` (firecracker host) or `box2` (docker + KVM host). Run box commands from the ORIGINAL repo root so the ssh_config path resolves. Always tear down box temp dirs after (shared runners).
+- GHCR: new package images push private; making public is a one-time manual UI toggle.
+
+---
+
+### Task 1: Standalone sandbox-server accepts `workload` + `resources`
+
+**Files:**
+- Modify: `cmd/sandbox-server/main.go` (the `createTemplateReq` struct near line 414 and `handleCreateTemplate` near line 476)
+- Test: `cmd/sandbox-server/main_test.go`
+
+**Interfaces:**
+- Consumes: `firecracker.WorkloadSpec{Command []string; Env map[string]string; Ready *firecracker.WorkloadHTTPReady}`, `firecracker.WorkloadHTTPReady{Port uint32; Path string; Expect uint32; TimeoutSeconds uint32}`, `firecracker.VMResources{VcpuCount int32; MemSizeMib int64}` (already defined in `internal/firecracker`).
+- Produces: two pure mapping helpers other code and tests use:
+  - `func workloadFromReq(w *workloadReq) *firecracker.WorkloadSpec`
+  - `func vmResFromReq(r *resourcesReq) *firecracker.VMResources`
+  and the extended JSON request types `workloadReq`, `workloadReadyReq`, `resourcesReq`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cmd/sandbox-server/main_test.go`:
+
+```go
+func TestWorkloadFromReq(t *testing.T) {
+	if got := workloadFromReq(nil); got != nil {
+		t.Fatalf("nil req should map to nil, got %v", got)
+	}
+	w := &workloadReq{
+		Command: []string{"/usr/local/bin/start-chromium.sh"},
+		Env:     map[string]string{"FOO": "bar"},
+		Ready:   &workloadReadyReq{Port: 9222, Path: "/json/version", Expect: 200, TimeoutSeconds: 90},
+	}
+	got := workloadFromReq(w)
+	if got == nil || len(got.Command) != 1 || got.Command[0] != "/usr/local/bin/start-chromium.sh" {
+		t.Fatalf("command not mapped: %+v", got)
+	}
+	if got.Env["FOO"] != "bar" {
+		t.Fatalf("env not mapped: %+v", got.Env)
+	}
+	if got.Ready == nil || got.Ready.Port != 9222 || got.Ready.Path != "/json/version" || got.Ready.Expect != 200 || got.Ready.TimeoutSeconds != 90 {
+		t.Fatalf("ready not mapped: %+v", got.Ready)
+	}
+}
+
+func TestVMResFromReq(t *testing.T) {
+	if got := vmResFromReq(nil); got != nil {
+		t.Fatalf("nil req should map to nil, got %v", got)
+	}
+	got := vmResFromReq(&resourcesReq{VcpuCount: 2, MemSizeMib: 1024})
+	if got == nil || got.VcpuCount != 2 || got.MemSizeMib != 1024 {
+		t.Fatalf("resources not mapped: %+v", got)
+	}
+}
+
+func TestCreateTemplateReqDecodesWorkloadAndResources(t *testing.T) {
+	body := `{"id":"chrome","workload":{"command":["/usr/local/bin/start-chromium.sh"],` +
+		`"ready":{"port":9222,"path":"/json/version","expect":200,"timeout_seconds":90}},` +
+		`"resources":{"vcpu_count":2,"mem_size_mib":1024}}`
+	var req createTemplateReq
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if req.Workload == nil || len(req.Workload.Command) != 1 {
+		t.Fatalf("workload not decoded: %+v", req.Workload)
+	}
+	if req.Resources == nil || req.Resources.MemSizeMib != 1024 {
+		t.Fatalf("resources not decoded: %+v", req.Resources)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd cmd/sandbox-server && go test ./... -run 'TestWorkloadFromReq|TestVMResFromReq|TestCreateTemplateReqDecodes' -v`
+Expected: FAIL to compile (`workloadReq`, `workloadFromReq`, etc. undefined).
+
+- [ ] **Step 3: Add the request types and mapping helpers**
+
+In `cmd/sandbox-server/main.go`, replace the `createTemplateReq` struct with:
+
+```go
+type workloadReadyReq struct {
+	Port           uint32 `json:"port"`
+	Path           string `json:"path,omitempty"`
+	Expect         uint32 `json:"expect,omitempty"`
+	TimeoutSeconds uint32 `json:"timeout_seconds,omitempty"`
+}
+
+type workloadReq struct {
+	Command []string          `json:"command,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	Ready   *workloadReadyReq `json:"ready,omitempty"`
+}
+
+type resourcesReq struct {
+	VcpuCount  int32 `json:"vcpu_count,omitempty"`
+	MemSizeMib int64 `json:"mem_size_mib,omitempty"`
+}
+
+type createTemplateReq struct {
+	ID           string         `json:"id"`
+	InitWaitSecs int            `json:"init_wait_seconds"`
+	Network      *networkConfig `json:"network,omitempty"`
+	// Workload starts a long-running process during template build so the
+	// snapshot captures it already serving and a fork wakes warm (issue #460).
+	// The engine already supports this; the cluster path wires it via forkd.
+	Workload *workloadReq `json:"workload,omitempty"`
+	// Resources sizes the build VM. Omitted leaves the engine default (512 MiB,
+	// 1 vCPU); a Chromium template needs more.
+	Resources *resourcesReq `json:"resources,omitempty"`
+}
+
+// workloadFromReq maps the JSON workload to the engine's firecracker.WorkloadSpec.
+// nil maps to nil so the engine keeps its no-workload default.
+func workloadFromReq(w *workloadReq) *firecracker.WorkloadSpec {
+	if w == nil || len(w.Command) == 0 {
+		return nil
+	}
+	spec := &firecracker.WorkloadSpec{Command: w.Command, Env: w.Env}
+	if w.Ready != nil {
+		spec.Ready = &firecracker.WorkloadHTTPReady{
+			Port:           w.Ready.Port,
+			Path:           w.Ready.Path,
+			Expect:         w.Ready.Expect,
+			TimeoutSeconds: w.Ready.TimeoutSeconds,
+		}
+	}
+	return spec
+}
+
+// vmResFromReq maps the JSON resources to the engine's firecracker.VMResources.
+// nil maps to nil so the engine keeps its default sizing.
+func vmResFromReq(r *resourcesReq) *firecracker.VMResources {
+	if r == nil || (r.VcpuCount == 0 && r.MemSizeMib == 0) {
+		return nil
+	}
+	return &firecracker.VMResources{VcpuCount: r.VcpuCount, MemSizeMib: r.MemSizeMib}
+}
+```
+
+Confirm `internal/firecracker` is imported in `main.go` (it is, for `JailerConfig`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cmd/sandbox-server && go test ./... -run 'TestWorkloadFromReq|TestVMResFromReq|TestCreateTemplateReqDecodes' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the helpers into the handler**
+
+In `handleCreateTemplate`, replace the real-mode CreateTemplate call:
+
+```go
+	} else if s.engine != nil {
+		if err := s.engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, workloadFromReq(req.Workload), vmResFromReq(req.Resources)); err != nil {
+			s.releaseIdempotent(idemKey)
+			errResp(w, fmt.Sprintf("create template: %v", err), 500)
+			return
+		}
+	}
+```
+
+- [ ] **Step 6: Build, vet, lint**
+
+Run: `go build ./cmd/sandbox-server/ && go vet ./cmd/sandbox-server/ && golangci-lint run cmd/sandbox-server/... --timeout=5m && GOOS=linux golangci-lint run cmd/sandbox-server/... --timeout=5m`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/sandbox-server/main.go cmd/sandbox-server/main_test.go
+git commit -s -m "feat(sandbox-server): accept workload and resources on POST /v1/templates (#314)
+
+The fork engine already supports a serving workload (#460) and per-template VM
+sizing; the standalone handler dropped them. Map them from JSON and pass them
+through so the warm-fork model and a memory override work on the no-k8s path."
+```
+
+---
+
+### Task 2: Python SDK passes `workload` + `resources` on template create
+
+**Files:**
+- Modify: `sdk/python/mitos/direct.py` (`create_template` near line 563, `ensure_template`, the flat `create` and `DirectSandbox.create`)
+- Test: `sdk/python/tests/test_direct.py` (or the existing direct-mode test module; create `test_template_workload.py` if cleaner)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `create_template(..., workload: Optional[dict] = None, resources: Optional[dict] = None)` adds `workload` / `resources` keys to the POST body when set; same optional args threaded through `ensure_template`, `create`, and `DirectSandbox.create`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_create_template_includes_workload_and_resources(monkeypatch):
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+        def json(self):
+            return {"id": "chrome", "ready": True, "creation_time_ms": 1.0}
+        @property
+        def text(self):
+            return ""
+
+    class _FakeHTTP:
+        def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _FakeResp()
+
+    from mitos.direct import SandboxServer
+    srv = SandboxServer(server_url="http://x", api_key=None)
+    srv._http = _FakeHTTP()
+    srv.create_template(
+        "chrome",
+        workload={"command": ["/usr/local/bin/start-chromium.sh"],
+                  "ready": {"port": 9222, "path": "/json/version", "expect": 200}},
+        resources={"vcpu_count": 2, "mem_size_mib": 1024},
+    )
+    assert captured["body"]["workload"]["command"] == ["/usr/local/bin/start-chromium.sh"]
+    assert captured["body"]["resources"]["mem_size_mib"] == 1024
+```
+
+Adjust `SandboxServer` construction to match its real constructor (check `sdk/python/mitos/direct.py`; if it needs different args, use them; the test only needs `_http` swapped and `create_template` called).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sdk/python && PYTHONPATH=. python3 -m pytest tests/ -k create_template_includes -q`
+Expected: FAIL (`workload` / `resources` not in body).
+
+- [ ] **Step 3: Thread the arguments through `create_template`**
+
+In `sdk/python/mitos/direct.py`, extend `create_template`:
+
+```python
+    def create_template(
+        self,
+        id: str,
+        init_wait_seconds: int = 5,
+        network: Optional[Network] = None,
+        idempotency_key: Optional[str] = None,
+        workload: Optional[dict] = None,
+        resources: Optional[dict] = None,
+    ) -> dict:
+        body: dict = {"id": id, "init_wait_seconds": init_wait_seconds}
+        if network is not None:
+            body["network"] = network.to_dict()
+        if workload is not None:
+            body["workload"] = workload
+        if resources is not None:
+            body["resources"] = resources
+        resp = self._http.post(
+            f"{self.url}/v1/templates",
+            json=body,
+            headers=self._creating_headers(idempotency_key),
+        )
+        raise_for_status(resp, token=self._api_key)
+        return resp.json()
+```
+
+Then add the same `workload`/`resources` optional params to `ensure_template` (pass them to `create_template`), to the flat `create(...)`, and to `DirectSandbox.create(...)` (pass to `ensure_template`). Keep them keyword-only-style optional with `None` defaults so existing callers are unaffected.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sdk/python && PYTHONPATH=. python3 -m pytest tests/ -k 'create_template or template' -q`
+Expected: PASS. Then run the full direct-mode suite: `PYTHONPATH=. python3 -m pytest tests/test_direct.py -q` (or the relevant module) and confirm no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/python/mitos/direct.py sdk/python/tests/
+git commit -s -m "feat(sdk-python): pass workload and resources on template create (#314)"
+```
+
+---
+
+### Task 3: Chromium template image and launcher
+
+**Files:**
+- Create: `images/computer-use/Dockerfile`
+- Create: `images/computer-use/start-chromium.sh`
+- Create: `images/computer-use/README.md`
+
+**Interfaces:**
+- Produces: an OCI image whose `/usr/local/bin/start-chromium.sh` starts headless Chromium listening on `127.0.0.1:9222` with a CDP HTTP endpoint at `/json/version`. The image ships `setsid` and `/bin/sh` (debian-slim) for the serving-workload path.
+
+- [ ] **Step 1: Write the launcher**
+
+`images/computer-use/start-chromium.sh`:
+
+```sh
+#!/bin/sh
+# Start headless Chromium with a CDP endpoint on guest loopback. Run as the
+# serving workload so the template snapshot captures it already listening and a
+# fork wakes warm. The microVM is the isolation boundary, so Chromium's own
+# sandbox is disabled (--no-sandbox); see docs/threat-model.md.
+set -eu
+mkdir -p /data/chrome
+exec chromium \
+  --headless=new \
+  --no-sandbox \
+  --disable-dev-shm-usage \
+  --disable-gpu \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/data/chrome \
+  about:blank
+```
+
+- [ ] **Step 2: Write the Dockerfile**
+
+`images/computer-use/Dockerfile`:
+
+```dockerfile
+# Headless Chromium + CDP template for Mitos browser-automation sandboxes (#314).
+# The microVM is the isolation boundary; Chromium runs with --no-sandbox.
+FROM debian:stable-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      chromium \
+      fonts-liberation \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY start-chromium.sh /usr/local/bin/start-chromium.sh
+RUN chmod +x /usr/local/bin/start-chromium.sh
+
+# CDP endpoint. Reach it over the Mitos expose proxy, never publicly.
+EXPOSE 9222
+```
+
+- [ ] **Step 3: Build the image locally and smoke-test CDP**
+
+Run (on a docker host; box2 has docker):
+
+```bash
+docker build -t mitos-computer-use:dev images/computer-use/
+# Smoke: start the launcher in the container, confirm CDP answers.
+docker run -d --name cu-smoke --entrypoint /usr/local/bin/start-chromium.sh mitos-computer-use:dev
+sleep 5
+docker exec cu-smoke sh -c 'apt-get install -y curl >/dev/null 2>&1 || true; curl -fsS http://127.0.0.1:9222/json/version'
+docker rm -f cu-smoke
+```
+
+Expected: `/json/version` returns a JSON document containing `"webSocketDebuggerUrl"`. If Chromium needs more than the container default memory, note it (the pool sets 1 GiB).
+
+- [ ] **Step 4: Write the image README**
+
+`images/computer-use/README.md`: what the image is, the CDP port, the `--no-sandbox` rationale (microVM is the boundary), and that it is meant to run as a Mitos serving workload behind the expose proxy. Link `docs/recipes/browser-automation.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add images/computer-use/Dockerfile images/computer-use/start-chromium.sh images/computer-use/README.md
+git commit -s -m "feat(images): headless Chromium + CDP computer-use template image (#314)"
+```
+
+---
+
+### Task 4: Spike on a KVM host: warm Chromium snapshot, fork survival, and CDP exposure path
+
+This task resolves the spec's open questions (proxy-only host normalization versus an in-image CDP relay, and whether Chromium survives snapshot/restore) on real hardware before any user-facing doc claims a behavior. It produces a recorded decision, not a unit test.
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md` (the recorded outcome)
+
+**Interfaces:**
+- Consumes: Tasks 1, 2, 3.
+- Produces: a decision recorded in the notes file: (a) the exposure path that works (proxy-only or relay), and (b) whether the warm-fork model holds or the start-on-connect fallback is needed. Later tasks read this.
+
+- [ ] **Step 1: Assemble the verification substrate on a KVM host**
+
+Use box2 (docker + KVM) and install Firecracker there the way `.github/workflows/kvm-test.yaml` does (download the pinned `v1.15.0` binary), plus the pinned kernel. Build a Chromium rootfs from the image:
+
+```bash
+# On box2: build the image, export its filesystem, assemble an ext4 rootfs with
+# the guest agent injected as /init and a /bin/sh present.
+docker build -t mitos-computer-use:dev images/computer-use/
+cid=$(docker create mitos-computer-use:dev)
+mkdir -p /root/cu-root && docker export "$cid" | tar -x -C /root/cu-root
+docker rm "$cid"
+# Inject the freshly built guest agent as /init (cross-compiled musl agent, the
+# same build used for the #316/#318/#320 verification), then mkfs.ext4 + copy.
+# (Follow the [[epic-323-agent-integrations-complete]] recipe for the agent build
+# and the kvm-test.yaml rootfs assembly for the ext4 packing; size the image to
+# the docker rootfs size plus headroom.)
+```
+
+Cross-compile `sandbox-server` (with the Task 1 change) for linux/amd64 and the guest agent (musl) as in the prior verification.
+
+- [ ] **Step 2: Boot the standalone server with the Chromium rootfs**
+
+```bash
+sandbox-server --addr :8080 \
+  --kernel <vmlinux> --rootfs /root/cu-rootfs.ext4 --agent-bin <agent> \
+  --firecracker /usr/local/bin/firecracker --data-dir /root/cu-data &
+```
+
+- [ ] **Step 3: Create a warm Chromium template (workload + 1 GiB) and confirm CDP at snapshot**
+
+```bash
+curl -fsS -X POST localhost:8080/v1/templates -H 'Content-Type: application/json' -d '{
+  "id":"chrome",
+  "workload":{"command":["/usr/local/bin/start-chromium.sh"],
+              "ready":{"port":9222,"path":"/json/version","expect":200,"timeout_seconds":120}},
+  "resources":{"vcpu_count":2,"mem_size_mib":1024}
+}'
+```
+
+Expected: the create returns `ready:true` only after the readiness probe saw CDP answer (the build blocks on it). If it times out, Chromium did not come up; inspect the launcher path and memory.
+
+- [ ] **Step 4: Fork and confirm the child has a live CDP endpoint (snapshot survival)**
+
+```bash
+curl -fsS -X POST localhost:8080/v1/fork -d '{"template":"chrome","id":"cu-1"}'
+# Open the expose route to the guest CDP port and hit /json/version through it.
+curl -fsS http://localhost:8080/v1/sandboxes/cu-1/expose/9222/json/version
+```
+
+Expected: a JSON CDP document from the forked child. This proves Chromium survived snapshot/restore. If it does not, record the start-on-connect fallback decision (start Chromium via `exec` after fork) and flag the lost warm-fork benefit back to the issue.
+
+- [ ] **Step 5: Determine the exposure path with a real CDP client**
+
+Tunnel `:8080` to the workstation and run Playwright against the exposed CDP URL:
+
+```python
+from playwright.sync_api import sync_playwright
+URL = "http://localhost:8080/v1/sandboxes/cu-1/expose/9222"
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp(URL)
+    page = browser.new_page()
+    page.goto("https://example.com")
+    print(page.title())
+    page.screenshot(path="/tmp/cu.png")
+    browser.close()
+```
+
+If `connect_over_cdp` succeeds with proxy-only behavior, record decision (a) proxy-only. If it fails on the `Host` header or the `ws://127.0.0.1` discovery URL, record decision (b) relay-needed and proceed to Task 5.
+
+- [ ] **Step 6: Record the decision and tear down**
+
+Write `docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md` with: the exposure decision, the snapshot-survival result, the observed Chromium memory floor, and the exact commands that worked. Tear down the box temp dirs.
+
+```bash
+git add docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md
+git commit -s -m "docs(specs): record computer-use CDP spike outcome (#314)"
+```
+
+---
+
+### Task 5 (contingency): In-image CDP relay
+
+Execute ONLY if Task 4 step 5 recorded decision (b). If proxy-only worked, skip and note it in the recipe.
+
+**Files:**
+- Create: `cmd/cdp-relay/main.go`
+- Create: `cmd/cdp-relay/main_test.go`
+- Modify: `images/computer-use/Dockerfile` (copy the relay binary, point the launcher at it)
+- Modify: `images/computer-use/start-chromium.sh` (run Chromium on an internal port, relay on 9222)
+
+**Interfaces:**
+- Produces: a static binary that listens on `:9222`, proxies HTTP to Chromium on `127.0.0.1:9223`, rewrites the host in `/json` and `/json/version` `webSocketDebuggerUrl` / `devtoolsFrontendUrl` to the request's forwarded host, and forwards the WebSocket upgrade with `Host: localhost`.
+
+- [ ] **Step 1: Write the failing test for the discovery rewrite**
+
+```go
+func TestRewriteDiscoveryHost(t *testing.T) {
+	in := `{"webSocketDebuggerUrl":"ws://127.0.0.1:9223/devtools/browser/ABC"}`
+	out := rewriteDiscoveryHost([]byte(in), "example.test", true)
+	if !strings.Contains(string(out), "wss://example.test/devtools/browser/ABC") {
+		t.Fatalf("host not rewritten: %s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/cdp-relay/ -run TestRewriteDiscoveryHost -v`
+Expected: FAIL (undefined `rewriteDiscoveryHost`).
+
+- [ ] **Step 3: Implement the relay**
+
+Implement `rewriteDiscoveryHost(body []byte, host string, tls bool) []byte` (regex-replace the `ws://127.0.0.1:9223` prefix with `wss://<host>` or `ws://<host>`), and a `main()` that runs an `httputil.ReverseProxy` to `127.0.0.1:9223` with a `ModifyResponse` applying the rewrite for `/json` paths and a `Director` setting `Host: localhost`. Keep it under one file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/cdp-relay/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the relay into the image and re-verify on box**
+
+Update `start-chromium.sh` to launch Chromium on `--remote-debugging-port=9223` and start the relay on 9222; rebuild the rootfs and repeat Task 4 step 5. Confirm `connect_over_cdp` now works.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/cdp-relay/ images/computer-use/Dockerfile images/computer-use/start-chromium.sh
+git commit -s -m "feat(cdp-relay): normalize CDP discovery + host header for remote exposure (#314)"
+```
+
+---
+
+### Task 6: Runnable example `browser_cdp.py`
+
+**Files:**
+- Create: `sdk/python/examples/browser_cdp.py`
+
+**Interfaces:**
+- Consumes: the proven exposure path from Task 4/5 and the SDK `create`/`fork` with `workload`+`resources` from Task 2.
+
+- [ ] **Step 1: Write the example**
+
+Follow `sdk/python/examples/direct.py` shape (module docstring with the run command, `main(base_url)`, non-zero exit on failure). It creates a warm Chromium template via the SDK (workload + 1 GiB), forks one sandbox, builds the exposed CDP URL, connects with `playwright.chromium.connect_over_cdp`, navigates to a stable page, clicks a known element, screenshots, asserts the page title, and prints `browser_cdp example OK`. Requires `pip install playwright` and `playwright install chromium` for the client side; state that in the docstring.
+
+- [ ] **Step 2: Run the example end to end on the box (against the running server from Task 4)**
+
+Run: `python3 sdk/python/examples/browser_cdp.py http://localhost:8080`
+Expected: prints `browser_cdp example OK` and writes a screenshot; exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sdk/python/examples/browser_cdp.py
+git commit -s -m "docs(examples): drive a Mitos headless Chromium sandbox over CDP (#314)"
+```
+
+---
+
+### Task 7: Recipe doc + README row
+
+**Files:**
+- Create: `docs/recipes/browser-automation.md`
+- Modify: `README.md` (Documentation table, after the agent-harness recipe row near line 392)
+
+**Interfaces:**
+- Consumes: the verified commands from Tasks 4 and 6.
+
+- [ ] **Step 1: Write the recipe**
+
+`docs/recipes/browser-automation.md`, paralleling `docs/recipes/agent-harness.md`:
+- What it is (a forkable headless-Chromium microVM with a CDP endpoint) and the wedge (self-host, isolation, fork-to-many warm browsers).
+- The cluster path: a `SandboxPool` with `spec.template.image`, `resources: {cpu, memory: 1Gi}`, and `workload` (command + ready probe on 9222 `/json/version`).
+- The standalone path: `POST /v1/templates` with `workload` + `resources` (the exact body from Task 4 step 3), verified on a KVM host.
+- Reaching CDP: the expose route or a Mitos Expose named URL, always auth-gated, never public; the exact `connect_over_cdp` URL form proven in Task 4/5; whether a relay is in the image (per the spike).
+- Fork-to-many "best-of-N browsing": warm one template, `fork(n)`, give each child a fresh page; in-flight pages do not transfer across a fork.
+- Honest "which path it runs on" note: warm-fork needs the workload (cluster or the standalone passthrough); Chromium needs ~1 GiB; CDP-over-WebSocket only; the VNC desktop surface for vision computer-use agents is a future variant.
+- The example: link `sdk/python/examples/browser_cdp.py`.
+
+- [ ] **Step 2: Add the README row**
+
+In `README.md`, after the `Recipe: host an agent harness over HTTP` row:
+
+```markdown
+| Recipe: headless Chromium / CDP for browser-automation agents | [docs/recipes/browser-automation.md](docs/recipes/browser-automation.md) |
+```
+
+- [ ] **Step 3: Dash scan and commit**
+
+Run: `grep -nP '[\x{2014}\x{2013}]' docs/recipes/browser-automation.md README.md` (expect no output).
+
+```bash
+git add docs/recipes/browser-automation.md README.md
+git commit -s -m "docs(recipes): headless Chromium / CDP browser-automation recipe (#314)"
+```
+
+---
+
+### Task 8: Threat-model delta
+
+**Files:**
+- Modify: `docs/threat-model.md`
+
+**Interfaces:**
+- Consumes: the security analysis in spec section 6.
+
+- [ ] **Step 1: Add the CDP-exposure row**
+
+Add a row recording: the new surface (an exposed CDP endpoint is full remote control of the browser: file reads, arbitrary JS); the mitigation (the expose access ladder gates it, private by default, never `public` for CDP); and the `--no-sandbox` posture (the Firecracker microVM is the containment boundary, the same model E2B and Browserbase use). Match the table's existing row format and status column.
+
+- [ ] **Step 2: Dash scan and commit**
+
+Run: `grep -nP '[\x{2014}\x{2013}]' docs/threat-model.md` (expect no output).
+
+```bash
+git add docs/threat-model.md
+git commit -s -m "docs(threat-model): record the CDP-exposure surface for the computer-use template (#314)"
+```
+
+---
+
+### Task 9: Publish the image and add CI coverage
+
+**Files:**
+- Modify: `.github/workflows/kvm-test.yaml` (a Chromium-template step) OR a new minimal job, sized to what is affordable.
+- Possibly: a GHCR publish workflow entry for the new image.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+
+- [ ] **Step 1: Publish the image to GHCR**
+
+Build and push `ghcr.io/mitos-run/mitos-computer-use:<version>` (and `:latest`). Record that the new package must be flipped to public once in the GHCR UI (repo convention). Pin the digest in the recipe.
+
+- [ ] **Step 2: Add CI coverage proportional to cost**
+
+Add a `firecracker-test`-style step that builds the image, boots the warm Chromium template, forks, and asserts `/json/version` answers through the expose route. If the Chromium image build is too heavy for the KVM job budget, instead add a lightweight job that builds the image and runs the Task 3 docker smoke (CDP answers `/json/version`), and state explicitly in `docs/recipes/browser-automation.md` that the full warm-fork + Playwright path is box-verified rather than CI-gated. Do not silently drop coverage.
+
+- [ ] **Step 3: Dash scan, lint workflow, commit**
+
+Run: `actionlint .github/workflows/kvm-test.yaml` (if available) and the dash scan.
+
+```bash
+git add .github/workflows/kvm-test.yaml
+git commit -s -m "ci(kvm): cover the headless Chromium / CDP template (#314)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Goal 1 (image): Task 3. Goal 2 (warm-fork wiring): Tasks 1, 4, 7. Goal 3 (exposure): Tasks 4, 5, 7. Goal 4 (example + recipe): Tasks 6, 7. Goal 5 (README + threat-model): Tasks 7, 8. Goal 6 (standalone parity): Tasks 1, 2. Spec section 7 sequencing maps to Tasks 1-9. Open questions 1 and 2 resolved in Task 4; open question 3 resolved in Task 9.
+- Non-goals (VNC desktop, stealth, captcha, browser SDK) are not implemented; the recipe notes VNC as a future variant.
+
+**Placeholder scan:** The contingency relay (Task 5) is explicitly conditional on the Task 4 outcome, not a placeholder; its code steps are concrete. `<vmlinux>`, `<agent>`, `<version>`, and `<tag>` are environment-specific values filled at run time, not unspecified logic.
+
+**Type consistency:** `workloadFromReq`/`vmResFromReq` return `*firecracker.WorkloadSpec` / `*firecracker.VMResources` (fields `Command`, `Env`, `Ready{Port,Path,Expect,TimeoutSeconds}`, `VcpuCount`, `MemSizeMib`) consistently across Tasks 1, 2, 4. The CDP port `9222`, the readiness path `/json/version`, and the expose URL form are consistent across Tasks 3, 4, 6, 7.
+
+**Risks carried forward:** Task 4 may flip the design to the relay (Task 5) or to start-on-connect; both are written as explicit, concrete branches, and the start-on-connect fallback returns to the issue because it changes the headline benefit.

--- a/docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md
+++ b/docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md
@@ -1,0 +1,58 @@
+# Computer-use CDP template: spike outcome (#314, Task 4)
+
+Verified on box2 (bare-metal KVM, Firecracker v1.15.0, kernel 6.1.155), with the
+standalone `sandbox-server` carrying the Task 1 workload+resources passthrough, a
+debian-stable-slim + chromium rootfs, and the freshly built Rust guest agent.
+
+## Resolved open questions
+
+1. **Does Chromium survive snapshot/restore (the warm-fork model)? YES.**
+   A serving-workload template that launches headless Chromium (workload command
+   `/usr/local/bin/start-chromium.sh`, ready probe `9222 /json/version`) reaches
+   Ready and snapshots Chromium live in ~17.5s. A fork restores a warm browser in
+   ~2.7s whose CDP endpoint is live immediately (no cold start), and a Playwright
+   `connect_over_cdp` client drives it end to end: navigate, click, observe the
+   DOM update, screenshot. The warm-fork headline benefit holds; the
+   start-on-connect fallback is NOT needed.
+
+2. **Exposure path: forward works with zero new code; the named-URL HTTP proxy
+   needs a relay.**
+   - The loopback host-forward (`POST /v1/sandboxes/{id}/forward`, raw TCP) works
+     perfectly: `/json/version` returns CDP, and Chromium reflects the request
+     `Host` into `webSocketDebuggerUrl`, so Playwright `connect_over_cdp` against
+     the forwarded `127.0.0.1:NNNNN` works unmodified. This covers the SDK / local
+     / self-host case.
+   - The HTTP expose reverse proxy (`/v1/sandboxes/{id}/expose/9222/...`, the
+     named-URL / preview-proxy path) returns `500: Host header is specified and is
+     not an IP address or localhost`. This is Chromium's DevTools host-header
+     check rejecting the proxied `Host`. There is no single `Host` value that is
+     both accepted by Chromium (IP or `localhost`) and usable by a remote client
+     (the external hostname), so a CDP-aware relay that (a) sends `Host: localhost`
+     upstream and (b) rewrites the `/json/*` discovery `webSocketDebuggerUrl` to
+     the external origin is required for the named-URL path. Decision: relay needed
+     for named-URL CDP; the forward path needs none.
+
+## Bug found and fixed during the spike
+
+The #460 serving-workload readiness probe sent `GET <path> HTTP/1.0`. Chromium's
+DevTools HTTP server rejects HTTP/1.0 (`Cannot handle request with protocol:
+HTTP/1.0`) and never returns 200, so the gate timed out against a Chromium that
+was listening, failing the build. Fixed in `guest/agent-rs/src/service/workload.rs`
+(HTTP/1.0 -> HTTP/1.1, `Connection: close` retained) with a contract test, commit
+`1f25a9d`. This is a general #460 fix, not browser-specific.
+
+## Sizing
+
+- 512 MiB (the standalone default) is far too small; 1024 MiB triggers V8
+  CodeRange OOM noise in a child renderer (CDP still binds). 1536 MiB builds and
+  serves cleanly; the recipe and pool set ~1.5 to 2 GiB via `resources`.
+- The debian-slim + chromium rootfs is ~766 MiB extracted; the template uses a
+  2.5 GiB ext4.
+
+## Incidental notes
+
+- The agent `mount /dev: Resource busy` line is benign: init is non-fatal by
+  design and the kernel already auto-mounts devtmpfs.
+- box2 root disk is only 59 GiB and a co-resident husk stack holds ~14 GiB; each
+  warm template costs ~2.5 GiB rootfs + ~1.5 GiB mem snapshot, so the CI / repro
+  story must budget disk or reuse one template.

--- a/docs/superpowers/specs/2026-06-27-computer-use-cdp-template-design.md
+++ b/docs/superpowers/specs/2026-06-27-computer-use-cdp-template-design.md
@@ -46,6 +46,10 @@ Goals:
    recipe doc with the honest "which path it runs on" note.
 5. A README documentation-table entry and a threat-model delta for the new
    CDP-exposure surface.
+6. Standalone parity: the standalone `sandbox-server` template endpoint accepts a
+   `workload` and `resources` (memory / vcpu) so the warm-fork browser model runs
+   on the no-Kubernetes path, not only on a cluster. The engine already supports
+   both; only the standalone HTTP handler currently drops them.
 
 Non-goals:
 
@@ -128,7 +132,32 @@ Decision rule: prefer (a); fall back to (b) only if the spike shows a standard
 normalization. The recipe and example only ever describe the path that is proven
 to work.
 
-### 3.4 Example and recipe
+### 3.4 Standalone sandbox-server workload + resources passthrough
+
+The serving-workload primitive (#460) and per-template memory sizing are wired on
+the cluster path only: `cmd/sandbox-server`'s `POST /v1/templates` decodes just
+`{id, init_wait_seconds, network}` (`main.go:414`) and calls
+`engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, nil, nil)` (`main.go:476`),
+dropping the `workload` and `vmRes` parameters the engine already accepts
+(`engine.go:2005`). The standalone build is therefore hardcoded to 512 MiB / 1
+vCPU with no running workload, which is too small for Chromium and cannot
+snapshot it live.
+
+This task extends the standalone handler to parity with the engine:
+
+- Add `workload` and `resources` to the `createTemplateReq` struct, mapping JSON
+  to `firecracker.WorkloadSpec` (command, env, ready probe) and
+  `firecracker.VMResources` (vcpu, mem MiB).
+- Pass them through:
+  `engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, workload, vmRes)`.
+- The Python SDK `DirectSandbox` template-create path gains optional `workload`
+  and `resources` arguments so the example and recipe can drive it.
+
+This unlocks the warm-fork browser model on the no-Kubernetes self-host path and
+makes the whole feature verifiable end to end on a single KVM host (box1) with the
+standalone server, the same harness used for the #316/#318/#320 verification.
+
+### 3.5 Example and recipe
 
 - `sdk/python/examples/browser_cdp.py`:
   `playwright.chromium.connect_over_cdp(<exposed-cdp-url>)`, then `goto`, `click`,
@@ -141,7 +170,7 @@ to work.
   sandbox-server; ~1 GiB RAM; CDP-over-WebSocket only; VNC desktop is a future
   variant). Parallels `docs/recipes/agent-harness.md`.
 
-### 3.5 README and threat-model
+### 3.6 README and threat-model
 
 - README documentation table: a row "Recipe: headless Chromium / CDP for
   browser-automation agents" linking the recipe, satisfying the issue comment's
@@ -209,12 +238,15 @@ auth-gating requirement, and the microVM-as-sandbox rationale, in the same PR.
    normalization (3.3a) lets `connect_over_cdp` work, or whether the relay (3.3b)
    is needed. This decides the image and proxy surface before anything is written
    down. Also validates that Chromium survives snapshot/restore across a fork.
-2. Image + launcher, built and pushed to GHCR.
-3. Pool / template wiring with the workload and resources.
-4. Exposure path finalized per the spike outcome.
-5. Example + recipe, verified end to end on box1 (navigate, click, screenshot).
-6. README row + threat-model delta.
-7. CI: a `firecracker-test`-style step if affordable (the Chromium image build is
+2. Standalone workload + resources passthrough (section 3.4): the engine already
+   supports them; this wires the standalone handler and the SDK so box1 can
+   verify the warm-fork model without a cluster.
+3. Image + launcher, built and pushed to GHCR.
+4. Pool / template wiring with the workload and resources.
+5. Exposure path finalized per the spike outcome.
+6. Example + recipe, verified end to end on box1 (navigate, click, screenshot).
+7. README row + threat-model delta.
+8. CI: a `firecracker-test`-style step if affordable (the Chromium image build is
    heavy); otherwise the box1 run is the authoritative end-to-end proof and the
    doc is explicit about what is CI-gated versus box1-verified, honoring the
    no-unverified-claims rule.

--- a/docs/superpowers/specs/2026-06-27-computer-use-cdp-template-design.md
+++ b/docs/superpowers/specs/2026-06-27-computer-use-cdp-template-design.md
@@ -1,0 +1,256 @@
+# Computer-use template: headless Chromium + CDP for browser-automation agents
+
+Status: design, approved for spec review.
+Issue: #314 (computer-use / VNC desktop template for browser-automation agents).
+Depends on the shipped guest port exposure (#228) and preview proxy (#126), and
+on the serving-workload primitive (#460) that boots a long-running process so it
+is already listening when the template snapshot is taken. The VNC desktop variant
+named in the issue is explicitly deferred to a follow-up.
+
+## 1. Summary
+
+Ship a first-party, CI-verified template that boots **headless Chromium with a
+Chrome DevTools Protocol (CDP) endpoint** inside a Mitos microVM, exposed over the
+existing authenticated preview proxy, plus the wiring that snapshots Chromium
+already listening so a `fork` yields N warm browsers in milliseconds.
+
+The scope is deliberately CDP-only. Research into the early-2026 landscape (see
+section 8) shows the momentum in agent browser automation is decisively toward
+raw CDP over WebSocket: Playwright `connect_over_cdp`, Stagehand v3 (Playwright
+removed, straight to CDP), and browser-use (migrated to direct CDP) all target a
+Chromium CDP endpoint. A CDP template therefore has the broadest framework
+interop, the lightest rootfs, and exposes natively over our HTTP/WebSocket proxy.
+The graphical VNC desktop that vision computer-use agents (Anthropic Computer Use,
+OpenAI CUA) need is a separate, heavier surface, deferred to its own issue.
+
+The strategic wedge, identical to the rest of Mitos and unavailable from the SaaS
+browser clouds (Browserbase, Hyperbrowser; Steel is the only self-host peer and
+is a shared-kernel container with no fork): self-host so cookies, sessions, and
+scraped data never leave your infrastructure; microVM hardware isolation for
+untrusted pages; and fork a warm browser into N isolated attempts at fork(2)
+speed.
+
+## 2. Goals and non-goals
+
+Goals:
+
+1. An OCI template image (`images/computer-use`) that boots headless Chromium with
+   a CDP endpoint on a known guest port, published to GHCR.
+2. Pool / template wiring (`SandboxPool` on a cluster, template on the standalone
+   `sandbox-server`) that snapshots Chromium already listening on CDP, so a fork
+   gives an instantly warm browser, gated by an HTTP readiness probe.
+3. The CDP endpoint reachable from outside over the existing authenticated expose
+   proxy, with standard tools (`playwright.chromium.connect_over_cdp`) working
+   unmodified.
+4. A runnable example driving it end to end (navigate, click, screenshot) and a
+   recipe doc with the honest "which path it runs on" note.
+5. A README documentation-table entry and a threat-model delta for the new
+   CDP-exposure surface.
+
+Non-goals:
+
+1. A graphical VNC / noVNC desktop (the vision-agent surface). Deferred to a
+   follow-up issue; this design notes the seam.
+2. Stealth / anti-detect / fingerprint evasion. The base template is a clean,
+   standards-compliant Chromium; anti-detect tooling is a gray-area niche the user
+   can layer themselves and is out of scope and off-brand.
+3. Captcha solving, proxy rotation, or a managed session-replay UI. Those are SaaS
+   product features, not a template.
+4. A Mitos-specific browser SDK. The value is that existing CDP tools just work.
+
+## 3. Components
+
+Each unit has one purpose and a defined interface.
+
+### 3.1 Template image (`images/computer-use/Dockerfile`)
+
+- Base `debian:stable-slim`. Rationale: it ships `setsid` and `/bin/sh`, both
+  required by the serving-workload path (the workload is started in its own
+  session via `setsid` so the fork SIGUSR2 broadcast does not terminate it).
+- Installs `chromium`, `fonts-liberation`, `ca-certificates`, and a launcher
+  script `start-chromium.sh`.
+- `start-chromium.sh` runs Chromium headless on guest loopback:
+  `chromium --headless=new --remote-debugging-port=9222 --no-sandbox
+  --disable-dev-shm-usage --user-data-dir=/data/chrome --remote-debugging-address=127.0.0.1`.
+  `--no-sandbox` is correct and intentional here: the microVM is the sandbox
+  boundary (the same model E2B Desktop and Browserbase use). This is recorded in
+  the threat-model delta, not hidden.
+- The guest agent is injected as `/init` by the existing OCI-image-to-rootfs
+  pipeline (`internal/fork/imagebuild.go`); the image does not provide its own
+  init.
+- Published as `ghcr.io/mitos-run/mitos-computer-use:<tag>`. New GHCR packages are
+  private by default and need the one-time manual public toggle (existing repo
+  convention).
+
+### 3.2 Pool / template wiring
+
+A `SandboxPool` (cluster) or a `POST /v1/templates`-shaped template (standalone)
+that sets:
+
+```yaml
+spec:
+  template:
+    image: ghcr.io/mitos-run/mitos-computer-use:<tag>
+    resources: { cpu: "2", memory: "1Gi" }     # Chromium needs ~1Gi
+    workload:
+      command: ["/usr/local/bin/start-chromium.sh"]
+      ready: { port: 9222, path: /json/version, expect: 200 }
+```
+
+The `ready` probe makes the template build block until CDP answers HTTP 200 on
+`/json/version`, so the snapshot always captures a live CDP endpoint. The
+`resources` override raises the default 512 MiB to 1 GiB for Chromium.
+
+### 3.3 CDP exposure
+
+CDP is HTTP plus a WebSocket upgrade, so it rides the existing expose paths, all
+WebSocket-safe (`FlushInterval: -1`, raw-byte vsock tunnel):
+
+- standalone: `GET /v1/sandboxes/{id}/expose/9222/...`
+- cluster named URL: `https://<label>.<expose-domain>/...` via Mitos Expose
+- local: the loopback host-forward (`POST /v1/sandboxes/{id}/forward`)
+
+Open technical decision, resolved by the spike in section 7: Chrome advertises a
+`ws://127.0.0.1:9222/...` URL in `/json/version` and enforces a `Host: localhost`
+check on the WS upgrade. Two candidate resolutions:
+
+- **(a) Proxy normalization only.** Normalize the upstream `Host` header to
+  `localhost` at the expose proxy and rely on the CDP client rewriting the
+  discovery host to the endpoint it was given (Playwright's documented behavior;
+  to be confirmed empirically). Zero new code if it holds.
+- **(b) A small CDP relay in the image.** A static binary on `:9222` that proxies
+  to Chromium on an internal port, rewrites the `/json/*` discovery doc to the
+  externally reachable host, and sets `Host: localhost` on the upstream WS dial.
+  Bulletproof and matches what Steel and Browserbase do; costs one small binary.
+
+Decision rule: prefer (a); fall back to (b) only if the spike shows a standard
+`connect_over_cdp` against the exposed URL does not work with proxy-only host
+normalization. The recipe and example only ever describe the path that is proven
+to work.
+
+### 3.4 Example and recipe
+
+- `sdk/python/examples/browser_cdp.py`:
+  `playwright.chromium.connect_over_cdp(<exposed-cdp-url>)`, then `goto`, `click`,
+  `screenshot`, and assert a marker, following the existing
+  `sdk/python/examples/direct.py` shape (docstring, `main()`, non-zero exit on
+  failure so CI gates).
+- `docs/recipes/browser-automation.md`: the pool YAML, the standalone path, the
+  example walkthrough, the fork-to-many "best-of-N browsing" pattern, and the
+  honest "which path it runs on" note (cluster husk pool or standalone
+  sandbox-server; ~1 GiB RAM; CDP-over-WebSocket only; VNC desktop is a future
+  variant). Parallels `docs/recipes/agent-harness.md`.
+
+### 3.5 README and threat-model
+
+- README documentation table: a row "Recipe: headless Chromium / CDP for
+  browser-automation agents" linking the recipe, satisfying the issue comment's
+  README follow-up.
+- `docs/threat-model.md`: a row for the CDP-exposure surface (see section 6).
+
+## 4. Data flow
+
+Build time: controller / sandbox-server pulls the image, extracts it, injects the
+agent as `/init`, boots the microVM, the agent runs `start-chromium.sh` as a
+detached session workload, the build blocks on the `ready` probe hitting
+`/json/version`, then pauses and snapshots with Chromium live.
+
+Claim / fork time: a fork restores the snapshot; each child has its own Chromium
+process state and its own loopback CDP listener. In-flight pages do not transfer
+across a fork (the child resumes snapshot state, not live connections); a client
+connects fresh and opens a new page or context. This matches the documented
+agent-harness fork semantics.
+
+Drive time: client -> expose proxy (auth-gated) -> vsock PortForward tunnel ->
+guest `127.0.0.1:9222` -> Chromium CDP. Playwright / Stagehand / browser-use
+connect over CDP and drive the browser.
+
+## 5. Error handling and failure behavior
+
+- Readiness probe timeout: if Chromium does not answer `/json/version` within the
+  probe `timeoutSeconds`, the template build fails with the existing workload
+  build error (actionable remediation: check the launcher logs, raise memory).
+  No silent half-built snapshot.
+- Out-of-memory: Chromium under-provisioned (below ~1 GiB) is the most likely
+  failure; the recipe states the requirement and the pool sets it. Documented,
+  not implied.
+- Fork restore: a child where Chromium did not survive snapshot/restore must fail
+  closed on the readiness re-check rather than serve a dead CDP endpoint. The
+  spike validates restore behavior (section 7); if Chromium does not survive
+  restore reliably, the fallback is start-on-first-connect (which loses the warm
+  fork advantage) and that trade-off is brought back to the issue, not shipped
+  silently.
+- Auth: the exposed CDP endpoint is gated by the expose access ladder, private by
+  default; an unauthenticated request gets the standard expose 401/403, never a
+  live CDP connection.
+
+## 6. Security and threat model
+
+The new surface is an exposed CDP endpoint. CDP is full remote control of the
+browser: it can navigate `file://`, read local files, and execute arbitrary JS in
+pages. Therefore:
+
+- The exposed endpoint MUST remain behind the expose access ladder, private by
+  default; the recipe never demonstrates the `public` tier for CDP.
+- `--no-sandbox` disables Chromium's own sandbox; the containment boundary is the
+  Firecracker microVM, not Chrome's seccomp/namespace sandbox. This is the same
+  posture as E2B and Browserbase and is stated plainly.
+- Rendering untrusted web content is the intended isolation story: a hostile page
+  is confined to the microVM and cannot reach the host, control plane, or sibling
+  sandboxes.
+
+`docs/threat-model.md` gains a row recording the CDP-exposure surface, the
+auth-gating requirement, and the microVM-as-sandbox rationale, in the same PR.
+
+## 7. Implementation sequencing
+
+1. **CDP-remote-exposure spike.** Build the image locally, boot it on a KVM host
+   (box1), expose CDP through the proxy, and determine whether proxy-only host
+   normalization (3.3a) lets `connect_over_cdp` work, or whether the relay (3.3b)
+   is needed. This decides the image and proxy surface before anything is written
+   down. Also validates that Chromium survives snapshot/restore across a fork.
+2. Image + launcher, built and pushed to GHCR.
+3. Pool / template wiring with the workload and resources.
+4. Exposure path finalized per the spike outcome.
+5. Example + recipe, verified end to end on box1 (navigate, click, screenshot).
+6. README row + threat-model delta.
+7. CI: a `firecracker-test`-style step if affordable (the Chromium image build is
+   heavy); otherwise the box1 run is the authoritative end-to-end proof and the
+   doc is explicit about what is CI-gated versus box1-verified, honoring the
+   no-unverified-claims rule.
+
+## 8. Landscape and positioning (research basis)
+
+From an early-2026 research pass (sources cited in the PR):
+
+- The dominant programmatic surface is CDP over WebSocket. Playwright
+  `connect_over_cdp` is Chromium-only; Stagehand v3 removed Playwright for raw CDP
+  (cited 44% faster on shadow DOM/iframes); browser-use migrated to direct CDP
+  (WebVoyager 89.1%). DOM-driven (CDP) stacks are 12-17 points more reliable than
+  vision stacks on common tasks.
+- Vision computer-use agents (Anthropic Computer Use, OpenAI CUA) instead need a
+  graphical screen (Xvfb + VNC + xdotool); E2B Desktop is exactly that (Xfce +
+  noVNC on 6080). That is the deferred VNC variant, a different and smaller
+  segment.
+- Self-host peers: Steel is open-source and self-hostable but a shared-kernel
+  container with no fork; Browserbase and Hyperbrowser are SaaS-only. None fork a
+  warm browser at fork(2) speed, and none keep your data on your own infra with
+  microVM isolation.
+- Stealth / anti-detect (Camoufox, Patchright, undetected-chromedriver) is a
+  scraping arms race and a gray area; the base template stays clean and
+  standards-compliant, leaving that to the user to layer.
+- Distribution norm: flagship browser surfaces ship first-party as a repo plus a
+  template image (E2B Desktop, Steel). Mitos ships this in-repo, CI-verified, for
+  the same reason; a community `awesome-mitos` discovery list is a separate, later
+  initiative, not where the canonical template lives.
+
+## 9. Open questions
+
+1. Spike outcome: proxy-only host normalization (3.3a) versus an in-image CDP
+   relay (3.3b). Resolved in implementation step 1.
+2. Whether Chromium survives VM snapshot/restore cleanly enough to keep the
+   warm-fork model, or whether start-on-first-connect is the honest fallback
+   (section 5). Resolved in implementation step 1; a fallback changes the
+   headline benefit and comes back to the issue.
+3. Whether the Chromium image build is affordable in CI or stays a box1-gated
+   verification (step 7).

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1213,6 +1213,24 @@ with `spec.expose` set and `Status.Phase==Ready` is reachable at
 | Authorization pipeline: fail-closed tier, network, audience | mitigated (unit-tested) | The `Authorize` function in `internal/preview/authz.go` applies three layers in sequence: (1) NETWORK: `route.Network` is a CIDR allowlist (`Route.Network []string`); if non-empty the client IP must fall within at least one listed CIDR (`NetworkAllows`). A nil or out-of-range IP against a non-empty allowlist is denied. Malformed CIDRs are skipped (fail closed: no match returns `DenyForbidden`). (2) TIER: `route.Sharing` selects the tier. `public` always allows (but `DenyForbidden` if audience fields are set, because audience evaluation requires an identity). `authenticated` requires a non-nil identity. `org`/`private` require a non-nil identity AND `route.OrgID` present in `identity.OrgIDs`. `link` requires a non-nil identity (the proxy decodes the link cookie before calling `Authorize`). Unknown or empty `Sharing` is `DenyForbidden` (fail closed; no default-deny coercion to a different tier). (3) AUDIENCE: `AllowedPrincipals` uses case-folded exact email match; `AllowedEmailDomains` requires `identity.EmailVerified == true` and an EXACT case-folded domain match (`containsDomainFolded`); a suffix like `evilacme.com` does NOT match an entry `acme.com`. Empty allowlist entries are skipped. `internal/preview/authz.go`. Unit-tested across all tier/network/audience combinations; CIDR gate; suffix-trick rejected; case-insensitive; empty entries guarded. |
 | OIDC live-IdP path: honest CI scope | partial | The OIDC authorization code flow (discovery, redirect to provider, callback with state validation, code exchange, ID token verify) is tested with a fake token verifier (`oidcauth.FakeVerifier`) in unit CI so the flow handlers can be exercised without a live issuer. The live-IdP path (a real `/.well-known/openid-configuration` discovery, a real code exchange) is maintainer-verified only; it is not covered by an automated CI job. PKCE is a documented follow-up. SAML and SCIM are deferred. This surface stays gated behind the external security review (issue #194) and the abuse-control envelope (issue #213). |
 
+### Headless-browser CDP exposure (issue #314)
+
+The computer-use template (`images/computer-use`) exposes a Chrome DevTools
+Protocol (CDP) endpoint over the section-7c expose ingress. CDP is FULL remote
+control of the browser: a CDP client can navigate `file://`, read local files, and
+execute arbitrary JavaScript in pages. The exposed CDP endpoint is therefore
+treated as a privileged control surface and inherits the section-7c PRODUCTION
+GATE: it is not cleared for untrusted tenants until the #194 external review and
+the #213 abuse-control envelope land, and it MUST stay behind the expose access
+ladder, private by default; the recipe never demonstrates the `public` tier for
+CDP.
+
+| Boundary | Status | Mechanism |
+|---|---|---|
+| In-guest CDP relay is unprivileged | mitigated | `cmd/cdp-relay` runs INSIDE the sandbox guest as part of the serving workload; it owns the exposed guest port and reverse-proxies to Chromium on an internal loopback port. It is an in-guest userspace proxy with no host, control-plane, or sibling-sandbox access; it is in the same untrusted-guest trust domain as the workload it fronts (section: Guest workload, untrusted). It exists only to satisfy Chromium's DevTools host-header check (Chromium rejects any `Host` that is not an IP literal or `localhost`): the relay sends the upstream loopback host:port as `Host` and rewrites the discovery `webSocketDebuggerUrl` to the external origin. |
+| Spoofable X-Forwarded-Host has no privileged effect | mitigated | The relay derives the rewritten discovery host from `X-Forwarded-Host` (set by the expose proxy from the client's Host) or, absent it, the client's own request Host. An authenticated client that spoofs `X-Forwarded-Host` only changes the host in the `webSocketDebuggerUrl` it gets back, an unreachable or self-chosen value: a self-inflicted bad URL. It does NOT steer the upstream (the expose proxy derives the forkd upstream solely from the route table, section 7c) and grants no cross-sandbox or cross-tenant access. |
+| Chromium `--no-sandbox`: the microVM is the boundary | mitigated | Chromium runs with `--no-sandbox`, disabling its in-process seccomp/namespace sandbox, the same posture as E2B Desktop and Browserbase. The containment boundary is the Firecracker microVM (sections 1 and 2): a hostile page or malicious script is confined to the one sandbox and cannot reach the host, the control plane, or sibling sandboxes. Rendering untrusted web content is the intended isolation use case. |
+
 ## 8. What we explicitly do NOT claim
 
 - No pod-scoped Kubernetes mechanism (NetworkPolicy, PodSecurity, pod quotas)

--- a/guest/agent-rs/src/service/workload.rs
+++ b/guest/agent-rs/src/service/workload.rs
@@ -90,7 +90,12 @@ pub async fn await_http_ready(
 ) -> Result<(), String> {
     let expect = if expect == 0 { 200 } else { expect };
     let path = if path.is_empty() { "/" } else { path };
-    let req = format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    // HTTP/1.1, not 1.0: some servers (for example Chromium's DevTools endpoint,
+    // the readiness target for a headless-browser workload) reject HTTP/1.0 with
+    // "Cannot handle request with protocol: HTTP/1.0" and never return 200, so an
+    // HTTP/1.0 probe would time out against a workload that is in fact listening.
+    // Connection: close keeps the single-read response handling below valid.
+    let req = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
     let want = format!(" {expect} ");
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
@@ -164,6 +169,32 @@ mod tests {
         });
         let r = await_http_ready(port, "/", 200, Duration::from_secs(5)).await;
         assert!(r.is_ok(), "ready gate should pass once the server listens: {r:?}");
+    }
+
+    #[tokio::test]
+    async fn await_http_ready_probes_with_http_1_1() {
+        // The probe must speak HTTP/1.1: servers like Chromium's DevTools endpoint
+        // reject HTTP/1.0 and never return 200, so an HTTP/1.0 probe would time out
+        // against a workload that is genuinely listening. This server returns 200
+        // only for an HTTP/1.1 request line and closes (mimicking that contract).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            for s in listener.incoming() {
+                use std::io::{Read, Write};
+                let mut s = s.unwrap();
+                let mut scratch = [0u8; 256];
+                let n = s.read(&mut scratch).unwrap_or(0);
+                let req = String::from_utf8_lossy(&scratch[..n]);
+                if req.contains("HTTP/1.1") {
+                    let _ = s.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+                } else {
+                    let _ = s.write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+                }
+            }
+        });
+        let r = await_http_ready(port, "/", 200, Duration::from_secs(5)).await;
+        assert!(r.is_ok(), "ready gate must use HTTP/1.1 so a 1.1-only server returns 200: {r:?}");
     }
 
     #[tokio::test]

--- a/images/computer-use/Dockerfile
+++ b/images/computer-use/Dockerfile
@@ -1,5 +1,21 @@
 # Headless Chromium + CDP template for Mitos browser-automation sandboxes (#314).
 # The microVM is the isolation boundary; Chromium runs with --no-sandbox.
+#
+# The build context is the repository root (the relay is compiled from source):
+#   docker build -f images/computer-use/Dockerfile -t mitos-computer-use .
+
+# Builder: compile the CDP relay (standard library only) from source. The relay
+# presents CDP on the exposed port, sends Host: localhost upstream so Chromium's
+# DevTools host-header check passes behind the named-URL expose proxy, and
+# rewrites the discovery webSocketDebuggerUrl to the external origin.
+FROM golang:1.26-bookworm AS relay-build
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY cmd/cdp-relay ./cmd/cdp-relay
+RUN CGO_ENABLED=0 GOFLAGS=-mod=mod go build -o /cdp-relay ./cmd/cdp-relay
+
+# Runtime: debian-stable-slim ships setsid and /bin/sh, both required by the
+# serving-workload path that snapshots Chromium already listening.
 FROM debian:stable-slim
 
 RUN apt-get update \
@@ -9,8 +25,10 @@ RUN apt-get update \
       ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-COPY start-chromium.sh /usr/local/bin/start-chromium.sh
-RUN chmod +x /usr/local/bin/start-chromium.sh
+COPY --from=relay-build /cdp-relay /usr/local/bin/cdp-relay
+COPY images/computer-use/start-chromium.sh /usr/local/bin/start-chromium.sh
+RUN chmod +x /usr/local/bin/start-chromium.sh /usr/local/bin/cdp-relay
 
-# CDP endpoint. Reach it over the Mitos expose proxy, never publicly.
+# CDP endpoint, served by the relay. Reach it over the Mitos expose proxy, never
+# publicly.
 EXPOSE 9222

--- a/images/computer-use/Dockerfile
+++ b/images/computer-use/Dockerfile
@@ -1,0 +1,16 @@
+# Headless Chromium + CDP template for Mitos browser-automation sandboxes (#314).
+# The microVM is the isolation boundary; Chromium runs with --no-sandbox.
+FROM debian:stable-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      chromium \
+      fonts-liberation \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY start-chromium.sh /usr/local/bin/start-chromium.sh
+RUN chmod +x /usr/local/bin/start-chromium.sh
+
+# CDP endpoint. Reach it over the Mitos expose proxy, never publicly.
+EXPOSE 9222

--- a/images/computer-use/Dockerfile
+++ b/images/computer-use/Dockerfile
@@ -5,7 +5,7 @@
 #   docker build -f images/computer-use/Dockerfile -t mitos-computer-use .
 
 # Builder: compile the CDP relay (standard library only) from source. The relay
-# presents CDP on the exposed port, sends Host: localhost upstream so Chromium's
+# presents CDP on the exposed port, sends the upstream host:port as Host so Chromium's
 # DevTools host-header check passes behind the named-URL expose proxy, and
 # rewrites the discovery webSocketDebuggerUrl to the external origin.
 FROM golang:1.26-bookworm AS relay-build

--- a/images/computer-use/README.md
+++ b/images/computer-use/README.md
@@ -1,0 +1,26 @@
+# Chromium Computer-Use Template
+
+This OCI image provides a headless Chromium browser with Chrome DevTools Protocol (CDP) support for browser-automation workloads in Mitos sandboxes.
+
+## Features
+
+- Headless Chromium with CDP endpoint on `127.0.0.1:9222`
+- Pre-launched on container startup via `start-chromium.sh`
+- Includes fonts and CA certificates for web rendering
+- Built on `debian:stable-slim` with `setsid` support for the serving-workload path
+
+## Design
+
+The image runs Chromium with `--no-sandbox` because the Firecracker microVM is the isolation boundary; Chrome's own sandbox is redundant and unnecessary. See `docs/threat-model.md` for the threat model.
+
+## Usage
+
+This image is designed to run as a Mitos serving workload, captured in a template snapshot and forked warm on demand. The guest exposes port 9222 via the Mitos expose proxy (authenticated, never public):
+
+```bash
+mitos workspace serve <workspace> --pool <pool> --expose 9222
+```
+
+Access the CDP endpoint via the authenticated expose URL at `/json/version`.
+
+For end-to-end browser automation examples, see the recipe at `../../docs/recipes/browser-automation.md`.

--- a/images/computer-use/README.md
+++ b/images/computer-use/README.md
@@ -18,7 +18,7 @@ The image runs Chromium with `--no-sandbox` because the Firecracker microVM is t
 This image is designed to run as a Mitos serving workload, captured in a template snapshot and forked warm on demand. The guest exposes port 9222 via the Mitos expose proxy (authenticated, never public):
 
 ```bash
-mitos workspace serve <workspace> --pool <pool> --expose 9222
+mitos workspace serve <workspace> --pool <pool> --port 9222 --expose-domain <domain>
 ```
 
 Access the CDP endpoint via the authenticated expose URL at `/json/version`.

--- a/images/computer-use/start-chromium.sh
+++ b/images/computer-use/start-chromium.sh
@@ -1,16 +1,22 @@
 #!/bin/sh
-# Start headless Chromium with a CDP endpoint on guest loopback. Run as the
-# serving workload so the template snapshot captures it already listening and a
-# fork wakes warm. The microVM is the isolation boundary, so Chromium's own
-# sandbox is disabled (--no-sandbox); see docs/threat-model.md.
+# Start headless Chromium plus the CDP relay. Run as the serving workload so the
+# template snapshot captures both already listening and a fork wakes warm. The
+# microVM is the isolation boundary, so Chromium's own sandbox is disabled
+# (--no-sandbox); see docs/threat-model.md.
+#
+# Chromium binds CDP on an internal loopback port (9223); the relay owns the
+# exposed port (9222). The relay sends Host: localhost upstream so Chromium's
+# DevTools host-header check passes behind the named-URL expose proxy, and
+# rewrites the discovery webSocketDebuggerUrl to the external origin.
 set -eu
 mkdir -p /data/chrome
-exec chromium \
+chromium \
   --headless=new \
   --no-sandbox \
   --disable-dev-shm-usage \
   --disable-gpu \
   --remote-debugging-address=127.0.0.1 \
-  --remote-debugging-port=9222 \
+  --remote-debugging-port=9223 \
   --user-data-dir=/data/chrome \
-  about:blank
+  about:blank &
+exec /usr/local/bin/cdp-relay --listen :9222 --upstream 127.0.0.1:9223

--- a/images/computer-use/start-chromium.sh
+++ b/images/computer-use/start-chromium.sh
@@ -5,7 +5,7 @@
 # (--no-sandbox); see docs/threat-model.md.
 #
 # Chromium binds CDP on an internal loopback port (9223); the relay owns the
-# exposed port (9222). The relay sends Host: localhost upstream so Chromium's
+# exposed port (9222). The relay sends the upstream host:port as Host so Chromium's
 # DevTools host-header check passes behind the named-URL expose proxy, and
 # rewrites the discovery webSocketDebuggerUrl to the external origin.
 set -eu

--- a/images/computer-use/start-chromium.sh
+++ b/images/computer-use/start-chromium.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Start headless Chromium with a CDP endpoint on guest loopback. Run as the
+# serving workload so the template snapshot captures it already listening and a
+# fork wakes warm. The microVM is the isolation boundary, so Chromium's own
+# sandbox is disabled (--no-sandbox); see docs/threat-model.md.
+set -eu
+mkdir -p /data/chrome
+exec chromium \
+  --headless=new \
+  --no-sandbox \
+  --disable-dev-shm-usage \
+  --disable-gpu \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/data/chrome \
+  about:blank

--- a/internal/daemon/expose.go
+++ b/internal/daemon/expose.go
@@ -51,6 +51,29 @@ func (api *SandboxAPI) ProxyHTTP(sandboxID string, guestPort int, prefix string)
 
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
+			// Propagate X-Forwarded-Host and X-Forwarded-Proto so that upstreams
+			// (e.g. the CDP relay) can learn the external origin. When the Rewrite
+			// hook is used, httputil.ReverseProxy strips incoming X-Forwarded-*
+			// headers before calling Rewrite, so we must re-propagate them
+			// explicitly from pr.In (the original, unmodified request). An edge
+			// proxy that already set these headers takes precedence; otherwise we
+			// derive the values from the request itself.
+			xfh := pr.In.Header.Get("X-Forwarded-Host")
+			if xfh == "" && pr.In.Host != "" {
+				xfh = pr.In.Host
+			}
+			if xfh != "" {
+				pr.Out.Header.Set("X-Forwarded-Host", xfh)
+			}
+			xfp := pr.In.Header.Get("X-Forwarded-Proto")
+			if xfp == "" {
+				if pr.In.TLS != nil {
+					xfp = "https"
+				} else {
+					xfp = "http"
+				}
+			}
+			pr.Out.Header.Set("X-Forwarded-Proto", xfp)
 			pr.Out.URL.Scheme = "http"
 			pr.Out.URL.Host = "guest" // ignored: DialContext returns the tunnel
 			pr.Out.Host = "guest"

--- a/internal/daemon/expose_test.go
+++ b/internal/daemon/expose_test.go
@@ -183,6 +183,98 @@ func TestHandleExposeStreamsSSEEndToEnd(t *testing.T) {
 	}
 }
 
+// TestProxyHTTPForwardsXForwardedHeaders asserts that a request routed through
+// ProxyHTTP reaches the upstream with X-Forwarded-Host set to the incoming
+// request Host and X-Forwarded-Proto set based on TLS state.
+func TestProxyHTTPForwardsXForwardedHeaders(t *testing.T) {
+	var mu sync.Mutex
+	var gotHost, gotProto string
+	var backendHit bool
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotHost = r.Header.Get("X-Forwarded-Host")
+		gotProto = r.Header.Get("X-Forwarded-Proto")
+		backendHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	port := portOf(t, backend)
+	api := newExposeTestAPI(t, backend.Listener.Addr().String())
+	prefix := "/v1/sandboxes/sb1/expose/" + itoa(port)
+	rp, err := api.ProxyHTTP("sb1", port, prefix)
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, prefix+"/check", nil)
+	req.Host = "example.test"
+	rec := httptest.NewRecorder()
+	rp.ServeHTTP(rec, req)
+
+	mu.Lock()
+	hit, host, proto := backendHit, gotHost, gotProto
+	mu.Unlock()
+
+	if !hit {
+		t.Fatal("backend handler was not called")
+	}
+	if host != "example.test" {
+		t.Errorf("X-Forwarded-Host: got %q, want %q", host, "example.test")
+	}
+	if proto != "http" {
+		t.Errorf("X-Forwarded-Proto: got %q, want %q", proto, "http")
+	}
+}
+
+// TestProxyHTTPPreservesExistingXForwardedHeaders asserts that an already-set
+// X-Forwarded-Host (from an edge proxy) is preserved and not overwritten with
+// the inner request Host.
+func TestProxyHTTPPreservesExistingXForwardedHeaders(t *testing.T) {
+	var mu sync.Mutex
+	var gotHost, gotProto string
+	var backendHit bool
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotHost = r.Header.Get("X-Forwarded-Host")
+		gotProto = r.Header.Get("X-Forwarded-Proto")
+		backendHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	port := portOf(t, backend)
+	api := newExposeTestAPI(t, backend.Listener.Addr().String())
+	prefix := "/v1/sandboxes/sb1/expose/" + itoa(port)
+	rp, err := api.ProxyHTTP("sb1", port, prefix)
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, prefix+"/check", nil)
+	req.Host = "inner.host"
+	req.Header.Set("X-Forwarded-Host", "edge.proxy.example")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	rp.ServeHTTP(rec, req)
+
+	mu.Lock()
+	hit, host, proto := backendHit, gotHost, gotProto
+	mu.Unlock()
+
+	if !hit {
+		t.Fatal("backend handler was not called")
+	}
+	if host != "edge.proxy.example" {
+		t.Errorf("X-Forwarded-Host: got %q, want %q", host, "edge.proxy.example")
+	}
+	if proto != "https" {
+		t.Errorf("X-Forwarded-Proto: got %q, want %q", proto, "https")
+	}
+}
+
 func itoa(n int) string { return strconv.Itoa(n) }
 
 func portOf(t *testing.T, s *httptest.Server) int {

--- a/sdk/python/examples/browser_cdp.py
+++ b/sdk/python/examples/browser_cdp.py
@@ -1,0 +1,92 @@
+"""Computer-use example: drive a headless Chromium sandbox over CDP.
+
+Prerequisites:
+  - A sandbox-server (cmd/sandbox-server) running against the computer-use
+    image rootfs (ghcr.io/mitos-run/mitos-computer-use), so a forked sandbox
+    boots Chromium listening on the Chrome DevTools Protocol (CDP) port 9222.
+    On a Kubernetes cluster this is a SandboxPool whose template sets the
+    workload and ~1.5 to 2 GiB of memory; see
+    docs/recipes/browser-automation.md.
+  - The Playwright client: ``pip install playwright`` (no browser download is
+    needed; this attaches to the remote Chromium over CDP).
+
+Run::
+
+    python3 browser_cdp.py [base_url]
+
+It creates a warm browser sandbox (Chromium snapshotted already listening, so the
+fork wakes warm), opens a CDP endpoint to it, then connects Playwright, navigates,
+clicks, screenshots, and prints "browser_cdp example OK". The base URL comes from
+argv[1], else MITOS_BASE_URL, else http://localhost:8080.
+
+This uses the loopback host-forward to reach CDP, which works against any
+standalone sandbox-server. For an authenticated named URL over the preview proxy,
+use ``sandbox.get_host(9222)`` instead (see the recipe).
+"""
+
+import os
+import sys
+
+import httpx
+
+import mitos
+
+
+def cdp_forward_url(base_url: str, sandbox_id: str) -> str:
+    """Open a loopback host-forward to the sandbox CDP port and return the
+    http://host:port a CDP client connects to. Chromium reflects the request
+    Host into webSocketDebuggerUrl, so connect_over_cdp works against it."""
+    resp = httpx.post(
+        f"{base_url}/v1/sandboxes/{sandbox_id}/forward",
+        json={"guest_port": 9222},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return "http://" + resp.json()["host"]
+
+
+def main(base_url: str) -> None:
+    from playwright.sync_api import sync_playwright
+
+    # Warm browser sandbox: the template runs Chromium as a serving workload and
+    # snapshots it already listening on CDP, so the fork wakes warm. Chromium
+    # needs more than the 512 MiB default.
+    sandbox = mitos.create(
+        "browser",
+        base_url=base_url,
+        workload={
+            "command": ["/usr/local/bin/start-chromium.sh"],
+            "ready": {"port": 9222, "path": "/json/version", "expect": 200,
+                      "timeout_seconds": 90},
+        },
+        resources={"vcpu_count": 2, "mem_size_mib": 1536},
+    )
+    try:
+        endpoint = cdp_forward_url(base_url, sandbox.id)
+        with sync_playwright() as p:
+            browser = p.chromium.connect_over_cdp(endpoint)
+            context = browser.contexts[0] if browser.contexts else browser.new_context()
+            page = context.new_page()
+            page.goto(
+                "data:text/html,<title>mitos</title>"
+                "<button id=go>go</button><div id=out>idle</div>"
+                "<script>go.onclick=()=>out.textContent='clicked'</script>"
+            )
+            page.click("#go")
+            title = page.title()
+            outcome = page.inner_text("#out")
+            page.screenshot(path="browser_cdp.png")
+            browser.close()
+        if title != "mitos" or outcome != "clicked":
+            raise SystemExit(f"unexpected result: title={title!r} out={outcome!r}")
+        print(f"navigated, title={title!r}, click result={outcome!r}, wrote browser_cdp.png")
+        print("browser_cdp example OK")
+    finally:
+        sandbox.terminate()
+
+
+if __name__ == "__main__":
+    url = sys.argv[1] if len(sys.argv) > 1 else os.environ.get(
+        "MITOS_BASE_URL", "http://localhost:8080"
+    )
+    main(url)

--- a/sdk/python/mitos/direct.py
+++ b/sdk/python/mitos/direct.py
@@ -240,6 +240,8 @@ class DirectSandbox:
         id: Optional[str] = None,
         network: Optional[Network] = None,
         idempotency_key: Optional[str] = None,
+        workload: Optional[dict] = None,
+        resources: Optional[dict] = None,
     ) -> "DirectSandbox":
         """Flat one-liner: return a READY sandbox handle for image.
 
@@ -254,9 +256,12 @@ class DirectSandbox:
         or CIDR rules. The SECURE DEFAULT when network is omitted is
         deny-by-default in both directions (the server applies it), so an
         untrusted sandbox cannot reach out or be dialed into unless you opt in.
+
+        workload and resources (issue #314) are forwarded to ensure_template when
+        set, so a caller can request a workload-backed warm template end to end.
         """
         server = SandboxServer.from_auth(api_key=api_key, base_url=base_url)
-        server.ensure_template(image, network=network)
+        server.ensure_template(image, network=network, workload=workload, resources=resources)
         return server.fork(image, id=id, idempotency_key=idempotency_key)
 
     def _auth_headers(self) -> dict[str, str]:
@@ -566,17 +571,30 @@ class SandboxServer:
         init_wait_seconds: int = 5,
         network: Optional[Network] = None,
         idempotency_key: Optional[str] = None,
+        workload: Optional[dict] = None,
+        resources: Optional[dict] = None,
     ) -> dict:
         """Create the template for id, optionally attaching a per-sandbox network
         posture (issue #219). The network applies to every sandbox forked from
         the template. Omit it for the secure default (deny-by-default both ways,
         applied server-side).
 
+        workload: optional serving-workload spec forwarded verbatim to the server
+        (issue #314). When set, the server starts the workload process inside the
+        VM before snapshotting so every fork inherits a warm serving process.
+
+        resources: optional VM resource overrides forwarded verbatim to the server
+        (issue #314). Omit to accept the server-side defaults.
+
         idempotency_key (issue #22): when set, a retried create with the same key
         returns the template the first call created instead of a duplicate."""
         body: dict = {"id": id, "init_wait_seconds": init_wait_seconds}
         if network is not None:
             body["network"] = network.to_dict()
+        if workload is not None:
+            body["workload"] = workload
+        if resources is not None:
+            body["resources"] = resources
         resp = self._http.post(
             f"{self.url}/v1/templates",
             json=body,
@@ -591,10 +609,14 @@ class SandboxServer:
         init_wait_seconds: int = 5,
         network: Optional[Network] = None,
         idempotency_key: Optional[str] = None,
+        workload: Optional[dict] = None,
+        resources: Optional[dict] = None,
     ) -> dict:
         """get-or-create the template for id. A 409 (already exists) is treated
         as success so the flat create path is idempotent across calls. network
         is the per-sandbox posture attached at create time (issue #219).
+        workload and resources (issue #314) are forwarded to create_template when
+        set; omit them to accept server-side defaults.
         idempotency_key (issue #22) makes a retried create safe server-side."""
         try:
             return self.create_template(
@@ -602,6 +624,8 @@ class SandboxServer:
                 init_wait_seconds=init_wait_seconds,
                 network=network,
                 idempotency_key=idempotency_key,
+                workload=workload,
+                resources=resources,
             )
         except AgentRunError as exc:
             if exc.status == 409:
@@ -651,6 +675,8 @@ def create(
     id: Optional[str] = None,
     network: Optional[Network] = None,
     idempotency_key: Optional[str] = None,
+    workload: Optional[dict] = None,
+    resources: Optional[dict] = None,
 ) -> DirectSandbox:
     """Flat one-liner native onboarding: return a READY sandbox handle.
 
@@ -667,6 +693,9 @@ def create(
     the fork step auto-generates one, so even a transparently retried create is
     safe; pass your own to make a retry across processes idempotent.
 
+    workload and resources (issue #314) are forwarded to ensure_template when
+    set, so a caller can request a workload-backed warm template end to end.
+
     The k8s operator path stays available as AgentRun(...).sandbox(...).
     """
     return DirectSandbox.create(
@@ -676,4 +705,6 @@ def create(
         id=id,
         network=network,
         idempotency_key=idempotency_key,
+        workload=workload,
+        resources=resources,
     )

--- a/sdk/python/tests/test_template_workload.py
+++ b/sdk/python/tests/test_template_workload.py
@@ -1,0 +1,41 @@
+"""Tests for workload and resources fields on template create (issue #314).
+
+Verifies that create_template forwards the optional workload and resources
+dicts into the POST body so callers can register a headless-Chromium (or any
+other serving-workload) template in one call.
+"""
+
+
+def test_create_template_includes_workload_and_resources(monkeypatch):
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+        is_success = True
+
+        def json(self):
+            return {"id": "chrome", "ready": True, "creation_time_ms": 1.0}
+
+        @property
+        def text(self):
+            return ""
+
+    class _FakeHTTP:
+        def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _FakeResp()
+
+    from mitos.direct import SandboxServer
+
+    srv = SandboxServer(url="http://x", api_key=None)
+    srv._http = _FakeHTTP()
+    srv.create_template(
+        "chrome",
+        workload={
+            "command": ["/usr/local/bin/start-chromium.sh"],
+            "ready": {"port": 9222, "path": "/json/version", "expect": 200},
+        },
+        resources={"vcpu_count": 2, "mem_size_mib": 1024},
+    )
+    assert captured["body"]["workload"]["command"] == ["/usr/local/bin/start-chromium.sh"]
+    assert captured["body"]["resources"]["mem_size_mib"] == 1024


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the wedge is a forkable, isolated computer per agent.
> - Computer-use and browser-automation are a proven, fast-growing segment (Browserbase, Steel, E2B Desktop, Daytona), and issue #314 asks for a first-party browser template exposed over the preview proxy.
> - Research showed CDP over WebSocket is the dominant programmatic surface (Playwright, Stagehand, browser-use all target it); a CDP-first template has the broadest interop and the lightest rootfs, so the design is CDP-only with VNC deferred.
> - The honest differentiator is self-host (data stays on your infra), microVM isolation for untrusted pages, and fork-to-many warm browsers; none of the SaaS clouds fork at fork(2) speed.
> - This pull request ships the headless-Chromium + CDP template, the warm-fork wiring (Chromium snapshotted live), the named-URL exposure path, an example, a recipe, and the threat-model delta, all verified end to end on real KVM.
> - The benefit is that an agent gets a forkable, hardware-isolated browser it drives over standard CDP, on your own infrastructure.

## Linked Issues or Issue Description

Closes #314

## What Changed

- `cmd/sandbox-server`: `POST /v1/templates` now accepts `workload` and `resources` (the fork engine already supported them; the standalone handler dropped them), so the warm-fork browser model and a memory override work on the no-Kubernetes path.
- `sdk/python`: `create_template` / `ensure_template` / `create` / `DirectSandbox.create` thread optional `workload` and `resources`.
- `images/computer-use`: a debian-slim image with Chromium and a CDP relay (multi-stage build compiles the relay from source); the launcher runs Chromium on internal loopback 9223 and the relay on the exposed 9222.
- `guest/agent-rs`: fix the #460 serving-workload readiness probe to use HTTP/1.1, not HTTP/1.0, which Chromium's DevTools server rejects (`Cannot handle request with protocol: HTTP/1.0`).
- `cmd/cdp-relay`: a new in-guest reverse proxy that sends the upstream host:port as Host (so Chromium's DevTools host-header check passes and the reflected host is rewritable) and rewrites the CDP discovery `webSocketDebuggerUrl` to the external origin from `X-Forwarded-Host`, falling back to the client Host on the host-forward path.
- `internal/daemon`: `ProxyHTTP` forwards `X-Forwarded-Host` / `X-Forwarded-Proto` (the ReverseProxy strips them before the Rewrite hook).
- Docs and CI: `sdk/python/examples/browser_cdp.py`, `docs/recipes/browser-automation.md`, a README row, a `docs/threat-model.md` 7c subsection for the CDP-exposure surface, a CI image-build + CDP smoke, and a publish-matrix entry.

## Verification

All of the following was run end to end on a bare-metal KVM host (Firecracker v1.15.0, kernel 6.1.155) with the standalone sandbox-server (carrying this branch's passthrough) and a debian-slim + Chromium rootfs. Spike record: `docs/superpowers/specs/2026-06-27-computer-use-cdp-spike-notes.md`.

- [x] Image builds; Chromium serves CDP (`webSocketDebuggerUrl` present).
- [x] Warm-fork: a Chromium serving workload reaches Ready and snapshots live (~17.5s); a fork wakes a warm browser in ~2.7s with CDP live from the snapshot.
- [x] Playwright `connect_over_cdp` drives Chromium (navigate, click, screenshot) over the host-forward path and through the relay (WebSocket hop).
- [x] Named-URL expose path: the relay turns the previous `500 Host header ...` into `200`, and `/json/version` is rewritten to `wss://<external-host>/devtools/...` from `X-Forwarded-Host`.
- [x] `sdk/python/examples/browser_cdp.py` runs against the real KVM server and prints `browser_cdp example OK`.
- [x] `go build` + `go test ./cmd/cdp-relay/ ./cmd/sandbox-server/ ./internal/daemon/` pass; gofmt clean.
- [x] `cd sdk/python && python3 -m pytest tests/` -> 301 passed, 1 skipped.
- [x] No em or en dashes anywhere in the diff.

The model-driving step (an LLM choosing CDP actions) uses the reader's own framework and credentials, as the recipe states.

## Risks

Medium: this adds a new internet-facing exposure surface (CDP is full remote control of the browser) and touches the expose reverse proxy. Mitigations and analysis are in the `docs/threat-model.md` 7c subsection: the in-guest relay is unprivileged and in the untrusted-guest trust domain; a spoofed `X-Forwarded-Host` only yields a self-inflicted bad ws URL (no SSRF, no unintended upstream, no header smuggling); Chromium `--no-sandbox` is acceptable because the microVM is the containment boundary; the CDP endpoint inherits the 7c production gate (auth-gated, never `public`, not cleared for untrusted tenants until #194 and #213).

## Model Used

- Claude Opus 4.8 (1M context), model id `claude-opus-4-8[1m]`, extended thinking enabled. Implementation via subagent-driven development (per-task implementer + reviewer, final whole-branch review on Opus).

## Checklist

- [x] PR title is a conventional commit (feat)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta included (docs/threat-model.md 7c)
- [x] Benchmark run: not applicable (no hot-path number claimed; fork/warm timings are reproducible on KVM per the spike notes)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer

## Named human reviewer required

Per `docs/security-review-policy.md` and CLAUDE.md, the `guest/agent-rs`, `internal/daemon`, and new `cmd/cdp-relay` changes are security-sensitive and need a named human reviewer before merge. This PR is intentionally NOT auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
