### PR TITLE
fix(frontdoor): no session 302 on console paths

### DIFF
--- a/internal/frontdoor/proxy.go
+++ b/internal/frontdoor/proxy.go
@@ -226,14 +226,16 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if dec.RequireSession {
-		id, authed := p.resolveSession(r)
-		if !authed {
-			// 302 to /login?next=<escaped original path>
-			next := url.QueryEscape(r.URL.RequestURI())
-			http.Redirect(w, r, "/login?next="+next, http.StatusFound)
-			return
+		// Resolve the session so an authenticated request carries its account and
+		// org to the console (X-Mitos-Account / X-Mitos-Org). We do NOT redirect
+		// the anonymous case: the console owns auth. Its BFF (/console/*) returns
+		// 401 so the SPA detects the signed-out state, and it serves the SPA shell
+		// (which routes to login) for page loads. A frontdoor 302 here turned the
+		// SPA's /console/capabilities probe into a redirect and hung every console
+		// page on "loading".
+		if id, authed := p.resolveSession(r); authed {
+			p.injectIdentity(r, id)
 		}
-		p.injectIdentity(r, id)
 		p.console.ServeHTTP(w, r)
 		return
 	}

--- a/internal/frontdoor/proxy_test.go
+++ b/internal/frontdoor/proxy_test.go
@@ -115,7 +115,11 @@ func TestProxy_ConsoleWithSession(t *testing.T) {
 	}
 }
 
-func TestProxy_ConsoleNoSession_Redirects(t *testing.T) {
+// An anonymous request to a session-required console path is PASSED THROUGH to
+// the console (which owns auth: it 401s its API and serves the SPA), not
+// 302-redirected by the frontdoor. A frontdoor redirect broke the SPA's
+// /console/capabilities probe (it expects a 401, not a 302 to /login).
+func TestProxy_ConsoleNoSession_PassesThrough(t *testing.T) {
 	mkt := mktServer(t)
 	defer mkt.Close()
 	con := consoleServer(t)
@@ -127,13 +131,16 @@ func TestProxy_ConsoleNoSession_Redirects(t *testing.T) {
 	rr := httptest.NewRecorder()
 	p.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302", rr.Code)
+	// No frontdoor redirect: the request reaches the console upstream.
+	if rr.Code == http.StatusFound {
+		t.Fatalf("frontdoor 302-redirected an anon console request; it must pass through to the console")
 	}
-	loc := rr.Header().Get("Location")
-	want := "/login?next=%2Fconsole%2Fkeys"
-	if loc != want {
-		t.Errorf("Location = %q, want %q", loc, want)
+	if loc := rr.Header().Get("Location"); loc != "" {
+		t.Errorf("Location = %q, want empty (no frontdoor redirect)", loc)
+	}
+	if got := rr.Header().Get("X-Frontdoor-Upstream"); got != "console" && rr.Body.Len() == 0 {
+		// consoleServer marks responses; ensure the console actually served it.
+		t.Errorf("anon console request did not reach the console upstream")
 	}
 }
 


### PR DESCRIPTION
The frontdoor 302-redirected anonymous session-required console paths to /login, turning the SPA's /console/capabilities probe (expects 401) into a redirect and hanging every console page on loading. Resolve the session (still inject X-Mitos-Org when authed) but pass through to the console on the anon case; the console owns auth (401 API, SPA shell).