### PR TITLE
fix(chart): marketing container port 8080

### DIFF
--- a/deploy/charts/mitos/templates/marketing.yaml
+++ b/deploy/charts/mitos/templates/marketing.yaml
@@ -44,7 +44,11 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 80
+              # The marketing image is nginxinc/nginx-unprivileged, which runs as
+              # uid 101 and listens on 8080 (it cannot bind 80 as non-root). The
+              # Service targetPort and the probes reference this named port, so
+              # the Service still exposes 80 while the pod serves on 8080.
+              containerPort: {{ .Values.marketing.containerPort | default 8080 }}
           resources:
             {{- toYaml .Values.marketing.resources | nindent 12 }}
           securityContext:

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -741,6 +741,9 @@ marketing:
   enabled: false
   # Number of marketing replicas.
   replicas: 1
+  # Container port the marketing image listens on. The default image
+  # (nginxinc/nginx-unprivileged) listens on 8080 as a non-root user.
+  containerPort: 8080
   # Full OCI image reference for the marketing static site. Required when
   # marketing.enabled is true. Use "nginxinc/nginx-unprivileged:latest" as a
   # staging placeholder; replace with the production Astro dist image from the


### PR DESCRIPTION
The marketing image (nginx-unprivileged) listens on 8080, but the chart wired the container/service/probe to 80, so the marketing Service had no endpoints and the frontdoor returned 502. Wire containerPort to 8080 (configurable via marketing.containerPort), Service still exposes 80.