### PR TITLE
fix(controller): rebuild pool snapshot on template-content edits

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -347,6 +347,14 @@ type SandboxPoolStatus struct {
 	// snapshot. A content address, safe to log.
 	TemplateDigest string `json:"templateDigest,omitempty"`
 
+	// TemplateBuildHash records the build identity (a content hash of the template
+	// image, init/buildSteps, workload, volumes, resources and encryption flag) the
+	// pool's snapshot was last built from. The controller rebuilds the snapshot when
+	// the template's current build identity no longer matches this, so a
+	// workload.command, env, or ready-probe edit re-runs the build instead of being
+	// silently ignored (issue #475). A content address, safe to log.
+	TemplateBuildHash string `json:"templateBuildHash,omitempty"`
+
 	// DesiredWarm is the autoscaler's computed desired dormant pod count.
 	DesiredWarm int32 `json:"desiredWarm,omitempty"`
 

--- a/deploy/charts/mitos/crds/mitos.run_sandboxpools.yaml
+++ b/deploy/charts/mitos/crds/mitos.run_sandboxpools.yaml
@@ -993,6 +993,15 @@ spec:
               restoringCount:
                 format: int32
                 type: integer
+              templateBuildHash:
+                description: |-
+                  TemplateBuildHash records the build identity (a content hash of the template
+                  image, init/buildSteps, workload, volumes, resources and encryption flag) the
+                  pool's snapshot was last built from. The controller rebuilds the snapshot when
+                  the template's current build identity no longer matches this, so a
+                  workload.command, env, or ready-probe edit re-runs the build instead of being
+                  silently ignored (issue #475). A content address, safe to log.
+                type: string
               templateDigest:
                 description: |-
                   TemplateDigest is the content-addressed manifest digest of the pool's

--- a/deploy/crds/mitos.run_sandboxpools.yaml
+++ b/deploy/crds/mitos.run_sandboxpools.yaml
@@ -993,6 +993,15 @@ spec:
               restoringCount:
                 format: int32
                 type: integer
+              templateBuildHash:
+                description: |-
+                  TemplateBuildHash records the build identity (a content hash of the template
+                  image, init/buildSteps, workload, volumes, resources and encryption flag) the
+                  pool's snapshot was last built from. The controller rebuilds the snapshot when
+                  the template's current build identity no longer matches this, so a
+                  workload.command, env, or ready-probe edit re-runs the build instead of being
+                  silently ignored (issue #475). A content address, safe to log.
+                type: string
               templateDigest:
                 description: |-
                   TemplateDigest is the content-addressed manifest digest of the pool's

--- a/deploy/olm/bundle/manifests/mitos.run_sandboxpools.yaml
+++ b/deploy/olm/bundle/manifests/mitos.run_sandboxpools.yaml
@@ -788,6 +788,15 @@ spec:
               restoringCount:
                 format: int32
                 type: integer
+              templateBuildHash:
+                description: |-
+                  TemplateBuildHash records the build identity (a content hash of the template
+                  image, init/buildSteps, workload, volumes, resources and encryption flag) the
+                  pool's snapshot was last built from. The controller rebuilds the snapshot when
+                  the template's current build identity no longer matches this, so a
+                  workload.command, env, or ready-probe edit re-runs the build instead of being
+                  silently ignored (issue #475). A content address, safe to log.
+                type: string
               templateDigest:
                 description: |-
                   TemplateDigest is the content-addressed manifest digest of the pool's

--- a/docs/husk-pods.md
+++ b/docs/husk-pods.md
@@ -196,9 +196,23 @@ addressed digest. A warm husk pod records the digest and node it verifies agains
 reconcile the controller reaps any DORMANT pod whose stamped digest no longer
 matches its node's current recorded digest, and the warm-pool deficit logic
 refills the slot against the fresh snapshot. Claimed (activating or active) pods
-are never reaped. This does not trigger the rebuild itself (a content change
-re-triggering a build is #475); it ensures that once a rebuild has happened, warm
-husks converge instead of CrashLoopBackOff on a stale digest.
+are never reaped. It ensures that once a rebuild has happened, warm husks
+converge instead of CrashLoopBackOff on a stale digest.
+
+### Template-content edits re-trigger the build (#475)
+
+The controller derives a build identity from everything that determines what the
+snapshot contains: the template image, the resolved init/buildSteps, the serving
+workload (command, env, ready probe), the baked volumes, the build VM resources,
+and the at-rest encryption flag. It records that identity in the pool status field
+`templateBuildHash`. On reconcile, when the template's current build identity no
+longer matches the recorded one, the snapshot is rebuilt in place on every holder
+node (a fresh content-addressed digest), and the #461 stale-digest reap above then
+converges the warm pool onto it. So editing `spec.template.workload.command` (or
+env, or the ready probe) on a pool re-runs the build the same way an image change
+does, instead of being silently ignored until the pool is deleted and recreated.
+Fields that do not change snapshot content (placement, network posture, warm-pool
+sizing, budgets) are excluded from the identity, so they never force a rebuild.
 
 ### Measured activation latency (CI husk-stub phase)
 

--- a/internal/controller/pool_build_identity_test.go
+++ b/internal/controller/pool_build_identity_test.go
@@ -1,0 +1,88 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// poolBuildIdentity is the content hash that decides whether a pool's template
+// snapshot must be rebuilt. A change to any build-affecting field (image,
+// init/buildSteps, workload command/env/ready probe, volumes, resources,
+// encryption) must change the identity so the controller rebuilds the snapshot
+// (issue #475). Two templates that differ only in a non-build field, or not at
+// all, must share an identity so a steady-state reconcile does not churn.
+func TestPoolBuildIdentity(t *testing.T) {
+	base := func() *v1.PoolTemplateSpec {
+		return &v1.PoolTemplateSpec{
+			Image: "python:3.12-slim",
+			Init:  []string{"pip install flask"},
+			Workload: &v1.WorkloadSpec{
+				Command: []string{"flask", "run"},
+				Env:     []corev1.EnvVar{{Name: "PORT", Value: "8080"}},
+				Ready:   &v1.HTTPReadyProbe{Port: 8080, Path: "/healthz"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(t *v1.PoolTemplateSpec)
+		differ bool
+	}{
+		{
+			name:   "identical template",
+			mutate: func(*v1.PoolTemplateSpec) {},
+			differ: false,
+		},
+		{
+			name:   "workload command changed",
+			mutate: func(t *v1.PoolTemplateSpec) { t.Workload.Command = []string{"gunicorn", "app:app"} },
+			differ: true,
+		},
+		{
+			name:   "workload env changed",
+			mutate: func(t *v1.PoolTemplateSpec) { t.Workload.Env[0].Value = "9090" },
+			differ: true,
+		},
+		{
+			name:   "workload ready probe changed",
+			mutate: func(t *v1.PoolTemplateSpec) { t.Workload.Ready.Path = "/ready" },
+			differ: true,
+		},
+		{
+			name:   "workload added",
+			mutate: func(t *v1.PoolTemplateSpec) { t.Workload = nil },
+			differ: true,
+		},
+		{
+			name:   "image changed",
+			mutate: func(t *v1.PoolTemplateSpec) { t.Image = "python:3.13-slim" },
+			differ: true,
+		},
+		{
+			name:   "init changed",
+			mutate: func(t *v1.PoolTemplateSpec) { t.Init = []string{"pip install django"} },
+			differ: true,
+		},
+	}
+
+	want := poolBuildIdentity(base())
+	if want == "" {
+		t.Fatal("poolBuildIdentity returned empty for a non-nil template")
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := base()
+			tc.mutate(mutated)
+			got := poolBuildIdentity(mutated)
+			if tc.differ && got == want {
+				t.Errorf("identity did not change after %s; both = %s", tc.name, got)
+			}
+			if !tc.differ && got != want {
+				t.Errorf("identity changed for %s: got %s want %s", tc.name, got, want)
+			}
+		})
+	}
+}

--- a/internal/controller/pool_template.go
+++ b/internal/controller/pool_template.go
@@ -2,6 +2,9 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +51,53 @@ func poolTemplateID(pool *v1.SandboxPool) string {
 		return pool.Spec.TemplateRef.Name
 	}
 	return pool.Name
+}
+
+// poolBuildIdentity is the content hash of everything that determines what a
+// pool's template snapshot CONTAINS, so the controller can tell a template-content
+// edit apart from a steady-state reconcile and rebuild the snapshot when (and only
+// when) the content changed (issue #475). It hashes exactly the inputs handed to
+// forkd's CreateTemplate build: the base image, the resolved init commands
+// (BuildSteps flattened, or the legacy Init), the serving workload (command, env,
+// ready probe), the baked volumes, the build VM resources, and the at-rest
+// encryption flag. A change to the workload command, env, or ready probe (the
+// silent-no-rebuild bug) therefore changes the identity exactly the way an image
+// change does. Fields that do not change snapshot content (placement, network
+// posture, warm-pool sizing, budgets) are deliberately excluded so they do not
+// trigger a needless rebuild. A nil template hashes to the empty string.
+func poolBuildIdentity(t *v1.PoolTemplateSpec) string {
+	if t == nil {
+		return ""
+	}
+	// An explicit, named payload (not the whole spec) so the hash is stable against
+	// unrelated PoolTemplateSpec additions and so it is obvious which fields gate a
+	// rebuild. Field order is fixed by the struct, and every member marshals
+	// deterministically (slices are ordered; resource.Quantity has a canonical
+	// JSON form), so the digest is reproducible across reconciles.
+	payload := struct {
+		Image     string              `json:"image"`
+		Init      []string            `json:"init"`
+		Workload  *v1.WorkloadSpec    `json:"workload"`
+		Volumes   []v1.SandboxVolume  `json:"volumes"`
+		Resources v1.SandboxResources `json:"resources"`
+		Encrypted bool                `json:"encrypted"`
+	}{
+		Image:     t.Image,
+		Init:      v1.InitCommands(t.BuildSteps, t.Init),
+		Workload:  t.Workload,
+		Volumes:   t.Volumes,
+		Resources: t.Resources,
+		Encrypted: t.Encrypted,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		// json.Marshal of these value types does not fail; fall back to a constant
+		// so a hypothetical error degrades to "rebuild on every reconcile" rather
+		// than silently colliding identities.
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 // poolReplicas is the desired per-node snapshot fan-out for a pool: the v1

--- a/internal/controller/pool_workload_rebuild_test.go
+++ b/internal/controller/pool_workload_rebuild_test.go
@@ -1,0 +1,77 @@
+package controller_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/controller"
+)
+
+// Editing a pool template's workload.command must re-trigger the snapshot build
+// (issue #475). Before the fix the snapshot was keyed by pool name alone, so the
+// holder count stayed satisfied and the changed command was silently ignored. The
+// build identity now folds in the workload, so a command edit rebuilds the
+// snapshot in place; an unchanged template does not churn.
+func TestPoolWorkloadEditTriggersRebuild(t *testing.T) {
+	c := k8sClient
+	const node = "rebuild-node-475"
+
+	pool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "rebuild-475-pool", Namespace: "default"},
+		Spec: v1.SandboxPoolSpec{
+			Template: &v1.PoolTemplateSpec{
+				Image:    "python:3.12-slim",
+				Workload: &v1.WorkloadSpec{Command: []string{"flask", "run"}},
+			},
+			Warm: &v1.PoolWarm{Min: 1},
+		},
+	}
+
+	reg := controller.NewNodeRegistry()
+	stop, rec, err := controller.StartFakeForkdNodeEncRecording(reg, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(stop)
+
+	r := &controller.SandboxPoolReconciler{
+		Client:       c,
+		NodeRegistry: reg,
+	}
+
+	// First build: no holder yet, so the snapshot is built once and the build
+	// identity is recorded.
+	if err := r.EnsureTemplateBuiltForTest(ctx, pool, pool.Spec.Template); err != nil {
+		t.Fatalf("ensureTemplateBuilt (first build): %v", err)
+	}
+	if got := rec.CreateTemplateCount(); got != 1 {
+		t.Fatalf("CreateTemplate count after first build = %d, want 1", got)
+	}
+	firstHash := pool.Status.TemplateBuildHash
+	if firstHash == "" {
+		t.Fatal("TemplateBuildHash was not recorded after the first build")
+	}
+
+	// A no-op reconcile (identical template, holder count satisfied) must NOT
+	// rebuild: no snapshot churn.
+	if err := r.EnsureTemplateBuiltForTest(ctx, pool, pool.Spec.Template); err != nil {
+		t.Fatalf("ensureTemplateBuilt (steady state): %v", err)
+	}
+	if got := rec.CreateTemplateCount(); got != 1 {
+		t.Fatalf("CreateTemplate count after a no-op reconcile = %d, want 1 (no churn)", got)
+	}
+
+	// Edit the workload command: the build identity changes, so the snapshot must
+	// be rebuilt in place on the holder even though the holder count is satisfied.
+	pool.Spec.Template.Workload.Command = []string{"gunicorn", "app:app"}
+	if err := r.EnsureTemplateBuiltForTest(ctx, pool, pool.Spec.Template); err != nil {
+		t.Fatalf("ensureTemplateBuilt (after workload edit): %v", err)
+	}
+	if got := rec.CreateTemplateCount(); got != 2 {
+		t.Fatalf("CreateTemplate count after a workload.command edit = %d, want 2 (the edit must rebuild)", got)
+	}
+	if pool.Status.TemplateBuildHash == firstHash {
+		t.Fatalf("TemplateBuildHash did not change after a workload.command edit (still %s)", firstHash)
+	}
+}

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -277,12 +277,20 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			recordWarmScaleDown(poolKey(&pool))
 		}
 
+		// Snapshot the stored status before mutating so a no-op reconcile can skip
+		// the status write (issue #163). Captured BEFORE ensureTemplateBuilt because
+		// that records the build identity into pool.Status.TemplateBuildHash (issue
+		// #475), which must be part of the change comparison so a rebuild is
+		// persisted. The metric setters above do not touch pool.Status.
+		before := pool.Status.DeepCopy()
+
 		// Build the snapshot the husk pods activate against, BEST-EFFORT. A build
 		// error is logged and reported in status, and we requeue to keep trying,
 		// but it does NOT return before the warm pool was maintained above. On a
 		// node that cannot snapshot (the documented nested-VMM boundary on kind)
 		// the build never completes, yet the warm pool above is still maintained
-		// and self-heals.
+		// and self-heals. A template-content edit (issue #475) rebuilds the snapshot
+		// in place here even when the holder count is already satisfied.
 		buildErr := r.ensureTemplateBuilt(ctx, &pool, template, nodeFilter)
 		if buildErr != nil {
 			logger.Error(buildErr, "failed to build template snapshot for husk pool (warm pool still maintained)")
@@ -298,10 +306,6 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
 		setPoolReadySnapshots(pool.Name, readySnapshots)
-		// Snapshot the stored status before mutating so a no-op reconcile can skip
-		// the status write (issue #163). Captured AFTER the metric setter (which
-		// does not touch status) and BEFORE any pool.Status mutation.
-		before := pool.Status.DeepCopy()
 		pool.Status.ReadySnapshots = readySnapshots
 		pool.Status.TotalSnapshots = readySnapshots
 		pool.Status.NodeDistribution = r.nodeDistribution(templateID)
@@ -340,19 +344,22 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Raw-forkd path (the --enable-raw-forkd fallback): build the snapshot on the
 	// target nodes and let each claim fork on a holder. No husk pods.
-	if rawReady := r.readySnapshotCountOn(templateID, nodeFilter); rawReady < desired {
-		logger.Info("snapshot deficit", "ready", rawReady, "desired", desired)
-		if err := r.ensureTemplateBuilt(ctx, &pool, template, nodeFilter); err != nil {
-			logger.Error(err, "failed to create snapshots")
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-		}
+	//
+	// Snapshot before mutating so a no-op reconcile skips the status write (#163).
+	// Captured BEFORE ensureTemplateBuilt because that records the build identity
+	// into pool.Status.TemplateBuildHash (issue #475), which must be part of the
+	// change comparison so a rebuild is persisted. ensureTemplateBuilt is always
+	// called now (not gated on a count deficit) so a template-content edit rebuilds
+	// the snapshot in place even when the holder count is already satisfied.
+	before := pool.Status.DeepCopy()
+	if err := r.ensureTemplateBuilt(ctx, &pool, template, nodeFilter); err != nil {
+		logger.Error(err, "failed to create snapshots")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
 
 	// Update status
 	setPoolReadySnapshots(pool.Name, readySnapshots)
-	// Snapshot before mutating so a no-op reconcile skips the status write (#163).
-	before := pool.Status.DeepCopy()
 	pool.Status.ReadySnapshots = readySnapshots
 	pool.Status.TotalSnapshots = readySnapshots
 	pool.Status.NodeDistribution = r.nodeDistribution(templateID)
@@ -497,10 +504,24 @@ func (r *SandboxPoolReconciler) ensureTemplateBuilt(ctx context.Context, pool *v
 	// placement nodes for BOTH the deficit count and the build targets, so a
 	// snapshot is never built off the dedicated set. nil => unconstrained.
 	readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
-	if readySnapshots >= desired {
+
+	// A template-content edit (image, init/buildSteps, workload command/env/ready
+	// probe, volumes, resources, encryption) makes every EXISTING snapshot stale
+	// even when the node COUNT already satisfies the deficit, so it must rebuild in
+	// place on the current holders; the #461 stale-digest reap then converges the
+	// warm husk pool onto the fresh snapshot (issue #475). The very first build (no
+	// recorded build hash yet) is the ordinary deficit path, not a content change,
+	// so an empty recorded hash never forces a rebuild.
+	want := poolBuildIdentity(template)
+	contentChanged := pool.Status.TemplateBuildHash != "" && pool.Status.TemplateBuildHash != want
+
+	if readySnapshots >= desired && !contentChanged {
+		// Snapshots are present and current: record the build identity the existing
+		// snapshots are assumed to carry so a later edit is detected. Idempotent
+		// once set (no rebuild, no churn on a steady-state reconcile).
+		pool.Status.TemplateBuildHash = want
 		return nil
 	}
-	deficit := desired - readySnapshots
 
 	var wrappedDEK []byte
 	var kekID string
@@ -515,13 +536,59 @@ func (r *SandboxPoolReconciler) ensureTemplateBuilt(ctx context.Context, pool *v
 			return fmt.Errorf("ensure encryption key for template %s: %w", templateID, keyErr)
 		}
 	}
-	// InitCommands flattens the declarative BuildSteps (issue #220) into the
-	// in-VM init commands, falling back to the legacy Init list when no
-	// BuildSteps are set, so a template authored either way builds identically.
-	if _, err := r.createSnapshotsOnNodes(ctx, templateID, template.Image, v1.InitCommands(template.BuildSteps, template.Init), template.Volumes, wrappedDEK, kekID, deficit, nodeFilter, forkdWorkload(template.Workload), forkdResources(template.Resources)); err != nil {
-		return fmt.Errorf("build template snapshot %s: %w", templateID, err)
+
+	// Content changed: rebuild the stale snapshot in place on every current holder
+	// so each produces a fresh content-addressed digest. This runs BEFORE the
+	// deficit fill so the deficit's distribution-by-pull source is the fresh
+	// snapshot, not a stale holder.
+	if contentChanged {
+		if err := r.rebuildStaleSnapshots(ctx, templateID, template, wrappedDEK, kekID, nodeFilter); err != nil {
+			return fmt.Errorf("rebuild template snapshot %s after a content change: %w", templateID, err)
+		}
+		// A rebuild does not change the holder count, but recompute so the deficit
+		// math below reflects any holder that failed its rebuild.
+		readySnapshots = r.readySnapshotCountOn(templateID, nodeFilter)
 	}
+
+	// Deficit fill: build/pull the snapshot onto additional nodes until the desired
+	// holder count is met. InitCommands flattens the declarative BuildSteps (issue
+	// #220) into the in-VM init commands, falling back to the legacy Init list when
+	// no BuildSteps are set, so a template authored either way builds identically.
+	if deficit := desired - readySnapshots; deficit > 0 {
+		if _, err := r.createSnapshotsOnNodes(ctx, templateID, template.Image, v1.InitCommands(template.BuildSteps, template.Init), template.Volumes, wrappedDEK, kekID, deficit, nodeFilter, forkdWorkload(template.Workload), forkdResources(template.Resources)); err != nil {
+			return fmt.Errorf("build template snapshot %s: %w", templateID, err)
+		}
+	}
+
+	// Record the identity the snapshot was just built (or rebuilt) from so the next
+	// reconcile compares against it. The Reconcile caller persists this via the
+	// pool status write.
+	pool.Status.TemplateBuildHash = want
 	return nil
+}
+
+// rebuildStaleSnapshots rebuilds the template snapshot in place on every healthy
+// node that currently holds it (within nodeFilter when set), after a template
+// content edit made the existing snapshots stale (issue #475). Each rebuild
+// overwrites the node's snapshot under the same templateID and produces a fresh
+// content-addressed digest, which the #461 stale-digest reap uses to refill the
+// warm husk pool. It never pulls (a peer's CAS chunks are stale too); every holder
+// rebuilds from the template. An empty holder set is a no-op (the deficit fill
+// then builds the snapshot fresh).
+func (r *SandboxPoolReconciler) rebuildStaleSnapshots(ctx context.Context, templateID string, template *v1.PoolTemplateSpec, wrappedDEK []byte, kekID string, nodeFilter map[string]bool) error {
+	var errs []error
+	for _, node := range r.NodeRegistry.NodesWithTemplate(templateID) {
+		if nodeFilter != nil && !nodeFilter[node.Name] {
+			continue
+		}
+		if !node.isHealthy() {
+			continue
+		}
+		if err := r.buildTemplateOnNode(ctx, node.Name, templateID, template.Image, v1.InitCommands(template.BuildSteps, template.Init), template.Volumes, wrappedDEK, kekID, forkdWorkload(template.Workload), forkdResources(template.Resources)); err != nil {
+			errs = append(errs, fmt.Errorf("node %s: %w", node.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // createSnapshotsOnNodes ensures the template is present on up to deficit
@@ -637,55 +704,65 @@ func (r *SandboxPoolReconciler) createSnapshotsOnNodes(ctx context.Context, temp
 			}
 		}
 
-		// Build path. Fail closed: an encrypted template's WRAPPED DEK travels in
-		// CreateTemplate, so the node connection must be mTLS. Refuse to send the
-		// wrapped DEK over an insecure channel (node.TLS nil and registry.TLS nil,
-		// i.e. PKI bootstrap disabled); skip the node without setting it and record
-		// the refusal. A plaintext template carries no DEK and is unaffected.
-		if len(wrappedDEK) > 0 && !r.NodeRegistry.NodeMTLS(node.Name) {
-			errs = append(errs, fmt.Errorf("node %s: refusing to deliver the wrapped DEK over an insecure gRPC channel: enable PKI bootstrap on the controller and mTLS on forkd, or disable template encryption", node.Name))
-			continue
-		}
-		conn, err := r.NodeRegistry.GetConnection(node.Name)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		// CreateTemplate on the real engine boots a VM and snapshots it:
-		// O(minutes). This blocks the pool reconcile worker; bounded here so a
-		// hung node cannot stall pool reconciliation forever. Moving builds to
-		// a background queue is roadmap work (snapshot distribution).
-		cctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-		// The template's declared volumes are baked into the snapshot as
-		// placeholder drives. No fork-policy override applies at build time, so
-		// volumeMounts is called with no overrides; each fork's ForkRequest must
-		// match this set by name.
-		resp, err := forkdpb.NewForkDaemonClient(conn).CreateTemplate(cctx, &forkdpb.CreateTemplateRequest{
-			TemplateId:   templateID,
-			Image:        image,
-			InitCommands: initCommands,
-			Workload:     workload,
-			Resources:    resources,
-			Volumes:      volumeMounts(templateVolumes, nil),
-			// EncryptionKey carries the WRAPPED DEK for an Encrypted template,
-			// delivered over mTLS; KekId names the KEK that wrapped it (non-secret)
-			// so the node selects the matching KEK to unwrap. Both empty for a
-			// plaintext template. The wrapped DEK is never logged.
-			EncryptionKey: wrappedDEK,
-			KekId:         kekID,
-		})
-		cancel()
-		if err != nil {
+		// Build path on a node that does not yet hold the template.
+		if err := r.buildTemplateOnNode(ctx, node.Name, templateID, image, initCommands, templateVolumes, wrappedDEK, kekID, workload, resources); err != nil {
 			errs = append(errs, fmt.Errorf("node %s: %w", node.Name, err))
 			continue
 		}
-		r.NodeRegistry.AddTemplateWithDigest(node.Name, templateID, resp.TemplateDigest)
 		added++
 	}
 	if added == 0 && len(errs) > 0 {
 		return 0, errors.Join(errs...)
 	}
 	return added, nil
+}
+
+// buildTemplateOnNode builds (or rebuilds in place) the template snapshot on a
+// single node via forkd CreateTemplate and records the resulting content-addressed
+// digest in the registry. It is the shared build primitive behind both the deficit
+// fill (createSnapshotsOnNodes) and the content-change rebuild (rebuildStaleSnapshots),
+// so the encryption fail-closed guard and the bounded build timeout live in exactly
+// one place. The returned error is un-prefixed; callers add the node name.
+func (r *SandboxPoolReconciler) buildTemplateOnNode(ctx context.Context, nodeName, templateID, image string, initCommands []string, templateVolumes []v1.SandboxVolume, wrappedDEK []byte, kekID string, workload *forkdpb.WorkloadSpec, resources *forkdpb.ResourceSpec) error {
+	// Fail closed: an encrypted template's WRAPPED DEK travels in CreateTemplate, so
+	// the node connection must be mTLS. Refuse to send the wrapped DEK over an
+	// insecure channel (node.TLS nil and registry.TLS nil, i.e. PKI bootstrap
+	// disabled). A plaintext template carries no DEK and is unaffected.
+	if len(wrappedDEK) > 0 && !r.NodeRegistry.NodeMTLS(nodeName) {
+		return fmt.Errorf("refusing to deliver the wrapped DEK over an insecure gRPC channel: enable PKI bootstrap on the controller and mTLS on forkd, or disable template encryption")
+	}
+	conn, err := r.NodeRegistry.GetConnection(nodeName)
+	if err != nil {
+		return err
+	}
+	// CreateTemplate on the real engine boots a VM and snapshots it: O(minutes).
+	// This blocks the pool reconcile worker; bounded here so a hung node cannot
+	// stall pool reconciliation forever. Moving builds to a background queue is
+	// roadmap work (snapshot distribution).
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	// The template's declared volumes are baked into the snapshot as placeholder
+	// drives. No fork-policy override applies at build time, so volumeMounts is
+	// called with no overrides; each fork's ForkRequest must match this set by name.
+	resp, err := forkdpb.NewForkDaemonClient(conn).CreateTemplate(cctx, &forkdpb.CreateTemplateRequest{
+		TemplateId:   templateID,
+		Image:        image,
+		InitCommands: initCommands,
+		Workload:     workload,
+		Resources:    resources,
+		Volumes:      volumeMounts(templateVolumes, nil),
+		// EncryptionKey carries the WRAPPED DEK for an Encrypted template,
+		// delivered over mTLS; KekId names the KEK that wrapped it (non-secret)
+		// so the node selects the matching KEK to unwrap. Both empty for a
+		// plaintext template. The wrapped DEK is never logged.
+		EncryptionKey: wrappedDEK,
+		KekId:         kekID,
+	})
+	if err != nil {
+		return err
+	}
+	r.NodeRegistry.AddTemplateWithDigest(nodeName, templateID, resp.TemplateDigest)
+	return nil
 }
 
 func (r *SandboxPoolReconciler) nodeDistribution(templateID string) map[string]int32 {

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -277,9 +277,19 @@ type EncKeyRecorder struct {
 	createKeyLen  int
 	createKeySeen bool
 	createKekID   string
+	createCount   int
 	forkKeyLen    int
 	forkKeySeen   bool
 	forkKekID     string
+}
+
+// CreateTemplateCount returns how many CreateTemplate RPCs the fake forkd has
+// served, so a test can assert a template-content edit re-triggered the build
+// (issue #475).
+func (r *EncKeyRecorder) CreateTemplateCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.createCount
 }
 
 // CreateTemplateKeyLen returns whether a CreateTemplate carried an encryption
@@ -320,6 +330,7 @@ func (r *EncKeyRecorder) interceptor() grpc.UnaryServerInterceptor {
 			r.createKeySeen = true
 			r.createKeyLen = len(m.EncryptionKey)
 			r.createKekID = m.KekId
+			r.createCount++
 			r.mu.Unlock()
 		case *forkdpb.ForkRequest:
 			r.mu.Lock()


### PR DESCRIPTION
## Summary

Editing a SandboxPool template's `workload.command` (or `env`, or the ready probe) did NOT rebuild the content-addressed snapshot. The snapshot was keyed by templateID (the pool name) alone, and the controller only built when the holder COUNT fell below the desired replicas, so the old snapshot kept satisfying `warm.min` and the changed command was silently ignored until the pool was deleted and recreated by hand. This breaks the Run-on-Mitos / mitos.yaml flow where config is part of the workload command. Fixes #475.

The fix derives a build identity (`poolBuildIdentity`) from everything that determines what the snapshot CONTAINS: image, resolved init/buildSteps, serving workload (command, env, ready probe), baked volumes, build VM resources, and the encryption flag. It is recorded in the new pool status field `templateBuildHash`. On reconcile, when the current identity no longer matches the recorded one, the snapshot is rebuilt in place on every holder node (fresh content-addressed digest); the existing #461 stale-digest reap then converges the warm husk pool onto it, exactly the way an image change is meant to. Fields that do not change snapshot content (placement, network, warm sizing, budgets) are excluded so they never force a needless rebuild.

The single-node build is extracted into `buildTemplateOnNode` so the deficit fill and the content-change rebuild share one encryption fail-closed guard and one bounded build timeout.

## Thinking Path

The pool's snapshot build is keyed by `poolTemplateID` (the pool name), and `ensureTemplateBuilt` rebuilt only on a node-count deficit (`readySnapshotCountOn < desired`). Once a holder exists, the count is satisfied and no build re-runs, regardless of content. So neither a workload edit nor an image edit re-triggered a build; docs/husk-pods.md explicitly flagged this as #475. The #461 machinery already reaps and refills warm husk pods when a holder's content-addressed digest changes under the same templateID; what was missing was triggering that rebuild. I kept templateID as the pool name (so #461 convergence, encryption-key Secret naming, and templateRef sharing are unchanged) and added a content hash that gates an in-place rebuild on the holders. Capturing the status `before` snapshot was moved ahead of `ensureTemplateBuilt` in both the husk and raw paths so the new `templateBuildHash` is part of the change comparison and actually persists (otherwise a rebuild with no other status delta would not write, causing a rebuild loop).

## Verification

Worktree: `.claude/worktrees/issue-475`. envtest assets from `setup-envtest use 1.31`.

- `go build ./...` : pass
- `gofmt -l` on all changed Go files : empty (clean)
- `go vet ./internal/controller/... ./api/...` : pass
- `go test ./internal/controller/ -run 'TestPoolBuildIdentity|TestPoolWorkloadEditTriggersRebuild' -v` : RED first (poolBuildIdentity undefined), GREEN after the fix. The unit test covers identical/non-build-field (same identity) and command, env, ready-probe, image, init edits (different identity); the envtest proves a workload command edit re-runs CreateTemplate (count 1 to 2) while a steady-state reconcile does not churn (stays 1).
- `go test ./internal/controller/ -timeout 560s` (FULL controller suite, envtest) : `ok  141.920s`
- `golangci-lint run --timeout=5m ./internal/controller/... ./api/...` : clean (exit 0)
- `GOOS=linux golangci-lint run --timeout=5m ./internal/controller/... ./api/...` : clean (exit 0)
- `controller-gen object` + `controller-gen crd` regenerated; only the CRD YAML changed (the new field is a plain string, so zz_generated.deepcopy.go is unaffected). The Helm chart CRD copy was synced via the Makefile rule and the OLM bundle CRD was updated to match (it already tracks the other recent status fields).

Envtest ran locally and is green. CI go-test also runs the full envtest suite.

## Model Used

Claude (subagent) via Claude Code