### PR TITLE
feat(console): show social login buttons only for configured connectors

### DIFF
--- a/cmd/console/capabilities.go
+++ b/cmd/console/capabilities.go
@@ -1,11 +1,23 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	"mitos.run/mitos/internal/saas/console"
 )
+
+// knownAuthConnectors is the closed set of social-login provider identifiers
+// the console recognises. Values outside this set are silently dropped so a
+// misconfigured env var does not expose unexpected connector URLs.
+var knownAuthConnectors = map[string]bool{
+	"github": true,
+	"google": true,
+}
 
 // capabilitiesFromEnv builds the console capabilities document from the
 // server-controlled environment the Helm chart sets. This is the single source
@@ -25,15 +37,64 @@ func capabilitiesFromEnv() console.Capabilities {
 		orgSwitcher = true
 	}
 	return console.Capabilities{
-		Edition:     edition,
-		Billing:     envBool("MITOS_CONSOLE_BILLING"),
-		Signup:      envBool("MITOS_CONSOLE_SIGNUP"),
-		Teams:       true,
-		IDP:         "oidc",
-		OrgSwitcher: orgSwitcher,
-		Secrets:     console.SecretsCapability{Providers: providers},
-		Proof:       true,
-		Ownership:   ownership,
+		Edition:        edition,
+		Billing:        envBool("MITOS_CONSOLE_BILLING"),
+		Signup:         envBool("MITOS_CONSOLE_SIGNUP"),
+		Teams:          true,
+		IDP:            "oidc",
+		OrgSwitcher:    orgSwitcher,
+		Secrets:        console.SecretsCapability{Providers: providers},
+		Proof:          true,
+		Ownership:      ownership,
+		AuthConnectors: parseAuthConnectors(os.Getenv("MITOS_CONSOLE_AUTH_CONNECTORS")),
+	}
+}
+
+// parseAuthConnectors splits a comma-separated connector list, filters to
+// known providers, deduplicates, and sorts. Unknown values are silently
+// dropped. The result is always non-nil (empty slice, not nil) so the JSON
+// field serialises as [] rather than null when no connectors are configured.
+func parseAuthConnectors(raw string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, v := range splitNonEmpty(raw) {
+		if knownAuthConnectors[v] && !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	if out == nil {
+		out = []string{}
+	}
+	return out
+}
+
+// newAuthConnectorsHandler returns a PUBLIC http.HandlerFunc for
+// GET /auth/connectors. It responds with the connector list from caps so the
+// Login/Signup SPA pages can render only the social-login buttons for
+// providers that are actually wired up. No auth cookie is required: the
+// response carries no org data, only server-controlled provider names.
+func newAuthConnectorsHandler(caps console.Capabilities) http.HandlerFunc {
+	// Capture the slice at startup; it is immutable for the lifetime of the
+	// process (capabilities change only on redeploy).
+	connectors := caps.AuthConnectors
+	if connectors == nil {
+		connectors = []string{}
+	}
+	type response struct {
+		Connectors []string `json:"connectors"`
+	}
+	body, err := json.Marshal(response{Connectors: connectors})
+	if err != nil {
+		// json.Marshal on a []string never errors; this branch is unreachable
+		// in practice, but keeps the compiler and errcheck satisfied.
+		panic(fmt.Sprintf("newAuthConnectorsHandler: marshal: %v", err))
+	}
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
 	}
 }
 

--- a/cmd/console/capabilities_test.go
+++ b/cmd/console/capabilities_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"mitos.run/mitos/internal/saas/console"
+)
 
 // TestCapabilitiesFromEnvDefaultsToCommunity asserts that, with no env set, the
 // binary advertises the self-hosted community edition with the #208 gate held
@@ -32,4 +39,114 @@ func TestCapabilitiesFromEnvHosted(t *testing.T) {
 	if len(c.Secrets.Providers) != 2 || c.Secrets.Providers[1] != "openbao" {
 		t.Fatalf("providers = %v, want [kube openbao]", c.Secrets.Providers)
 	}
+}
+
+// TestCapabilitiesFromEnvConnectors asserts MITOS_CONSOLE_AUTH_CONNECTORS
+// controls which social-login buttons the SPA renders. Only "github" and
+// "google" are known; unknown values are silently dropped; empty yields none.
+func TestCapabilitiesFromEnvConnectors(t *testing.T) {
+	clearBase := func(t *testing.T) {
+		t.Helper()
+		for _, k := range []string{"MITOS_CONSOLE_EDITION", "MITOS_CONSOLE_BILLING", "MITOS_CONSOLE_SIGNUP", "MITOS_CONSOLE_SECRET_PROVIDERS", "MITOS_CONSOLE_AUTH_CONNECTORS"} {
+			t.Setenv(k, "")
+		}
+	}
+
+	t.Run("github only", func(t *testing.T) {
+		clearBase(t)
+		t.Setenv("MITOS_CONSOLE_AUTH_CONNECTORS", "github")
+		c := capabilitiesFromEnv()
+		if len(c.AuthConnectors) != 1 || c.AuthConnectors[0] != "github" {
+			t.Fatalf("authConnectors = %v, want [github]", c.AuthConnectors)
+		}
+	})
+
+	t.Run("both providers sorted", func(t *testing.T) {
+		clearBase(t)
+		t.Setenv("MITOS_CONSOLE_AUTH_CONNECTORS", "google,github")
+		c := capabilitiesFromEnv()
+		if len(c.AuthConnectors) != 2 || c.AuthConnectors[0] != "github" || c.AuthConnectors[1] != "google" {
+			t.Fatalf("authConnectors = %v, want [github google]", c.AuthConnectors)
+		}
+	})
+
+	t.Run("unknown values dropped", func(t *testing.T) {
+		clearBase(t)
+		t.Setenv("MITOS_CONSOLE_AUTH_CONNECTORS", "github,gitlab,okta")
+		c := capabilitiesFromEnv()
+		if len(c.AuthConnectors) != 1 || c.AuthConnectors[0] != "github" {
+			t.Fatalf("authConnectors = %v, want [github] (unknown dropped)", c.AuthConnectors)
+		}
+	})
+
+	t.Run("empty yields no social buttons", func(t *testing.T) {
+		clearBase(t)
+		// MITOS_CONSOLE_AUTH_CONNECTORS is already empty from clearBase.
+		c := capabilitiesFromEnv()
+		if len(c.AuthConnectors) != 0 {
+			t.Fatalf("authConnectors = %v, want []", c.AuthConnectors)
+		}
+	})
+
+	t.Run("duplicates deduplicated", func(t *testing.T) {
+		clearBase(t)
+		t.Setenv("MITOS_CONSOLE_AUTH_CONNECTORS", "github,github,google")
+		c := capabilitiesFromEnv()
+		if len(c.AuthConnectors) != 2 || c.AuthConnectors[0] != "github" || c.AuthConnectors[1] != "google" {
+			t.Fatalf("authConnectors = %v, want [github google]", c.AuthConnectors)
+		}
+	})
+}
+
+// TestAuthConnectorsEndpoint asserts the public GET /auth/connectors handler
+// returns the correct JSON payload without requiring a session. This endpoint
+// is the pre-auth data source the SPA Login/Signup pages consume to render
+// only the social-login buttons for configured providers.
+func TestAuthConnectorsEndpoint(t *testing.T) {
+	type resp struct {
+		Connectors []string `json:"connectors"`
+	}
+
+	hit := func(t *testing.T, caps console.Capabilities) resp {
+		t.Helper()
+		h := newAuthConnectorsHandler(caps)
+		r := httptest.NewRequest(http.MethodGet, "/auth/connectors", nil)
+		w := httptest.NewRecorder()
+		h(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d", w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		var got resp
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return got
+	}
+
+	t.Run("github only", func(t *testing.T) {
+		got := hit(t, console.Capabilities{AuthConnectors: []string{"github"}})
+		if len(got.Connectors) != 1 || got.Connectors[0] != "github" {
+			t.Errorf("connectors = %v, want [github]", got.Connectors)
+		}
+	})
+
+	t.Run("github and google", func(t *testing.T) {
+		got := hit(t, console.Capabilities{AuthConnectors: []string{"github", "google"}})
+		if len(got.Connectors) != 2 {
+			t.Fatalf("connectors = %v, want [github google]", got.Connectors)
+		}
+	})
+
+	t.Run("empty returns array not null", func(t *testing.T) {
+		got := hit(t, console.Capabilities{AuthConnectors: []string{}})
+		if got.Connectors == nil {
+			t.Error("connectors must be [] not null")
+		}
+		if len(got.Connectors) != 0 {
+			t.Errorf("connectors = %v, want []", got.Connectors)
+		}
+	})
 }

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -189,6 +189,16 @@ func main() {
 		mux.Handle("/webhooks/billing", bill.webhook)
 		logger.Info("billing webhook mounted at /webhooks/billing")
 	}
+	// GET /auth/connectors is a PUBLIC, pre-auth endpoint that returns the list
+	// of configured social-login providers (e.g. ["github"]). The SPA fetches
+	// it before any session exists so the Login/Signup pages can show only the
+	// buttons for providers that are actually configured. The response carries
+	// NO org data: only provider names that came from a server-controlled env
+	// var. It is mounted OUTSIDE the session middleware so no cookie is needed.
+	// The endpoint is intentionally minimal: {"connectors":["github"]} or
+	// {"connectors":[]} when none are configured.
+	mux.HandleFunc("GET /auth/connectors", newAuthConnectorsHandler(caps))
+
 	// The identity resolve endpoint is an INTERNAL machine-to-machine endpoint,
 	// bearer-gated by a shared secret. It is mounted OUTSIDE the session
 	// middleware (no browser session involved) and OUTSIDE the dev/prod

--- a/internal/saas/console/capabilities.go
+++ b/internal/saas/console/capabilities.go
@@ -34,6 +34,14 @@ type Capabilities struct {
 	Proof bool `json:"proof"`
 	// Ownership is "self-hosted" or "hosted"; drives the chrome badge.
 	Ownership string `json:"ownership"`
+	// AuthConnectors is the sorted, deduplicated list of social-login providers
+	// that are actually configured (e.g. ["github"] or ["github","google"]).
+	// The SPA renders a social-login button ONLY for each entry. An empty list
+	// means no social buttons; the email magic-link form is always available.
+	// The value is set server-side from MITOS_CONSOLE_AUTH_CONNECTORS; the SPA
+	// cannot override it. Only "github" and "google" are recognised; unknown
+	// values are silently dropped.
+	AuthConnectors []string `json:"authConnectors"`
 }
 
 // SecretsCapability advertises which secret-store providers are enabled. The
@@ -47,15 +55,16 @@ type SecretsCapability struct {
 // off. It is applied when a Console is built without an explicit Capabilities.
 func defaultCapabilities() Capabilities {
 	return Capabilities{
-		Edition:     "community",
-		Billing:     false,
-		Signup:      false,
-		Teams:       true,
-		IDP:         "oidc",
-		OrgSwitcher: false,
-		Secrets:     SecretsCapability{Providers: []string{"kube"}},
-		Proof:       true,
-		Ownership:   "self-hosted",
+		Edition:        "community",
+		Billing:        false,
+		Signup:         false,
+		Teams:          true,
+		IDP:            "oidc",
+		OrgSwitcher:    false,
+		Secrets:        SecretsCapability{Providers: []string{"kube"}},
+		Proof:          true,
+		Ownership:      "self-hosted",
+		AuthConnectors: []string{},
 	}
 }
 

--- a/internal/saas/console/capabilities_test.go
+++ b/internal/saas/console/capabilities_test.go
@@ -94,3 +94,55 @@ func TestCapabilitiesHostedEditionVerbatim(t *testing.T) {
 		t.Errorf("secrets.providers = %v, want [kube openbao]", caps.Secrets.Providers)
 	}
 }
+
+// TestCapabilitiesAuthConnectorsInResponse asserts that the authConnectors
+// field is serialised into the capabilities response and reflects the value
+// set in Deps.Capabilities. An empty slice serialises as [] (not null) so the
+// SPA can safely iterate without a nil-guard.
+func TestCapabilitiesAuthConnectorsInResponse(t *testing.T) {
+	t.Run("github only", func(t *testing.T) {
+		c := New(Deps{Capabilities: Capabilities{
+			Edition:        "community",
+			Teams:          true,
+			IDP:            "oidc",
+			Proof:          true,
+			Ownership:      "self-hosted",
+			Secrets:        SecretsCapability{Providers: []string{"kube"}},
+			AuthConnectors: []string{"github"},
+		}})
+		_, caps := getCaps(t, c)
+		if len(caps.AuthConnectors) != 1 || caps.AuthConnectors[0] != "github" {
+			t.Errorf("authConnectors = %v, want [github]", caps.AuthConnectors)
+		}
+	})
+
+	t.Run("github and google", func(t *testing.T) {
+		c := New(Deps{Capabilities: Capabilities{
+			Edition:        "hosted",
+			Teams:          true,
+			IDP:            "oidc",
+			Proof:          true,
+			Ownership:      "hosted",
+			Secrets:        SecretsCapability{Providers: []string{"kube"}},
+			AuthConnectors: []string{"github", "google"},
+		}})
+		_, caps := getCaps(t, c)
+		if len(caps.AuthConnectors) != 2 {
+			t.Fatalf("authConnectors = %v, want [github google]", caps.AuthConnectors)
+		}
+		if caps.AuthConnectors[0] != "github" || caps.AuthConnectors[1] != "google" {
+			t.Errorf("authConnectors order wrong: %v", caps.AuthConnectors)
+		}
+	})
+
+	t.Run("empty serialises as array not null", func(t *testing.T) {
+		c := New(Deps{}) // defaultCapabilities() sets AuthConnectors: []string{}
+		_, caps := getCaps(t, c)
+		if caps.AuthConnectors == nil {
+			t.Error("authConnectors must be [] not null when no connectors configured")
+		}
+		if len(caps.AuthConnectors) != 0 {
+			t.Errorf("authConnectors = %v, want []", caps.AuthConnectors)
+		}
+	})
+}

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -20,6 +20,13 @@ export type Capabilities = {
   secrets: { providers: string[] }
   proof: boolean
   ownership: 'self-hosted' | 'hosted'
+  // authConnectors is the sorted list of configured social-login providers.
+  // Present when the server is new enough to return it; absent on old deploys.
+  authConnectors?: string[]
+}
+
+export type AuthConnectorsResponse = {
+  connectors: string[]
 }
 
 export type Instruments = {
@@ -150,6 +157,10 @@ export async function post<T>(path: string, body: unknown): Promise<T | null> {
 
 export const api = {
   capabilities: () => get<Capabilities>('/console/capabilities'),
+  // authConnectors fetches the public /auth/connectors endpoint which returns
+  // the configured social-login providers without requiring a session. The SPA
+  // reads this before login to decide which social buttons to render.
+  authConnectors: () => get<AuthConnectorsResponse>('/auth/connectors').then((r) => r.connectors ?? []),
   instruments: () => get<Instruments>('/console/instruments'),
   secrets: () => get<{ secrets: SecretView[] }>('/console/secrets').then((r) => r.secrets ?? []),
   createSecret: async (name: string, value: string) => {

--- a/web/app/src/auth/Login.test.tsx
+++ b/web/app/src/auth/Login.test.tsx
@@ -1,46 +1,98 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Login } from './Login'
 
+// mockConnectors stubs fetch so that GET /auth/connectors returns the given
+// connector list. Other fetch calls fall through to the test's own stub or
+// return a generic rejection so they do not accidentally succeed.
+function mockConnectors(connectors: string[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string) => {
+      if (url === '/auth/connectors') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ connectors }),
+        })
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    }),
+  )
+}
+
 describe('Login page', () => {
-  it('offers GitHub and Google with connector hints', () => {
-    render(<Login />)
-    expect(screen.getByRole('link', { name: /Continue with GitHub/i })).toHaveAttribute(
-      'href',
-      '/auth/login?connector=github',
-    )
-    expect(screen.getByRole('link', { name: /Continue with Google/i })).toHaveAttribute(
-      'href',
-      '/auth/login?connector=google',
-    )
+  beforeEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it('renders an email input', () => {
+  it('renders a GitHub button and no Google button when only github is configured', async () => {
+    mockConnectors(['github'])
     render(<Login />)
-    expect(screen.getByRole('textbox', { name: /email/i })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('link', { name: /Continue with GitHub/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=github')
+    expect(screen.queryByRole('link', { name: /Continue with Google/i })).not.toBeInTheDocument()
   })
 
-  it('renders a signup affordance', () => {
+  it('renders both buttons when github and google are configured', async () => {
+    mockConnectors(['github', 'google'])
     render(<Login />)
-    expect(screen.getByRole('button', { name: /sign up with email/i })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('link', { name: /Continue with GitHub/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=github')
+    expect(
+      await screen.findByRole('link', { name: /Continue with Google/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=google')
   })
 
-  it('propagates ?next= to provider connector hrefs', () => {
+  it('renders no social buttons when connectors list is empty', async () => {
+    mockConnectors([])
+    render(<Login />)
+    // Wait for the fetch to settle, then verify no provider links appear.
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: /Continue with GitHub/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /Continue with Google/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders an email input', async () => {
+    mockConnectors([])
+    render(<Login />)
+    // Use waitFor to flush the connectors fetch microtask before asserting.
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /email/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders a signup affordance', async () => {
+    mockConnectors([])
+    render(<Login />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign up with email/i })).toBeInTheDocument()
+    })
+  })
+
+  it('propagates ?next= to provider connector hrefs', async () => {
+    mockConnectors(['github', 'google'])
     render(<Login next="/dashboard" />)
-    expect(screen.getByRole('link', { name: /Continue with GitHub/i })).toHaveAttribute(
-      'href',
-      '/auth/login?connector=github&next=%2Fdashboard',
-    )
-    expect(screen.getByRole('link', { name: /Continue with Google/i })).toHaveAttribute(
-      'href',
-      '/auth/login?connector=google&next=%2Fdashboard',
-    )
+    expect(
+      await screen.findByRole('link', { name: /Continue with GitHub/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=github&next=%2Fdashboard')
+    expect(
+      await screen.findByRole('link', { name: /Continue with Google/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=google&next=%2Fdashboard')
   })
 
-  it('propagates next= on email form submission', () => {
+  it('propagates next= on email form submission', async () => {
+    mockConnectors([])
     const assign = vi.fn()
     vi.stubGlobal('location', { ...window.location, assign })
     render(<Login next="/dashboard" />)
+    // Wait for connectors fetch to settle before interacting.
+    await waitFor(() => {
+      expect(screen.getByRole('form', { name: /continue with email/i })).toBeInTheDocument()
+    })
     fireEvent.submit(screen.getByRole('form', { name: /continue with email/i }))
     expect(assign).toHaveBeenCalledWith(expect.stringContaining('next=%2Fdashboard'))
     vi.unstubAllGlobals()

--- a/web/app/src/auth/Login.tsx
+++ b/web/app/src/auth/Login.tsx
@@ -10,7 +10,7 @@
 import { useState } from 'react'
 import type { FormEvent } from 'react'
 import { Button } from '@mitos/brand'
-import { AuthShell, ProviderButtons, resolveNext } from './authCommon'
+import { AuthShell, ProviderButtons, resolveNext, useAuthConnectors } from './authCommon'
 
 // ---- Page-specific styles --------------------------------------------------
 
@@ -32,6 +32,7 @@ export type LoginProps = {
 export function Login({ next }: LoginProps) {
   const [email, setEmail] = useState('')
   const resolvedNext = resolveNext(next)
+  const connectors = useAuthConnectors()
 
   function handleEmailSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -46,8 +47,9 @@ export function Login({ next }: LoginProps) {
     <AuthShell title="Sign in" subtitle="A computer for every agent.">
       <style>{styles}</style>
 
-      {/* Provider links: full navigations to the Go /auth/login endpoint */}
-      <ProviderButtons next={resolvedNext} />
+      {/* Provider links: full navigations to the Go /auth/login endpoint.
+          Only renders buttons for providers returned by /auth/connectors. */}
+      <ProviderButtons next={resolvedNext} connectors={connectors} />
 
       {/* Email to signup flow */}
       <form

--- a/web/app/src/auth/Signup.test.tsx
+++ b/web/app/src/auth/Signup.test.tsx
@@ -1,35 +1,93 @@
 // Signup page tests. Mirrors Login.test.tsx conventions.
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Signup } from './Signup'
 
+// mockFetch stubs global fetch so /auth/connectors returns the given list and
+// POST /onboarding/signup returns the given response. Extra URLs return a
+// rejection so unintended calls surface immediately.
+function mockFetch({
+  connectors = [] as string[],
+  signupStatus = 202,
+} = {}) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === '/auth/connectors') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ connectors }),
+        })
+      }
+      if (url === '/onboarding/signup' && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: signupStatus < 400,
+          status: signupStatus,
+          text: async () => '',
+        })
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    }),
+  )
+}
+
 describe('Signup page', () => {
-  it('offers GitHub and Google provider options', () => {
-    render(<Signup />)
-    expect(screen.getByRole('link', { name: /Continue with GitHub/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Continue with Google/i })).toBeInTheDocument()
+  beforeEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it('renders an email input with a visible label', () => {
+  it('offers GitHub button when only github is configured', async () => {
+    mockFetch({ connectors: ['github'] })
     render(<Signup />)
-    expect(screen.getByRole('textbox', { name: /email/i })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('link', { name: /Continue with GitHub/i }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Continue with Google/i })).not.toBeInTheDocument()
   })
 
-  it('renders the submit button', () => {
+  it('offers GitHub and Google when both are configured', async () => {
+    mockFetch({ connectors: ['github', 'google'] })
     render(<Signup />)
-    expect(screen.getByRole('button', { name: /send me a sign-in link/i })).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: /Continue with GitHub/i })).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: /Continue with Google/i })).toBeInTheDocument()
   })
 
-  it('prefills email from initialEmail prop (simulates ?email= query param)', () => {
+  it('renders no social buttons when connectors list is empty', async () => {
+    mockFetch({ connectors: [] })
+    render(<Signup />)
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: /Continue with GitHub/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /Continue with Google/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders an email input with a visible label', async () => {
+    mockFetch()
+    render(<Signup />)
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /email/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders the submit button', async () => {
+    mockFetch()
+    render(<Signup />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /send me a sign-in link/i })).toBeInTheDocument()
+    })
+  })
+
+  it('prefills email from initialEmail prop (simulates ?email= query param)', async () => {
+    mockFetch()
     render(<Signup initialEmail="prefilled@example.com" />)
-    expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue('prefilled@example.com')
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue('prefilled@example.com')
+    })
   })
 
   it('shows confirmation after successful submit (202) and calls fetch with the email', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({ ok: true, status: 202, text: async () => '' }),
-    )
+    mockFetch({ signupStatus: 202 })
     render(<Signup />)
     const input = screen.getByRole('textbox', { name: /email/i })
     fireEvent.change(input, { target: { value: 'user@example.com' } })
@@ -48,10 +106,7 @@ describe('Signup page', () => {
   })
 
   it('echoes the submitted email in the confirmation message', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({ ok: true, status: 202, text: async () => '' }),
-    )
+    mockFetch({ signupStatus: 202 })
     render(<Signup />)
     const input = screen.getByRole('textbox', { name: /email/i })
     fireEvent.change(input, { target: { value: 'jannes@example.com' } })
@@ -63,10 +118,7 @@ describe('Signup page', () => {
   })
 
   it('shows a non-leaky error message on failure and does not expose whether the email exists', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({ ok: false, status: 400, text: async () => '' }),
-    )
+    mockFetch({ signupStatus: 400 })
     render(<Signup />)
     const input = screen.getByRole('textbox', { name: /email/i })
     fireEvent.change(input, { target: { value: 'bad@example.com' } })
@@ -81,29 +133,45 @@ describe('Signup page', () => {
     vi.unstubAllGlobals()
   })
 
-  it('propagates ?next= to provider connector hrefs', () => {
+  it('propagates ?next= to provider connector hrefs', async () => {
+    mockFetch({ connectors: ['github', 'google'] })
     render(<Signup next="/dashboard" />)
-    expect(screen.getByRole('link', { name: /Continue with GitHub/i })).toHaveAttribute(
-      'href',
-      '/auth/login?connector=github&next=%2Fdashboard',
-    )
-    expect(screen.getByRole('link', { name: /Continue with Google/i })).toHaveAttribute(
-      'href',
-      '/auth/login?connector=google&next=%2Fdashboard',
-    )
+    expect(
+      await screen.findByRole('link', { name: /Continue with GitHub/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=github&next=%2Fdashboard')
+    expect(
+      await screen.findByRole('link', { name: /Continue with Google/i }),
+    ).toHaveAttribute('href', '/auth/login?connector=google&next=%2Fdashboard')
   })
 
-  it('renders a link to the sign-in page', () => {
+  it('renders a link to the sign-in page', async () => {
+    mockFetch()
     render(<Signup />)
-    expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+    })
   })
 
   it('disables the submit button while the POST is in flight', async () => {
+    // connectors resolves immediately; signup never resolves (in-flight)
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockReturnValue(new Promise(() => {})), // never resolves
+      vi.fn().mockImplementation((url: string) => {
+        if (url === '/auth/connectors') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ connectors: [] }),
+          })
+        }
+        return new Promise(() => {}) // never resolves
+      }),
     )
     render(<Signup />)
+    // Wait for connectors fetch to settle before interacting.
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /email/i })).toBeInTheDocument()
+    })
     const input = screen.getByRole('textbox', { name: /email/i })
     fireEvent.change(input, { target: { value: 'test@example.com' } })
     fireEvent.submit(input.closest('form')!)
@@ -114,10 +182,7 @@ describe('Signup page', () => {
   })
 
   it('clicking "Use a different email" resets back to the form', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({ ok: true, status: 202, text: async () => '' }),
-    )
+    mockFetch({ signupStatus: 202 })
     render(<Signup />)
     const input = screen.getByRole('textbox', { name: /email/i })
     fireEvent.change(input, { target: { value: 'user@example.com' } })

--- a/web/app/src/auth/Signup.tsx
+++ b/web/app/src/auth/Signup.tsx
@@ -12,7 +12,7 @@ import { useState } from 'react'
 import type { FormEvent } from 'react'
 import { Button } from '@mitos/brand'
 import { post } from '../api'
-import { AuthShell, ProviderButtons, resolveNext } from './authCommon'
+import { AuthShell, ProviderButtons, resolveNext, useAuthConnectors } from './authCommon'
 
 // ---- Page-specific styles --------------------------------------------------
 
@@ -65,6 +65,7 @@ export type SignupProps = {
 
 export function Signup({ next, initialEmail }: SignupProps) {
   const resolvedNext = resolveNext(next)
+  const connectors = useAuthConnectors()
 
   // Resolve ?email= query param for the Login-to-Signup email handoff.
   const emailDefault =
@@ -146,10 +147,10 @@ export function Signup({ next, initialEmail }: SignupProps) {
         )}
       </div>
 
-      {/* Provider links (always visible; social signs up new users too) */}
+      {/* Provider links: only renders buttons for configured providers. */}
       {signupState !== 'success' && (
         <>
-          <ProviderButtons next={resolvedNext} />
+          <ProviderButtons next={resolvedNext} connectors={connectors} />
 
           {/* Email form */}
           <form

--- a/web/app/src/auth/authCommon.tsx
+++ b/web/app/src/auth/authCommon.tsx
@@ -5,8 +5,10 @@
 // Brand: Fluorescence tokens only; no hardcoded hex. Mark (glow) + wordmark.
 // A11y: aria-hidden glyphs, magenta focus ring, keyboard-operable targets.
 
+import { useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import { Mark, Card } from '@mitos/brand'
+import { api } from '../api'
 
 // ---- Provider glyphs -------------------------------------------------------
 // Inline SVGs: aria-hidden, focusable=false. Parent carries the accessible name.
@@ -141,15 +143,50 @@ export const authCommonStyles = `
 }
 `
 
+// ---- Provider glyph map ----------------------------------------------------
+// Maps connector id to its display label and glyph element. Extend this map
+// when a new provider is added server-side.
+
+type ProviderMeta = { label: string; glyph: ReactNode }
+
+const providerMeta: Record<string, ProviderMeta> = {
+  github: { label: 'Continue with GitHub', glyph: <GitHubGlyph /> },
+  google: { label: 'Continue with Google', glyph: <GoogleGlyph /> },
+}
+
+// ---- useAuthConnectors ------------------------------------------------------
+// Fetches the configured social-login connectors from the public
+// GET /auth/connectors endpoint. Returns [] while loading or on error so the
+// "or" divider is hidden until the server answers; the email form is always
+// visible. The fetch is performed once per component mount; connectors change
+// only on redeploy. State is never updated after the component unmounts.
+
+export function useAuthConnectors(): string[] {
+  const [connectors, setConnectors] = useState<string[]>([])
+  useEffect(() => {
+    let live = true
+    api
+      .authConnectors()
+      .then((c) => { if (live) setConnectors(c) })
+      .catch(() => { if (live) setConnectors([]) })
+    return () => { live = false }
+  }, [])
+  return connectors
+}
+
 // ---- ProviderButtons --------------------------------------------------------
-// The two full-navigation <a> links (GitHub first, then Google) plus the
-// hairline "or" divider. Uses shared .auth-link-btn / .auth-divider classes.
+// Renders one full-navigation <a> link per configured connector plus the
+// hairline "or" divider. When connectors is empty (server returned none or
+// the fetch is still in flight) nothing is rendered, so the email form stands
+// alone without an orphaned divider.
 
 export type ProviderButtonsProps = {
   next: string
+  connectors: string[]
 }
 
-export function ProviderButtons({ next }: ProviderButtonsProps) {
+export function ProviderButtons({ next, connectors }: ProviderButtonsProps) {
+  if (connectors.length === 0) return null
   return (
     <>
       <div
@@ -159,14 +196,16 @@ export function ProviderButtons({ next }: ProviderButtonsProps) {
           gap: 'var(--space-3)',
         }}
       >
-        <a href={connectorHref('github', next)} className="auth-link-btn">
-          <GitHubGlyph />
-          Continue with GitHub
-        </a>
-        <a href={connectorHref('google', next)} className="auth-link-btn">
-          <GoogleGlyph />
-          Continue with Google
-        </a>
+        {connectors.map((id) => {
+          const meta = providerMeta[id]
+          if (!meta) return null
+          return (
+            <a key={id} href={connectorHref(id, next)} className="auth-link-btn">
+              {meta.glyph}
+              {meta.label}
+            </a>
+          )
+        })}
       </div>
       <div className="auth-divider" aria-hidden>
         <hr className="auth-divider-line" />

--- a/web/app/src/auth/preauthRouter.test.tsx
+++ b/web/app/src/auth/preauthRouter.test.tsx
@@ -1,16 +1,45 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { RouterProvider } from '@tanstack/react-router'
 import { createPreAuthRouter } from './preauthRouter'
 
+// Stub fetch so GET /auth/connectors returns ["github"] for the router tests.
+// This makes the Login/Signup pages show the GitHub button, which the tests
+// verify below. Unstubbing is handled by the restoreMocks: true vitest config.
+function stubConnectors(connectors: string[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string) => {
+      if (url === '/auth/connectors') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ connectors }),
+        })
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    }),
+  )
+}
+
 describe('pre-auth router', () => {
-  it('renders the login route with a GitHub affordance', async () => {
+  it('renders the login route with a GitHub affordance when github is configured', async () => {
+    stubConnectors(['github'])
     const router = createPreAuthRouter('/login')
     render(<RouterProvider router={router} />)
     expect(await screen.findByText(/Continue with GitHub/i)).toBeInTheDocument()
   })
 
+  it('does not render a Google button when only github is configured', async () => {
+    stubConnectors(['github'])
+    const router = createPreAuthRouter('/login')
+    render(<RouterProvider router={router} />)
+    await screen.findByText(/Continue with GitHub/i) // wait for connectors to load
+    expect(screen.queryByText(/Continue with Google/i)).not.toBeInTheDocument()
+  })
+
   it('redirects unmatched paths to the login affordance', async () => {
+    stubConnectors(['github'])
     const router = createPreAuthRouter('/sandboxes')
     render(<RouterProvider router={router} />)
     expect(await screen.findByText(/Continue with GitHub/i)).toBeInTheDocument()


### PR DESCRIPTION
## Thinking Path

The Login and Signup pages hard-coded GitHub and Google buttons. Adding a
provider secret should show its button; removing one should hide it. The
source of truth is server configuration, not code.

**Why a new public endpoint and not the existing capabilities endpoint:**
GET /console/capabilities sits behind SessionMiddleware, which returns 401
for unauthenticated requests. The SPA currently detects the unauthenticated
state from that 401 and switches to the pre-auth router. Making capabilities
public would break that detection without a second auth-state endpoint.
A tiny dedicated GET /auth/connectors endpoint (no session required, no org
data, just provider names) fits the existing pre-auth pattern used by the
onboarding funnel and is the minimal new surface.

**Go side:**
- AuthConnectors []string added to Capabilities struct
  (internal/saas/console/capabilities.go).
- MITOS_CONSOLE_AUTH_CONNECTORS parsed in capabilitiesFromEnv()
  (cmd/console/capabilities.go): known values github/google filtered,
  unknown silently dropped, duplicates removed, sorted.
- GET /auth/connectors handler (cmd/console/capabilities.go:
  newAuthConnectorsHandler) mounted in cmd/console/main.go OUTSIDE the
  session middleware. Returns {"connectors":["github"]} or {"connectors":[]}.

**SPA side:**
- AuthConnectors added to Capabilities type (web/app/src/api.ts).
- api.authConnectors() helper added, fetches /auth/connectors.
- useAuthConnectors() hook (web/app/src/auth/authCommon.tsx) fetches once
  on mount with an unmount guard. Returns [] while loading or on error.
- ProviderButtons now takes connectors: string[] prop and renders only
  entries in the list. Each connector maps to a label/glyph in providerMeta.
- Login.tsx and Signup.tsx call useAuthConnectors() and pass the result.

## Verification

Go tests:

```
go test ./internal/saas/console/... ./cmd/console/... -run 'Cap|Connector|Auth' -v
# All pass: TestCapabilitiesFromEnvConnectors (5 subtests),
# TestAuthConnectorsEndpoint (3 subtests),
# TestCapabilitiesAuthConnectorsInResponse (3 subtests)
```

SPA tests:

```
cd web/app && pnpm test
# Test Files  51 passed (51)
# Tests  181 passed (181)
```

Build and lint:

```
go build ./cmd/console/...   # clean
go vet ./...                 # clean
golangci-lint run ./...      # clean
npx tsc --noEmit             # clean
```

**Launch state behavior:** Set MITOS_CONSOLE_AUTH_CONNECTORS=github. The
GitHub button appears on Login and Signup. Google button does not appear.
Add google to the env var and restart: both appear. Clear the env var:
neither appears, email magic-link is the only auth path.

**Dist embed:** cmd/console/spa/dist/ holds only a placeholder index.html.
The real SPA build runs in Dockerfile.console during CI. No built assets
committed.

## Model Used

Claude Sonnet 4.6