### PR TITLE
fix(frontdoor): route /webhooks/* to console as public (was 302 to login)

### DIFF
--- a/internal/frontdoor/router.go
+++ b/internal/frontdoor/router.go
@@ -33,14 +33,16 @@ var marketingSegments = map[string]bool{
 }
 
 // authSegments are the first-segment values that map to the console upstream
-// but do NOT require a session (login, signup, verification, and onboarding
-// are all public-facing flows).
+// but do NOT require a session (login, signup, verification, onboarding, and
+// webhook ingress are all public-facing flows). Billing providers POST to
+// /webhooks/* without a session; the console handler is signature-gated.
 var authSegments = map[string]bool{
 	"login":      true,
 	"signup":     true,
 	"verify":     true,
 	"auth":       true,
 	"onboarding": true,
+	"webhooks":   true,
 }
 
 // appSegments are the first-segment values that map to the console upstream

--- a/internal/frontdoor/router_test.go
+++ b/internal/frontdoor/router_test.go
@@ -38,6 +38,11 @@ func TestDecide(t *testing.T) {
 		{"/onboarding", "console", false, false},
 		{"/onboarding/org", "console", false, false},
 
+		// Webhook paths: console, no session required. Billing providers POST
+		// without a session so this must be public, exactly like onboarding.
+		{"/webhooks/billing", "console", false, false},
+		{"/webhooks/anything", "console", false, false},
+
 		// App paths: console, session required.
 		{"/console", "console", true, false},
 		{"/console/keys", "console", true, false},


### PR DESCRIPTION
## Thinking Path

The `Decide` function in `internal/frontdoor/router.go` routes by first path segment. `/webhooks/billing` has first segment `webhooks`, which was absent from all three segment maps (`marketingSegments`, `authSegments`, `appSegments`). It therefore fell through to the org-slug catch-all at line 97, returning `{Upstream: "console", RequireSession: true}`. The front-door middleware then 302-redirected any anonymous POST (billing provider webhook) to `/login` before it could reach the console handler that is itself signature-gated and public by design.

Fix: add `"webhooks": true` to `authSegments` (the public-console map, same mechanism as `onboarding`). One line change; no other routing is affected.

TDD sequence followed:
1. Added two failing table rows (`/webhooks/billing`, `/webhooks/anything`) asserting `Upstream=console, RequireSession=false`.
2. Ran `go test ./internal/frontdoor/... -run TestDecide -v`; both rows failed with `RequireSession = true, want false`.
3. Added `"webhooks": true` to `authSegments`.
4. Re-ran; all 33 cases passed.

## Verification

```
go test ./internal/frontdoor/... -run TestDecide -v   PASS (33/33)
go build ./cmd/frontdoor/...                          clean
golangci-lint run --timeout=5m ./internal/frontdoor/... clean
GOOS=linux golangci-lint run --timeout=5m ./internal/frontdoor/... clean
```

## Model Used

Claude Sonnet 4.6

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>