### PR TITLE
feat(frontdoor): proxy marketing to github pages (sni/host pinned) and mount resolve-token under frontdoor

### DIFF
--- a/cmd/frontdoor/main.go
+++ b/cmd/frontdoor/main.go
@@ -7,11 +7,15 @@
 // Configuration is entirely via environment variables; no CLI flags are used so
 // that secrets never appear in process listings.
 //
-//	MITOS_FRONTDOOR_ADDR              listen address (default ":8080")
-//	MITOS_FRONTDOOR_MARKETING_URL     base URL of the marketing upstream (required)
-//	MITOS_FRONTDOOR_CONSOLE_URL       base URL of the console upstream (required)
-//	MITOS_FRONTDOOR_SESSION_RESOLVE_URL URL of POST /internal/session/resolve (required)
-//	MITOS_IDENTITY_RESOLVE_TOKEN      bearer token for the session-resolve endpoint (required)
+//	MITOS_FRONTDOOR_ADDR                      listen address (default ":8080")
+//	MITOS_FRONTDOOR_MARKETING_URL             base URL of the marketing upstream (required)
+//	MITOS_FRONTDOOR_MARKETING_PAGES_ADDRS     comma-separated GitHub Pages IP:port list;
+//	                                          when set, DNS for the marketing host is bypassed
+//	                                          and one of these addresses is dialed instead.
+//	                                          Example: "185.199.108.153:443,185.199.109.153:443"
+//	MITOS_FRONTDOOR_CONSOLE_URL               base URL of the console upstream (required)
+//	MITOS_FRONTDOOR_SESSION_RESOLVE_URL        URL of POST /internal/session/resolve (required)
+//	MITOS_IDENTITY_RESOLVE_TOKEN              bearer token for the session-resolve endpoint (required)
 package main
 
 import (
@@ -23,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -65,13 +70,27 @@ func main() {
 		log.Fatalf("frontdoor: invalid MITOS_FRONTDOOR_SESSION_RESOLVE_URL: %v", err)
 	}
 
+	// Parse MITOS_FRONTDOOR_MARKETING_PAGES_ADDRS (optional). When present the
+	// marketing proxy bypasses DNS and dials one of these IPs directly, keeping
+	// TLS SNI and Host as the marketing URL host. The values are not secrets
+	// (they are public GitHub Pages IPs) so logging the count is acceptable.
+	var marketingPagesAddrs []string
+	if raw := os.Getenv("MITOS_FRONTDOOR_MARKETING_PAGES_ADDRS"); raw != "" {
+		for _, a := range strings.Split(raw, ",") {
+			if a = strings.TrimSpace(a); a != "" {
+				marketingPagesAddrs = append(marketingPagesAddrs, a)
+			}
+		}
+	}
+
 	resolver := frontdoor.NewHTTPSessionResolver(resolveURL, resolveToken, nil)
 
 	proxy, err := frontdoor.NewProxy(frontdoor.ProxyConfig{
-		MarketingURL: marketingRaw,
-		ConsoleURL:   consoleRaw,
-		Resolver:     resolver,
-		Logger:       logger,
+		MarketingURL:        marketingRaw,
+		MarketingPagesAddrs: marketingPagesAddrs,
+		ConsoleURL:          consoleRaw,
+		Resolver:            resolver,
+		Logger:              logger,
 	})
 	if err != nil {
 		log.Fatalf("frontdoor: build proxy: %v", err)
@@ -96,6 +115,7 @@ func main() {
 	logger.Info("frontdoor starting",
 		"addr", addr,
 		"marketing_url", marketingRaw,
+		"marketing_pages_addrs_count", len(marketingPagesAddrs),
 		"console_url", consoleRaw,
 		"resolve_url", resolveURL,
 	)

--- a/deploy/charts/mitos/templates/console.yaml
+++ b/deploy/charts/mitos/templates/console.yaml
@@ -213,13 +213,14 @@ spec:
             - name: MITOS_CONSOLE_OPENBAO_PER_ORG
               value: {{ .Values.console.secrets.openbao.perOrg | quote }}
             {{- end }}
-            {{- if .Values.expose.enabled }}
+            {{- if or .Values.expose.enabled .Values.frontdoor.enabled }}
             {{- /*
-            Mount the shared resolve token so the console serves
-            POST /internal/identity/resolve for the expose proxy's org-resolution
-            hop. The token value is NEVER inlined; it is sourced from the same
-            Secret key (resolve-token) as the proxy's MITOS_EXPOSE_RESOLVE_TOKEN.
-            Gated by expose.enabled so the endpoint is inactive when expose is off.
+            Mount the shared resolve token so the console serves POST
+            /internal/session/resolve for the expose proxy or the frontdoor's
+            session-resolution hop. The token is NEVER inlined; it is sourced
+            from the same Secret key (resolve-token) in expose.secretName
+            (default: mitos-expose). Gated so the endpoint is inactive when
+            neither expose nor frontdoor is enabled.
             */}}
             - name: MITOS_IDENTITY_RESOLVE_TOKEN
               valueFrom:

--- a/deploy/charts/mitos/templates/frontdoor.yaml
+++ b/deploy/charts/mitos/templates/frontdoor.yaml
@@ -52,6 +52,17 @@ spec:
               value: {{ .Values.frontdoor.consoleURL | default (printf "http://mitos-console.%s.svc" (include "mitos.namespace" .)) | quote }}
             - name: MITOS_FRONTDOOR_SESSION_RESOLVE_URL
               value: {{ .Values.frontdoor.sessionResolveURL | default (printf "http://mitos-console.%s.svc/internal/session/resolve" (include "mitos.namespace" .)) | quote }}
+            {{- if .Values.frontdoor.marketingPagesAddrs }}
+            {{- /*
+            GitHub Pages anycast IP:port list. When set, the frontdoor dials
+            one of these IPs directly for marketing traffic, bypassing DNS for
+            mitos.run (which points at our gateway). TLS SNI and the upstream
+            Host header remain mitos.run; InsecureSkipVerify is never set.
+            Default empty (in-cluster mode uses DNS to the marketing Service).
+            */}}
+            - name: MITOS_FRONTDOOR_MARKETING_PAGES_ADDRS
+              value: {{ .Values.frontdoor.marketingPagesAddrs | join "," | quote }}
+            {{- end }}
             {{- /*
             Shared bearer token for POST /internal/session/resolve. Sourced from
             the same Secret key (resolve-token) used by the expose proxy and the

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -698,6 +698,13 @@ frontdoor:
   # In-cluster URL of the console session-resolve endpoint. Defaults to the
   # mitos-console Service path /internal/session/resolve.
   sessionResolveURL: ""
+  # GitHub Pages anycast IP:port addresses for the marketing upstream. When
+  # non-empty, the frontdoor dials one of these IPs instead of resolving
+  # mitos.run via DNS; TLS SNI and the upstream Host header remain mitos.run.
+  # Default empty (in-cluster mode: DNS resolves to the marketing Deployment).
+  # Production (GitHub Pages hosting):
+  #   ["185.199.108.153:443","185.199.109.153:443","185.199.110.153:443","185.199.111.153:443"]
+  marketingPagesAddrs: []
   # Frontdoor container resource requests and limits.
   resources: {}
 

--- a/internal/frontdoor/proxy.go
+++ b/internal/frontdoor/proxy.go
@@ -188,7 +188,7 @@ func buildPagesMarketingReverseProxy(target *url.URL, pagesAddrs []string, label
 	var counter atomic.Uint64
 	base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		if addr == needle {
-			n := int(counter.Add(1)-1) % len(pagesAddrs)
+			n := counter.Add(1) % uint64(len(pagesAddrs))
 			return origDial(ctx, network, pagesAddrs[n])
 		}
 		return origDial(ctx, network, addr)

--- a/internal/frontdoor/proxy.go
+++ b/internal/frontdoor/proxy.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync/atomic"
+	"time"
 )
 
 // ErrNoSession is returned by SessionResolver.Resolve when the token does not
@@ -38,6 +41,13 @@ type ProxyConfig struct {
 	// MarketingURL is the base URL of the marketing upstream (e.g. the Next.js
 	// site). Required.
 	MarketingURL string
+	// MarketingPagesAddrs is the list of GitHub Pages anycast IP:port
+	// addresses (e.g. ["185.199.108.153:443", "185.199.109.153:443"]) to
+	// dial when proxying the marketing upstream. When non-empty, DNS
+	// resolution for the marketing host is bypassed; TLS SNI and the
+	// upstream Host header remain the marketing URL host (mitos.run). When
+	// empty, the marketing host is resolved normally via DNS.
+	MarketingPagesAddrs []string
 	// ConsoleURL is the base URL of the console upstream. Required.
 	ConsoleURL string
 	// Resolver resolves session tokens to identities. Required.
@@ -84,7 +94,12 @@ func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 		log = slog.New(slog.NewTextHandler(discardWriter{}, nil))
 	}
 
-	mkt := buildReverseProxy(mktURL, "marketing", log)
+	var mkt *httputil.ReverseProxy
+	if len(cfg.MarketingPagesAddrs) > 0 {
+		mkt = buildPagesMarketingReverseProxy(mktURL, cfg.MarketingPagesAddrs, "marketing", log)
+	} else {
+		mkt = buildReverseProxy(mktURL, "marketing", log)
+	}
 	con := buildReverseProxy(conURL, "console", log)
 
 	return &Proxy{
@@ -105,6 +120,80 @@ func buildReverseProxy(target *url.URL, label string, log *slog.Logger) *httputi
 		log.Info("upstream error", "upstream", label, "status", http.StatusBadGateway)
 		http.Error(w, "upstream unavailable", http.StatusBadGateway)
 	}
+	return rp
+}
+
+// buildPagesMarketingReverseProxy builds a marketing reverse proxy that dials
+// pagesAddrs instead of resolving target.Host via DNS. It is used when the
+// marketing site is hosted on GitHub Pages and mitos.run DNS points at our own
+// gateway (which would loop if we resolved normally).
+//
+// Security properties:
+//   - TLS SNI stays target.Host (mitos.run): Go's http.Transport derives SNI
+//     from the URL host, not from the dialed address, so the Pages cert is
+//     validated correctly.
+//   - InsecureSkipVerify is never set: the GitHub Pages cert is valid for
+//     mitos.run.
+//   - The upstream Host header is pinned to target.Host by the wrapped
+//     Director, regardless of the incoming client Host value.
+//   - The dial override is scoped to the marketing upstream only; console
+//     dials are unaffected.
+//
+// pagesAddrs are dialed round-robin using a lock-free atomic counter.
+func buildPagesMarketingReverseProxy(target *url.URL, pagesAddrs []string, label string, log *slog.Logger) *httputil.ReverseProxy {
+	rp := buildReverseProxy(target, label, log)
+
+	// Wrap the Director to pin the upstream Host header to the marketing URL
+	// host. This is necessary because req.Host may carry the original client
+	// Host value (which is correct for mitos.run in production but may be
+	// absent or wrong in tests and non-standard deployments).
+	origDirector := rp.Director
+	rp.Director = func(req *http.Request) {
+		origDirector(req)
+		req.Host = target.Host
+	}
+
+	// Construct the needle: the host:port string the http.Transport will pass
+	// to DialContext when dialing the marketing upstream.
+	targetPort := target.Port()
+	if targetPort == "" {
+		switch target.Scheme {
+		case "https":
+			targetPort = "443"
+		default:
+			targetPort = "80"
+		}
+	}
+	needle := net.JoinHostPort(target.Hostname(), targetPort)
+
+	// Clone http.DefaultTransport to inherit its production-ready defaults
+	// (connection pooling, keep-alive, HTTP/2 support). Only DialContext is
+	// overridden; TLSClientConfig is left untouched so ServerName defaults to
+	// the URL host (mitos.run) for SNI, and InsecureSkipVerify stays false.
+	dt, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		dt = &http.Transport{}
+	}
+	base := dt.Clone()
+
+	origDial := base.DialContext
+	if origDial == nil {
+		d := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		origDial = d.DialContext
+	}
+
+	var counter atomic.Uint64
+	base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if addr == needle {
+			n := int(counter.Add(1)-1) % len(pagesAddrs)
+			return origDial(ctx, network, pagesAddrs[n])
+		}
+		return origDial(ctx, network, addr)
+	}
+	rp.Transport = base
 	return rp
 }
 

--- a/internal/frontdoor/proxy_test.go
+++ b/internal/frontdoor/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"mitos.run/mitos/internal/frontdoor"
@@ -221,9 +222,12 @@ func TestProxy_ForgeProtection_HeadersStripped(t *testing.T) {
 // the only mechanism that lets the request reach the local stub rather than the
 // real network host. InsecureSkipVerify is never set.
 func TestProxy_MarketingPagesDialOverride(t *testing.T) {
+	var mu sync.Mutex
 	var capturedHost string
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		capturedHost = r.Host
+		mu.Unlock()
 		_, _ = io.WriteString(w, "PAGES")
 	}))
 	defer stub.Close()
@@ -256,7 +260,10 @@ func TestProxy_MarketingPagesDialOverride(t *testing.T) {
 	if body := rr.Body.String(); body != "PAGES" {
 		t.Errorf("body = %q, want %q (dial override did not reach stub)", body, "PAGES")
 	}
-	if capturedHost != fakeHost {
-		t.Errorf("upstream Host header = %q, want %q (Host not pinned by Director)", capturedHost, fakeHost)
+	mu.Lock()
+	got := capturedHost
+	mu.Unlock()
+	if got != fakeHost {
+		t.Errorf("upstream Host header = %q, want %q (Host not pinned by Director)", got, fakeHost)
 	}
 }

--- a/internal/frontdoor/proxy_test.go
+++ b/internal/frontdoor/proxy_test.go
@@ -211,3 +211,52 @@ func TestProxy_ForgeProtection_HeadersStripped(t *testing.T) {
 		t.Errorf("forged X-Mitos-Account leaked to upstream: %q", body)
 	}
 }
+
+// TestProxy_MarketingPagesDialOverride verifies that when MarketingPagesAddrs
+// is non-empty, the marketing reverse proxy dials one of the listed addresses
+// instead of resolving the marketing host via DNS, and that the upstream Host
+// header is pinned to the marketing URL host (mitos.run in production).
+//
+// The test uses http:// so TLS is not in the path; the DialContext override is
+// the only mechanism that lets the request reach the local stub rather than the
+// real network host. InsecureSkipVerify is never set.
+func TestProxy_MarketingPagesDialOverride(t *testing.T) {
+	var capturedHost string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHost = r.Host
+		_, _ = io.WriteString(w, "PAGES")
+	}))
+	defer stub.Close()
+
+	con := consoleServer(t)
+	defer con.Close()
+
+	// Use a host whose DNS we do not control. The DialContext override in
+	// buildPagesMarketingReverseProxy must redirect dials to this host to the
+	// stub address instead.
+	const fakeHost = "mitos.run"
+	p, err := frontdoor.NewProxy(frontdoor.ProxyConfig{
+		MarketingURL:        "http://" + fakeHost,
+		MarketingPagesAddrs: []string{stub.Listener.Addr().String()},
+		ConsoleURL:          con.URL,
+		Resolver:            fakeResolver{},
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	// Anonymous request to a marketing path; no session cookie.
+	req := httptest.NewRequest(http.MethodGet, "/pricing", nil)
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (dial override did not reach stub)", rr.Code)
+	}
+	if body := rr.Body.String(); body != "PAGES" {
+		t.Errorf("body = %q, want %q (dial override did not reach stub)", body, "PAGES")
+	}
+	if capturedHost != fakeHost {
+		t.Errorf("upstream Host header = %q, want %q (Host not pinned by Director)", capturedHost, fakeHost)
+	}
+}


### PR DESCRIPTION
## Thinking Path

Two related changes to finish enabling the single-origin mitos.run frontdoor.

**Change 1: Marketing upstream dials GitHub Pages IPs directly**

Since mitos.run DNS will point at our gateway (Cilium edge), a normal DNS
lookup for the marketing upstream host would loop back to us. The fix: build
the marketing reverse proxy with a custom http.Transport whose DialContext
intercepts dials to the marketing host and redirects them to the configured
GitHub Pages anycast IPs (185.199.108-111.153:443) instead.

Security properties preserved:

- TLS SNI remains mitos.run: Go derives SNI from the URL host, not the
  dialed address. Pages serves the correct cert and validation succeeds.
- InsecureSkipVerify is never set anywhere in the production path.
- The upstream Host header is pinned to mitos.run by the wrapped Director,
  so Pages serves the correct site regardless of the incoming client Host.
- The dial override is scoped to the marketing ReverseProxy only; console
  traffic uses an independent proxy with the default transport.
- Round-robin across the Pages IPs uses a lock-free atomic.Uint64 counter
  (safe form: counter.Add(1) % uint64(len(pagesAddrs)) to avoid int overflow).
- When MarketingPagesAddrs is empty (default), behavior is unchanged
  (normal DNS). All existing tests pass without modification.

**Change 2: Console mounts the resolve-token when frontdoor is enabled**

The console serves POST /internal/session/resolve only when
MITOS_IDENTITY_RESOLVE_TOKEN is set. Previously the env was only mounted
when expose.enabled. The frontdoor also needs it for session resolution,
so the condition is broadened to expose.enabled OR frontdoor.enabled.
The secret source (expose.secretName, default mitos-expose, key resolve-token)
is unchanged; frontdoor-only mode references the same Secret.

## Verification

Tests:

- TestProxy_MarketingPagesDialOverride: stub server on localhost; configures
  MarketingPagesAddrs to stub address; asserts request reaches stub AND
  upstream Host = mitos.run. Mutex protects capturedHost across goroutines;
  go test -race passes (40 tests).
- All existing proxy and httpresolver tests pass unmodified.

Build:

- go build ./cmd/frontdoor/... clean.
- go test ./internal/frontdoor/... -v -race all PASS (40 tests).
- golangci-lint run AND GOOS=linux golangci-lint run both clean.

Helm:

- helm template with frontdoor.enabled=true renders console Deployment
  with MITOS_IDENTITY_RESOLVE_TOKEN and frontdoor Deployment with
  MITOS_FRONTDOOR_MARKETING_PAGES_ADDRS when Pages addrs are set.
- Default render (no Pages addrs) is clean and backward-compatible.
- expose.enabled=true alone still mounts the token (backward compat confirmed).

## HelmRelease Wiring

New chart value to set in the HelmRelease for production:

```yaml
frontdoor:
  marketingPagesAddrs:
    - "185.199.108.153:443"
    - "185.199.109.153:443"
    - "185.199.110.153:443"
    - "185.199.111.153:443"
```

Env var rendered by the chart: MITOS_FRONTDOOR_MARKETING_PAGES_ADDRS (comma-joined).

No new secrets. The console resolve-token is already in mitos-expose
(key resolve-token); frontdoor reads it via MITOS_IDENTITY_RESOLVE_TOKEN
from the same Secret.

## Model Used

Claude Opus 4.8 (1M context)