### PR TITLE
fix: accept mitos_ keys in hosted harness; env-configurable signup credit

### DIFF
--- a/cmd/console/onboarding.go
+++ b/cmd/console/onboarding.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,6 +63,18 @@ func mountOnboarding(mux *http.ServeMux, logger *slog.Logger, accounts *saas.Acc
 	}
 	if prov != nil {
 		opts = append(opts, onboarding.WithOrgProvisioner(prov))
+	}
+	// MITOS_CONSOLE_SIGNUP_CREDIT_CENTS overrides the signup credit for this
+	// deployment. When set to a positive integer it takes precedence over
+	// billing.DefaultSignupCredit; unset or non-positive values fall through
+	// to the default. Example: MITOS_CONSOLE_SIGNUP_CREDIT_CENTS=500 yields
+	// a $5.00 (500 cent) grant.
+	if m, ok := signupCreditFromEnv(); ok {
+		opts = append(opts, onboarding.WithSignupCredit(m))
+		logger.Info("onboarding signup credit overridden via env",
+			"env", "MITOS_CONSOLE_SIGNUP_CREDIT_CENTS",
+			"cents", int64(m),
+		)
 	}
 
 	// E2E QA seam: capture raw tokens in-process when MITOS_CONSOLE_E2E is set.
@@ -200,6 +213,25 @@ func onboardingScheme() *runtime.Scheme {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))
 	return scheme
+}
+
+// signupCreditFromEnv reads MITOS_CONSOLE_SIGNUP_CREDIT_CENTS and returns the
+// billing.Money value (minor-unit cents) and true when the env is set to a
+// positive integer. Invalid, zero, or negative values return 0, false so the
+// caller falls through to billing.DefaultSignupCredit.
+//
+// billing.Money is an int64 count of cents (100 = $1.00), so
+// MITOS_CONSOLE_SIGNUP_CREDIT_CENTS=500 yields billing.Money(500) = $5.00.
+func signupCreditFromEnv() (billing.Money, bool) {
+	s := strings.TrimSpace(os.Getenv("MITOS_CONSOLE_SIGNUP_CREDIT_CENTS"))
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return billing.Money(n), true
 }
 
 // devLogEmailSender is the development EmailSender: it logs that a verification

--- a/cmd/console/onboarding_test.go
+++ b/cmd/console/onboarding_test.go
@@ -111,6 +111,39 @@ func TestE2EEndpointNotMountedWhenFlagOff(t *testing.T) {
 	}
 }
 
+// TestSignupCreditFromEnv asserts that MITOS_CONSOLE_SIGNUP_CREDIT_CENTS=500
+// produces billing.Money(500) (500 cents = $5.00) and that invalid or unset
+// values return false so billing.DefaultSignupCredit applies.
+func TestSignupCreditFromEnv(t *testing.T) {
+	cases := []struct {
+		name      string
+		val       string
+		wantMoney billing.Money
+		wantOK    bool
+	}{
+		{"set to 500", "500", billing.Money(500), true},
+		{"set to 100", "100", billing.Money(100), true},
+		{"set to 10000", "10000", billing.Money(10000), true},
+		{"zero", "0", 0, false},
+		{"negative", "-1", 0, false},
+		{"invalid", "abc", 0, false},
+		{"empty", "", 0, false},
+		{"whitespace", "  500  ", billing.Money(500), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MITOS_CONSOLE_SIGNUP_CREDIT_CENTS", tc.val)
+			got, ok := signupCreditFromEnv()
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.wantMoney {
+				t.Fatalf("money = %v, want %v", got, tc.wantMoney)
+			}
+		})
+	}
+}
+
 // TestE2EEndpointMountedWhenFlagOn asserts GET /onboarding/e2e/token is reachable
 // (401 for missing bearer) when MITOS_CONSOLE_E2E is truthy.
 func TestE2EEndpointMountedWhenFlagOn(t *testing.T) {

--- a/test/hosted-e2e/verify_hosted.py
+++ b/test/hosted-e2e/verify_hosted.py
@@ -283,8 +283,8 @@ def step_verify(cfg: Config, token: str) -> tuple[str, str, str, str]:
             "verify",
             "200 but no apiKey (an idempotent re-verify returns no key; expected a fresh signup)",
         )
-    if not api_key.startswith("sk-"):
-        raise StepError("verify", f"apiKey does not look like an sk- key: {api_key[:6]}...")
+    if not (api_key.startswith("mitos_") or api_key.startswith("sk-")):
+        raise StepError("verify", f"apiKey has an unexpected format: {api_key[:6]}...")
     cookie = _extract_cookie(r.set_cookies, "mitos_session")
     if not cookie:
         raise StepError("verify", "200 with apiKey but no mitos_session Set-Cookie")


### PR DESCRIPTION
## Thinking Path

Two fixes that were verified live against app.mitos.run (10/10 signup+credit runs):

**FIX 1** (test/hosted-e2e/verify_hosted.py line 286): The verify step was asserting `api_key.startswith("sk-")`. Real hosted keys use the `mitos_live_...` / `mitos_test_...` format. The assertion is broadened to accept either prefix; the error message is updated to "apiKey has an unexpected format" to cover both shapes.

**FIX 2** (cmd/console/onboarding.go): The console binary was hardwired to `billing.DefaultSignupCredit()` ($100, 10000 cents). The hosted deploy needs to grant $5 (500 cents). A new `MITOS_CONSOLE_SIGNUP_CREDIT_CENTS` env var is read at startup; when set to a positive integer that value is passed as `billing.Money(cents)` to `onboarding.WithSignupCredit`. `billing.Money` is `type Money int64` (minor-unit cents), so `billing.Money(500)` = 500 cents = $5.00 exactly.

The logic lives in a new `signupCreditFromEnv()` helper (returns Money, bool) so the parse-and-validate path is unit-tested independently of the HTTP wiring.

## Verification

TDD: `TestSignupCreditFromEnv` was written and confirmed failing before the implementation was added.

- `go vet ./cmd/console/... ./internal/saas/...` clean
- `go test ./cmd/console/... ./internal/saas/billing/...` passed (3 packages, 0 failures)
- `python3 -m py_compile test/hosted-e2e/verify_hosted.py` clean

Note: `go build ./...` (link step) hits a disk-space error on this machine (`no space left on device` in `/var/folders`; disk is at 100%). The vet and test steps both passed, confirming no compilation errors in the changed packages.

## Model Used

Claude Sonnet 4.6