### PR TITLE
docs: single-user Dex example and k3s quickstart (#400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The husk pod-native path is the default. A few capabilities run today only on th
 | CoW-aware metering | The shared template page set is counted once, not once per fork, so billing and scheduling reflect the honest physical footprint | [mitos.run/docs/metering](https://mitos.run/docs/metering) |
 | Operator tooling | `kubectl mitos` plugin (`ls` / `ps`) and the operational `GET /v1/metering` report | [mitos.run/docs/observability](https://mitos.run/docs/observability) |
 | Bare metal first-class | Talos + Hetzner is the reference platform | [docs/platforms/talos-hetzner.md](docs/platforms/talos-hetzner.md) |
+| Single-user first run | k3s quickstart with a one-user login gate (QA only, not production) | [docs/platforms/k3s-quickstart.md](docs/platforms/k3s-quickstart.md) |
 
 ## Comparison
 

--- a/docs/platforms/k3s-quickstart.md
+++ b/docs/platforms/k3s-quickstart.md
@@ -1,0 +1,177 @@
+# k3s single-user quickstart
+
+This is the fastest way to get a working Mitos install with a console you can log
+into, on a single [k3s](https://k3s.io) node, gated behind ONE static
+username/password. It is meant for first-run evaluation and solo QA. k3s is much
+easier to stand up than Talos for a first try; for a production bare-metal fleet,
+see `talos-hetzner.md`.
+
+> WARNING: single-user QA / first-run ONLY. NOT FOR PRODUCTION. NOT MULTI-TENANT.
+>
+> The login gate in this guide (`examples/single-user-dex`) is one static
+> credential over plaintext-HTTP Dex with a self-signed console certificate. It
+> does NOT provide tenant isolation: Mitos sandboxes are microVMs, not pods, and
+> nothing here governs sandbox isolation. For more than one user or any
+> production use, run a real identity provider (the chart's federated Dex, or
+> Keycloak / Okta / Google) and a trusted TLS certificate.
+
+## Verification status
+
+Honesty rule: a step is only marked verified when it was actually run. No cluster
+was available when this guide was written, so the end-to-end cluster steps are
+marked accordingly.
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `examples/single-user-dex` manifests parse as valid YAML | VALIDATED | parsed locally |
+| `kubectl kustomize examples/single-user-dex` renders | VALIDATED | rendered locally |
+| OIDC value/env names match what `cmd/console` reads | VERIFIED | traced against `cmd/console/main.go` and the chart |
+| k3s install + Helm install on a live node | NOT VERIFIED HERE | requires a host; steps are the intended path |
+| Console login with the static user end to end | NOT VERIFIED HERE | requires a cluster |
+| Firecracker fork on `/dev/kvm` | HARDWARE-REQUIRED | needs hardware virtualization on the node |
+
+## What you need
+
+- A Linux host you control. To actually fork microVMs, the host must expose
+  hardware virtualization (`/dev/kvm`): bare metal, or a VM with nested
+  virtualization enabled. Confirm with `egrep -c 'vmx|svm' /proc/cpuinfo` (a
+  nonzero count) and `test -e /dev/kvm`. Without KVM the control plane installs
+  and the console works, but forkd cannot create real sandboxes.
+- `kubectl`, `helm`, `htpasswd` (from `apache2-utils` / `httpd-tools`), and
+  `openssl` on your workstation.
+
+## 1. Install k3s
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+```
+
+This installs a single-node k3s with Traefik as the Ingress controller, which the
+single-user-dex example relies on. Point `kubectl` at the cluster:
+
+```bash
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes
+```
+
+(Copy the kubeconfig to your workstation if you are driving the cluster
+remotely; replace `127.0.0.1` in the server URL with the node's reachable IP.)
+
+## 2. Label the node for KVM
+
+forkd schedules onto nodes labelled for KVM. Even for evaluation, set the label
+so the daemon and husk pods land:
+
+```bash
+kubectl label node "$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')" mitos.run/kvm=true
+```
+
+## 3. Create the install namespace
+
+forkd, the husk pods, and the device plugin are privileged, so the namespace MUST
+carry the PodSecurity `privileged` labels. `helm --create-namespace` would make an
+unlabeled namespace that the `restricted` policy then rejects, so create and label
+it first:
+
+```bash
+kubectl create namespace mitos
+kubectl label namespace mitos \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged
+```
+
+## 4. Install the Mitos chart
+
+From a checkout:
+
+```bash
+helm install mitos deploy/charts/mitos -n mitos --set namespace.create=false
+```
+
+Or from the published OCI chart (no checkout needed):
+
+```bash
+helm install mitos oci://ghcr.io/mitos-run/charts/mitos -n mitos --set namespace.create=false
+```
+
+See `deploy/charts/mitos/README.md` for the full value reference and the image
+pull-secret notes. Wait for the controller and console to become Ready:
+
+```bash
+kubectl get pods -n mitos -w
+```
+
+## 5. Gate the console behind one user
+
+Follow `examples/single-user-dex/README.md`. In short:
+
+1. Derive hostnames from the node IP (both must resolve from the browser and from
+   inside the cluster; `nip.io` does this on a single node):
+
+   ```bash
+   export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+   export DEX_HOST="dex.${NODE_IP}.nip.io"
+   export CONSOLE_HOST="console.${NODE_IP}.nip.io"
+   ```
+
+2. Stamp the hostnames into copies of the example files:
+
+   ```bash
+   cd examples/single-user-dex
+   for f in dex.yaml console-ingress.yaml console-oidc-values.yaml; do
+     sed -e "s/dex.example.com/${DEX_HOST}/g" \
+         -e "s/console.example.com/${CONSOLE_HOST}/g" \
+         "$f" > "/tmp/${f}"
+   done
+   ```
+
+3. Set your password: generate a bcrypt hash and paste it (and your email) into
+   `/tmp/dex.yaml` (`staticPasswords[0]`). The committed hash is an unusable
+   placeholder.
+
+   ```bash
+   htpasswd -bnBC 10 "" 'your-strong-password' | tr -d ':\n' | sed 's/^\$2y\$/\$2a\$/'
+   ```
+
+4. Create the shared client-secret Secret and the self-signed console TLS Secret:
+
+   ```bash
+   kubectl create secret generic mitos-console-oidc -n mitos \
+     --from-literal=client-secret="$(openssl rand -hex 32)"
+
+   openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+     -keyout /tmp/console.key -out /tmp/console.crt \
+     -subj "/CN=${CONSOLE_HOST}" -addext "subjectAltName=DNS:${CONSOLE_HOST}"
+   kubectl create secret tls mitos-console-tls -n mitos \
+     --cert=/tmp/console.crt --key=/tmp/console.key
+   ```
+
+5. Apply Dex and the console Ingress, then wire the console:
+
+   ```bash
+   kubectl apply -n mitos -f /tmp/dex.yaml -f /tmp/console-ingress.yaml
+   helm upgrade mitos deploy/charts/mitos -n mitos \
+     --set namespace.create=false -f /tmp/console-oidc-values.yaml
+   ```
+
+## 6. Log in
+
+Open `https://${CONSOLE_HOST}` in a browser, accept the self-signed certificate
+warning, and sign in with the email and password you set. The console
+auto-creates your account and organization on first login.
+
+If the browser cannot reach the hostname, confirm the node IP is reachable from
+your machine and that `nip.io` resolves it (`getent hosts "$CONSOLE_HOST"`). If
+login bounces back to the login page, the most common cause is an `issuer`
+mismatch: `console.oidc.issuerURL` must be byte-for-byte the Dex `issuer`, and the
+console pod must be able to reach that URL.
+
+## Where to go next
+
+- Real sandbox forking requires `/dev/kvm` on the node (see What you need).
+  Validate the engine with the smoke steps in `docs/quickstart.md` and the SDK.
+- For a production bare-metal cluster, follow `talos-hetzner.md` and replace the
+  single-user Dex with a real identity provider and trusted TLS.
+- For the federated GitHub/Google Dex the chart ships, see the `dex.*` values in
+  `deploy/charts/mitos/values.yaml`.

--- a/examples/single-user-dex/README.md
+++ b/examples/single-user-dex/README.md
@@ -1,0 +1,181 @@
+# Single-user Dex for the Mitos console
+
+> WARNING: QA and first-run ONLY. NOT FOR PRODUCTION. NOT MULTI-TENANT.
+>
+> This example gates the Mitos console behind exactly ONE static
+> username/password so you can log in without standing up GitHub/Google OAuth
+> apps or a full identity provider. It uses in-memory storage, plaintext HTTP
+> for the issuer, a self-signed TLS certificate for the console, and a single
+> hardcoded credential. None of that is acceptable for a shared, internet-facing,
+> or multi-user deployment.
+>
+> This does NOT provide tenant isolation. Mitos sandboxes are microVMs, not
+> pods; nothing here governs sandbox isolation. It only gates who can log into
+> the console. For more than one user, or anything production, run the chart's
+> federated Dex (`dex.enabled`, GitHub/Google) or point `console.oidc.*` at a
+> real issuer (Keycloak, Okta, Auth0, Google).
+
+## What this gives you
+
+A minimal [Dex](https://dexidp.io) deployment with a single static-password user,
+wired to the Mitos console's OIDC login flow. After applying it you can open the
+console in a browser and sign in with one email and password.
+
+## How it fits the console's OIDC contract
+
+The console (`cmd/console`) reads its OIDC settings from env the Helm chart sets
+from `console.oidc.*`:
+
+| Chart value | Console env | Must equal |
+| --- | --- | --- |
+| `console.oidc.issuerURL` | `MITOS_CONSOLE_OIDC_ISSUER` | the Dex `issuer` in `dex.yaml` |
+| `console.oidc.clientID` | `MITOS_CONSOLE_OIDC_CLIENT_ID` | the Dex static client `id` in `dex.yaml` |
+| `console.oidc.clientSecretRef` | `MITOS_CONSOLE_OIDC_CLIENT_SECRET` (key `client-secret`) | the Secret Dex also reads its client secret from |
+| `console.oidc.redirectURL` | `MITOS_CONSOLE_OIDC_REDIRECT_URL` | a `redirectURIs` entry on the Dex static client |
+
+The console requests the `email` and `profile` scopes and REJECTS any login whose
+email is not verified. Dex's password-DB connector (`enablePasswordDB: true`)
+marks the static user's email as verified, so login succeeds. On first successful
+login the console auto-creates the account and its organization.
+
+Two URL rules matter and are easy to get wrong:
+
+- The `issuer` URL must be byte-for-byte identical from the browser AND from
+  inside the console pod (OIDC discovery compares the issuer string exactly). A
+  `nip.io` hostname built from your node IP satisfies both. Dex runs over plain
+  HTTP so the console pod can discover it without a trusted TLS certificate.
+- The console must be served over HTTPS, because it sets its session and CSRF
+  cookies with the `Secure` flag (the browser drops them otherwise). This example
+  gives the console a self-signed certificate so login works on a first install
+  with no cert-manager. The browser shows a certificate warning you click
+  through; that is expected for QA and unacceptable for production.
+
+## Files
+
+- `dex.yaml`: Dex ConfigMap, Deployment, Service, and a plain-HTTP Ingress. One
+  static-password user. No external connectors.
+- `console-ingress.yaml`: HTTPS Ingress for the `mitos-console` Service (the one
+  the chart renders), using a self-signed certificate you create.
+- `console-oidc-values.yaml`: Helm values overlay that points `console.oidc.*` at
+  this Dex, turns the chart's federated Dex off, and turns the chart's non-TLS
+  console Ingress off.
+- `kustomization.yaml`: lets you render or apply `dex.yaml` + `console-ingress.yaml`
+  as a set.
+
+## Prerequisites
+
+- A running Mitos install (the Helm chart) in the `mitos` namespace. See
+  `docs/platforms/k3s-quickstart.md` for a from-scratch k3s walkthrough that
+  uses this example.
+- An Ingress controller. On k3s, Traefik is installed by default.
+- `kubectl`, `helm`, `htpasswd` (from `apache2-utils` / `httpd-tools`), and
+  `openssl` on your workstation.
+
+## Step 1: choose hostnames
+
+Pick hostnames that resolve to your cluster from both your browser and the
+console pod. On a single node, `nip.io` works (it resolves `<anything>.<ip>.nip.io`
+to `<ip>`). Export the node IP and derive the two hostnames:
+
+```bash
+export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+export DEX_HOST="dex.${NODE_IP}.nip.io"
+export CONSOLE_HOST="console.${NODE_IP}.nip.io"
+echo "Dex:     http://${DEX_HOST}"
+echo "Console: https://${CONSOLE_HOST}"
+```
+
+Replace `dex.example.com` with `$DEX_HOST` and `console.example.com` with
+`$CONSOLE_HOST` in `dex.yaml`, `console-ingress.yaml`, and
+`console-oidc-values.yaml` before applying. Edit the files, or stamp them with
+`sed` into copies:
+
+```bash
+for f in dex.yaml console-ingress.yaml console-oidc-values.yaml; do
+  sed -e "s/dex.example.com/${DEX_HOST}/g" \
+      -e "s/console.example.com/${CONSOLE_HOST}/g" \
+      "$f" > "/tmp/${f}"
+done
+```
+
+## Step 2: set your password
+
+The committed bcrypt hash is a deliberately UNUSABLE placeholder, so you MUST
+generate your own. Generate a bcrypt hash for your chosen password:
+
+```bash
+# Prompts for the password twice, prints a bcrypt hash.
+htpasswd -bnBC 10 "" 'your-strong-password' | tr -d ':\n' | sed 's/^\$2y\$/\$2a\$/'
+```
+
+Paste the output into `staticPasswords[0].hash` in `dex.yaml`, and set
+`staticPasswords[0].email` to the address you will sign in as. The leading
+`$2a$`/`$2y$` form is bcrypt; the `sed` normalizes the prefix Dex expects. Never
+commit your real hash back to a shared repo.
+
+## Step 3: create the shared client-secret Secret
+
+The console's OIDC client secret and Dex's static-client secret are the SAME
+value, read from one Secret (key `client-secret`). It is never inlined in any
+manifest. Generate a random value and create the Secret:
+
+```bash
+kubectl create secret generic mitos-console-oidc \
+  --namespace mitos \
+  --from-literal=client-secret="$(openssl rand -hex 32)"
+```
+
+## Step 4: create the self-signed console TLS Secret
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout /tmp/console.key -out /tmp/console.crt \
+  -subj "/CN=${CONSOLE_HOST}" \
+  -addext "subjectAltName=DNS:${CONSOLE_HOST}"
+
+kubectl create secret tls mitos-console-tls \
+  --namespace mitos \
+  --cert=/tmp/console.crt --key=/tmp/console.key
+```
+
+## Step 5: apply Dex and the console Ingress
+
+```bash
+kubectl apply -n mitos -f /tmp/dex.yaml -f /tmp/console-ingress.yaml
+# or, if you edited the files in place:
+# kubectl apply -k examples/single-user-dex
+```
+
+## Step 6: wire the console and roll it out
+
+```bash
+helm upgrade mitos deploy/charts/mitos -n mitos \
+  --set namespace.create=false \
+  -f /tmp/console-oidc-values.yaml
+```
+
+(Use the same chart reference you installed with: a checkout path, `mitos/mitos`,
+or `oci://ghcr.io/mitos-run/charts/mitos`.)
+
+## Step 7: log in
+
+Open `https://${CONSOLE_HOST}` in a browser, accept the self-signed certificate
+warning, and sign in with the email and password from Step 2. The console
+auto-creates your account and organization on first login.
+
+## Rotating or removing the user
+
+- Change the password: regenerate the hash (Step 2), edit `dex.yaml`, re-apply,
+  and restart Dex: `kubectl rollout restart deploy/mitos-dex-single-user -n mitos`.
+- Remove single-user login: delete the Dex resources
+  (`kubectl delete -k examples/single-user-dex`), the two Secrets, and re-run
+  `helm upgrade` without `console-oidc-values.yaml`.
+
+## Validation status
+
+| Item | Status |
+| --- | --- |
+| Manifests parse as valid YAML | VALIDATED locally |
+| `kubectl kustomize examples/single-user-dex` renders | VALIDATED locally |
+| OIDC env/value names match what `cmd/console` reads | VERIFIED against source |
+| End-to-end login on a live cluster | NOT verified here; requires a cluster |

--- a/examples/single-user-dex/console-ingress.yaml
+++ b/examples/single-user-dex/console-ingress.yaml
@@ -1,0 +1,50 @@
+# =============================================================================
+# HTTPS Ingress for the Mitos console, single-user QA / first-run ONLY.
+#
+# !!! NOT FOR PRODUCTION. !!!
+#
+# The console sets its session and CSRF cookies with the Secure flag, so the
+# browser only accepts them over HTTPS (or http://localhost). This Ingress
+# terminates TLS for the console host using a self-signed certificate you create
+# out of band (see README.md), so the login flow works on a first install
+# without cert-manager.
+#
+# A self-signed certificate makes the browser show a security warning that you
+# click through. That is fine for solo QA and unacceptable for production: for a
+# real deployment, issue a trusted certificate (cert-manager + a real DNS name)
+# and serve the console behind it.
+#
+# This Ingress points at the mitos-console Service that the Mitos Helm chart
+# renders (console.enabled, the default). Set console.ingress.enabled=false in
+# your chart values so the chart does not also render a non-TLS console Ingress
+# for the same host (the values overlay in console-oidc-values.yaml does this).
+#
+# Replace console.example.com with a hostname that resolves to your cluster.
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mitos-console-single-user
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos-console-single-user
+    app.kubernetes.io/component: console
+    app.kubernetes.io/part-of: mitos
+spec:
+  tls:
+    - hosts:
+        - console.example.com
+      # Self-signed TLS Secret you create out of band (README.md). NEVER commit
+      # a real key or certificate to the repo.
+      secretName: mitos-console-tls
+  rules:
+    - host: console.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mitos-console
+                port:
+                  name: http

--- a/examples/single-user-dex/console-oidc-values.yaml
+++ b/examples/single-user-dex/console-oidc-values.yaml
@@ -1,0 +1,40 @@
+# Helm values overlay that wires the Mitos console to the single-user Dex.
+# QA / first-run ONLY. NOT FOR PRODUCTION. NOT MULTI-TENANT. See README.md.
+#
+# Apply on top of your normal install values:
+#   helm upgrade mitos deploy/charts/mitos -n mitos \
+#     --set namespace.create=false \
+#     -f examples/single-user-dex/console-oidc-values.yaml
+#
+# Replace the placeholder hostnames with the ones you used in dex.yaml and
+# console-ingress.yaml. The issuerURL MUST be byte-for-byte the Dex issuer in
+# dex.yaml. The redirectURL MUST be byte-for-byte a redirectURI in the Dex
+# static client (dex.yaml). The clientID MUST match the Dex static client id.
+
+console:
+  enabled: true
+  # The single-user Dex is for community / self-host QA. Keep the community
+  # edition; do not set edition: hosted.
+  edition: community
+  oidc:
+    # Must equal the Dex issuer in dex.yaml (plain HTTP on purpose for QA).
+    issuerURL: "http://dex.example.com"
+    # Must equal the Dex static client id in dex.yaml.
+    clientID: "mitos-console"
+    # The Secret you create out of band (README.md). The chart reads key
+    # "client-secret" from it; the same Secret feeds Dex's static-client secret.
+    clientSecretRef: "mitos-console-oidc"
+    # Must equal a redirectURI on the Dex static client in dex.yaml. The console
+    # serves its callback at /auth/callback. HTTPS because the console session
+    # cookie is Secure (see console-ingress.yaml).
+    redirectURL: "https://console.example.com/auth/callback"
+  # We supply our own HTTPS Ingress for the console (console-ingress.yaml) so the
+  # Secure session cookie works over TLS. Turn the chart's plain console Ingress
+  # off so two Ingresses do not fight over the same host.
+  ingress:
+    enabled: false
+
+# The chart also ships a federated Dex (GitHub/Google). Keep it OFF: the
+# single-user Dex in this example replaces it for QA. Do not run both.
+dex:
+  enabled: false

--- a/examples/single-user-dex/dex.yaml
+++ b/examples/single-user-dex/dex.yaml
@@ -1,0 +1,216 @@
+# =============================================================================
+# SINGLE-USER DEX FOR MITOS CONSOLE QA / FIRST-RUN ONLY.
+#
+# !!! NOT FOR PRODUCTION. NOT MULTI-TENANT. !!!
+#
+# This is a minimal Dex (https://dexidp.io) that federates exactly ONE static
+# username/password into an OIDC issuer the Mitos console trusts. It exists so
+# you can log into the console without standing up GitHub/Google OAuth apps or a
+# full IdP. It deliberately uses in-memory storage, plaintext HTTP, and a single
+# hardcoded credential. None of that is acceptable for a shared, internet-facing,
+# or multi-user deployment.
+#
+# What this is NOT:
+#   - It is NOT a tenant-isolation boundary. Mitos sandboxes are microVMs, not
+#     pods; nothing here governs sandbox isolation. This only gates console login.
+#   - It is NOT highly available: storage.type is memory, so a pod restart loses
+#     all Dex state (auth codes, refresh tokens). Single replica only.
+#   - It is NOT a substitute for a real IdP. For more than one user, or anything
+#     production, run the chart's federated Dex (dex.enabled, GitHub/Google) or
+#     point console.oidc.* at Keycloak / Okta / your own issuer.
+#
+# Before applying, you MUST:
+#   1. Replace the bcrypt hash below with your own (see README.md). The committed
+#      hash is a deliberately UNUSABLE placeholder (a bcrypt of a random string
+#      nobody knows), so login will fail until you set your own.
+#   2. Replace the email with the address you will sign in as.
+#   3. Replace the placeholder hostnames (dex.example.com / console.example.com)
+#      with hostnames that resolve to your cluster, both from your browser AND
+#      from inside the cluster (a nip.io name built from the node IP works; see
+#      docs/platforms/k3s-quickstart.md).
+#   4. Create the shared client-secret Secret (see README.md); it is NOT inlined
+#      here.
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mitos-dex-single-user
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos-dex-single-user
+    app.kubernetes.io/component: dex
+    app.kubernetes.io/part-of: mitos
+data:
+  config.yaml: |
+    # The issuer URL Dex advertises. It MUST be byte-for-byte the URL that both
+    # your browser AND the console pod use to reach Dex, because OIDC discovery
+    # compares the issuer string exactly. HTTP (not HTTPS) is used on purpose so
+    # the console pod can run OIDC discovery against Dex without a trusted TLS
+    # cert. This is acceptable ONLY for single-user local QA.
+    issuer: http://dex.example.com
+
+    # In-memory storage: correct for ONE replica, lost on restart. Production
+    # needs storage.type kubernetes with the Dex CRDs. NOT for production.
+    storage:
+      type: memory
+
+    web:
+      http: 0.0.0.0:5556
+
+    oauth2:
+      # Skip the per-login "grant access?" screen. Fine for a single trusted user.
+      skipApprovalScreen: true
+
+    # Enable the built-in password database connector. This is what serves the
+    # single static credential below. The local connector marks the identity's
+    # email as verified, which the Mitos console requires (it rejects any login
+    # whose email is not verified).
+    enablePasswordDB: true
+
+    # The ONE static user. CHANGE the email and hash before use.
+    # hash: bcrypt of your password. The value below is a PLACEHOLDER bcrypt of a
+    # random string nobody knows, so it cannot be used to log in. Generate your
+    # own (README.md) and paste it here.
+    staticPasswords:
+      - email: "you@example.com"
+        hash: "$2a$10$OmvlI/Z3AiWKIDrP2mT6ZuToWfKr.OwomDtFfniYe4xeVQxDhi416"
+        username: "single-user"
+        userID: "00000000-0000-0000-0000-000000000001"
+
+    # The static OIDC client for the Mitos console. The client secret is NOT
+    # inlined: Dex expands $DEX_CONSOLE_CLIENT_SECRET from the env var injected
+    # via secretKeyRef (the mitos-console-oidc Secret, key client-secret). The
+    # SAME Secret is read by the console as its OIDC client secret, so one Secret
+    # with one key satisfies both sides.
+    staticClients:
+      - id: mitos-console
+        name: Mitos Console
+        secret: $DEX_CONSOLE_CLIENT_SECRET
+        redirectURIs:
+          - https://console.example.com/auth/callback
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mitos-dex-single-user
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos-dex-single-user
+    app.kubernetes.io/component: dex
+    app.kubernetes.io/part-of: mitos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mitos-dex-single-user
+      app.kubernetes.io/component: dex
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mitos-dex-single-user
+        app.kubernetes.io/component: dex
+        app.kubernetes.io/part-of: mitos
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.41.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/dex
+          args:
+            - serve
+            - /etc/dex/config.yaml
+          env:
+            # The console static-client secret. Sourced via secretKeyRef and
+            # NEVER inlined. Dex expands $DEX_CONSOLE_CLIENT_SECRET in config.yaml
+            # from this env var at startup.
+            - name: DEX_CONSOLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mitos-console-oidc
+                  key: client-secret
+          ports:
+            - name: http
+              containerPort: 5556
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex/config.yaml
+              subPath: config.yaml
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: mitos-dex-single-user
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mitos-dex-single-user
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos-dex-single-user
+    app.kubernetes.io/component: dex
+    app.kubernetes.io/part-of: mitos
+spec:
+  selector:
+    app.kubernetes.io/name: mitos-dex-single-user
+    app.kubernetes.io/component: dex
+  ports:
+    - name: http
+      port: 5556
+      targetPort: http
+---
+# Ingress that exposes Dex over plain HTTP at the issuer hostname. The hostname
+# MUST match the issuer in the ConfigMap above and must resolve to your cluster
+# from BOTH the browser and the console pod. Replace dex.example.com. HTTP is
+# intentional here (see the ConfigMap note); do NOT expose this to untrusted
+# networks. NOT FOR PRODUCTION.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mitos-dex-single-user
+  namespace: mitos
+  labels:
+    app.kubernetes.io/name: mitos-dex-single-user
+    app.kubernetes.io/component: dex
+    app.kubernetes.io/part-of: mitos
+spec:
+  rules:
+    - host: dex.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mitos-dex-single-user
+                port:
+                  name: http

--- a/examples/single-user-dex/kustomization.yaml
+++ b/examples/single-user-dex/kustomization.yaml
@@ -1,0 +1,17 @@
+# Single-user Dex example for the Mitos console. QA / first-run ONLY.
+# NOT FOR PRODUCTION. NOT MULTI-TENANT. See README.md.
+#
+# This kustomization exists so the manifests can be validated and applied as a
+# set:
+#   kubectl kustomize examples/single-user-dex   # render / validate
+#   kubectl apply -k examples/single-user-dex     # apply
+#
+# It does NOT include the prerequisite Secret (mitos-console-oidc) or the
+# self-signed TLS Secret (mitos-console-tls); create those out of band first
+# (see README.md) so no secret value is ever committed to the repo.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mitos
+resources:
+  - dex.yaml
+  - console-ingress.yaml


### PR DESCRIPTION
Closes #400.

Ships a batteries-included, single-user login gate for the Mitos console so a first install or solo QA does not require bringing your own IdP and wiring OIDC by hand.

What is added:

- `examples/single-user-dex/`: a minimal Dex with ONE static-password user (`enablePasswordDB`, no GitHub/Google connectors), a plain-HTTP issuer Ingress, a self-signed HTTPS Ingress for the console, a Helm values overlay that wires `console.oidc.*` to that Dex, a `kustomization.yaml`, and a `README.md`.
- `docs/platforms/k3s-quickstart.md`: a from-scratch k3s walkthrough (install k3s, label the node, create the labeled namespace, install the chart, gate the console, log in).
- `README.md`: one row linking the k3s quickstart from the platforms table.

Safety gating (single-user QA / first-run ONLY, not multi-tenant, not production) is stated prominently in the manifest comments, the example README, and the doc. It is honest that this does not provide tenant isolation (sandboxes are microVMs, not pods). No secret value is committed: the bcrypt hash is an unusable placeholder (a bcrypt of a random string nobody knows) and the shared client secret + the console TLS cert are created out of band.

## Thinking Path

The console (`cmd/console/main.go`) is the OIDC consumer for browser login; the gateway authenticates API keys, not browser sessions, so the OIDC gate lives at the console. I traced the exact settings the console reads rather than guessing them:

- `mountAuth` reads `MITOS_CONSOLE_OIDC_ISSUER`, `MITOS_CONSOLE_OIDC_CLIENT_ID`, `MITOS_CONSOLE_OIDC_CLIENT_SECRET`, `MITOS_CONSOLE_OIDC_REDIRECT_URL`, and `MITOS_CONSOLE_OIDC_SCOPES` (default `email profile`).
- The Helm `console.yaml` template maps those from `console.oidc.issuerURL` / `clientID` / `clientSecretRef` (key `client-secret`) / `redirectURL`.
- The verifier (`internal/saas/oidcauth/verifier.go`) and login manager require a verified email; `AccountService.FindOrCreateByEmail` auto-creates the account and org on first verified login. Dex's password-DB connector marks the email verified, so a static user logs in cleanly.
- The OIDC handlers set the session and CSRF cookies with `Secure: true` (hardcoded in `mountAuth`), so the console must be HTTPS. Dex is kept on plain HTTP so the console pod can run OIDC discovery without a trusted cert; the issuer hostname is chosen (a `nip.io` name from the node IP) so it resolves identically from the browser and the pod, satisfying the exact issuer-string match OIDC discovery requires.

I built on the prior Dex work already in the repo (the federated `dex.enabled` chart template and its `console.oidc.*` wiring contract) rather than inventing a parallel mechanism.

## Verification

No real cluster was available, so cluster steps are documented as the intended path and marked NOT VERIFIED in the doc's and README's status tables. What I did validate locally:

- OIDC value/env-name tracing against `cmd/console/main.go`, the chart `console.yaml` template, and `internal/saas/oidcauth` (VERIFIED against source).
- `kubectl kustomize examples/single-user-dex` renders (5 kinds).
- Every example YAML file parses with `yaml.safe_load_all`, including the Dex `config.yaml` embedded in the ConfigMap (issuer, `enablePasswordDB`, static password, static client + redirect URI all parse).
- No em or en dashes in any authored file, the commit message, or this diff.
- Exactly one `Signed-off-by` trailer (DCO).

Not verified (requires a cluster / hardware): k3s + Helm install end to end, console login with the static user, and Firecracker fork on `/dev/kvm`.

No threat-model delta: this adds opt-in example manifests and docs over the existing, already-modeled console OIDC path and changes no runtime security surface. The deliberately weak QA-only posture is captured by the prominent warnings in the example and doc.

## Model Used

Claude (subagent) via Claude Code.
