### PR TITLE
chore: repoint stale issue refs to live trackers (#336, #372)

### DIFF
--- a/internal/controller/distribution_test.go
+++ b/internal/controller/distribution_test.go
@@ -368,7 +368,7 @@ func TestSnapshotRebuildsOnHolderNodeLoss(t *testing.T) {
 
 // TestRawForkdClaimAutoReplacementAfterNodeLossOpen documents, as an explicit
 // skipped placeholder, the part of issue #163 item 6 that is NOT a missing test
-// but a missing FEATURE and a deliberate open product decision (epic #12).
+// but a missing FEATURE and a deliberate open product decision (#372).
 //
 // In HUSK mode a Ready claim on a lost node re-pends onto a surviving dormant
 // warm slot (checkHuskPodLost + the husk pod watch self-heal the warm pool). In
@@ -387,5 +387,5 @@ func TestSnapshotRebuildsOnHolderNodeLoss(t *testing.T) {
 // claim. It needs no KVM; it needs the product decision to give raw claims
 // husk-like resilience at the cost of the pure fork-per-claim model.
 func TestRawForkdClaimAutoReplacementAfterNodeLossOpen(t *testing.T) {
-	t.Skip("#12: raw-forkd claim auto-replacement after NodeLost is an open product decision; today the claim is marked NodeLost and the caller re-claims (husk mode self-heals via the warm pool instead). Snapshot rebuild-elsewhere IS covered by TestSnapshotRebuildsOnHolderNodeLoss.")
+	t.Skip("#372: raw-forkd claim auto-replacement after NodeLost is an open product decision; today the claim is marked NodeLost and the caller re-claims (husk mode self-heals via the warm pool instead). Snapshot rebuild-elsewhere IS covered by TestSnapshotRebuildsOnHolderNodeLoss.")
 }

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -1492,7 +1492,7 @@ func (e *Engine) ForkRunning(sourceSandboxID, newSandboxID string, pauseSource b
 	// (husk pods #18) isolates each fork's interface, live-forking a networked
 	// sandbox is unsupported.
 	if e.networkEnabled() {
-		return nil, fmt.Errorf("live fork (ForkRunning) of a networked sandbox is not supported yet; tracked in #18")
+		return nil, fmt.Errorf("live fork (ForkRunning) of a networked sandbox is not supported yet; tracked in #336")
 	}
 
 	if pauseSource && source.fcClient != nil {

--- a/internal/fork/network_test.go
+++ b/internal/fork/network_test.go
@@ -180,7 +180,7 @@ func TestPrepareForkNetworkDistinctPerFork(t *testing.T) {
 
 // TestForkRunningFailsClosedWithNetworking asserts that a live fork
 // (ForkRunning) of a sandbox is rejected with an explicit, actionable error
-// while per-VM netns is not yet available (#18). Restoring the source's baked
+// while per-VM netns is not yet available (#336). Restoring the source's baked
 // NIC into a second live VM would collide on tap/MAC/IP, so we fail closed
 // rather than silently break networking.
 func TestForkRunningFailsClosedWithNetworking(t *testing.T) {
@@ -193,8 +193,8 @@ func TestForkRunningFailsClosedWithNetworking(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected ForkRunning to fail closed when networking is enabled")
 	}
-	if !strings.Contains(err.Error(), "not supported yet") || !strings.Contains(err.Error(), "#18") {
-		t.Errorf("error = %q, want an explicit unsupported message referencing #18", err)
+	if !strings.Contains(err.Error(), "not supported yet") || !strings.Contains(err.Error(), "#336") {
+		t.Errorf("error = %q, want an explicit unsupported message referencing #336", err)
 	}
 }
 


### PR DESCRIPTION
## Thinking Path

Backlog-grooming cleanup. Two code locations cited closed epics in user-visible strings, which violates the docs-hygiene rule (no stale/closed internal refs in user-facing copy):

- `internal/fork/engine.go`: the `ForkRunning` fail-closed error said `tracked in #18` (the closed husk-pods epic); the live unblock work is #336.
- `internal/controller/distribution_test.go`: the auto-replacement skip test cited the closed failure/GC epic #12; the live follow-up is #372.

The original change repointed the `engine.go` error string but missed `internal/fork/network_test.go`, whose `TestForkRunningFailsClosedWithNetworking` asserts the exact `#18` substring; that assertion broke `go-test`. This revision updates the test (and its doc comment) to assert `#336` so the test matches the message in the same change (TDD).

## What Changed

- `internal/fork/engine.go`: error string `#18` -> `#336`.
- `internal/fork/network_test.go`: assertion and comment `#18` -> `#336` (keeps the test green with the new message).
- `internal/controller/distribution_test.go`: skip-reason and comment `#12` -> `#372`.

Comment and string changes only. No behavior change; no security surface change (the error path and its fail-closed semantics are unchanged).

## Verification

- [x] `go test ./internal/fork/ -run TestForkRunningFailsClosedWithNetworking` (passes)
- [x] Rebased onto current main
- [x] No em or en dashes introduced

## Model Used

Claude Opus 4.8 (1M context).
