### PR TITLE
ci: build and type-check every SDK example so docs cannot drift (#446)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,6 +267,99 @@ jobs:
             kill "${SANDBOX_SERVER_PID}" 2>/dev/null || true
           fi
 
+  sdk-examples:
+    # Build / type-check EVERY file under each SDK's examples/ so a README or
+    # per-SDK example cannot silently drift from the real API and ship broken
+    # (issue #446, spun out of #22). This is the uniform, fast, non-KVM gate: it
+    # compiles, it does not boot a VM.
+    #
+    # Per-SDK honesty (executed vs compiled):
+    #   Python: byte-compiled AND import-checked. Import runs each example's
+    #           module-level code (imports plus the quickstart drift-guard
+    #           asserts), so a renamed SDK symbol fails here. The examples exec
+    #           inside a guest VM the mock lacks, so they are EXECUTED end to end
+    #           only on real KVM (examples/direct.py in the kvm-test job).
+    #   Go:     compiled (go build) and vetted (go vet) for every example.
+    #           examples/direct is EXECUTED end to end on real KVM (kvm-test).
+    #   TS:     type-checked against the built dist types via check:examples
+    #           (tsconfig.examples.json), which catches signature drift.
+    #   Rust / Java / Ruby: no examples/ directory exists, so nothing to gate.
+    #
+    # README drift: the hosted quickstart hero is extracted into a checked
+    # example per SDK (examples/quickstart.*), and every fenced python block in
+    # the repo and Python SDK READMEs is byte-compiled, so the docs cannot drift
+    # into broken code.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: sdk/go/go.mod
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "20"
+
+      - name: Python examples (byte-compile, import-check, README fences)
+        run: |
+          set -euo pipefail
+          # Install the SDK so the example imports resolve exactly as a user's
+          # would. browser_cdp.py imports playwright only inside main(), so the
+          # import-check below does not need it.
+          pip install ./sdk/python
+          echo "=== byte-compile every Python example ==="
+          python3 -m py_compile sdk/python/examples/*.py
+          echo "=== import-check every Python example (runs module-level code, not main) ==="
+          for f in sdk/python/examples/*.py; do
+            python3 - "$f" <<'PY'
+          import importlib.util, sys
+          path = sys.argv[1]
+          spec = importlib.util.spec_from_file_location("example_under_test", path)
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          print("import OK:", path)
+          PY
+          done
+          echo "=== byte-compile every python fence in the READMEs (docs cannot drift) ==="
+          python3 - README.md sdk/python/README.md <<'PY'
+          import os, re, sys, tempfile, py_compile
+          failures = 0
+          checked = 0
+          for f in sys.argv[1:]:
+              text = open(f, encoding="utf-8").read()
+              for i, m in enumerate(re.finditer(r"```python\n(.*?)```", text, re.DOTALL)):
+                  checked += 1
+                  with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as t:
+                      t.write(m.group(1))
+                      tmp = t.name
+                  try:
+                      py_compile.compile(tmp, doraise=True)
+                  except py_compile.PyCompileError as e:
+                      failures += 1
+                      print(f"SYNTAX FAIL in {f} fence #{i}:\n{e}")
+                  finally:
+                      os.unlink(tmp)
+          print(f"checked {checked} python fences; failures={failures}")
+          sys.exit(1 if failures else 0)
+          PY
+
+      - name: Go examples (build and vet)
+        working-directory: sdk/go
+        run: |
+          set -euo pipefail
+          go build ./examples/...
+          go vet ./examples/...
+
+      - name: TypeScript examples (type-check against built types)
+        working-directory: sdk/typescript
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+          npm run check:examples
+
   docker-build:
     runs-on: ubuntu-latest
     steps:

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -74,6 +74,9 @@ func main() {
 }
 ```
 
+This hero is the checked example `examples/quickstart`: CI builds and vets it
+against the real SDK, so this snippet cannot drift.
+
 `Fork` is the snapshot-fork primitive: each call forks a warm template into a
 fresh, independent sandbox, so parallel attempts start from the same state.
 

--- a/sdk/go/examples/quickstart/main.go
+++ b/sdk/go/examples/quickstart/main.go
@@ -1,0 +1,43 @@
+// Hosted quickstart: the snippet shown in the Go SDK README.
+//
+// This file is the checked copy of the hosted "Quickstart" hero so the README
+// code cannot drift from the real SDK surface. The sdk-examples CI job compiles
+// it (go build ./examples/... and go vet), so a renamed or removed method fails
+// the build.
+//
+// It is NOT executed in CI: the hosted default (NewSandboxServer with no base
+// URL) talks to https://mitos.run with a real MITOS_API_KEY, which CI does not
+// carry. End-to-end execution of the direct path is proven against a real KVM
+// sandbox-server by examples/direct in the kvm-test job. Run this one yourself:
+//
+//	export MITOS_API_KEY="sk-..."
+//	go run ./sdk/go/examples/quickstart
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	mitos "github.com/mitos-run/mitos/sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	srv := mitos.NewSandboxServer() // base URL + token resolved from the env
+
+	if _, err := srv.CreateTemplate(ctx, "python"); err != nil {
+		log.Fatal(err)
+	}
+	sb, err := srv.Fork(ctx, "python", "") // empty id -> generated sandbox-<hex>
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sb.Terminate(ctx)
+
+	res, err := sb.Exec(ctx, "echo hi")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(res.Stdout)
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -54,6 +54,9 @@ print(ex.text)                                    # 12.0
 sb.terminate()
 ```
 
+This hero is the checked example `examples/quickstart.py`: CI byte-compiles and
+import-checks it against the real SDK, so this snippet cannot drift.
+
 `mitos.create(image, api_key=..., base_url=...)` resolves auth (see precedence
 below), gets-or-creates the template for `image`, forks it, and returns a READY
 `DirectSandbox` exposing `exec`, `run_code`, `files`, `pty`, `fork`,

--- a/sdk/python/examples/quickstart.py
+++ b/sdk/python/examples/quickstart.py
@@ -1,0 +1,48 @@
+"""Hosted quickstart: the snippet shown in the repository and Python SDK READMEs.
+
+This file is the checked copy of the hosted "Quickstart" hero so the README code
+cannot drift from the real SDK surface. The sdk-examples CI job byte-compiles it
+and imports it; the module-level guard below asserts every symbol the hero calls
+still exists, so a renamed or removed method fails the build at import time.
+
+It is NOT executed in CI: the hosted default talks to https://mitos.run with a
+real MITOS_API_KEY, which CI does not carry. End-to-end execution of the direct
+path is proven against a real KVM sandbox-server by examples/direct.py in the
+kvm-test job. Run this one yourself with an API key in the environment::
+
+    export MITOS_API_KEY=sk-...
+    python3 quickstart.py
+"""
+
+import mitos
+from mitos.direct import DirectSandbox, DirectSandboxFiles
+
+# Drift guard: the hero below calls these. Asserting them at import time turns the
+# CI import-check into a real API-surface check (not just a syntax check), so a
+# rename in the SDK fails this example before the README can ship stale.
+assert callable(mitos.create)
+assert all(hasattr(DirectSandbox, m) for m in ("exec", "run_code", "fork", "terminate"))
+assert hasattr(DirectSandboxFiles, "write")
+
+
+def main() -> None:
+    # MITOS_API_KEY from the environment; base URL defaults to https://mitos.run.
+    sb = mitos.create("python")
+    print(sb.exec("echo hello").stdout)              # hello
+
+    # Files and a stateful code interpreter hang off the same flat handle.
+    sb.files.write("/workspace/plan.txt", "draft")
+
+    # N-way copy-on-write fork of the live VM: each sibling lands warm.
+    fork_a, fork_b = sb.fork(2)                       # two independent siblings
+    fork_a.exec("echo a > /workspace/a.txt")
+    fork_b.exec("echo b > /workspace/b.txt")          # b does not see a's write
+
+    ex = sb.run_code("import math; math.sqrt(144)")
+    print(ex.text)                                    # 12.0
+
+    sb.terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -44,6 +44,9 @@ console.log((await sandbox.files.read("/workspace/hello.txt")).trim()); // hello
 await sandbox.terminate();
 ```
 
+This hero is the checked example `examples/quickstart.ts`: CI type-checks it
+against the built types via `npm run check:examples`, so this snippet cannot drift.
+
 Point at a local standalone server by setting `MITOS_BASE_URL` or passing the
 URL: `new SandboxServer("http://localhost:8080")`.
 

--- a/sdk/typescript/examples/quickstart.ts
+++ b/sdk/typescript/examples/quickstart.ts
@@ -1,0 +1,36 @@
+/**
+ * Hosted quickstart: the snippet shown in the TypeScript SDK README.
+ *
+ * This file is the checked copy of the hosted "Quickstart" hero so the README
+ * code cannot drift from the real SDK surface. It type-checks under
+ * `npm run check:examples` (tsconfig.examples.json compiles examples against the
+ * built dist types), so a renamed or removed method fails the build.
+ *
+ * It is NOT executed in CI: the hosted default (new SandboxServer() with no URL)
+ * talks to https://mitos.run with a real MITOS_API_KEY, which CI does not carry.
+ * Wire shapes and error semantics are conformance-tested against a mock server
+ * in test/. Point at a local server with new SandboxServer("http://...") to run.
+ */
+
+import { SandboxServer } from "@mitos/sdk";
+
+async function main(): Promise<void> {
+  // MITOS_API_KEY from the environment; base URL defaults to https://mitos.run.
+  const server = new SandboxServer();
+
+  // Fork a sandbox from a template (a fresh, independent VM from a warm snapshot).
+  const sandbox = await server.fork("python");
+
+  const result = await sandbox.exec("python3 -c 'print(1 + 1)'");
+  console.log(result.exitCode, result.stdout.trim()); // 0  2
+
+  await sandbox.files.write("/workspace/hello.txt", "hello\n");
+  console.log((await sandbox.files.read("/workspace/hello.txt")).trim()); // hello
+
+  await sandbox.terminate();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #446 (spun out of #22).

Today only the TypeScript SDK type-checks its `examples/` in CI, so an example or a README hero in another SDK can silently drift from the API and ship broken. This adds one uniform, fast, non-KVM gate that builds or type-checks every file under each SDK's `examples/`, and extracts the hosted quickstart hero into a checked example per SDK so the READMEs cannot drift either.

What landed:

* New always-run `sdk-examples` job in `ci.yaml` covering every SDK that has an `examples/` directory.
* Extracted the hosted quickstart hero into a checked example per SDK: `sdk/python/examples/quickstart.py`, `sdk/go/examples/quickstart/main.go`, `sdk/typescript/examples/quickstart.ts`.
* Every fenced python block in the repo README and the Python SDK README is byte-compiled by the job, so the docs cannot drift into broken code.
* Per-SDK README pointers noting the hero is a checked example.

Rust, Java and Ruby have no `examples/` directory, so there is nothing to gate for them; the job documents this in its comments.

## Thinking Path

The honest bar differs per SDK. The mock `sandbox-server` (`--mock`) serves the control plane (create template, fork, list, terminate) but has no guest VM, so `exec` / `files` / `run_code` cannot run against it; every example execs, so executing them against the mock is not possible. End-to-end execution of the direct path is already proven on real KVM (`examples/direct.py` and `examples/direct` in the kvm-test job). The fast gate therefore compiles or type-checks, and is explicit in its comments about which SDKs are executed (on KVM) versus compiled here. I chose compile and type-check coverage for all present SDKs over flaky execution, per the no-unverified-claims rule. For Python, the quickstart example carries a module-level drift guard that asserts each symbol the hero calls still exists, so the import-check is a real API-surface check, not just a syntax check.

## Verification

All commands run locally in the worktree.

* Python (byte-compiled and import-checked locally; executed only on KVM):
  * `python3 -m py_compile sdk/python/examples/*.py` -> OK
  * import-check loop over `sdk/python/examples/*.py` (loads each module, runs module-level code and the quickstart drift-guard asserts, not `main`) -> `import OK` for browser_cdp.py, direct.py, quickstart.py
  * README python-fence byte-compile over `README.md` and `sdk/python/README.md` -> `checked 22 python fences; failures=0`
* Go (compiled and vetted locally; executed only on KVM):
  * `cd sdk/go && go build ./examples/...` -> OK
  * `cd sdk/go && go vet ./examples/...` -> OK
  * `gofmt -l examples/quickstart/main.go` -> clean
* TypeScript (type-checked locally):
  * `cd sdk/typescript && npm ci && npm run build && npm run check:examples` -> exit 0
* Rust, Java, Ruby: no `examples/` directory exists, so skipped (nothing to gate). Java toolchain is also unavailable locally, but it is moot here.
* actionlint: `actionlint .github/workflows/ci.yaml` reports only two findings (SC2034 and SC2016), both pre-existing on `origin/main` and outside this job; my added job introduces zero new findings. The rendered heredoc scripts were confirmed correct by parsing the YAML.

## Model Used

Claude (subagent) via Claude Code
