### PR TITLE
fix(chart): harden marketing pod (read-only root)

### DIFF
--- a/deploy/charts/mitos/templates/marketing.yaml
+++ b/deploy/charts/mitos/templates/marketing.yaml
@@ -42,6 +42,14 @@ spec:
           # staging placeholder until the production image is available.
           image: {{ required "marketing.image is required when marketing.enabled is true; set it to the Astro dist OCI reference or a staging placeholder" .Values.marketing.image }}
           imagePullPolicy: IfNotPresent
+          # Run nginx directly, bypassing the nginx-unprivileged
+          # /docker-entrypoint.sh. Its startup scripts (10-listen-on-ipv6,
+          # 20-envsubst) write to /etc/nginx/conf.d, which readOnlyRootFilesystem
+          # forbids. The image ships a STATIC default.conf that already binds both
+          # 8080 and [::]:8080, so those scripts are no-ops; skipping them lets the
+          # pod run with a read-only root. nginx still writes its pid and temp dirs
+          # under /tmp (per nginx.conf), backed by the emptyDir below.
+          command: ["nginx", "-g", "daemon off;"]
           ports:
             - name: http
               # The marketing image is nginxinc/nginx-unprivileged, which runs as
@@ -53,13 +61,12 @@ spec:
             {{- toYaml .Values.marketing.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
-            # readOnlyRootFilesystem is intentionally OFF: the nginx-unprivileged
-            # image's docker-entrypoint scripts must write /etc/nginx/conf.d
-            # (10-listen-on-ipv6) and nginx writes temp dirs under /tmp, so a
-            # read-only root crashloops the pod. The pod still runs as the image's
-            # non-root uid 101 with all capabilities dropped and no privilege
-            # escalation; it serves only static files.
-            readOnlyRootFilesystem: false
+            # Read-only root is safe here: the entrypoint scripts that wrote to
+            # /etc/nginx are bypassed (command above runs nginx directly), and
+            # nginx's pid + temp paths live under /tmp (writable emptyDir below).
+            # Fully hardened: non-root uid 101, all caps dropped, no privilege
+            # escalation, read-only root filesystem.
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
Bypass nginx-unprivileged entrypoint (command: nginx -g daemon off) so the static-site pod runs readOnlyRootFilesystem: true. Config is static, already binds [::]:8080; pid+temp under /tmp emptyDir.