### PR TITLE
feat(gateway): single-tenant-namespace override for the control plane

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -64,7 +64,7 @@ func newScheme() *runtime.Scheme {
 
 // newControlPlane builds the real control plane over an in-cluster
 // controller-runtime client.
-func newControlPlane(readyTimeout time.Duration, defaultPool string) (saas.ControlPlane, error) {
+func newControlPlane(readyTimeout time.Duration, defaultPool, singleTenantNS string) (saas.ControlPlane, error) {
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, err
@@ -77,6 +77,7 @@ func newControlPlane(readyTimeout time.Duration, defaultPool string) (saas.Contr
 	if defaultPool != "" {
 		opts = append(opts, controlplane.WithDefaultPool(defaultPool))
 	}
+	opts = append(opts, controlplane.WithSingleTenantNamespace(singleTenantNS))
 	return controlplane.New(c, opts...), nil
 }
 
@@ -85,6 +86,7 @@ func main() {
 	allowStub := flag.Bool("allow-stub", false, "DEV ONLY: forward to an in-memory stub control plane that creates nothing; the default is the real control plane")
 	readyTimeout := flag.Duration("ready-timeout", 120*time.Second, "how long a create waits for the sandbox to become Ready before returning a timeout error")
 	defaultPool := flag.String("default-pool", "", "fallback pool name used when a create request names neither a pool nor an image")
+	singleTenantNS := flag.String("single-tenant-namespace", os.Getenv("MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE"), "pin all sandbox operations to this fixed namespace instead of the per-org mitos-org-<id> namespace; use for QA deployments where per-org namespaces are not provisioned and a shared SandboxPool exists in this namespace; empty (the default) keeps per-org namespacing; org-label authz is preserved regardless")
 	databaseDSN := flag.String("database-dsn", "", "Postgres DSN for durable persistence (accounts, orgs, memberships, API keys). Falls back to the "+pgstore.EnvDSN+" env var. Empty means in-memory persistence (DEV ONLY). The value is a secret and is never logged.")
 	enforceQuota := flag.Bool("enforce-quota", true, "enforce per-organization quotas, rate limits, and the abuse kill-switch before forwarding. Default on (the hosted profile). Set to false only for a trusted single-tenant deployment; the bypass is logged at startup.")
 	trustedProxyHops := flag.Int("trusted-proxy-hops", 0, "number of trusted reverse-proxy hops in front of the gateway for client-IP resolution. 0 (the default) does NOT trust X-Forwarded-For and uses the connection RemoteAddr. Set to the count of trusted proxies (for example 1 behind a single ingress) so the per-IP rate limit keys on the real client; a too-short or spoofed X-Forwarded-For fails closed to RemoteAddr.")
@@ -107,12 +109,16 @@ func main() {
 		logger.Warn("gateway running with the DEV stub control plane; no sandboxes are created (--allow-stub)")
 		cp = stubControlPlane{}
 	} else {
-		real, err := newControlPlane(*readyTimeout, *defaultPool)
+		real, err := newControlPlane(*readyTimeout, *defaultPool, *singleTenantNS)
 		if err != nil {
 			log.Fatalf("build control plane: %v", err)
 		}
 		cp = real
-		logger.Info("gateway using the real control plane", "ready_timeout", readyTimeout.String(), "default_pool", *defaultPool)
+		if *singleTenantNS != "" {
+			logger.Info("gateway using the real control plane in single-tenant mode", "ready_timeout", readyTimeout.String(), "default_pool", *defaultPool, "single_tenant_namespace", *singleTenantNS)
+		} else {
+			logger.Info("gateway using the real control plane", "ready_timeout", readyTimeout.String(), "default_pool", *defaultPool)
+		}
 	}
 
 	// Build the quota/abuse enforcement surface: the real quota.Enforcer wrapped in

--- a/deploy/charts/charttest/gateway_test.go
+++ b/deploy/charts/charttest/gateway_test.go
@@ -63,6 +63,27 @@ func TestGatewayEnforcementOverridable(t *testing.T) {
 	mustContain(t, deploy, "--trusted-proxy-hops=1")
 }
 
+// TestGatewaySingleTenantNamespaceAbsentByDefault asserts the default render
+// does NOT inject MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE: the default is
+// per-org namespace mode and the QA override must be an explicit opt-in.
+func TestGatewaySingleTenantNamespaceAbsentByDefault(t *testing.T) {
+	out := render(t)
+	if strings.Contains(out, "MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE") {
+		t.Fatal("default render contains MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE; single-tenant mode must be an explicit opt-in")
+	}
+}
+
+// TestGatewaySingleTenantNamespaceRendersWhenSet asserts that setting
+// gateway.singleTenantNamespace injects MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE
+// as a plain env var into the gateway Deployment. The value is a namespace
+// name, not a secret, so a direct value (not secretKeyRef) is correct.
+func TestGatewaySingleTenantNamespaceRendersWhenSet(t *testing.T) {
+	out := render(t, "gateway.singleTenantNamespace=mitos")
+	deploy := section(t, out, "kind: Deployment", "mitos-gateway")
+	mustContain(t, deploy, "MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE")
+	mustContain(t, deploy, `value: "mitos"`)
+}
+
 // section returns the YAML document containing both marker and name, to scope an
 // assertion to one rendered resource.
 func section(t *testing.T, out, marker, name string) string {

--- a/deploy/charts/mitos/templates/gateway.yaml
+++ b/deploy/charts/mitos/templates/gateway.yaml
@@ -37,10 +37,14 @@ spec:
             - --addr=:8080
             - --enforce-quota={{ .Values.gateway.enforce.enabled }}
             - --trusted-proxy-hops={{ int .Values.gateway.enforce.trustedProxyHops }}
-          {{- if or .Values.database.dsnSecretRef.name (and .Values.telemetry.enabled .Values.telemetry.endpoint) }}
+          {{- if or .Values.database.dsnSecretRef.name (and .Values.telemetry.enabled .Values.telemetry.endpoint) .Values.gateway.singleTenantNamespace }}
           env:
             {{- include "mitos.database.env" . | nindent 12 }}
             {{- include "mitos.telemetry.env" . | nindent 12 }}
+            {{- if .Values.gateway.singleTenantNamespace }}
+            - name: MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE
+              value: {{ .Values.gateway.singleTenantNamespace | quote }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -442,6 +442,15 @@ gateway:
     limits:
       memory: "256Mi"
       cpu: "500m"
+  # Single-tenant namespace override. When non-empty, the gateway pins all
+  # sandbox create/status/list/terminate/proxy operations to this fixed
+  # namespace instead of the per-org mitos-org-<id> namespace. Use for QA
+  # deployments where per-org namespaces are not provisioned and a shared
+  # SandboxPool already exists in this namespace (e.g. "mitos"). Default
+  # empty (per-org namespacing, the production path). Org-label authz is
+  # preserved regardless: a key for org B cannot read or mutate org A's
+  # sandbox even in a shared namespace.
+  singleTenantNamespace: ""
   ingress:
     enabled: false
     className: ""

--- a/internal/saas/controlplane/controlplane.go
+++ b/internal/saas/controlplane/controlplane.go
@@ -8,11 +8,16 @@
 // Security: this is the cross-tenant boundary. The org id is taken ONLY from
 // ForwardRequest.OrgID (the gateway verified it from the customer key); a
 // customer can never influence it. Every Get, List, Delete, and proxy is scoped
-// to NamespaceForOrg(orgID) AND re-checks the mitos.run/org label on the object,
+// to namespaceForOrg(orgID) AND re-checks the mitos.run/org label on the object,
 // so a request that names another org's sandbox id returns not_found and never
 // mutates or reaches it. The per-sandbox token is read from the controller-owned
 // Secret and is returned to the caller ONLY on create (so the SDK can address the
 // sandbox directly); it is never logged and never placed in an error.
+//
+// Single-tenant mode: when WithSingleTenantNamespace is set all namespace
+// derivation is pinned to one fixed namespace (the shared pool namespace).
+// Org-label authz is still enforced in that mode: a key for org B cannot read
+// or mutate a sandbox owned by org A, even though both share the namespace.
 package controlplane
 
 import (
@@ -20,6 +25,8 @@ import (
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"mitos.run/mitos/internal/tenant"
 )
 
 // Defaults for the readiness poll. A create call blocks until the sandbox is
@@ -39,7 +46,13 @@ type K8sControlPlane struct {
 	// defaultPool is the pool a create request falls back to when it names neither
 	// a pool nor an image. Empty means a create without a pool is rejected.
 	defaultPool string
-	now          func() time.Time
+	// singleTenantNamespace, when non-empty, pins all sandbox operations to this
+	// fixed namespace instead of the per-org mitos-org-<id> namespace. Use only
+	// for QA deployments where per-org namespaces are not provisioned. Org-label
+	// authz is still enforced: sandboxes still carry the org label and cross-org
+	// checks still apply.
+	singleTenantNamespace string
+	now                   func() time.Time
 }
 
 // Option configures a K8sControlPlane.
@@ -79,6 +92,32 @@ func WithHTTPClient(h *http.Client) Option {
 			k.httpClient = h
 		}
 	}
+}
+
+// WithSingleTenantNamespace pins all sandbox operations to ns instead of the
+// per-org mitos-org-<id> namespace. When ns is empty the option is a no-op
+// and per-org namespacing applies. Use this ONLY for single-tenant QA
+// deployments where per-org namespaces are not provisioned: the shared pool
+// namespace (e.g. "mitos") already contains the SandboxPool and forkd can
+// reach it. Org-label authz is preserved: sandboxes still carry the org label
+// and cross-org access checks still reject keys for the wrong org, so a key
+// for org B cannot read or mutate org A's sandbox even in a shared namespace.
+func WithSingleTenantNamespace(ns string) Option {
+	return func(k *K8sControlPlane) {
+		if ns != "" {
+			k.singleTenantNamespace = ns
+		}
+	}
+}
+
+// namespaceForOrg returns the sandbox namespace for orgID. In single-tenant
+// mode (WithSingleTenantNamespace set) it returns the fixed namespace for all
+// orgs. Otherwise it delegates to tenant.NamespaceForOrg.
+func (k *K8sControlPlane) namespaceForOrg(orgID string) string {
+	if k.singleTenantNamespace != "" {
+		return k.singleTenantNamespace
+	}
+	return tenant.NamespaceForOrg(orgID)
 }
 
 // New builds a K8sControlPlane over the given controller-runtime client. The

--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -638,6 +638,154 @@ func TestCreateResponseIncludesTemplateIDAndForkTimeMs(t *testing.T) {
 	}
 }
 
+// ----- single-tenant namespace override -----
+
+// TestSingleTenantNamespaceAllOpsUseMitosNS asserts that when
+// WithSingleTenantNamespace("mitos") is set, create/status/terminate all use
+// "mitos" as the namespace, not the per-org mitos-org-<id> namespace. This
+// unblocks hosted QA where a shared pool exists in "mitos" but per-org
+// namespaces are not provisioned.
+func TestSingleTenantNamespaceAllOpsUseMitosNS(t *testing.T) {
+	const ns = "mitos"
+	c := newFakeClient(t)
+	cp := New(c,
+		WithPollInterval(5*time.Millisecond),
+		WithReadyTimeout(2*time.Second),
+		WithDefaultPool("python"),
+		WithSingleTenantNamespace(ns),
+	)
+
+	stop := flipToReadyWhenCreatedInNs(t, c, ns, "10.0.0.1:9091", "tok-single")
+	defer stop()
+
+	// create: must land in "mitos", not "mitos-org-alpha".
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"python"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward create: %v", err)
+	}
+	if resp.Status != http.StatusCreated {
+		t.Fatalf("create: status = %d, body = %s", resp.Status, resp.Body)
+	}
+	m := decodeBody(t, resp.Body)
+	id, _ := m["id"].(string)
+	if id == "" {
+		t.Fatalf("create response missing id: %v", m)
+	}
+
+	// Sandbox must exist in "mitos".
+	var sb v1.Sandbox
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: id}, &sb); err != nil {
+		t.Fatalf("sandbox not found in namespace %q: %v", ns, err)
+	}
+	if sb.Namespace != ns {
+		t.Errorf("namespace = %q, want %q", sb.Namespace, ns)
+	}
+	// Org label must still be set for authz.
+	if sb.Labels[tenant.OrgLabelKey] != orgA {
+		t.Errorf("org label = %q, want %q", sb.Labels[tenant.OrgLabelKey], orgA)
+	}
+	// Must NOT exist in the per-org namespace.
+	var wrongSB v1.Sandbox
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgA), Name: id}, &wrongSB); err == nil {
+		t.Errorf("sandbox found in per-org namespace %q; it should only be in %q", tenant.NamespaceForOrg(orgA), ns)
+	}
+
+	// status: must find the sandbox in "mitos".
+	resp, _ = cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.status", Path: "/v1/sandboxes/" + id,
+	})
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status: status = %d, body = %s", resp.Status, resp.Body)
+	}
+
+	// terminate: must delete from "mitos".
+	resp, _ = cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.terminate", Path: "/v1/sandboxes/" + id,
+	})
+	if resp.Status != http.StatusNoContent {
+		t.Fatalf("terminate: status = %d, body = %s", resp.Status, resp.Body)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: id}, &sb); err == nil {
+		t.Error("sandbox still exists in mitos namespace after terminate")
+	}
+}
+
+// TestSingleTenantNamespaceCrossOrgAuthzPreserved asserts that single-tenant
+// mode does NOT weaken org-label authz: org A cannot read or delete org B's
+// sandbox even though both share the fixed namespace. The org-label check, not
+// the namespace, is the authz boundary in single-tenant mode.
+func TestSingleTenantNamespaceCrossOrgAuthzPreserved(t *testing.T) {
+	const ns = "mitos"
+	// Pre-seed a sandbox in "mitos" labeled for org B.
+	sb := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sb-orgb-shared",
+			Namespace: ns,
+			Labels:    tenant.OrgLabels(orgB),
+		},
+		Status: v1.SandboxStatus{Phase: v1.SandboxReady, Endpoint: "2.2.2.2:9091"},
+	}
+	c := newFakeClient(t, sb)
+	cp := New(c, WithSingleTenantNamespace(ns))
+
+	// org A must not read org B's sandbox.
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.status", Path: "/v1/sandboxes/sb-orgb-shared",
+	})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("cross-org status in single-tenant mode: status = %d, want 404 (org-label authz broken)", resp.Status)
+	}
+
+	// org A must not terminate org B's sandbox.
+	resp, _ = cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.terminate", Path: "/v1/sandboxes/sb-orgb-shared",
+	})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("cross-org terminate in single-tenant mode: status = %d, want 404 (org-label authz broken)", resp.Status)
+	}
+	// Sandbox must survive.
+	var got v1.Sandbox
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: "sb-orgb-shared"}, &got); err != nil {
+		t.Fatalf("org B sandbox was deleted by org A in single-tenant mode: %v", err)
+	}
+}
+
+// TestSingleTenantNamespaceEmptyIsNoOp asserts WithSingleTenantNamespace("")
+// is a no-op: the per-org namespace is still used, preserving the
+// mitos-org-alpha default-mode behavior.
+func TestSingleTenantNamespaceEmptyIsNoOp(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c,
+		WithPollInterval(5*time.Millisecond),
+		WithReadyTimeout(2*time.Second),
+		WithDefaultPool("default"),
+		WithSingleTenantNamespace(""),
+	)
+	stop := flipToReadyWhenCreated(t, c, orgA, "10.0.0.1:9091", "tok")
+	defer stop()
+
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"default"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	id, _ := decodeBody(t, resp.Body)["id"].(string)
+
+	var sb v1.Sandbox
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: tenant.NamespaceForOrg(orgA), Name: id}, &sb); err != nil {
+		t.Fatalf("sandbox not in per-org namespace (empty WithSingleTenantNamespace must be a no-op): %v", err)
+	}
+	if sb.Namespace != "mitos-org-alpha" {
+		t.Errorf("namespace = %q, want mitos-org-alpha", sb.Namespace)
+	}
+}
+
 // ----- test helpers -----
 
 // flipToReadyWhenCreated watches the org namespace for a newly created sandbox
@@ -662,6 +810,53 @@ func flipWhenCreated(t *testing.T, c client.Client, org string, mutate func(*v1.
 	var once sync.Once
 	go func() {
 		ns := tenant.NamespaceForOrg(org)
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			var list v1.SandboxList
+			if err := c.List(context.Background(), &list, client.InNamespace(ns)); err == nil {
+				for i := range list.Items {
+					sb := &list.Items[i]
+					if sb.Status.Phase == "" {
+						mutate(sb)
+						_ = c.Status().Update(context.Background(), sb)
+						return
+					}
+				}
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
+}
+
+// flipToReadyWhenCreatedInNs is the namespace-explicit counterpart to
+// flipToReadyWhenCreated, used by single-tenant tests where the sandbox lands
+// in a fixed namespace rather than a per-org namespace.
+func flipToReadyWhenCreatedInNs(t *testing.T, c client.Client, ns, endpoint, token string) (stop func()) {
+	t.Helper()
+	return flipWhenCreatedInNs(t, c, ns, func(sb *v1.Sandbox) {
+		sb.Status.Phase = v1.SandboxReady
+		sb.Status.Endpoint = endpoint
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: sb.Name + tokenSecretSuffix, Namespace: sb.Namespace},
+			Data:       map[string][]byte{"token": []byte(token), "endpoint": []byte(endpoint)},
+		}
+		_ = c.Create(context.Background(), secret)
+	})
+}
+
+// flipWhenCreatedInNs polls ns until a sandbox appears, then applies mutate to
+// its status. It is the namespace-explicit counterpart to flipWhenCreated.
+func flipWhenCreatedInNs(t *testing.T, c client.Client, ns string, mutate func(*v1.Sandbox)) (stop func()) {
+	t.Helper()
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
 			select {

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -116,7 +116,7 @@ func (k *K8sControlPlane) create(ctx context.Context, req saas.ForwardRequest) (
 			WithCause("the create request names neither a pool nor an image and no default pool is configured")), nil
 	}
 
-	ns := tenant.NamespaceForOrg(req.OrgID)
+	ns := k.namespaceForOrg(req.OrgID)
 	name := generateName()
 
 	sb := &v1.Sandbox{
@@ -279,7 +279,7 @@ func (k *K8sControlPlane) status(ctx context.Context, req saas.ForwardRequest) (
 
 // list returns every sandbox in the org namespace carrying the org label.
 func (k *K8sControlPlane) list(ctx context.Context, req saas.ForwardRequest) (saas.ForwardResponse, error) {
-	ns := tenant.NamespaceForOrg(req.OrgID)
+	ns := k.namespaceForOrg(req.OrgID)
 	var sbs v1.SandboxList
 	err := k.c.List(ctx, &sbs,
 		client.InNamespace(ns),
@@ -328,7 +328,7 @@ func (k *K8sControlPlane) terminate(ctx context.Context, req saas.ForwardRequest
 // collapsing both to not_found so a cross-org probe cannot map ids. The org id is
 // taken ONLY from the verified request.
 func (k *K8sControlPlane) getOwned(ctx context.Context, orgID, name string) (*v1.Sandbox, bool) {
-	ns := tenant.NamespaceForOrg(orgID)
+	ns := k.namespaceForOrg(orgID)
 	var sb v1.Sandbox
 	if err := k.c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &sb); err != nil {
 		return nil, false


### PR DESCRIPTION
## Thinking Path

Unblocks hosted QA create+fork without per-org provisioning. The root cause: `Forward()` derives the sandbox namespace as `tenant.NamespaceForOrg(req.OrgID)` = `mitos-org-<id>`, but in the QA slice those per-org namespaces are not provisioned. A `python` SandboxPool already exists in the `mitos` namespace with forkd on the bare-metal box.

Fix: one helper `namespaceForOrg(orgID)` on `K8sControlPlane`. When `singleTenantNamespace` is set it returns that fixed namespace; otherwise it delegates to `tenant.NamespaceForOrg`. All three `tenant.NamespaceForOrg` call sites in `forward.go` (`create`, `list`, `getOwned`) route through it. `proxy` and `status`/`terminate` reach the same helper via `getOwned`, so no path is left on the old derivation.

Org-label authz is preserved. Sandboxes still carry the `mitos.run/org` label on create. `getOwned` re-checks the label on every read/delete, so a key for org B returns 404 and never touches org A's sandbox even in a shared namespace. The existing `TestCrossTenantSameNamespaceMislabeledIsNotFound` (mislabeled object in the same namespace) still passes.

Per-org tenancy is the production path. The default (`singleTenantNamespace = ""`) is unchanged: `namespaceForOrg` falls through to `tenant.NamespaceForOrg`. No existing behavior changes.

## Namespace derivation call sites routed through namespaceForOrg

All three sites in `internal/saas/controlplane/forward.go`:
1. `create()` line 103: `ns := k.namespaceForOrg(req.OrgID)` (was `tenant.NamespaceForOrg`)
2. `list()` line 255: `ns := k.namespaceForOrg(req.OrgID)` (was `tenant.NamespaceForOrg`)
3. `getOwned()` line 304: `ns := k.namespaceForOrg(orgID)` (was `tenant.NamespaceForOrg`)

`proxy` calls `getOwned` so it picks up site 3. `status` and `terminate` also call `getOwned`. No call site missed.

## Verification

```
go build ./internal/saas/... ./cmd/gateway/...   clean
go vet ./internal/saas/... ./cmd/gateway/...      clean
go test ./internal/saas/controlplane/... -v       26/26 PASS
go test ./deploy/charts/charttest/... -run Gateway 8/8 PASS
```

New tests:
- `TestSingleTenantNamespaceAllOpsUseMitosNS`: create lands in "mitos", status returns 200, terminate returns 204; sandbox absent from per-org namespace.
- `TestSingleTenantNamespaceCrossOrgAuthzPreserved`: org A gets 404 on org B's sandbox (status + terminate); sandbox survives.
- `TestSingleTenantNamespaceEmptyIsNoOp`: empty option still routes to `mitos-org-alpha`.
- `TestGatewaySingleTenantNamespaceAbsentByDefault`: env var absent from default chart render.
- `TestGatewaySingleTenantNamespaceRendersWhenSet`: env var present when `gateway.singleTenantNamespace=mitos`.

All 23 pre-existing controlplane tests pass.

## Chart value

`gateway.singleTenantNamespace` (default `""`). When set, the gateway Deployment gets `MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE=<value>` as a plain env var (not a secret; namespace names are not sensitive). The `--single-tenant-namespace` flag reads from the env fallback `MITOS_GATEWAY_SINGLE_TENANT_NAMESPACE`, so both the flag and the chart env wire are effective.

## Model Used

Claude Sonnet 4.6