### PR TITLE
docs: add runnable use-case examples for the Python SDK

### DIFF
--- a/sdk/python/examples/README.md
+++ b/sdk/python/examples/README.md
@@ -1,0 +1,105 @@
+# Mitos Python SDK examples
+
+Runnable, copy-paste examples for the Mitos Python SDK. Each file is import-safe
+(all real work is behind a `if __name__ == "__main__":` guard) and is gated by
+the `sdk-examples` CI job, which byte-compiles every file here and imports it so a
+renamed or removed SDK symbol fails the build.
+
+## Two paths, one SDK
+
+- Flat / direct path (`mitos.create(...)`): the standalone sandbox-server or the
+  hosted control plane. No Kubernetes required. Auth and base URL resolve from
+  `MITOS_API_KEY` and `MITOS_BASE_URL` (the hosted default is `https://mitos.run`
+  when `MITOS_BASE_URL` is unset).
+- Operator path (`mitos.AgentRun(...)`): the Kubernetes operator, for durable
+  Workspaces and the `{git}` rendezvous push. Needs a cluster and `KUBECONFIG`.
+
+Install the SDK:
+
+```
+pip install mitos-run        # import name stays `mitos`
+```
+
+## Use-case examples
+
+| File | Use case | One-line hook | Path |
+| --- | --- | --- | --- |
+| `code_interpreter.py` | Code interpreter | A stateful `run_code` data-analysis loop that returns a chart. | direct |
+| `best_of_n.py` | Best-of-N | Fork one warm sandbox into N, run attempts in parallel, keep the winner. | direct |
+| `rl_evals.py` | RL / evals | A SWE-bench-style harness that forks many environments from one golden state. | direct |
+| `background_agent.py` | Background agent | Task in, PR out: a durable workspace pushed to a rendezvous git remote on terminate. | operator |
+
+Other examples in this directory: `quickstart.py` (the README hero),
+`direct.py` (the minimal standalone smoke test, executed end to end on real KVM
+in CI), and `browser_cdp.py` (drive a headless Chromium sandbox over CDP).
+
+### code_interpreter.py
+
+Hand an agent a sandboxed Python kernel, feed it cells, and get back stdout plus
+rich display artifacts (last-expression value, a PNG chart). State persists
+across `run_code` calls for the sandbox lifetime. Needs a base image carrying the
+code-interpreter kernel (pandas + matplotlib for the plotting cell).
+
+```
+export MITOS_API_KEY=sk-...            # hosted
+python3 code_interpreter.py
+# or, standalone (run a sandbox-server first):
+python3 code_interpreter.py http://localhost:8080
+```
+
+### best_of_n.py
+
+One warm parent, N copy-on-write siblings via `source.fork(N)`. Each sibling is
+isolated; the example runs an attempt in each concurrently, scores them, and
+keeps the winner.
+
+```
+export MITOS_API_KEY=sk-...
+python3 best_of_n.py
+# or: python3 best_of_n.py http://localhost:8080
+```
+
+### rl_evals.py
+
+Set up one golden environment, fork it once per task instance so every candidate
+runs against a byte-identical start, run the grader in each fork, and report the
+aggregate pass-rate. The bundled instances are a self-contained toy grader; swap
+the setup, candidate, and grader strings for a real benchmark.
+
+```
+export MITOS_API_KEY=sk-...
+python3 rl_evals.py
+# or: python3 rl_evals.py http://localhost:8080
+```
+
+### background_agent.py
+
+Operator path. Binds a sandbox to a durable Workspace, lets it edit a repo under
+`/workspace`, and on terminate pushes the repo paths to a rendezvous git remote
+on a per-attempt branch via the `{git}` output. A human or CI opens the PR from
+that branch; git is the merge layer.
+
+Requirements: a reachable cluster with the Mitos CRDs, `KUBECONFIG` set, and a
+rendezvous remote in `MITOS_GIT_REMOTE`. On the husk warm-pool path the push is
+best-effort today; see `docs/workspaces.md` for the fully wired path and for
+authenticating a push to an external remote.
+
+```
+export KUBECONFIG=~/.kube/config
+export MITOS_GIT_REMOTE=https://git.example.com/org/repo.git
+python3 background_agent.py
+```
+
+Honest gap: the SDK has no first-class helper for `spec.git.paths` yet, so this
+example sets it by patching the Workspace CRD through the Kubernetes client
+`AgentRun` already loaded. A `spec.git` helper is a follow-up.
+
+## What CI verifies (and what it does not)
+
+The `sdk-examples` job byte-compiles and import-checks every file here on each
+PR. Import runs each example's module-level code (imports plus the drift-guard
+asserts), so a renamed SDK symbol fails the build. The examples are NOT executed
+in that job: `run_code`, `exec`, fork, and the `{git}` push all need a guest VM
+the job does not boot, so end-to-end execution is proven separately on real KVM
+(`examples/direct.py` in the kvm-test job). Run the examples above yourself
+against the hosted service or a standalone sandbox-server to see them end to end.

--- a/sdk/python/examples/background_agent.py
+++ b/sdk/python/examples/background_agent.py
@@ -1,0 +1,125 @@
+"""Background agent: task in, PR out, on a durable workspace via the {git} output.
+
+Use case hook: kick off a long-running agent against a durable, forkable
+Workspace, let it edit a repo checked out under /workspace, and on terminate have
+the controller push the repo paths to a rendezvous git remote on a per-attempt
+branch. A human or CI then opens the PR from that branch. Git is the merge layer;
+the engine only ever pushes a branch, it never merges.
+
+This rides the Kubernetes operator path (AgentRun), not the flat direct path,
+because durable Workspaces and the {git} rendezvous push are cluster features:
+
+    agent = mitos.AgentRun(namespace="default")
+    ws = agent.create_workspace("feature-x")
+    sb = agent.sandbox(image="python", workspace="feature-x", ready=True)
+    sb.exec("... edit /workspace/repo ...")
+    sb.terminate(outputs=[{"git": {"remote": REMOTE, "branch": "attempt/{{.name}}"}}])
+
+How the pieces fit (see docs/workspaces.md):
+  - A bound sandbox hydrates the workspace head into /workspace on start and
+    dehydrates a new committed WorkspaceRevision on terminate.
+  - A {git} output pushes the workspace ``spec.git.paths`` content to ``remote``
+    on a branch rendered from the ``{{.name}}`` (claim name) template, defaulting
+    to ``attempt/<name>``.
+  - A {git} output on a workspace with no ``spec.git.paths`` is a no-op, so this
+    example sets ``spec.git.paths`` on the workspace before running.
+  - On the husk warm-pool path the push is currently BEST-EFFORT (logged and
+    skipped if the node-CAS read is not wired); on the raw forkd path it is fully
+    wired. Authenticating a push to an external remote needs a credentials Secret
+    (``spec.git.credentialsSecretRef``); see docs/workspaces.md.
+
+Honest gap: the Python SDK has no first-class helper for ``spec.git.paths`` yet,
+so this example sets it by patching the Workspace CRD through the same Kubernetes
+client AgentRun already loaded (a documented follow-up, not a new public API).
+
+Requirements to run end to end: a reachable cluster with the mitos CRDs and a
+SandboxPool (or the default-pool path), KUBECONFIG set, and a rendezvous remote
+in MITOS_GIT_REMOTE (a bare repo URL the controller can push to). Without those
+this is illustrative; it is byte-compiled and import-checked by the sdk-examples
+CI job, and the asserts below run at import time as a real API-surface check.
+
+Run::
+
+    export KUBECONFIG=~/.kube/config
+    export MITOS_GIT_REMOTE=https://git.example.com/org/repo.git
+    python3 background_agent.py
+"""
+
+import os
+import uuid
+
+import mitos
+from mitos.client import AgentRun
+from mitos.sandbox import Sandbox
+from mitos.workspace import Workspace
+
+# Drift guard: attribute access on the classes does not import kubernetes (it is
+# an optional, lazily loaded extra), so this stays safe in the import-check job
+# while still failing if a method the example relies on is renamed or dropped.
+assert hasattr(mitos, "AgentRun")
+assert all(hasattr(AgentRun, m) for m in ("sandbox", "create_workspace", "workspace"))
+assert all(hasattr(Sandbox, m) for m in ("exec", "terminate"))
+assert all(hasattr(Workspace, m) for m in ("log", "diff"))
+
+
+# The task the background agent performs inside /workspace/repo. A real agent
+# would run a model here; this writes one file and stages it so there is a repo
+# diff to push.
+TASK = """
+set -e
+mkdir -p /workspace/repo
+cd /workspace/repo
+git init -q 2>/dev/null || true
+printf 'print("hello from the background agent")\\n' > app.py
+git add app.py
+git -c user.email=agent@mitos.run -c user.name=agent commit -q -m 'add app.py' || true
+echo wrote /workspace/repo/app.py
+"""
+
+
+def main() -> None:
+    remote = os.environ.get("MITOS_GIT_REMOTE")
+    if not remote:
+        raise SystemExit(
+            "set MITOS_GIT_REMOTE to a rendezvous git remote the controller can "
+            "push to (a bare repo URL); see docs/workspaces.md for auth."
+        )
+
+    agent = mitos.AgentRun(namespace=os.environ.get("MITOS_NAMESPACE", "default"))
+    ws_name = f"bg-{uuid.uuid4().hex[:8]}"
+    ws = agent.create_workspace(ws_name)
+
+    # Declare the repo paths that get history and the rendezvous push. No SDK
+    # helper for spec.git yet, so patch the Workspace CRD directly through the
+    # client AgentRun already holds (honest gap, see the module docstring).
+    ws._api.patch_namespaced_custom_object(
+        group="mitos.run",
+        version="v1",
+        namespace=ws.namespace,
+        plural="workspaces",
+        name=ws_name,
+        body={"spec": {"git": {"paths": ["/workspace/repo"]}}},
+    )
+
+    # Bind a sandbox to the workspace; ready=True blocks until it is Ready so the
+    # task does not race the hydrate. image= uses the lazy default-pool path.
+    sb = agent.sandbox(image="python", workspace=ws_name, ready=True)
+    result = sb.exec(TASK, timeout=120)
+    print(result.stdout, end="")
+    if result.exit_code != 0:
+        raise SystemExit(f"task FAILED: exit {result.exit_code} stderr={result.stderr!r}")
+
+    # Terminate with a {git} output: the controller dehydrates /workspace into a
+    # new committed revision, then pushes spec.git.paths to the rendezvous remote
+    # on a per-attempt branch. The returned name is the workspace; its revisions
+    # (and gitPushes) are discoverable with ws.log().
+    returned = sb.terminate(
+        outputs=[{"git": {"remote": remote, "branch": "attempt/{{.name}}"}}],
+    )
+    print(f"terminated; workspace={returned}")
+    print(f"open a PR from branch attempt/<claim-name> on {remote}")
+    print("background_agent example OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/examples/best_of_n.py
+++ b/sdk/python/examples/best_of_n.py
@@ -1,0 +1,121 @@
+"""Best-of-N: fork one warm sandbox into N, run attempts in parallel, keep the winner.
+
+Use case hook: an agent has one warm, set-up environment and wants N independent
+attempts at a task (different prompts, seeds, or candidate patches). Fork the live
+sandbox into N copy-on-write siblings, run each attempt concurrently, score the
+results, keep the best, and discard the rest. Each sibling is fully isolated: a
+write in one is invisible to the others.
+
+This rides the flat mitos.create() / DirectSandbox path:
+
+    source = mitos.create("python")
+    children = source.fork(N)          # N independent warm siblings
+    # run an attempt in each child concurrently, score, keep the winner
+
+fork(N) here is a loop of single forks under the hood (the standalone server
+re-forks the template per child); the ergonomic stays one call. The siblings run
+concurrently from the client via a thread pool, since each exec is an independent
+HTTP stream.
+
+Hosted vs standalone (honest):
+  - Default (no MITOS_BASE_URL): hosted control plane at https://mitos.run with
+    MITOS_API_KEY from the environment.
+  - Standalone: run a sandbox-server and set MITOS_BASE_URL (or pass argv[1]).
+
+Run::
+
+    export MITOS_API_KEY=sk-...        # hosted
+    python3 best_of_n.py
+    # or, standalone:
+    python3 best_of_n.py http://localhost:8080
+
+Byte-compiled and import-checked by the sdk-examples CI job; not executed there
+(no VM). The asserts below run at import time as a real API-surface check.
+"""
+
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Optional
+
+import mitos
+from mitos.direct import DirectSandbox
+
+# Drift guard: assert the surface the example uses, so a rename fails import.
+assert callable(mitos.create)
+assert all(hasattr(DirectSandbox, m) for m in ("fork", "exec", "terminate"))
+
+N = 4
+
+# A toy task: each attempt computes a candidate and prints a score on the last
+# line. A real harness would run a model, a candidate patch, or a search seed
+# here; the shape (run, capture, score) is the same.
+ATTEMPT_CODE = (
+    "python3 -c \""
+    "seed={seed}; "
+    "score=(seed*7 + 13) % 17; "
+    "print(f'attempt seed={{seed}} score={{score}}')\""
+)
+
+
+@dataclass
+class Attempt:
+    child: DirectSandbox
+    seed: int
+    score: int
+    output: str
+
+
+def run_attempt(child: DirectSandbox, seed: int) -> Attempt:
+    """Run one attempt in its own sandbox and parse the score off the last line."""
+    result = child.exec(ATTEMPT_CODE.format(seed=seed))
+    if result.exit_code != 0:
+        raise SystemExit(
+            f"attempt seed={seed} FAILED: exit {result.exit_code} stderr={result.stderr!r}"
+        )
+    last = result.stdout.strip().splitlines()[-1]
+    score = int(last.rsplit("score=", 1)[1])
+    return Attempt(child=child, seed=seed, score=score, output=last)
+
+
+def main(base_url: Optional[str]) -> None:
+    source = mitos.create("python", base_url=base_url)
+    children: list[DirectSandbox] = []
+    try:
+        # One warm parent, N copy-on-write siblings.
+        children = source.fork(N)
+        print(f"forked {len(children)} siblings from {source.id}")
+
+        # Run all attempts concurrently; each exec is an independent stream.
+        with ThreadPoolExecutor(max_workers=N) as pool:
+            attempts = list(
+                pool.map(lambda pair: run_attempt(*pair),
+                         [(child, seed) for seed, child in enumerate(children)])
+            )
+
+        for a in attempts:
+            print(f"  {a.output}")
+
+        winner = max(attempts, key=lambda a: a.score)
+        print(f"winner: seed={winner.seed} score={winner.score}")
+
+        # Keep the winner (here we just report it); discard the losing siblings.
+        for a in attempts:
+            if a is not winner:
+                a.child.terminate()
+        print("best_of_n example OK")
+    finally:
+        # Terminate the winner (if any) and the source. Already-terminated
+        # losers are skipped; terminate is idempotent enough for cleanup.
+        for child in children:
+            try:
+                child.terminate()
+            except Exception:
+                pass
+        source.terminate()
+
+
+if __name__ == "__main__":
+    url = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("MITOS_BASE_URL")
+    main(url)

--- a/sdk/python/examples/code_interpreter.py
+++ b/sdk/python/examples/code_interpreter.py
@@ -1,0 +1,120 @@
+"""Code interpreter: a stateful run_code data-analysis loop that returns a chart.
+
+Use case hook: hand an agent a sandboxed Python kernel, feed it cells, and get
+back stdout plus rich display artifacts (the last-expression value, a PNG chart,
+structured chart JSON). State persists across run_code calls for the sandbox
+lifetime, so the loop builds up a dataframe in one cell and plots it in the next.
+
+This rides the flat mitos.create() / DirectSandbox path:
+
+    sb = mitos.create("python")
+    ex = sb.run_code("import pandas as pd; ...")
+    ex.results[0].png        # base64 PNG of a matplotlib figure, when produced
+
+Hosted vs standalone (honest):
+  - Default (no MITOS_BASE_URL): talks to the hosted control plane at
+    https://mitos.run with MITOS_API_KEY from the environment.
+  - Standalone: run a sandbox-server (cmd/sandbox-server) and set
+    MITOS_BASE_URL=http://localhost:8080 (or pass it as argv[1]).
+  - Either way run_code needs a base image carrying the code-interpreter kernel
+    (pandas + matplotlib for the plotting cell below); without it the Execution
+    comes back with a KernelUnavailable error, which this example reports.
+
+Run::
+
+    export MITOS_API_KEY=sk-...        # hosted
+    python3 code_interpreter.py
+    # or, standalone:
+    python3 code_interpreter.py http://localhost:8080
+
+This example is byte-compiled and import-checked by the sdk-examples CI job; it
+is NOT executed there (no kernel-backed VM in that job). The asserts below run at
+import time and turn the import-check into a real API-surface check.
+"""
+
+import os
+import sys
+
+import mitos
+from mitos.direct import DirectSandbox
+from mitos.types import Execution, Result
+
+# Drift guard: the loop below calls these. Asserting them at import time makes
+# the CI import-check fail if the SDK renames or drops a symbol the example uses.
+assert callable(mitos.create)
+assert all(hasattr(DirectSandbox, m) for m in ("run_code", "exec", "terminate"))
+assert all(hasattr(Result, p) for p in ("png", "text", "chart"))
+assert hasattr(Execution, "results") or "results" in Execution.__dataclass_fields__
+
+
+# Each cell is one run_code call; the kernel keeps state between them, so the
+# frame built in cell 1 is still in scope when cell 3 plots it.
+CELLS = [
+    # 1. Build a small dataset in the kernel.
+    """
+import pandas as pd
+df = pd.DataFrame({"day": [1, 2, 3, 4, 5], "signups": [10, 14, 9, 22, 31]})
+df.shape
+""",
+    # 2. Reduce over the state from the previous cell.
+    "total = int(df['signups'].sum()); total",
+    # 3. Plot the state and let the kernel emit the figure as a rich result.
+    """
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots()
+ax.plot(df["day"], df["signups"], marker="o")
+ax.set_title("signups by day")
+fig  # last expression: the kernel renders it as an image/png result
+""",
+]
+
+
+def run_cell(sandbox: DirectSandbox, code: str) -> Execution:
+    """Run one cell and print its streamed logs and last-expression value."""
+    ex = sandbox.run_code(
+        code,
+        on_stdout=lambda line: print(f"  stdout: {line}", end=""),
+        on_stderr=lambda line: print(f"  stderr: {line}", end=""),
+    )
+    if ex.error is not None:
+        # KernelUnavailable shows up here on a base image without the kernel.
+        raise SystemExit(
+            f"run_code error: {ex.error.name}: {ex.error.value}\n"
+            "Use a base image that carries the code-interpreter kernel "
+            "(pandas + matplotlib for the plotting cell)."
+        )
+    if ex.text is not None:
+        print(f"  => {ex.text}")
+    return ex
+
+
+def main(base_url: str | None) -> None:
+    # base_url=None lets the SDK resolve MITOS_BASE_URL, else the hosted default.
+    sandbox = mitos.create("python", base_url=base_url)
+    try:
+        chart_png: str | None = None
+        for i, code in enumerate(CELLS, start=1):
+            print(f"cell {i}:")
+            ex = run_cell(sandbox, code)
+            for result in ex.results:
+                if result.png is not None:
+                    chart_png = result.png
+
+        if chart_png is None:
+            raise SystemExit(
+                "example FAILED: no chart was produced (expected an image/png "
+                "result from the plotting cell)"
+            )
+        # The PNG is base64; in a real loop you would decode and save or display
+        # it. Here we just prove one came back.
+        print(f"chart produced: {len(chart_png)} base64 chars of image/png")
+        print("code_interpreter example OK")
+    finally:
+        sandbox.terminate()
+
+
+if __name__ == "__main__":
+    url = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("MITOS_BASE_URL")
+    main(url)

--- a/sdk/python/examples/rl_evals.py
+++ b/sdk/python/examples/rl_evals.py
@@ -1,0 +1,133 @@
+"""RL / evals: a SWE-bench-style harness that forks many environments from one golden state.
+
+Use case hook: set up one golden environment (repo checked out, deps installed,
+fixtures in place), snapshot it, then fork it once per task instance so every
+candidate runs against a byte-identical starting state. Run the grader command in
+each fork, collect pass/fail, and report the aggregate pass-rate. Because each
+fork starts from the same golden snapshot, the only variable is the candidate, so
+the score is reproducible.
+
+This rides the flat mitos.create() / DirectSandbox path:
+
+    golden = mitos.create("python")    # set up the golden state once
+    envs = golden.fork(len(instances)) # one isolated env per instance
+    # apply each candidate, run the grader, collect exit codes
+
+Hosted vs standalone (honest):
+  - Default (no MITOS_BASE_URL): hosted control plane at https://mitos.run with
+    MITOS_API_KEY from the environment.
+  - Standalone: run a sandbox-server and set MITOS_BASE_URL (or pass argv[1]).
+
+The instances below are a self-contained toy grader (a tiny arithmetic task with
+a known fix), so the harness shape is real even without a SWE-bench dataset. Swap
+the setup, candidate, and grader strings for a real benchmark.
+
+Run::
+
+    export MITOS_API_KEY=sk-...        # hosted
+    python3 rl_evals.py
+    # or, standalone:
+    python3 rl_evals.py http://localhost:8080
+
+Byte-compiled and import-checked by the sdk-examples CI job; not executed there
+(no VM). The asserts below run at import time as a real API-surface check.
+"""
+
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Optional
+
+import mitos
+from mitos.direct import DirectSandbox
+
+# Drift guard: assert the surface the example uses, so a rename fails import.
+assert callable(mitos.create)
+assert all(hasattr(DirectSandbox, m) for m in ("fork", "exec", "terminate"))
+
+
+@dataclass
+class Instance:
+    """One task instance: a candidate solution and the grader that scores it."""
+
+    name: str
+    # The candidate writes a module; the grader imports it and asserts. A passing
+    # candidate makes the grader exit 0, a failing one exits non-zero.
+    candidate: str
+    grader: str
+
+
+# A toy "benchmark": two instances, one whose candidate is correct and one whose
+# candidate is buggy, so the harness reports a 1/2 pass-rate deterministically.
+INSTANCES = [
+    Instance(
+        name="add-correct",
+        candidate="def solve(a, b):\n    return a + b\n",
+        grader="from solution import solve; assert solve(2, 3) == 5",
+    ),
+    Instance(
+        name="add-buggy",
+        candidate="def solve(a, b):\n    return a - b\n",
+        grader="from solution import solve; assert solve(2, 3) == 5",
+    ),
+]
+
+
+@dataclass
+class EvalResult:
+    instance: str
+    passed: bool
+    detail: str
+
+
+def grade(env: DirectSandbox, inst: Instance) -> EvalResult:
+    """Apply one candidate to a forked env and run its grader."""
+    env.files.write("/workspace/solution.py", inst.candidate)
+    result = env.exec(
+        f"cd /workspace && python3 -c {inst.grader!r}",
+    )
+    passed = result.exit_code == 0
+    detail = "ok" if passed else (result.stderr.strip().splitlines() or ["assert failed"])[-1]
+    return EvalResult(instance=inst.name, passed=passed, detail=detail)
+
+
+def main(base_url: Optional[str]) -> None:
+    # Golden state: in a real harness you would check out the repo and install
+    # deps here, so every fork inherits the identical prepared environment.
+    golden = mitos.create("python", base_url=base_url)
+    envs: list[DirectSandbox] = []
+    try:
+        envs = golden.fork(len(INSTANCES))
+        print(f"forked {len(envs)} eval environments from golden {golden.id}")
+
+        with ThreadPoolExecutor(max_workers=len(envs)) as pool:
+            results = list(
+                pool.map(lambda pair: grade(*pair), zip(envs, INSTANCES))
+            )
+
+        passed = 0
+        for r in results:
+            mark = "PASS" if r.passed else "FAIL"
+            print(f"  [{mark}] {r.instance}: {r.detail}")
+            passed += int(r.passed)
+
+        total = len(results)
+        print(f"pass-rate: {passed}/{total}")
+        # The toy benchmark is constructed to score exactly 1/2; assert it so the
+        # harness itself is self-checking when run end to end.
+        if passed != 1:
+            raise SystemExit(f"example FAILED: expected 1 pass, got {passed}")
+        print("rl_evals example OK")
+    finally:
+        for env in envs:
+            try:
+                env.terminate()
+            except Exception:
+                pass
+        golden.terminate()
+
+
+if __name__ == "__main__":
+    url = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("MITOS_BASE_URL")
+    main(url)


### PR DESCRIPTION
Adds four runnable, copy-paste Python SDK examples that map to the use-case pages, so a developer goes from page to running code in minutes. Closes part of #313.

## Thinking Path

Issue #313 asks for in-repo runnable examples (not a separate repo) for four use cases: best-of-N, RL/evals, background agent, and code interpreter. I read the existing examples (`quickstart.py`, `direct.py`, `browser_cdp.py`) and the `sdk-examples` CI job to match its contract: the job globs `sdk/python/examples/*.py`, byte-compiles each file, and import-checks it (running module-level code), so every example must be import-safe with the real work behind a main guard. I then read the actual Python SDK surface (`mitos.create` / `DirectSandbox` for the flat path: `exec`, `run_code`, `fork`, `files`, `terminate`; and `AgentRun` / `Sandbox` / `Workspace` for the operator path: durable workspaces and `terminate(outputs=[{git: ...}])`) and used only APIs that exist. Each example carries a module-level drift-guard asserting the symbols it uses, mirroring the existing `quickstart.py`, so a rename fails the import-check rather than shipping stale docs. I implemented all four use cases on Python (the most complete SDK) to keep scope tight. Examples live directly under `sdk/python/examples/`, which the existing CI glob already covers, so no workflow change was needed.

Honest scope: the examples are byte-compiled and import-checked in CI; they are NOT executed there (no guest VM in that job), so I do not claim end-to-end execution I did not perform. The flat-path examples run against the hosted service or a standalone sandbox-server; the background-agent example needs a cluster. The background-agent example sets `spec.git.paths` by patching the Workspace CRD through the Kubernetes client AgentRun already loaded, because the SDK has no first-class `spec.git` helper yet (noted in the example and README as a follow-up gap), and the husk `{git}` push is best-effort today per docs/workspaces.md.

## Verification

Examples added (all under `sdk/python/examples/`, Python SDK):
- `code_interpreter.py`: stateful `run_code` data-analysis loop returning a chart.
- `best_of_n.py`: fork one warm sandbox into N, run attempts in parallel, keep the winner.
- `rl_evals.py`: SWE-bench-style harness forking many environments from one golden state, reporting an aggregate pass-rate.
- `background_agent.py`: task in, PR out, on a durable workspace via the `{git}` rendezvous output (operator path).
- `README.md`: per-directory README with the use-case hooks and run instructions.

Commands run locally (all passed):
- `python3 -m py_compile sdk/python/examples/*.py` -> all byte-compile OK.
- Import-check loop, exactly as the `sdk-examples` job runs it (import each module, executing module-level code including the drift-guard asserts) -> all four import OK.
- Re-ran the import-check with `kubernetes` import blocked to mirror the CI environment (the job installs `pip install ./sdk/python` without the k8s extra) -> `rl_evals.py` and `background_agent.py` both import OK with no kubernetes installed.
- Full CI Python step including the README python-fence byte-compile over `README.md` and `sdk/python/README.md` -> checked 22 fences, 0 failures.
- em/en dash scan over all five new files -> none.

No workflow file was edited (the existing `sdk/python/examples/*.py` glob already covers the new files), so actionlint was not required.

The `sdk-examples` CI job covers all four new examples: it byte-compiles and import-checks every `sdk/python/examples/*.py`, so a renamed SDK symbol fails the drift-guard asserts at import time.

## Model Used

Claude (subagent) via Claude Code

## Follow-ups

- Link each use-case page on the website to its example file here.
- A first-class SDK helper for `spec.git.paths` (the background-agent example currently patches the Workspace CRD directly).
- The examples are compiled and import-checked in CI but not executed there; end-to-end execution against the hosted service or a standalone sandbox-server is left to the reader (the existing `direct.py` is the one example executed end to end on real KVM).