### PR TITLE
fix(frontdoor): extension-based static assets to marketing

### DIFF
--- a/internal/frontdoor/router.go
+++ b/internal/frontdoor/router.go
@@ -104,6 +104,20 @@ func Decide(path string) Decision {
 		return Decision{Upstream: "console", RequireSession: true}
 	}
 
-	// Non-reserved segment: treat as an org slug. Session required.
+	// A path whose final segment carries a file extension (a dot) is a static
+	// asset: marketing CSS/JS/images/fonts/sitemap/favicon, emitted at arbitrary
+	// root paths. Route it to marketing, public. The console's own Vite bundle
+	// lives under /assets (authSegments, matched above), and org slugs and SPA
+	// routes never contain a dot, so this does not steal app traffic.
+	last := path
+	if idx := strings.LastIndexByte(path, '/'); idx >= 0 {
+		last = path[idx+1:]
+	}
+	if strings.Contains(last, ".") {
+		return Decision{Upstream: "marketing"}
+	}
+
+	// Non-reserved, extension-less segment: treat as an org slug. Session
+	// required.
 	return Decision{Upstream: "console", RequireSession: true}
 }

--- a/internal/frontdoor/router_test.go
+++ b/internal/frontdoor/router_test.go
@@ -29,6 +29,10 @@ func TestDecide(t *testing.T) {
 		{"/about", "marketing", false, false},
 		{"/assets/x.js", "console", false, false},
 		{"/_astro/x.css", "marketing", false, false},
+		{"/og-image.png", "marketing", false, false},
+		{"/favicon.ico", "marketing", false, false},
+		{"/sitemap.xml", "marketing", false, false},
+		{"/some-org-slug", "console", true, false},
 
 		// Auth + onboarding paths: console, no session.
 		{"/login", "console", false, false},


### PR DESCRIPTION
Marketing emits static assets (images, favicon, sitemap) at arbitrary root paths; the org-slug catch-all sent them to the console. Route paths whose final segment has a file extension to marketing (console bundle at /assets is matched earlier).