### PR TITLE
fix(gateway): handle POST/GET /v1/templates so hosted SDK create works

### DIFF
--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -468,6 +468,112 @@ func TestTokenNeverAppearsInErrorOrNonCreateResponse(t *testing.T) {
 	}
 }
 
+// ----- template.ensure / template.list -----
+
+// TestEnsureTemplateReturnsReadyDescriptor asserts Forward("template.ensure") with
+// a valid id returns 200 with a descriptor that matches the SDK-expected shape:
+// id, ready (true), and created_at. This is the critical path broken by the bug:
+// POST /v1/templates previously fell through to "sandbox.post" -> unknown op ->
+// NotFound; this test proves it now returns 200+ready.
+func TestEnsureTemplateReturnsReadyDescriptor(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c)
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "template.ensure", Body: []byte(`{"id":"python"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, body = %s (want 200+ready, got error)", resp.Status, resp.Body)
+	}
+	m := decodeBody(t, resp.Body)
+	if m["id"] != "python" {
+		t.Errorf("id = %v, want python", m["id"])
+	}
+	if m["ready"] != true {
+		t.Errorf("ready = %v, want true", m["ready"])
+	}
+	if m["created_at"] == nil || m["created_at"] == "" {
+		t.Errorf("created_at missing from descriptor: %v", m)
+	}
+}
+
+// TestEnsureTemplateRejectsEmptyID asserts Forward("template.ensure") with an
+// empty or missing id field returns 400. A caller cannot ensure a nameless template.
+func TestEnsureTemplateRejectsEmptyID(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c)
+	for _, body := range []string{`{}`, `{"id":""}`} {
+		resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+			OrgID: orgA, Op: "template.ensure", Body: []byte(body),
+		})
+		if resp.Status != http.StatusBadRequest {
+			t.Errorf("body=%q: status = %d, want 400; body = %s", body, resp.Status, resp.Body)
+		}
+	}
+}
+
+// TestListTemplatesReturnsPoolDescriptors asserts Forward("template.list") maps
+// existing SandboxPools to template descriptors. A pool with ReadySnapshots > 0
+// returns ready: true; one with none returns ready: false.
+func TestListTemplatesReturnsPoolDescriptors(t *testing.T) {
+	readyPool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "python", Namespace: "mitos-system"},
+		Status:     v1.SandboxPoolStatus{ReadySnapshots: 3},
+	}
+	emptyPool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "mitos-system"},
+		Status:     v1.SandboxPoolStatus{ReadySnapshots: 0},
+	}
+	c := newFakeClient(t, readyPool, emptyPool)
+	cp := New(c)
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "template.list",
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(resp.Body, &items); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	byID := map[string]map[string]any{}
+	for _, it := range items {
+		id, _ := it["id"].(string)
+		byID[id] = it
+	}
+	if _, ok := byID["python"]; !ok {
+		t.Errorf("python pool missing from template list: %v", byID)
+	}
+	if byID["python"]["ready"] != true {
+		t.Errorf("python ready = %v, want true (ReadySnapshots=3)", byID["python"]["ready"])
+	}
+	if byID["node"]["ready"] != false {
+		t.Errorf("node ready = %v, want false (ReadySnapshots=0)", byID["node"]["ready"])
+	}
+}
+
+// TestForwardUnknownOpReturnsNotFound is a regression guard asserting the fallback
+// ("sandbox.post", "sandbox.delete", etc.) still returns not_found, not a panic or
+// silent success.
+func TestForwardUnknownOpReturnsNotFound(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.post",
+	})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for unknown op", resp.Status)
+	}
+}
+
 // ----- test helpers -----
 
 // flipToReadyWhenCreated watches the org namespace for a newly created sandbox

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -44,6 +44,10 @@ func (k *K8sControlPlane) Forward(ctx context.Context, req saas.ForwardRequest) 
 		return k.terminate(ctx, req)
 	case "sandbox.runtime":
 		return k.proxy(ctx, req)
+	case "template.ensure":
+		return k.ensureTemplate(ctx, req)
+	case "template.list":
+		return k.listTemplates(ctx, req)
 	default:
 		return errResp(apierr.Get(apierr.CodeNotFound).
 			WithCause(fmt.Sprintf("unknown operation %q", req.Op))), nil

--- a/internal/saas/controlplane/template.go
+++ b/internal/saas/controlplane/template.go
@@ -1,0 +1,85 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// templateDescriptor is the template shape the SDK and standalone sandbox-server
+// agree on. The hosted path maps a named SandboxPool to this shape; the
+// standalone path records the snapshot build result. JSON tags must match
+// sandbox-server's templateInfo exactly so the SDK parses both consistently.
+type templateDescriptor struct {
+	ID        string    `json:"id"`
+	Ready     bool      `json:"ready"`
+	CreatedAt time.Time `json:"created_at"`
+	TimeMs    float64   `json:"creation_time_ms"`
+}
+
+// ensureTemplateBody is the create-template request shape sent by the Python SDK's
+// create_template / ensure_template call (POST /v1/templates).
+type ensureTemplateBody struct {
+	ID string `json:"id"`
+}
+
+// ensureTemplate handles the "template.ensure" op (POST /v1/templates). In the
+// hosted model a template maps to a SandboxPool: the SDK calls ensure_template
+// before forking to confirm the named pool is intended. This handler validates the
+// request body and returns a ready descriptor without creating any object. Actual
+// pool existence is checked by the controller when the caller forks: if no pool
+// carries the requested name the resulting Sandbox lands in Failed with a clear
+// human-readable condition message, which the SDK surfaces as an error. Auth and
+// org context flow through the standard gateway pipeline unchanged; this handler
+// adds no new privilege.
+//
+// An empty id is rejected 400. Any non-empty id is accepted and returns 200+ready
+// so the SDK create() can proceed to fork.
+func (k *K8sControlPlane) ensureTemplate(_ context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
+	var body ensureTemplateBody
+	if len(req.Body) > 0 {
+		if err := json.Unmarshal(req.Body, &body); err != nil {
+			return errResp(apierr.Get(apierr.CodeInvalidJSON).
+				WithCause("the template request body is not valid JSON")), nil
+		}
+	}
+	if body.ID == "" {
+		return errResp(apierr.Get(apierr.CodeInvalidJSON).
+			WithCause("template id is required: set \"id\" in the request body to the pool or image name")), nil
+	}
+	desc := templateDescriptor{
+		ID:        body.ID,
+		Ready:     true,
+		CreatedAt: k.now(),
+	}
+	return jsonResp(http.StatusOK, desc), nil
+}
+
+// listTemplates handles the "template.list" op (GET /v1/templates). It lists all
+// SandboxPools across all namespaces and maps each to a templateDescriptor so the
+// response shape matches the standalone sandbox-server (GET /v1/templates returns
+// []templateInfo). SandboxPools are cluster-wide shared infrastructure, not
+// per-tenant data, so listing without a namespace filter is correct here.
+// A pool with ReadySnapshots > 0 is reported as ready: true.
+func (k *K8sControlPlane) listTemplates(ctx context.Context, _ saas.ForwardRequest) (saas.ForwardResponse, error) {
+	var pools v1.SandboxPoolList
+	if err := k.c.List(ctx, &pools); err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).
+			WithCause("could not list available templates")), nil
+	}
+	items := make([]templateDescriptor, 0, len(pools.Items))
+	for i := range pools.Items {
+		p := &pools.Items[i]
+		items = append(items, templateDescriptor{
+			ID:        p.Name,
+			Ready:     p.Status.ReadySnapshots > 0,
+			CreatedAt: p.CreationTimestamp.Time,
+		})
+	}
+	return jsonResp(http.StatusOK, items), nil
+}

--- a/internal/saas/gateway.go
+++ b/internal/saas/gateway.go
@@ -61,7 +61,7 @@ func runtimeMethod(path string) (string, bool) {
 // scope. An unknown op requires the sandbox scope (fail closed).
 func requiredScopeFor(op string) string {
 	switch op {
-	case "sandbox.list", "sandbox.status":
+	case "sandbox.list", "sandbox.status", "template.list":
 		return ScopeReadOnly
 	default:
 		return ScopeSandboxes
@@ -153,6 +153,14 @@ func opFromPath(method, path string) string {
 		return "sandbox.status"
 	case strings.HasPrefix(p, "sandboxes/") && method == http.MethodDelete:
 		return "sandbox.terminate"
+	// Template operations: the SDK calls POST /v1/templates (ensure_template) before
+	// forking, and GET /v1/templates (list_templates) to discover available pools.
+	// Without these cases both fall through to "sandbox.<method>", which the control
+	// plane does not handle, producing "unknown operation" and breaking SDK create().
+	case p == "templates" && method == http.MethodPost:
+		return "template.ensure"
+	case p == "templates" && method == http.MethodGet:
+		return "template.list"
 	default:
 		return "sandbox." + strings.ToLower(method)
 	}

--- a/internal/saas/gateway_test.go
+++ b/internal/saas/gateway_test.go
@@ -338,6 +338,65 @@ func TestGatewayStreamsRuntimeResponse(t *testing.T) {
 	}
 }
 
+// TestGatewayTemplateEnsureRoutesAndForwards asserts POST /v1/templates is routed
+// as the "template.ensure" op, the org is correctly attached from the verified key
+// (not from the request body), and the control plane is reached exactly once.
+func TestGatewayTemplateEnsureRoutesAndForwards(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	f.cp.respBody = []byte(`{"id":"python","ready":true}`)
+	rec := doRequest(f.gw, http.MethodPost, "/v1/templates", f.rawA, `{"id":"python"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(f.cp.got) != 1 {
+		t.Fatalf("control plane saw %d requests, want 1", len(f.cp.got))
+	}
+	if f.cp.got[0].Op != "template.ensure" {
+		t.Errorf("op = %q, want template.ensure", f.cp.got[0].Op)
+	}
+	if f.cp.got[0].OrgID != "org-a" {
+		t.Errorf("OrgID = %q, want org-a (must come from the verified key, not the body)", f.cp.got[0].OrgID)
+	}
+}
+
+// TestGatewayTemplateEnsureRequiresAuth asserts POST /v1/templates without a
+// bearer key is rejected 401 and never reaches the control plane.
+func TestGatewayTemplateEnsureRequiresAuth(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	rec := doRequest(f.gw, http.MethodPost, "/v1/templates", "", `{"id":"python"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if code := decodeErr(t, rec); code != "unauthorized" {
+		t.Errorf("error code = %q, want unauthorized", code)
+	}
+	if len(f.cp.got) != 0 {
+		t.Error("control plane reached despite missing auth")
+	}
+}
+
+// TestGatewayTemplateListRoutesAsReadOp asserts GET /v1/templates routes as
+// "template.list" and accepts a read-only key (it is a read op, not a mutating
+// one, so the sandbox scope is not required).
+func TestGatewayTemplateListRoutesAsReadOp(t *testing.T) {
+	store := NewMemStore()
+	newTestOrg(t, store, "org-a")
+	keys := NewKeyService(store)
+	created, err := keys.CreateKey(context.Background(), CreateKeyRequest{OrgID: "org-a", Scopes: []string{ScopeReadOnly}})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	cp := &fakeControlPlane{respBody: []byte(`[]`)}
+	gw := NewGateway(keys, nil, cp, nil)
+	rec := doRequest(gw, http.MethodGet, "/v1/templates", created.RawKey, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(cp.got) != 1 || cp.got[0].Op != "template.list" {
+		t.Errorf("forwarded op = %+v, want template.list", cp.got)
+	}
+}
+
 // TestGatewayReadScopeAllowsList asserts a read-only key can list (a read op) but
 // the op is correctly classified so the read scope suffices.
 func TestGatewayReadScopeAllowsList(t *testing.T) {


### PR DESCRIPTION
## Thinking Path

The Python SDK `create("python")` calls `ensure_template` which POSTs to `/v1/templates`.
In `opFromPath`, that path had no case, so it fell through to the default:
`"sandbox." + strings.ToLower("POST")` = `"sandbox.post"`. The `Forward` switch
in `controlplane/forward.go` had no case for `"sandbox.post"`, so it returned
`unknown operation "sandbox.post"`, which the gateway mapped to a 404. The SDK
`raise_for_status` threw `NotFoundError` and `create()` was broken.

Fix: add two cases to `opFromPath`:
- `POST /v1/templates` maps to `"template.ensure"` (requires `ScopeSandboxes`)
- `GET /v1/templates` maps to `"template.list"` (requires `ScopeReadOnly`)

Add matching cases to `K8sControlPlane.Forward` delegating to new handlers in
`internal/saas/controlplane/template.go`.

`ensureTemplate` parses `{"id": "python"}`, rejects empty id (400), and returns
a ready `templateDescriptor` with 200. Pool existence is NOT checked at ensure
time; the controller surfaces a clear condition message on the Sandbox if the pool
is absent when the caller later forks.

`listTemplates` lists `SandboxPoolList` across all namespaces (pools are shared
cluster infrastructure, not per-tenant data) and maps each to a descriptor.
`Ready` is true when `ReadySnapshots > 0`.

Response shape matches the standalone sandbox-server `templateInfo` JSON tags
(`id`, `ready`, `created_at`, `creation_time_ms`) so both paths return
SDK-compatible JSON.

## Verification

```
go test ./internal/saas/... ./cmd/gateway/... -run 'Template|Gateway|Forward' -v
```

All 7 new tests pass; all pre-existing tests pass. `go build ./internal/saas/...
./cmd/gateway/...` and `go vet ./internal/saas/...` clean.

New tests:
- `TestGatewayTemplateEnsureRoutesAndForwards`: 200, op=template.ensure, OrgID from key
- `TestGatewayTemplateEnsureRequiresAuth`: 401 without key, CP never reached
- `TestGatewayTemplateListRoutesAsReadOp`: read-only key accepted for list, op=template.list
- `TestEnsureTemplateReturnsReadyDescriptor`: 200, id=python, ready=true, created_at set
- `TestEnsureTemplateRejectsEmptyID`: 400 for `{}` and `{"id":""}`
- `TestListTemplatesReturnsPoolDescriptors`: two pools, ready reflects ReadySnapshots
- `TestForwardUnknownOpReturnsNotFound`: regression guard for fallback

## Auth

Unchanged. Both new ops travel the full gateway pipeline: bearer extraction,
`keys.Verify`, quota check, `ForwardRequest.OrgID` from the verified key only.
`template.list` is `ScopeReadOnly`; `template.ensure` is `ScopeSandboxes`.
No secret is logged. The OrgID in the `ForwardRequest` is set by the gateway
from the verified key, never from the request body.

## Model Used

Claude Sonnet 4.6