### PR TITLE
fix(husk-stub): remove stale per-vm jailer chroot before start so retries do not fail MkdirOldRoot

### DIFF
--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -167,6 +167,24 @@ func startJailedVM(cfg VMConfig) (*Client, error) {
 	}()
 
 	chrootDir := jailerChrootDir(cfg.Jailer.ChrootBaseDir, id)
+
+	// Before creating the fresh chroot tree, remove any stale per-vm dir left
+	// by a prior aborted launch of this vm-id. The jailer creates
+	// <vmDir>/root/ (the chroot root) and then mkdir <chroot>/old_root inside
+	// it for pivot_root(2); a leftover old_root from a prior failed run causes
+	// MkdirOldRoot(EEXIST) and the jailer refuses to start. Removing the entire
+	// per-vm dir (strictly within ChrootBaseDir, verified by guardJailerLayout
+	// above) starts fresh and lets the jailer succeed on a retry. Path only is
+	// logged; no secrets are involved. Mirrors the control-socket os.Remove in
+	// the direct-exec path.
+	vmDir := jailerVMDir(cfg.Jailer.ChrootBaseDir, id)
+	if _, statErr := os.Stat(vmDir); statErr == nil {
+		fmt.Fprintf(os.Stderr, "firecracker: removing stale jailer dir %s before launch\n", vmDir)
+		if err := os.RemoveAll(vmDir); err != nil {
+			return nil, fmt.Errorf("remove stale jailer dir %s before launch: %w", vmDir, err)
+		}
+	}
+
 	if err := os.MkdirAll(filepath.Join(chrootDir, "run"), 0o755); err != nil {
 		return nil, fmt.Errorf("create chroot run dir: %w", err)
 	}

--- a/internal/firecracker/jailer_test.go
+++ b/internal/firecracker/jailer_test.go
@@ -568,6 +568,82 @@ func TestStartVMJailedReleasesUIDOnLaunchFailure(t *testing.T) {
 	}
 }
 
+// TestStartVMJailedCleansStaleChroot verifies that startJailedVM removes any
+// stale per-vm jailer dir from a prior aborted launch before creating a fresh
+// chroot. The jailer binary creates <vmDir>/root/ (the chroot root) and then
+// mkdir <chroot>/old_root inside it for pivot_root(2). A leftover old_root from
+// a prior run causes MkdirOldRoot(EEXIST) and the jailer refuses to start. The
+// cleanup must be scoped strictly to THIS vm-id's directory; a sibling vm-id
+// dir must not be touched.
+func TestStartVMJailedCleansStaleChroot(t *testing.T) {
+	root := t.TempDir()
+	jailBase := filepath.Join(root, "jail")
+	dataDir := filepath.Join(root, "data")
+	vmID := "vm-clean"
+	siblingID := "vm-sibling"
+
+	// Pre-create the exact stale artifact the jailer's MkdirOldRoot trips over:
+	// <vmDir>/root/old_root left by a prior pivot_root setup.
+	staleOldRoot := filepath.Join(jailerChrootDir(jailBase, vmID), "old_root")
+	if err := os.MkdirAll(staleOldRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A sibling vm's dir must survive untouched.
+	siblingDir := jailerVMDir(jailBase, siblingID)
+	if err := os.MkdirAll(siblingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultVMConfig()
+	cfg.ID = vmID
+	cfg.WorkDir = filepath.Join(dataDir, "sandboxes", vmID)
+	cfg.Jailer = testJailerConfig(jailBase, dataDir)
+	cfg.Jailer.JailerBin = filepath.Join(root, "no-such-jailer")
+	cfg.Jailer.UIDRange = [2]uint32{64000, 64000}
+	cfg.Jailer.Allocator = NewUIDAllocator(64000, 64000)
+
+	// StartVM fails (no jailer binary) but must clean the stale dir first.
+	if _, err := StartVM(cfg); err == nil {
+		t.Fatal("StartVM succeeded with a nonexistent jailer binary")
+	}
+
+	// The stale old_root must be gone: the cleanup removed the entire vmDir
+	// before MkdirAll re-created it fresh (without old_root inside it).
+	if _, err := os.Stat(staleOldRoot); !os.IsNotExist(err) {
+		t.Fatalf("stale old_root dir %s was not cleaned; stat err = %v", staleOldRoot, err)
+	}
+
+	// The sibling vm-id's dir must be untouched.
+	if _, err := os.Stat(siblingDir); err != nil {
+		t.Fatalf("sibling jailer dir %s was unexpectedly removed: %v", siblingDir, err)
+	}
+}
+
+// TestStartVMJailedStaleCleanIsNoop verifies that the stale-chroot cleanup is a
+// no-op when no leftover dir exists: StartVM must not fail or panic because the
+// per-vm jailer dir is absent before launch.
+func TestStartVMJailedStaleCleanIsNoop(t *testing.T) {
+	root := t.TempDir()
+	cfg := DefaultVMConfig()
+	cfg.ID = "vm-noop"
+	cfg.WorkDir = filepath.Join(root, "data", "sandboxes", "vm-noop")
+	cfg.Jailer = testJailerConfig(filepath.Join(root, "jail"), filepath.Join(root, "data"))
+	cfg.Jailer.JailerBin = filepath.Join(root, "no-such-jailer")
+	cfg.Jailer.UIDRange = [2]uint32{64000, 64000}
+	cfg.Jailer.Allocator = NewUIDAllocator(64000, 64000)
+
+	// No stale dir exists. StartVM must fail only because the jailer binary is
+	// absent, not because the cleanup itself errored on a missing dir.
+	_, err := StartVM(cfg)
+	if err == nil {
+		t.Fatal("StartVM succeeded with a nonexistent jailer binary")
+	}
+	if strings.Contains(err.Error(), "remove stale jailer dir") {
+		t.Fatalf("StartVM reported a stale-dir removal error when no stale dir existed: %v", err)
+	}
+}
+
 func TestClientHostPath(t *testing.T) {
 	direct := &Client{}
 	if got := direct.HostPath("/var/lib/mitos/sandboxes/s1/vsock.sock"); got != "/var/lib/mitos/sandboxes/s1/vsock.sock" {


### PR DESCRIPTION
## Thinking Path

The Firecracker jailer creates `<ChrootBaseDir>/firecracker/<vm-id>/` as its per-vm workspace and then `mkdir <chroot>/old_root` inside it for `pivot_root(2)`. On a pod restart (same pod name = same vm-id), the prior run's directory is still present on the node filesystem. The jailer's `MkdirOldRoot` call then fails with `EEXIST` and refuses to start, causing:

```
husk activation failed: load snapshot ... dial unix /run/husk/vm/firecracker.sock: connect: connection refused
```

The existing codebase already handles the analogous control-socket case in `cmd/husk-stub/main.go`:

```go
// Fresh control socket; a stale file from a prior run would block bind.
_ = os.Remove(*controlSocket)
```

The same pattern applies to the jailer chroot dir. The fix: in `startJailedVM` (`internal/firecracker/client.go`), after `guardJailerLayout` has verified the per-vm path is bounded within `ChrootBaseDir`, check whether the per-vm dir already exists and `os.RemoveAll` it before the fresh `os.MkdirAll`. The jailer then sees a clean directory and `MkdirOldRoot` succeeds.

The cleanup is placed in `startJailedVM` rather than in `cmd/husk-stub/main.go` because `internal/firecracker` owns the chroot path layout (`jailerVMDir`). The fix benefits any caller of `startJailedVM` (both forkd and any future husk-stub jailer configuration).

## Verification

Tests added to `internal/firecracker/jailer_test.go`:

- `TestStartVMJailedCleansStaleChroot`: pre-creates `<chroot>/old_root` for a vm-id, calls `StartVM` (fails: no jailer binary), asserts that `old_root` is gone and a sibling vm-id dir is untouched.
- `TestStartVMJailedStaleCleanIsNoop`: calls `StartVM` with no pre-existing stale dir, asserts no removal error is reported.

```
go test ./cmd/husk-stub/... ./internal/firecracker/... ./cmd/forkd/... -run 'Chroot|Jailer|Husk|Clean|Stale' -v
PASS (all existing + new tests)

go build ./cmd/husk-stub/... ./cmd/forkd/...  BUILD OK
go vet ./cmd/... ./internal/firecracker/...   VET OK
```

## Isolation unchanged

This PR does NOT change the jailer's isolation behavior, uid mapping, or the `pivot_root` mechanism. It only ensures the per-vm jailer workspace is clean before the jailer binary starts, exactly analogous to the existing control-socket cleanup. The `docs/threat-model.md` isolation surface is unchanged.

The scope of `os.RemoveAll` is strictly `jailerVMDir(ChrootBaseDir, vmID)` = `<ChrootBaseDir>/firecracker/<vmID>`. The path is verified safe by `guardJailerLayout` (which runs before the cleanup and rejects any vm-id that would escape `ChrootBaseDir`).

## Model Used

Claude Opus 4.8 (1M context)