### PR TITLE
fix(controller): auto re-fork raw-forkd claims after node loss (#372)

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -49,7 +49,8 @@ respective reconcilers in `internal/controller` for the precise emission points.
 | `HuskPodRaced` | Sandbox (source.poolRef) | Two sandboxes raced for the same dormant husk pod; this one lost and retries. |
 | `NoHuskPod` | Sandbox (source.poolRef) | No dormant husk pod was available to activate. |
 | `NoCapacity` / `CapacityExhausted` | Sandbox (source.poolRef) | No node had capacity to admit the sandbox before the pending deadline. |
-| `NodeLost` | Sandbox (source.poolRef) | The node backing an active sandbox was lost (drain, eviction, deletion). |
+| `NodeLost` | Sandbox (source.poolRef) | The node backing an active sandbox was lost (drain, eviction, deletion), and the sandbox failed closed: no surviving node holds the pool template snapshot to re-fork onto, or the bounded auto re-fork retries were exhausted. Terminal. |
+| `NodeLostReforking` | Sandbox (source.poolRef) | The raw-forkd node backing an active sandbox was lost, but a surviving node holds the pool template snapshot, so the sandbox is being automatically re-forked onto it (issue #372). The sandbox is re-pended and the claim reconciler re-issues the fork on its normal placement path. Bounded by a per-claim retry count; exhausting it fails closed with `NodeLost`. |
 | `OrphanReaped` | Sandbox (source.poolRef) | The GC orphan sweep reaped a backing VM that lingered past this (terminal) sandbox's transition, e.g. a terminate that crashed or was missed and was then re-adopted by a restarted forkd. Informational; the VM is gone. |
 | `SecretInheritanceDenied` | Sandbox (source.fromSandbox) | A fork was rejected because the source sandbox holds secrets and inheritance was not explicitly opted into. |
 | `ExplicitOptIn` | Sandbox (source.fromSandbox) | Secret inheritance was explicitly permitted on the fork. |
@@ -78,7 +79,8 @@ catalogue is the normative reference the alerts and runbooks cite (see
 | `HuskPodRaced` | False | None; two sandboxes raced for one husk pod, the loser retries. Benign under load. |
 | `NoHuskPod` | False | Warm pool is empty for this sandbox's pool; scale the SandboxPool warm count (the WarmPoolStarved runbook). |
 | `NoCapacity` / `CapacityExhausted` | False | No node had admission capacity before the pending deadline; add capacity or scale pools (the ClaimsPendingSustained runbook). |
-| `NodeLost` | False | The backing node was lost (drain, eviction, deletion); the sandbox re-places. Confirm the node and recover it if unexpected. |
+| `NodeLost` | False | Terminal. The backing node was lost and the sandbox could not be auto re-forked: no surviving node holds the pool template snapshot, or the bounded retries were exhausted. Confirm node and snapshot-holder health, then recreate the claim. |
+| `NodeLostReforking` | False | None; the backing node was lost and the sandbox is being automatically re-forked onto a surviving snapshot holder. Investigate only if it recurs for one sandbox (a replacement node that keeps dying eventually fails closed with `NodeLost`). |
 | `OrphanReaped` | False | None; the GC reaped a VM that outlived this terminal sandbox. Investigate only if it recurs, which would point at a forkd terminate path crashing or being missed. |
 | `WorkspaceBusy` | False | None; the sandbox waits on the single-writer-per-workspace lock and retries. Investigate only if a writer never releases it. |
 | `CheckpointNotImplemented` | False | The pool requested `DrainPolicy: Checkpoint`, which is not yet implemented; the claim re-pended with Kill semantics and in-VM state was lost. Set `DrainPolicy: Kill` knowingly, or persist state via a workspace, until the live-VM checkpoint engine lands (a KVM-gated follow-up). |

--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -230,39 +230,65 @@ well inside the heartbeat TTL.
 - Proving tests: `TestNodeUnhealthyAfterProbeFailureThreshold`,
   `TestSyncPodsDropsNodeOnRepeatedProbeFailure`.
 
-### NodeLost: a raw-forkd claim on a lost node reaches a terminal phase
+### NodeLost: a raw-forkd claim on a lost node is re-forked or fails closed
 
 In RAW-FORKD mode, a Ready claim whose node is no longer a healthy registered
-node is transitioned to the terminal `Failed` phase with a `NodeLost` reason and
-`FinishedAt` stamped (`markNodeLost`, `gc.go:301`; phase + FinishedAt + condition
-at `gc.go:314`). The node is gone, so there is nothing to terminate; the GC only
-stamps state. The ephemeral VM died with the node and there is no recovery, so
-failing the claim (and letting the TTL pass reap it) is correct. The orphan sweep
-and NodeLost never fight: the sweep visits only healthy nodes (`gc.go:193`), so a
-claim on a lost node is never swept. A claim on a still-healthy node is untouched
-(`gc.go:310`).
+node is handled by `markNodeLost` -> `handleRawNodeLost` (`gc.go`), which chooses
+between automatic re-fork and failing closed (issue #372):
 
-In HUSK mode, `markNodeLost` is a no-op (`if g.EnableHuskPods { return }`,
-`gc.go:302`): a Ready husk-backed claim recovers from node loss by RE-PENDING
-onto a replacement dormant slot (owned by `checkHuskPodLost`,
-`huskdrain.go:86`, and the husk pod watch, which the warm pool self-heals). The
-GC must not race that re-pend into a terminal `Failed`, so it skips the
-node-lost-fail entirely in husk mode. The GC carries `EnableHuskPods` from the
-controller run mode to make this decision (`gc.go:42`).
+- AUTO RE-FORK: when a SURVIVING healthy node still holds the pool's template
+  snapshot (`snapshotHolderSurvives` asks the NodeRegistry via `NodesWithTemplate`
+  for `poolTemplateID(pool)`) AND the per-claim re-fork bound is not yet spent,
+  the claim is RE-PENDED. The GC clears the stale placement
+  (`status.node`/`endpoint`/`sandboxID`), stamps a typed `Ready=False` /
+  `NodeLostReforking` condition, and bumps the durable per-claim re-fork count
+  (the `mitos.run/nodelost-refork-count` annotation, metadata so it survives the
+  status write). The claim reconciler then re-issues the fork onto a surviving
+  holder through its NORMAL placement path (`SelectNode` + `forkOnNode`), which
+  selects only healthy nodes, so it never re-places onto the dead node. This is a
+  placement-only decision and needs no KVM. The surviving snapshot holder is
+  guaranteed to exist or be rebuilt by the snapshot redistribution described under
+  the orphan-sweep guarantees (`TestSnapshotRebuildsOnHolderNodeLoss`).
+- FAIL CLOSED: when NO surviving node holds the template snapshot, OR the bounded
+  retries are exhausted (`maxRawForkdNodeLostReforks`, default 3, counted over the
+  claim's whole life so a claim whose replacement node keeps dying cannot retry
+  forever), the claim is transitioned to the terminal `Failed` phase with a
+  `NodeLost` reason and `FinishedAt` stamped. The condition message names the
+  actual cause (no surviving holder vs retries exhausted) so the remediation is
+  clear: recreate the claim once a snapshot holder is available. The TTL pass then
+  reaps the terminal claim. A claim with no `source.poolRef` (a `fromSandbox` or
+  `fromRevision` sandbox) is never auto-re-forked; it fails closed, preserving the
+  prior terminal behavior.
 
-- Bound: raw mode fails within one `Interval` of the node going unhealthy or
-  leaving the registry; husk mode re-pends on the pod event (or the claim's own
-  requeue).
+The node is gone, so there is nothing to terminate in either branch; the GC only
+stamps state. The orphan sweep and NodeLost never fight: the sweep visits only
+healthy nodes, so a claim on a lost node is never swept. A claim on a
+still-healthy node is untouched.
+
+In HUSK mode, `markNodeLost` is a no-op (`if g.EnableHuskPods { return }`): a
+Ready husk-backed claim recovers from node loss by RE-PENDING onto a replacement
+dormant slot (owned by `checkHuskPodLost`, `huskdrain.go`, and the husk pod
+watch, which the warm pool self-heals). The GC must not race that re-pend into a
+terminal `Failed`, so it skips the node-lost path entirely in husk mode. The GC
+carries `EnableHuskPods` from the controller run mode to make this decision.
+
+- Bound: raw mode re-pends (or fails closed) within one `Interval` of the node
+  going unhealthy or leaving the registry; the re-fork then runs on the claim
+  reconciler's normal placement path. Husk mode re-pends on the pod event (or the
+  claim's own requeue).
 - Husk hard-node-loss latency is cluster-dependent, not a Mitos GC interval. Husk
   node-loss recovery fires immediately on a pod delete or `DeletionTimestamp`
   event. But a HARD host loss where the pod object lingers `Running` with no
   `DeletionTimestamp` is bounded by the cluster's own unreachable-pod eviction
   setting (the `node.kubernetes.io/unreachable` taint toleration husk pods carry,
-  `huskpod.go:1194`), since no pod event fires until the cluster evicts the pod.
+  `huskpod.go`), since no pod event fires until the cluster evicts the pod.
   Operators wanting faster husk node-loss recovery should tune the unreachable
   toleration or the pod-eviction timeout; Mitos cannot shorten it.
-- Proving tests: `TestGCMarksNodeLost`, `TestGCLeavesHealthyNodeClaim`,
-  `TestGCInHuskModeDoesNotFailNodeLostClaim`.
+- Proving tests: `TestRawForkdClaimAutoReplacementAfterNodeLossOpen` (the GC
+  re-pend-vs-fail-closed decision), `TestGCRawForkdClaimReforksOntoSurvivingHolder`
+  (the end-to-end re-fork onto a surviving holder by the live reconciler),
+  `TestGCMarksNodeLost` (fail closed when no holder survives),
+  `TestGCLeavesHealthyNodeClaim`, `TestGCInHuskModeDoesNotFailNodeLostClaim`.
 
 ### DrainPolicy Checkpoint: honest degrade to Kill, never a silent lie
 
@@ -367,24 +393,15 @@ Shipped since (now in main):
   (`createSnapshotsOnNodes`, called from `sandboxpool_controller.go:509`)
   redistributes the snapshot onto a surviving node to restore the replica count,
   with no operator action. Proven by `TestSnapshotRebuildsOnHolderNodeLoss`
-  (`distribution_test.go`). This is the SNAPSHOT rebuild only; the CLAIM on the
-  lost raw-forkd node is not auto-replaced (see Known gaps below).
+  (`distribution_test.go`). The CLAIM on the lost raw-forkd node is now also
+  auto-replaced (issue #372): it is re-forked onto a surviving snapshot holder, or
+  fails closed when none survives. See the NodeLost guarantee above.
 
 ### Not yet built (known gaps)
 
 The following are NOT yet built. Each is verified
 against the code below so the gap is honest, not assumed:
 
-- raw-forkd CLAIM auto-replacement after node loss: in the husk default the warm
-  pool self-heals a lost node's dormant slots and the claim re-pends onto a
-  surviving slot, but a raw-forkd claim on a dead node fails (NodeLost) with no
-  automatic replacement, because raw mode has no standing dormant capacity to
-  re-pend onto (its forks are ephemeral). This is acceptable for ephemeral
-  sandboxes; the caller re-claims. It is a product decision, not a missing
-  mechanism, and is held as the documented skip
-  `TestRawForkdClaimAutoReplacementAfterNodeLossOpen` (`distribution_test.go`,
-  `t.Skip("#12: ...")`) with its design (re-issue the fork on a surviving
-  snapshot-holder, which the snapshot rebuild above guarantees exists).
 - status-update rate-limiting and batching: the SandboxPool reconcile elides a
   no-op status write (`writePoolStatusIfChanged`, `sandboxpool_controller.go:434`
   / `poolStatusUnchanged`, `sandboxpool_controller.go:420`), and the Sandbox

--- a/internal/controller/distribution_test.go
+++ b/internal/controller/distribution_test.go
@@ -4,13 +4,22 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"strconv"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/daemon"
 	"mitos.run/mitos/internal/fork"
 	"mitos.run/mitos/internal/pki"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // distMTLSPair builds a CA and the forkd server + controller client TLS configs
@@ -366,26 +375,154 @@ func TestSnapshotRebuildsOnHolderNodeLoss(t *testing.T) {
 	}
 }
 
-// TestRawForkdClaimAutoReplacementAfterNodeLossOpen documents, as an explicit
-// skipped placeholder, the part of issue #163 item 6 that is NOT a missing test
-// but a missing FEATURE and a deliberate open product decision (#372).
+// TestRawForkdClaimAutoReplacementAfterNodeLossOpen proves raw-forkd claim
+// auto-replacement after node loss (issue #372): the part of issue #163 item 6
+// that was a missing FEATURE, now implemented.
 //
 // In HUSK mode a Ready claim on a lost node re-pends onto a surviving dormant
 // warm slot (checkHuskPodLost + the husk pod watch self-heal the warm pool). In
-// RAW-FORKD mode there is no standing dormant capacity to re-pend onto: a
-// raw-forkd pool holds only template snapshots, and per-claim forks are
-// ephemeral. So a raw-forkd claim on a dead node is correctly marked NodeLost /
-// Failed (proven by TestGCMarksNodeLost) and is NOT auto-replaced; the caller
-// re-claims. This is acceptable open behavior for ephemeral sandboxes
-// (docs/failure-gc.md), not a half-built mechanism, so this is a t.Skip, not a
-// faked or failing assertion.
+// RAW-FORKD mode there is no standing dormant capacity to re-pend onto, but a
+// raw-forkd pool DOES hold per-node template snapshots, and
+// TestSnapshotRebuildsOnHolderNodeLoss guarantees a surviving holder exists (or
+// is rebuilt). So on node loss the GC re-pends the claim instead of failing it
+// terminally, and the claim reconciler re-issues the fork onto a surviving
+// snapshot holder via its normal SelectNode + forkOnNode placement path (no KVM
+// needed to decide). It fails closed (terminal NodeLost) only when no holder
+// survives or the bounded retries are exhausted.
 //
-// Design IF a future product decision wants raw-mode auto-replacement: on a
-// NodeLost transition in raw mode, the claim reconciler would re-issue the fork
-// on a surviving snapshot-holder node (which TestSnapshotRebuildsOnHolderNodeLoss
-// guarantees still exists or is rebuilt), rather than terminally failing the
-// claim. It needs no KVM; it needs the product decision to give raw claims
-// husk-like resilience at the cost of the pure fork-per-claim model.
+// This is the GC decision half (re-pend vs fail-closed). The end-to-end re-fork
+// onto a surviving holder by the live reconciler is proven by the envtest
+// TestGCRawForkdClaimReforksOntoSurvivingHolder (nodelost_test.go).
 func TestRawForkdClaimAutoReplacementAfterNodeLossOpen(t *testing.T) {
-	t.Skip("#372: raw-forkd claim auto-replacement after NodeLost is an open product decision; today the claim is marked NodeLost and the caller re-claims (husk mode self-heals via the warm pool instead). Snapshot rebuild-elsewhere IS covered by TestSnapshotRebuildsOnHolderNodeLoss.")
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	const poolName = "rf-pool"
+	const claimName = "rf-claim"
+	const lostNode = "lost-node"
+
+	// newCase builds a fake client holding a pool (inline template, so the
+	// template id is the pool name) and a Ready claim bound to the lost node, plus
+	// a registry with the given healthy snapshot holders. lostNode is never
+	// registered, so it always reads as lost. reforks pre-seeds the per-claim
+	// re-fork count annotation.
+	newCase := func(t *testing.T, reforks int, holders ...string) *GarbageCollector {
+		t.Helper()
+		pool := &v1.SandboxPool{
+			ObjectMeta: metav1.ObjectMeta{Name: poolName, Namespace: "default"},
+			Spec:       v1.SandboxPoolSpec{Template: &v1.PoolTemplateSpec{Image: "python:3.12-slim"}},
+		}
+		claim := &v1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default"},
+			Spec:       v1.SandboxSpec{Source: v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: poolName}}},
+			Status: v1.SandboxStatus{
+				Phase:     v1.SandboxReady,
+				Node:      lostNode,
+				Endpoint:  "10.9.9.9:9091",
+				SandboxID: claimName,
+			},
+		}
+		if reforks > 0 {
+			claim.Annotations = map[string]string{nodeLostReforkCountAnnotation: strconv.Itoa(reforks)}
+		}
+		registry := NewNodeRegistry()
+		for _, h := range holders {
+			registry.Register(&NodeInfo{Name: h, TemplateIDs: []string{poolName}, MaxSandboxes: 100})
+		}
+		c := fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1.Sandbox{}).
+			WithObjects(pool, claim).
+			Build()
+		return &GarbageCollector{Client: c, Registry: registry}
+	}
+
+	run := func(t *testing.T, gc *GarbageCollector) {
+		t.Helper()
+		var list v1.SandboxList
+		if err := gc.Client.List(context.Background(), &list); err != nil {
+			t.Fatal(err)
+		}
+		gc.markNodeLost(context.Background(), logr.Discard(), list.Items)
+	}
+
+	get := func(t *testing.T, gc *GarbageCollector) *v1.Sandbox {
+		t.Helper()
+		var got v1.Sandbox
+		if err := gc.Client.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: claimName}, &got); err != nil {
+			t.Fatal(err)
+		}
+		return &got
+	}
+
+	t.Run("re-forks onto a surviving snapshot holder", func(t *testing.T) {
+		gc := newCase(t, 0, "survivor")
+		run(t, gc)
+		got := get(t, gc)
+		if got.Status.Phase != v1.SandboxPending {
+			t.Fatalf("phase = %q, want Pending (re-pended for auto re-fork)", got.Status.Phase)
+		}
+		cond := meta.FindStatusCondition(got.Status.Conditions, "Ready")
+		if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "NodeLostReforking" {
+			t.Fatalf("Ready condition = %+v, want Status=False Reason=NodeLostReforking", cond)
+		}
+		if got.Status.Node != "" || got.Status.SandboxID != "" || got.Status.Endpoint != "" {
+			t.Fatalf("stale placement not cleared: node=%q sandbox=%q endpoint=%q", got.Status.Node, got.Status.SandboxID, got.Status.Endpoint)
+		}
+		if got.Status.FinishedAt != nil {
+			t.Fatal("FinishedAt must not be stamped on a re-pended claim")
+		}
+		if got.Annotations[nodeLostReforkCountAnnotation] != "1" {
+			t.Fatalf("re-fork count annotation = %q, want 1", got.Annotations[nodeLostReforkCountAnnotation])
+		}
+	})
+
+	t.Run("fails closed when no snapshot holder survives", func(t *testing.T) {
+		gc := newCase(t, 0) // no holders registered
+		run(t, gc)
+		got := get(t, gc)
+		if got.Status.Phase != v1.SandboxFailed {
+			t.Fatalf("phase = %q, want Failed (no holder to re-fork onto)", got.Status.Phase)
+		}
+		cond := meta.FindStatusCondition(got.Status.Conditions, "Ready")
+		if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "NodeLost" {
+			t.Fatalf("Ready condition = %+v, want Status=False Reason=NodeLost", cond)
+		}
+		if got.Status.FinishedAt == nil {
+			t.Fatal("FinishedAt not stamped on terminal NodeLost claim")
+		}
+	})
+
+	t.Run("fails closed after the bounded retries are exhausted", func(t *testing.T) {
+		// The count is already at the bound, so even with a surviving holder the
+		// GC must fail the claim closed rather than re-fork forever.
+		gc := newCase(t, maxRawForkdNodeLostReforks, "survivor")
+		run(t, gc)
+		got := get(t, gc)
+		if got.Status.Phase != v1.SandboxFailed {
+			t.Fatalf("phase = %q, want Failed (re-fork bound exhausted)", got.Status.Phase)
+		}
+		cond := meta.FindStatusCondition(got.Status.Conditions, "Ready")
+		if cond == nil || cond.Reason != "NodeLost" {
+			t.Fatalf("Ready condition = %+v, want Reason=NodeLost", cond)
+		}
+		if got.Status.FinishedAt == nil {
+			t.Fatal("FinishedAt not stamped on terminal NodeLost claim")
+		}
+	})
+
+	t.Run("husk mode is unchanged: no re-pend, no fail", func(t *testing.T) {
+		gc := newCase(t, 0, "survivor")
+		gc.EnableHuskPods = true
+		run(t, gc)
+		got := get(t, gc)
+		if got.Status.Phase != v1.SandboxReady {
+			t.Fatalf("husk-mode markNodeLost must be a no-op; phase = %q, want Ready", got.Status.Phase)
+		}
+	})
 }

--- a/internal/controller/gc.go
+++ b/internal/controller/gc.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -11,6 +13,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// nodeLostReforkCountAnnotation records how many times a raw-forkd claim has been
+// automatically re-forked after node loss. It is the durable, per-claim bound on
+// the auto-replacement retries (issue #372): the GC reads it to decide re-fork vs
+// fail-closed and bumps it on each re-pend, so a claim whose replacement node
+// keeps dying cannot retry forever. It is metadata, not status, so it survives the
+// status re-pend write below.
+const nodeLostReforkCountAnnotation = "mitos.run/nodelost-refork-count"
+
+// maxRawForkdNodeLostReforks bounds how many times a single raw-forkd claim is
+// automatically re-forked onto a surviving snapshot-holder after node loss before
+// the GC fails it closed with a terminal NodeLost. The bound is over the claim's
+// whole life (the count is never reset), so a claim repeatedly landing on dying
+// nodes fails closed instead of churning forever. Husk mode is unaffected; it
+// self-heals via the warm pool re-pend.
+const maxRawForkdNodeLostReforks = 3
 
 // GarbageCollector is a manager Runnable that periodically reconciles forkd
 // actuals against CRD-desired state. In one pass it sweeps orphan VMs: a forkd
@@ -274,19 +292,25 @@ func (g *GarbageCollector) sweepOrphanVolumes(ctx context.Context, logger logr.L
 	}
 }
 
-// markNodeLost transitions Ready claims whose node is no longer a healthy
-// registered node to a terminal Failed phase with a NodeLost condition.
+// markNodeLost handles raw-forkd Ready claims whose node is no longer a healthy
+// registered node. In raw-forkd mode (issue #372) a lost node does not always
+// end the claim: when a surviving node still holds the pool's template snapshot
+// and the per-claim re-fork bound is not yet spent, the claim is RE-PENDED so the
+// claim reconciler re-issues the fork onto that surviving holder (the same
+// SelectNode + forkOnNode placement path, no KVM needed to decide). The claim
+// only reaches the terminal Failed phase with a NodeLost condition when it fails
+// closed: no surviving snapshot holder, or the bounded retries are exhausted.
 //
-// We reuse the existing SandboxFailed phase with a NodeLost reason rather than
-// adding a dedicated phase const: the phase set stays small and a NodeLost
-// claim is, for every consumer, just a failed claim with a specific reason.
-// The node is gone, so there is nothing to terminate; we only stamp state,
-// bounded by the GC interval.
+// We reuse the existing SandboxFailed phase with a NodeLost reason for the
+// terminal case rather than adding a dedicated phase const: the phase set stays
+// small and a NodeLost claim is, for every consumer, just a failed claim with a
+// specific reason. The node is gone, so there is nothing to terminate; we only
+// stamp state, bounded by the GC interval.
 //
-// In husk mode this is a no-op: a Ready husk-backed claim recovers from node
-// loss by re-pending onto a replacement dormant slot (checkHuskPodLost + the
-// husk pod watch own that path). Failing it here would race that re-pend into a
-// terminal state and defeat the husk self-heal.
+// In husk mode this whole path is a no-op: a Ready husk-backed claim recovers
+// from node loss by re-pending onto a replacement dormant slot (checkHuskPodLost
+// + the husk pod watch own that path). Acting here would race that re-pend and
+// defeat the husk self-heal.
 func (g *GarbageCollector) markNodeLost(ctx context.Context, logger logr.Logger, sandboxes []v1.Sandbox) {
 	if g.EnableHuskPods {
 		return
@@ -299,23 +323,108 @@ func (g *GarbageCollector) markNodeLost(ctx context.Context, logger logr.Logger,
 		if c.Status.Node == "" || g.Registry.NodeHealthy(c.Status.Node) {
 			continue
 		}
-		now := metav1.Now()
-		c.Status.Phase = v1.SandboxFailed
-		c.Status.FinishedAt = &now
+		g.handleRawNodeLost(ctx, logger, c)
+	}
+}
+
+// handleRawNodeLost decides between auto re-fork and fail-closed for a single
+// raw-forkd Ready claim on a lost node. It re-pends the claim (back to Pending,
+// stale placement cleared, a typed NodeLostReforking condition, the per-claim
+// re-fork count bumped) when a surviving snapshot holder exists AND the bound is
+// not yet spent; the claim reconciler then re-issues the fork onto a surviving
+// holder via its normal placement path. Otherwise it fails the claim closed with
+// a terminal NodeLost condition whose message names the actual cause (no surviving
+// holder, or the retries exhausted).
+func (g *GarbageCollector) handleRawNodeLost(ctx context.Context, logger logr.Logger, c *v1.Sandbox) {
+	holderSurvives := g.snapshotHolderSurvives(ctx, c)
+	reforks := nodeLostReforkCount(c)
+	lostNode := c.Status.Node
+
+	if holderSurvives && reforks < maxRawForkdNodeLostReforks {
+		// Bump the durable per-claim re-fork count first (metadata, so it survives
+		// the status re-pend write). On a write error, leave the claim Ready and
+		// retry next pass rather than re-pending without recording the attempt.
+		if c.Annotations == nil {
+			c.Annotations = map[string]string{}
+		}
+		c.Annotations[nodeLostReforkCountAnnotation] = strconv.Itoa(reforks + 1)
+		if err := g.Client.Update(ctx, c); err != nil {
+			logger.Error(err, "stamp re-fork count for NodeLost claim", "claim", c.Name, "node", lostNode)
+			return
+		}
+		// Re-pend: clear the stale placement so no consumer reads a dead endpoint,
+		// and let the claim reconciler re-fork onto a surviving holder.
+		c.Status.Phase = v1.SandboxPending
+		c.Status.Node = ""
+		c.Status.Endpoint = ""
+		c.Status.SandboxID = ""
+		c.Status.StartedAt = nil
 		setCondition(&c.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
-			LastTransitionTime: now,
-			Reason:             "NodeLost",
-			Message:            "node running this sandbox is no longer healthy or registered",
+			LastTransitionTime: metav1.Now(),
+			Reason:             "NodeLostReforking",
+			Message:            fmt.Sprintf("node %s running this sandbox was lost; a surviving node holds the pool template snapshot, so the sandbox is being re-forked onto it (attempt %d of %d)", lostNode, reforks+1, maxRawForkdNodeLostReforks),
 		})
 		if err := g.Client.Status().Update(ctx, c); err != nil {
-			logger.Error(err, "mark claim NodeLost", "claim", c.Name, "node", c.Status.Node)
-			continue
+			logger.Error(err, "re-pend NodeLost claim for auto re-fork", "claim", c.Name, "node", lostNode)
+			return
 		}
-		recordNodeLost(c.Status.Node)
-		logger.Info("claim transitioned to NodeLost", "claim", c.Name, "node", c.Status.Node)
+		recordNodeLostRefork(lostNode)
+		logger.Info("raw-forkd claim re-pending for auto re-fork after node loss", "claim", c.Name, "node", lostNode, "attempt", reforks+1)
+		return
 	}
+
+	// Fail closed: no surviving snapshot holder, or the bounded retries are spent.
+	now := metav1.Now()
+	c.Status.Phase = v1.SandboxFailed
+	c.Status.FinishedAt = &now
+	message := fmt.Sprintf("node %s running this sandbox is no longer healthy or registered, and no surviving node holds the pool template snapshot to re-fork onto; recreate the claim once a snapshot holder is available", lostNode)
+	if holderSurvives {
+		message = fmt.Sprintf("node %s running this sandbox was lost; automatic re-fork onto a surviving snapshot holder was attempted %d times (the bound) without a durable placement, so the claim is failed; recreate the claim", lostNode, reforks)
+	}
+	setCondition(&c.Status.Conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: now,
+		Reason:             "NodeLost",
+		Message:            message,
+	})
+	if err := g.Client.Status().Update(ctx, c); err != nil {
+		logger.Error(err, "mark claim NodeLost", "claim", c.Name, "node", lostNode)
+		return
+	}
+	recordNodeLost(lostNode)
+	logger.Info("claim transitioned to NodeLost", "claim", c.Name, "node", lostNode)
+}
+
+// snapshotHolderSurvives reports whether a healthy node still holds the template
+// snapshot the claim's pool forks from, so the claim can be re-forked onto it.
+// It is the placement-only decision (no KVM): it resolves the pool's template id
+// (poolTemplateID) and asks the NodeRegistry whether any healthy node holds it.
+// It returns false (fail closed) for a claim with no pool source (a fromSandbox
+// or fromRevision sandbox is never auto-re-forked) or when the pool cannot be
+// read, preserving the terminal NodeLost behavior for those.
+func (g *GarbageCollector) snapshotHolderSurvives(ctx context.Context, c *v1.Sandbox) bool {
+	if c.Spec.Source.PoolRef == nil || c.Spec.Source.PoolRef.Name == "" {
+		return false
+	}
+	var pool v1.SandboxPool
+	if err := g.Client.Get(ctx, client.ObjectKey{Namespace: c.Namespace, Name: c.Spec.Source.PoolRef.Name}, &pool); err != nil {
+		return false
+	}
+	return len(g.Registry.NodesWithTemplate(poolTemplateID(&pool))) > 0
+}
+
+// nodeLostReforkCount reads the durable per-claim auto re-fork count from the
+// claim's annotation, defaulting to 0 when absent or unparseable.
+func nodeLostReforkCount(c *v1.Sandbox) int {
+	if v := c.Annotations[nodeLostReforkCountAnnotation]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
 }
 
 // ttlFinished deletes claims in a terminal phase (Terminated or Failed) whose

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -122,6 +122,16 @@ var (
 		Help: "Number of Ready claims marked NodeLost after their node went unhealthy (raw-forkd path), by node.",
 	}, []string{"node"})
 
+	// nodeLostReforkTotal counts raw-forkd claims that were re-pended for
+	// automatic re-fork onto a surviving snapshot holder after their node was lost
+	// (issue #372), rather than failed closed. Labeled by the LOST node, never a
+	// secret. A claim that fails closed (no surviving holder, or the bounded
+	// retries exhausted) is counted by nodeLostTotal instead.
+	nodeLostReforkTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "mitos_node_lost_refork_total",
+		Help: "Number of raw-forkd claims re-pended for automatic re-fork onto a surviving snapshot holder after node loss, by lost node.",
+	}, []string{"node"})
+
 	// claimWaitForWarmSeconds measures, per claim, the wall-clock the claim waited
 	// for a ready dormant pod from its creation to a successful husk activate. A
 	// burst absorbed by warm capacity shows up near the activate cost (~27 ms);
@@ -166,6 +176,7 @@ func init() {
 		huskPodCreatedTotal,
 		huskPodLostTotal,
 		nodeLostTotal,
+		nodeLostReforkTotal,
 		refillLatencySeconds,
 		claimWaitForWarmSeconds,
 		snapshotDistributionLagSeconds,
@@ -232,6 +243,11 @@ func recordHuskPodLost(pool string) { huskPodLostTotal.WithLabelValues(pool).Inc
 // recordNodeLost bumps the per-node counter for a Ready claim marked NodeLost.
 // node is a hostname (never a secret).
 func recordNodeLost(node string) { nodeLostTotal.WithLabelValues(node).Inc() }
+
+// recordNodeLostRefork bumps the per-node counter for a raw-forkd claim re-pended
+// for automatic re-fork after node loss (issue #372). node is the LOST hostname
+// (never a secret).
+func recordNodeLostRefork(node string) { nodeLostReforkTotal.WithLabelValues(node).Inc() }
 
 // forgetPoolMetrics drops every per-pool warm-pool label series for the given
 // pool key. It is called only when a SandboxPool is genuinely deleted (the

--- a/internal/controller/nodelost_test.go
+++ b/internal/controller/nodelost_test.go
@@ -122,6 +122,84 @@ func TestGCInHuskModeDoesNotFailNodeLostClaim(t *testing.T) {
 	}
 }
 
+// TestGCRawForkdClaimReforksOntoSurvivingHolder is the end-to-end proof of
+// raw-forkd claim auto-replacement after node loss (issue #372): a Ready claim
+// whose node is lost is re-forked, by the live raw reconciler, onto a SURVIVING
+// node that holds the same pool template snapshot, instead of failing terminally.
+//
+// Two forkd nodes hold the pool's template snapshot; the claim is pinned to
+// node-1 so the test controls which node to lose. After node-1 leaves the
+// registry, a raw GC pass re-pends the claim (a surviving holder exists), and the
+// live reconciler re-issues the fork onto node-2, returning the claim to Ready
+// there. This is the GC-decision plus reconciler-placement loop the unit test
+// TestRawForkdClaimAutoReplacementAfterNodeLossOpen proves at the GC level.
+func TestGCRawForkdClaimReforksOntoSurvivingHolder(t *testing.T) {
+	// node-1 and node-2 both hold the pool's template snapshot (template id ==
+	// pool name for an inline template).
+	stop1, _, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "nlrf-node-1", "nlrf-pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped1 := false
+	defer func() {
+		if !stopped1 {
+			stop1()
+		}
+	}()
+	stop2, _, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "nlrf-node-2", "nlrf-pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop2()
+
+	// A pool plus a claim PINNED to node-1 via spec.nodeName, so the placed node
+	// is deterministic and the test loses a known node.
+	pool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "nlrf-pool", Namespace: "default"},
+		Spec: v1.SandboxPoolSpec{
+			Template: &v1.PoolTemplateSpec{Image: "python:3.12-slim"},
+			Warm:     &v1.PoolWarm{Min: 1},
+		},
+	}
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "nlrf-claim", Namespace: "default"},
+		Spec: v1.SandboxSpec{
+			Source:   v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "nlrf-pool"}},
+			NodeName: "nlrf-node-1",
+		},
+	}
+	for _, obj := range []client.Object{pool, claim} {
+		if err := k8sClient.Create(ctx, obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, claim)
+		_ = k8sClient.Delete(ctx, pool)
+	})
+
+	ready := waitClaimReady(t, "nlrf-claim")
+	if ready.Status.Node != "nlrf-node-1" {
+		t.Fatalf("claim placed on %q, want nlrf-node-1 (pinned)", ready.Status.Node)
+	}
+
+	// Lose node-1: the VM died with it. node-2 survives and holds the snapshot.
+	stop1()
+	stopped1 = true
+
+	// A raw GC pass re-pends the claim (a surviving holder exists) instead of
+	// failing it; the live raw reconciler then re-forks it onto node-2.
+	gc := &controller.GarbageCollector{Client: k8sClient, Registry: testRegistry}
+	gc.RunOnce(ctx)
+
+	got := waitClaimPhase(t, "nlrf-claim", func(s *v1.Sandbox) bool {
+		return s.Status.Phase == v1.SandboxReady && s.Status.Node == "nlrf-node-2"
+	})
+	if got.Status.Node != "nlrf-node-2" {
+		t.Fatalf("claim re-forked onto %q, want nlrf-node-2 (the surviving holder)", got.Status.Node)
+	}
+}
+
 func TestGCLeavesHealthyNodeClaim(t *testing.T) {
 	stop, _, _, err := controller.StartFakeForkdNodeRecording(testRegistry, "nl-node-2", "nl2-pool")
 	if err != nil {


### PR DESCRIPTION
## Summary

In raw-forkd mode (`--enable-raw-forkd`), a Ready claim whose node was lost went terminally `SandboxFailed` / `NodeLost` and the caller had to re-claim, while husk mode (the default) self-heals via the warm-pool re-pend. This closes #372 by giving raw-forkd claims the same resilience: on node loss the claim is automatically re-forked onto a surviving snapshot holder instead of going terminal.

What changed:

- `markNodeLost` -> `handleRawNodeLost` (`internal/controller/gc.go`) now chooses between auto re-fork and fail-closed. When a surviving healthy node still holds the pool template snapshot (`snapshotHolderSurvives` asks the NodeRegistry via `NodesWithTemplate(poolTemplateID(pool))`) AND the per-claim re-fork bound is not yet spent, the claim is RE-PENDED: stale placement cleared, a typed `Ready=False` / `NodeLostReforking` condition stamped, and a durable per-claim re-fork count bumped (the `mitos.run/nodelost-refork-count` annotation).
- The claim reconciler then re-issues the fork onto a surviving holder through its NORMAL placement path (`SelectNode` + `forkOnNode`), which selects only healthy nodes, so it never re-places onto the dead node. No KVM is needed for the decision.
- BOUNDED retries: `maxRawForkdNodeLostReforks` (default 3), counted over the claim's whole life, so a claim whose replacement node keeps dying cannot retry forever.
- FAIL CLOSED: when no surviving holder exists or the retries are exhausted, the claim reaches terminal `Failed` / `NodeLost` with `FinishedAt` stamped and an actionable condition message naming the cause. A non-`poolRef` sandbox (`fromSandbox` / `fromRevision`) is never auto-re-forked.
- Husk mode is unchanged: `markNodeLost` stays a no-op there (the warm pool owns recovery).
- New `mitos_node_lost_refork_total` metric (by lost node). Docs updated: `docs/failure-gc.md` (NodeLost guarantee + known-gaps) and `docs/conditions.md` (the `NodeLostReforking` reason and the refined terminal `NodeLost` row).

Closes #372.

## Thinking Path

Node-loss detection for raw-forkd claims already lives in the GC's `markNodeLost`; husk mode early-returns there and self-heals via `checkHuskPodLost` + the warm-pool re-pend. The minimal, honest way to give raw claims the same resilience without inventing a new placement path was to make the GC re-pend the claim (set `Pending`, clear stale placement) instead of failing it, and let the EXISTING claim reconciler raw path (`SelectNode` + `forkOnNode`, which only considers healthy nodes) re-issue the fork. `TestSnapshotRebuildsOnHolderNodeLoss` already guarantees a surviving snapshot holder exists or is rebuilt, so the re-fork target is real. Bounding is a durable per-claim annotation count (never reset, so a tight failure loop fails closed rather than churning forever); fail-closed reuses the existing terminal `NodeLost` state, which is the correct behavior when no holder survives. The decision is placement-only and needs no KVM. Husk behavior is untouched because the husk early-return is unchanged.

## Verification

Commands run in the worktree (`KUBEBUILDER_ASSETS` set via `setup-envtest use 1.31`):

- `go build ./...` : PASS (no output).
- Unit test (the unskipped one), `go test ./internal/controller/ -run TestRawForkdClaimAutoReplacementAfterNodeLossOpen -count=1 -v` : PASS (4 subtests: re-fork onto surviving holder; fail closed when no holder; fail closed when bounded retries exhausted; husk mode unchanged).
- Targeted node-loss + end-to-end re-fork: `go test ./internal/controller/ -run 'TestGCRawForkdClaimReforksOntoSurvivingHolder|TestGCMarksNodeLost|TestGCInHuskModeDoesNotFailNodeLostClaim|TestGCLeavesHealthyNodeClaim|TestSnapshotRebuildsOnHolderNodeLoss' -count=1` : PASS (all 5).
- FULL controller envtest suite: `go test ./internal/controller/ -count=1 -timeout 300s` : PASS, `ok ... 142.308s` (envtest assets present locally).
- `go vet ./internal/controller/` : PASS.
- Lint (binary `golangci-lint`): `run --timeout=5m ./internal/controller/...` exit 0 AND `GOOS=linux run --timeout=5m ./internal/controller/...` exit 0.
- `gofmt -l` on the four changed Go files : empty (clean). (An unrelated pre-existing `org_controller.go` gofmt finding is not in this change set.)
- Em/en dash scan on all changed files and the commit message : none.

## Model Used

Claude (subagent) via Claude Code
