### PR TITLE
feat(runmanifest): inject MITOS_PUBLIC_URL and template ${MITOS_PUBLIC_URL}

### DIFF
--- a/docs/preview-urls.md
+++ b/docs/preview-urls.md
@@ -295,6 +295,51 @@ expose the proxy returns a typed `501`. The E2B compatibility shim
 (`mitos.e2b.Sandbox.get_host`) delegates to this same method, so an
 E2B script's `sandbox.get_host(port)` works unchanged.
 
+## Self-configuring with MITOS_PUBLIC_URL
+
+An exposed app often needs to know its own public URL at config or build time: a
+CORS or origin allowlist, an OAuth redirect URI, a base URL. Because Mitos assigns
+the subdomain dynamically (`<label>.<expose-domain>`), the app cannot hardcode it.
+The Run with Mitos provisioner (the `mitos.yaml` path) injects it for you.
+
+- `MITOS_PUBLIC_URL` is set in the environment to the sandbox's resolved public
+  URL, for example `https://app.mitos.run`. It is delivered both into the golden
+  template env at build time (so a `run.ready`-gated serving workload, which starts
+  during the snapshot build, sees it at startup) and into each fork's env at run
+  time (so exec sessions and processes started after the fork see this instance's
+  own URL). The value is a plain non-secret URL; it is safe to read, log, and bake
+  into the shareable golden snapshot.
+
+- `${MITOS_PUBLIC_URL}` may be referenced in `run.command`, `run.env`, and any
+  config string the manifest maps, and it is substituted with the resolved URL.
+  This is a single, well-defined substitution of one known token, not a shell:
+  only `${MITOS_PUBLIC_URL}` is expanded, and every other `${...}`, `$name`, or
+  shell construct is left exactly as written, so there is no expansion or injection
+  surface. A bare `$MITOS_PUBLIC_URL` (no braces) is NOT substituted; use the
+  braced form. When no public URL is resolved the token is left literal rather than
+  silently blanked.
+
+```yaml
+run:
+  command: ["node", "app.js", "--origin", "${MITOS_PUBLIC_URL}"]
+  env:
+    ALLOWED_ORIGINS: ${MITOS_PUBLIC_URL}
+    OAUTH_REDIRECT_URI: ${MITOS_PUBLIC_URL}/auth/callback
+```
+
+URL resolution detail: the golden pool is shared across a tenant's forks, so it is
+built once with the stable per-pool URL (`https://<pool>.<expose-domain>`), while
+each fork's `MITOS_PUBLIC_URL` is its own per-instance URL
+(`https://<label>.<expose-domain>`). For a single-instance app these are the same.
+For per-user apps where many forks share one golden, a snapshot-after-ready
+workload is captured with the per-pool URL and per-fork exec sessions see the
+per-instance URL; an app that must self-configure its origin per fork should read
+`MITOS_PUBLIC_URL` from the environment at run time.
+
+Forwarding the caller's verified Mitos Expose identity into the app (forward-auth
+headers and a signed identity assertion, deep SSO) is a separate, tracked
+follow-up (the auth bridge); it is NOT part of this URL injection.
+
 ## Operating the proxy
 
 ```bash

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -627,6 +627,12 @@ escape the exec process-group kill or the per-fork SIGUSR2 reset outside its own
 budget. The workload command and env are non-secret build-time config (env values
 are non-secret; secrets are still injected per fork via `Configure`); the agent
 logs only the workload session id and env-key count, never argv or values. The
+`MITOS_PUBLIC_URL` value injected into the build-time and per-fork env (the Run
+with Mitos public-URL injection, issue #476) is a non-secret URL (the sandbox's
+own Mitos Expose address), never a credential, and the `${MITOS_PUBLIC_URL}`
+manifest substitution expands only that one known token (no shell, path, or
+arbitrary variable expansion), so it adds no secret-exposure or injection surface.
+The
 per-fork SIGUSR2 reset no longer default-terminates a non-handler process: the
 broadcast delivers only to confirmed SIGUSR2 handlers (the `SigCgt` bit in
 `/proc/<pid>/status`), so a captured serving workload that installs no handler

--- a/internal/runmanifest/manifest_test.go
+++ b/internal/runmanifest/manifest_test.go
@@ -32,7 +32,7 @@ func TestGoldenPoolOpenClaw(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	pool, err := m.GoldenPool("sandboxes")
+	pool, err := m.GoldenPool("sandboxes", "")
 	if err != nil {
 		t.Fatalf("GoldenPool: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestSecretValuesNeverInGolden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	pool, err := m.GoldenPool("sandboxes")
+	pool, err := m.GoldenPool("sandboxes", "")
 	if err != nil {
 		t.Fatalf("GoldenPool: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestGoldenPoolTrackAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	pool, err := m.GoldenPool("ns")
+	pool, err := m.GoldenPool("ns", "")
 	if err != nil {
 		t.Fatalf("GoldenPool: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestGoldenPoolBuildNotYet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if _, err := m.GoldenPool("sandboxes"); err == nil {
+	if _, err := m.GoldenPool("sandboxes", ""); err == nil {
 		t.Fatal("GoldenPool on a build-from-source manifest should error until that slice lands")
 	} else if !strings.Contains(err.Error(), "source.image") {
 		t.Errorf("error should name source.image, got: %v", err)
@@ -191,7 +191,7 @@ preview:
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	pool, err := m.GoldenPool("inst")
+	pool, err := m.GoldenPool("inst", "")
 	if err != nil {
 		t.Fatalf("GoldenPool: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestGoldenPoolNoWorkloadWithoutReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	pool, err := m.GoldenPool("inst")
+	pool, err := m.GoldenPool("inst", "")
 	if err != nil {
 		t.Fatalf("GoldenPool: %v", err)
 	}

--- a/internal/runmanifest/plan.go
+++ b/internal/runmanifest/plan.go
@@ -63,7 +63,16 @@ func (m *Manifest) PoolName() string {
 // error otherwise. The HTTP ready gate is preserved on the manifest for the
 // snapshot-after-serving slice; this mapping uses the existing SnapshotAfterReady
 // trigger.
-func (m *Manifest) GoldenPool(namespace string) (*v1.SandboxPool, error) {
+//
+// publicURL is the golden's stable public URL (its Mitos Expose address, for
+// example "https://app.mitos.run"). It is injected as MITOS_PUBLIC_URL into the
+// template env and substituted for ${MITOS_PUBLIC_URL} in run.command and run.env,
+// so a snapshot-after-ready app (whose serving workload starts at build time) can
+// self-configure its origin allowlists and redirect URIs (issue #476). Because the
+// golden is shared across a tenant's forks, publicURL must be the stable
+// per-pool URL, not a per-fork one; an empty publicURL injects nothing and leaves
+// ${MITOS_PUBLIC_URL} references literal (back-compat).
+func (m *Manifest) GoldenPool(namespace, publicURL string) (*v1.SandboxPool, error) {
 	if m.Source.Image == "" {
 		return nil, fmt.Errorf("mitos.yaml %q: GoldenPool needs source.image; build-from-source golden resolution is a later slice", m.Name)
 	}
@@ -84,11 +93,11 @@ func (m *Manifest) GoldenPool(namespace string) (*v1.SandboxPool, error) {
 		Spec: v1.SandboxPoolSpec{
 			Template: &v1.PoolTemplateSpec{
 				Image:     m.Source.Image,
-				Command:   m.effectiveCommand(),
-				Env:       m.nonSecretEnv(),
+				Command:   m.effectiveCommand(publicURL),
+				Env:       m.nonSecretEnv(publicURL),
 				Resources: res,
 				Network:   m.egressPolicy(),
-				Workload:  m.workload(),
+				Workload:  m.workload(publicURL),
 			},
 			Snapshots: &v1.PoolSnapshots{
 				ReplicasPerNode: 1,
@@ -102,19 +111,26 @@ func (m *Manifest) GoldenPool(namespace string) (*v1.SandboxPool, error) {
 
 // effectiveCommand returns the command to run in the guest, honoring run.workdir by
 // wrapping in a shell when a workdir is set. With no command the image entrypoint
-// is inherited (nil).
-func (m *Manifest) effectiveCommand() []string {
+// is inherited (nil). Each command element and the workdir have ${MITOS_PUBLIC_URL}
+// substituted for publicURL; the resolved value is embedded as a literal (and, in
+// the workdir case, shell-quoted) so there is no shell re-expansion of it.
+func (m *Manifest) effectiveCommand(publicURL string) []string {
 	if len(m.Run.Command) == 0 {
 		return nil
 	}
-	if m.Run.Workdir == "" {
-		return append([]string(nil), m.Run.Command...)
-	}
-	quoted := make([]string, len(m.Run.Command))
+	cmd := make([]string, len(m.Run.Command))
 	for i, c := range m.Run.Command {
+		cmd[i] = expandPublicURL(c, publicURL)
+	}
+	if m.Run.Workdir == "" {
+		return cmd
+	}
+	quoted := make([]string, len(cmd))
+	for i, c := range cmd {
 		quoted[i] = shellQuote(c)
 	}
-	return []string{"sh", "-c", fmt.Sprintf("cd %s && exec %s", shellQuote(m.Run.Workdir), strings.Join(quoted, " "))}
+	workdir := expandPublicURL(m.Run.Workdir, publicURL)
+	return []string{"sh", "-c", fmt.Sprintf("cd %s && exec %s", shellQuote(workdir), strings.Join(quoted, " "))}
 }
 
 // workload maps run.command + run.ready onto a serving WorkloadSpec the build
@@ -123,13 +139,13 @@ func (m *Manifest) effectiveCommand() []string {
 // while listening" signal, so a plain run.command (a batch job) stays an exec-time
 // default and is never started during the build. The workload command is the same
 // workdir-wrapped command effectiveCommand builds; env is non-secret only.
-func (m *Manifest) workload() *v1.WorkloadSpec {
+func (m *Manifest) workload(publicURL string) *v1.WorkloadSpec {
 	if len(m.Run.Command) == 0 || m.Run.Ready == nil {
 		return nil
 	}
 	w := &v1.WorkloadSpec{
-		Command: m.effectiveCommand(),
-		Env:     m.nonSecretEnv(),
+		Command: m.effectiveCommand(publicURL),
+		Env:     m.nonSecretEnv(publicURL),
 	}
 	if h := m.Run.Ready.HTTP; h != nil {
 		w.Ready = &v1.HTTPReadyProbe{
@@ -144,20 +160,30 @@ func (m *Manifest) workload() *v1.WorkloadSpec {
 	return w
 }
 
-// nonSecretEnv maps run.env to a deterministically ordered []corev1.EnvVar. Secret
-// values are NOT here; they are injected per-fork.
-func (m *Manifest) nonSecretEnv() []corev1.EnvVar {
-	if len(m.Run.Env) == 0 {
+// nonSecretEnv maps run.env to a deterministically ordered []corev1.EnvVar, with
+// ${MITOS_PUBLIC_URL} substituted for publicURL in each value, and injects
+// MITOS_PUBLIC_URL itself when publicURL is non-empty (a caller-supplied run.env
+// entry of the same name is overridden by the resolved value). Secret values are
+// NOT here; they are injected per-fork.
+func (m *Manifest) nonSecretEnv(publicURL string) []corev1.EnvVar {
+	vals := make(map[string]string, len(m.Run.Env)+1)
+	for k, v := range m.Run.Env {
+		vals[k] = expandPublicURL(v, publicURL)
+	}
+	if publicURL != "" {
+		vals[PublicURLEnvVar] = publicURL
+	}
+	if len(vals) == 0 {
 		return nil
 	}
-	keys := make([]string, 0, len(m.Run.Env))
-	for k := range m.Run.Env {
+	keys := make([]string, 0, len(vals))
+	for k := range vals {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	out := make([]corev1.EnvVar, 0, len(keys))
 	for _, k := range keys {
-		out = append(out, corev1.EnvVar{Name: k, Value: m.Run.Env[k]})
+		out = append(out, corev1.EnvVar{Name: k, Value: vals[k]})
 	}
 	return out
 }

--- a/internal/runmanifest/provision.go
+++ b/internal/runmanifest/provision.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,14 @@ var randSource = rand.Read
 // that are neither supplied nor mintable fail closed. Mintable secrets
 // (generate > 0) left blank are minted from crypto/rand. SecretInheritance is set
 // to reissue so a fork never inherits the golden's in-memory secrets.
-func Provision(m *Manifest, supplied map[string]string, namespace, instanceLabel string) (*ProvisionResult, error) {
+//
+// publicURL is this instance's resolved public URL (https://<instanceLabel>.<expose
+// -domain>). It is delivered to the fork as the MITOS_PUBLIC_URL env var, and any
+// run.env value referencing ${MITOS_PUBLIC_URL} is resolved per-fork into the
+// Sandbox env (overlaying the shared golden's value), so this fork's exec sessions
+// and runtime reads see its own URL (issue #476). An empty publicURL injects
+// nothing. publicURL is a non-secret URL, never a credential.
+func Provision(m *Manifest, supplied map[string]string, namespace, instanceLabel, publicURL string) (*ProvisionResult, error) {
 	if err := m.Validate(); err != nil {
 		return nil, err
 	}
@@ -103,8 +111,35 @@ func Provision(m *Manifest, supplied map[string]string, namespace, instanceLabel
 	if m.Workspace != nil && m.Workspace.Persist {
 		sandbox.Spec.WorkspaceRef = &v1.LocalObjectReference{Name: instanceLabel + "-workspace"}
 	}
+	sandbox.Spec.Env = publicURLEnv(m, publicURL)
 
 	return &ProvisionResult{Secret: secret, Sandbox: sandbox}, nil
+}
+
+// publicURLEnv builds the per-fork env that carries this instance's public URL:
+// MITOS_PUBLIC_URL set to publicURL, plus every run.env entry that references
+// ${MITOS_PUBLIC_URL} resolved to publicURL (so a fork's exec sessions see this
+// instance's own URL, overlaying the shared golden's value). Entries that do not
+// reference the URL are left in the golden only and not duplicated here. Returns
+// nil when publicURL is empty, so a caller without a resolved URL provisions
+// exactly as before.
+func publicURLEnv(m *Manifest, publicURL string) []corev1.EnvVar {
+	if publicURL == "" {
+		return nil
+	}
+	keys := make([]string, 0, len(m.Run.Env))
+	for k, v := range m.Run.Env {
+		if k != PublicURLEnvVar && referencesPublicURL(v) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	out := make([]corev1.EnvVar, 0, len(keys)+1)
+	out = append(out, corev1.EnvVar{Name: PublicURLEnvVar, Value: publicURL})
+	for _, k := range keys {
+		out = append(out, corev1.EnvVar{Name: k, Value: expandPublicURL(m.Run.Env[k], publicURL)})
+	}
+	return out
 }
 
 // exposeSharing maps the manifest preview.auth to the expose sharing tier. The

--- a/internal/runmanifest/provision_test.go
+++ b/internal/runmanifest/provision_test.go
@@ -14,7 +14,7 @@ func TestGoldenPoolEgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	pool, err := m.GoldenPool("sandboxes")
+	pool, err := m.GoldenPool("sandboxes", "")
 	if err != nil {
 		t.Fatalf("GoldenPool: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestProvisionOpenClaw(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "sk-real"}, "tenant-jannes", "jannes-openclaw")
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "sk-real"}, "tenant-jannes", "jannes-openclaw", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestProvisionOpenClaw(t *testing.T) {
 // Secret, never inlined into the Sandbox spec.
 func TestProvisionSecretValuesOnlyInSecret(t *testing.T) {
 	m, _ := Parse(mustRead(t, "openclaw.yaml"))
-	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "sk-leak-canary"}, "ns", "inst")
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "sk-leak-canary"}, "ns", "inst", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -94,10 +94,60 @@ func TestProvisionSecretValuesOnlyInSecret(t *testing.T) {
 	}
 }
 
+// TestProvisionInjectsPublicURL asserts the resolved per-instance public URL is
+// delivered to the fork as the MITOS_PUBLIC_URL env var, and that run.env values
+// referencing ${MITOS_PUBLIC_URL} are resolved per-fork into the Sandbox env so a
+// fork's exec sessions and runtime reads see this instance's own URL.
+func TestProvisionInjectsPublicURL(t *testing.T) {
+	m, err := Parse([]byte(`
+name: app
+source:
+  image: ghcr.io/x/y:latest
+run:
+  env:
+    ALLOWED_ORIGINS: ${MITOS_PUBLIC_URL}
+    HOME: /home/node
+preview:
+  port: 8080
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	const url = "https://jannes-app.mitos.run"
+	res, err := Provision(m, nil, "ns", "jannes-app", url)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got := envValue(res.Sandbox.Spec.Env, PublicURLEnvVar); got != url {
+		t.Errorf("sandbox env %s = %q, want %q", PublicURLEnvVar, got, url)
+	}
+	if got := envValue(res.Sandbox.Spec.Env, "ALLOWED_ORIGINS"); got != url {
+		t.Errorf("per-fork ALLOWED_ORIGINS = %q, want %q (resolved)", got, url)
+	}
+	// A non-referencing run.env value is not duplicated into the per-fork env (it
+	// stays in the shared golden only).
+	if got := envValue(res.Sandbox.Spec.Env, "HOME"); got != "" {
+		t.Errorf("HOME should not be overlaid per-fork, got %q", got)
+	}
+}
+
+// TestProvisionNoURLNoInjection asserts an empty public URL injects nothing, so a
+// caller without a resolved URL provisions exactly as before.
+func TestProvisionNoURLNoInjection(t *testing.T) {
+	m, _ := Parse(mustRead(t, "openclaw.yaml"))
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", "inst", "")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got := envValue(res.Sandbox.Spec.Env, PublicURLEnvVar); got != "" {
+		t.Errorf("no MITOS_PUBLIC_URL should be injected with an empty url, got %q", got)
+	}
+}
+
 // TestProvisionRequiredMissing fails closed when a required secret is absent.
 func TestProvisionRequiredMissing(t *testing.T) {
 	m, _ := Parse(mustRead(t, "openclaw.yaml"))
-	_, err := Provision(m, map[string]string{}, "ns", "inst")
+	_, err := Provision(m, map[string]string{}, "ns", "inst", "")
 	if err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("expected required-secret error, got: %v", err)
 	}
@@ -115,7 +165,7 @@ func TestProvisionDeterministicMint(t *testing.T) {
 		return len(b), nil
 	}
 	m, _ := Parse(mustRead(t, "openclaw.yaml"))
-	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", "inst")
+	res, err := Provision(m, map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", "inst", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/runmanifest/template.go
+++ b/internal/runmanifest/template.go
@@ -1,0 +1,35 @@
+package runmanifest
+
+import "strings"
+
+// PublicURLEnvVar is the environment variable carrying a sandbox's resolved public
+// URL (its Mitos Expose address, for example "https://app.mitos.run"). It is
+// injected into the golden template env at build time and into each fork's env at
+// provision time so an exposed app can self-configure surfaces that cannot be
+// hardcoded against the dynamically assigned subdomain: CORS and origin
+// allowlists, OAuth redirect URIs, and base URLs (issue #476, part 1).
+//
+// The value is a non-secret URL, never a credential; it is safe to bake into the
+// shareable golden snapshot.
+const PublicURLEnvVar = "MITOS_PUBLIC_URL"
+
+// publicURLRef is the single template token expandPublicURL substitutes.
+const publicURLRef = "${" + PublicURLEnvVar + "}"
+
+// expandPublicURL substitutes the ${MITOS_PUBLIC_URL} token in s with url. It is a
+// single, well-defined substitution, NOT a shell or general template engine: only
+// this one braced token is expanded, and every other ${...}, $name, command,
+// arithmetic, or path expression is left exactly as written, so there is no
+// injection surface. When url is empty the token is left literal, so a missing URL
+// never silently blanks a configured value (the caller decides whether to inject).
+func expandPublicURL(s, url string) string {
+	if url == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, publicURLRef, url)
+}
+
+// referencesPublicURL reports whether s contains the ${MITOS_PUBLIC_URL} token.
+func referencesPublicURL(s string) bool {
+	return strings.Contains(s, publicURLRef)
+}

--- a/internal/runmanifest/template_test.go
+++ b/internal/runmanifest/template_test.go
@@ -1,0 +1,139 @@
+package runmanifest
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestExpandPublicURL covers the single, well-defined MITOS_PUBLIC_URL
+// substitution: only ${MITOS_PUBLIC_URL} is expanded, every other token is left
+// exactly as written, an empty url leaves the reference literal, and there is no
+// shell, path, or arithmetic expansion (no injection surface).
+func TestExpandPublicURL(t *testing.T) {
+	const url = "https://app.mitos.run"
+	cases := []struct {
+		name string
+		in   string
+		url  string
+		want string
+	}{
+		{"braced", "origin=${MITOS_PUBLIC_URL}", url, "origin=https://app.mitos.run"},
+		{"embedded", "${MITOS_PUBLIC_URL}/callback", url, "https://app.mitos.run/callback"},
+		{"twice", "${MITOS_PUBLIC_URL},${MITOS_PUBLIC_URL}", url, "https://app.mitos.run,https://app.mitos.run"},
+		{"no token", "plain value", url, "plain value"},
+		{"unknown var left literal", "${OTHER} and ${MITOS_PUBLIC_URL}", url, "${OTHER} and https://app.mitos.run"},
+		{"bare dollar not expanded", "$MITOS_PUBLIC_URL", url, "$MITOS_PUBLIC_URL"},
+		{"empty url leaves literal", "${MITOS_PUBLIC_URL}", "", "${MITOS_PUBLIC_URL}"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := expandPublicURL(c.in, c.url); got != c.want {
+				t.Errorf("expandPublicURL(%q, %q) = %q, want %q", c.in, c.url, got, c.want)
+			}
+		})
+	}
+}
+
+// TestGoldenPoolInjectsPublicURL asserts the resolved public URL is injected as
+// MITOS_PUBLIC_URL into the golden template env (and the captured-running workload
+// env), and that ${MITOS_PUBLIC_URL} references in run.command and run.env are
+// substituted with the resolved URL so a snapshot-after-ready app self-configures
+// at build time.
+func TestGoldenPoolInjectsPublicURL(t *testing.T) {
+	m, err := Parse([]byte(`
+name: app
+source:
+  image: ghcr.io/x/y:latest
+run:
+  command: ["node", "app.js", "--origin", "${MITOS_PUBLIC_URL}"]
+  env:
+    ALLOWED_ORIGINS: ${MITOS_PUBLIC_URL}
+    HOME: /home/node
+  ready:
+    http: { port: 8080, path: /healthz, expect: 200 }
+    timeout: 60s
+preview:
+  port: 8080
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	const url = "https://app.mitos.run"
+	pool, err := m.GoldenPool("ns", url)
+	if err != nil {
+		t.Fatalf("GoldenPool: %v", err)
+	}
+	tpl := pool.Spec.Template
+
+	// MITOS_PUBLIC_URL is injected into the template env.
+	if got := envValue(tpl.Env, PublicURLEnvVar); got != url {
+		t.Errorf("template env %s = %q, want %q", PublicURLEnvVar, got, url)
+	}
+	// run.env reference is substituted.
+	if got := envValue(tpl.Env, "ALLOWED_ORIGINS"); got != url {
+		t.Errorf("ALLOWED_ORIGINS = %q, want %q", got, url)
+	}
+	// A non-referencing run.env value is untouched.
+	if got := envValue(tpl.Env, "HOME"); got != "/home/node" {
+		t.Errorf("HOME = %q, want /home/node", got)
+	}
+	// run.command reference is substituted (the resolved URL appears literally in
+	// the command, not a token).
+	joined := strings.Join(tpl.Command, " ")
+	if !strings.Contains(joined, url) {
+		t.Errorf("command %v does not carry the resolved URL %q", tpl.Command, url)
+	}
+	if strings.Contains(joined, "${MITOS_PUBLIC_URL}") {
+		t.Errorf("command %v still carries an unresolved token", tpl.Command)
+	}
+	// The captured-running workload env carries it too (build-time config).
+	if tpl.Workload == nil {
+		t.Fatal("expected a workload from the ready gate")
+	}
+	if got := envValue(tpl.Workload.Env, PublicURLEnvVar); got != url {
+		t.Errorf("workload env %s = %q, want %q", PublicURLEnvVar, got, url)
+	}
+	if got := envValue(tpl.Workload.Env, "ALLOWED_ORIGINS"); got != url {
+		t.Errorf("workload ALLOWED_ORIGINS = %q, want %q", got, url)
+	}
+}
+
+// TestGoldenPoolNoURLLeavesLiteral asserts an empty public URL leaves references
+// literal and injects no MITOS_PUBLIC_URL (back-compat for callers with no URL).
+func TestGoldenPoolNoURLLeavesLiteral(t *testing.T) {
+	m, err := Parse([]byte(`
+name: app
+source:
+  image: ghcr.io/x/y:latest
+run:
+  env:
+    ALLOWED_ORIGINS: ${MITOS_PUBLIC_URL}
+preview:
+  port: 8080
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	pool, err := m.GoldenPool("ns", "")
+	if err != nil {
+		t.Fatalf("GoldenPool: %v", err)
+	}
+	if got := envValue(pool.Spec.Template.Env, PublicURLEnvVar); got != "" {
+		t.Errorf("no MITOS_PUBLIC_URL should be injected with an empty url, got %q", got)
+	}
+	if got := envValue(pool.Spec.Template.Env, "ALLOWED_ORIGINS"); got != "${MITOS_PUBLIC_URL}" {
+		t.Errorf("ALLOWED_ORIGINS = %q, want the literal token left intact", got)
+	}
+}
+
+// envValue is a test helper returning the value of name in a []corev1.EnvVar.
+func envValue(env []corev1.EnvVar, name string) string {
+	for _, e := range env {
+		if e.Name == name {
+			return e.Value
+		}
+	}
+	return ""
+}

--- a/internal/runservice/adapters_test.go
+++ b/internal/runservice/adapters_test.go
@@ -41,7 +41,7 @@ func TestK8sApplierCreateThenUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pool, err := m.GoldenPool("ns")
+	pool, err := m.GoldenPool("ns", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestK8sApplierCreateThenUpdate(t *testing.T) {
 
 	// A fresh object (no resourceVersion), as a second run would build, must update
 	// in place, not error.
-	pool2, _ := m.GoldenPool("ns")
+	pool2, _ := m.GoldenPool("ns", "")
 	if err := ap.Apply(context.Background(), pool2); err != nil {
 		t.Fatalf("second apply (update): %v", err)
 	}
@@ -97,7 +97,7 @@ func TestInstanceLabel(t *testing.T) {
 		t.Errorf("label %q should start with the repo name", a)
 	}
 	// Must be a valid manifest DNS label (Provision will accept it).
-	if _, err := runmanifest.Provision(mustManifest(t, openclawYAML), map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", a); err != nil {
+	if _, err := runmanifest.Provision(mustManifest(t, openclawYAML), map[string]string{"ANTHROPIC_API_KEY": "x"}, "ns", a, ""); err != nil {
 		t.Errorf("instance label not provisionable: %v", err)
 	}
 }

--- a/internal/runservice/service.go
+++ b/internal/runservice/service.go
@@ -112,11 +112,15 @@ func (s *Service) Run(ctx context.Context, src string, id Identity, secrets map[
 	if err != nil {
 		return nil, fmt.Errorf("run %q: %w", src, err)
 	}
-	pool, err := m.GoldenPool(id.Namespace)
+	// The golden is shared across a tenant's forks, so it gets the stable per-pool
+	// canonical URL; each fork gets its own per-instance URL (issue #476).
+	goldenURL := fmt.Sprintf("https://%s.%s", m.PoolName(), s.exposeDomain)
+	instanceURL := fmt.Sprintf("https://%s.%s", id.InstanceLabel, s.exposeDomain)
+	pool, err := m.GoldenPool(id.Namespace, goldenURL)
 	if err != nil {
 		return nil, fmt.Errorf("run %q: golden pool: %w", src, err)
 	}
-	res, err := runmanifest.Provision(m, secrets, id.Namespace, id.InstanceLabel)
+	res, err := runmanifest.Provision(m, secrets, id.Namespace, id.InstanceLabel, instanceURL)
 	if err != nil {
 		return nil, fmt.Errorf("run %q: provision: %w", src, err)
 	}
@@ -125,6 +129,6 @@ func (s *Service) Run(ctx context.Context, src string, id Identity, secrets map[
 	}
 	return &RunResult{
 		Instance: id.InstanceLabel,
-		URL:      fmt.Sprintf("https://%s.%s", id.InstanceLabel, s.exposeDomain),
+		URL:      instanceURL,
 	}, nil
 }

--- a/internal/runservice/service_test.go
+++ b/internal/runservice/service_test.go
@@ -137,6 +137,50 @@ func TestRunProvisionsAndApplies(t *testing.T) {
 	}
 }
 
+// TestRunThreadsPublicURL asserts Run resolves the public URL and threads it
+// through: the shared golden pool gets the stable canonical URL
+// (https://<pool>.<domain>) at build time, while the per-fork Sandbox gets its own
+// per-instance URL (https://<label>.<domain>) in its env.
+func TestRunThreadsPublicURL(t *testing.T) {
+	ap := &fakeApplier{}
+	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, ap, "mitos.run")
+	if _, err := svc.Run(context.Background(), "github.com/openclaw/openclaw",
+		Identity{Namespace: "tenant-jannes", InstanceLabel: "jannes-openclaw"},
+		map[string]string{"ANTHROPIC_API_KEY": "sk-real"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var pool *v1.SandboxPool
+	var sandbox *v1.Sandbox
+	for _, o := range ap.applied {
+		switch obj := o.(type) {
+		case *v1.SandboxPool:
+			pool = obj
+		case *v1.Sandbox:
+			sandbox = obj
+		}
+	}
+	if pool == nil || sandbox == nil {
+		t.Fatalf("missing applied objects: pool=%v sandbox=%v", pool != nil, sandbox != nil)
+	}
+	const wantGolden = "https://openclaw.mitos.run"
+	if got := envValue(pool.Spec.Template.Env, runmanifest.PublicURLEnvVar); got != wantGolden {
+		t.Errorf("golden %s = %q, want %q", runmanifest.PublicURLEnvVar, got, wantGolden)
+	}
+	const wantInstance = "https://jannes-openclaw.mitos.run"
+	if got := envValue(sandbox.Spec.Env, runmanifest.PublicURLEnvVar); got != wantInstance {
+		t.Errorf("instance %s = %q, want %q", runmanifest.PublicURLEnvVar, got, wantInstance)
+	}
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for _, e := range env {
+		if e.Name == name {
+			return e.Value
+		}
+	}
+	return ""
+}
+
 func TestRunRequiredSecretMissing(t *testing.T) {
 	ap := &fakeApplier{}
 	svc := New(&fakeFetcher{m: mustManifest(t, openclawYAML)}, ap, "mitos.run")


### PR DESCRIPTION
## Thinking Path

A forked, exposed app needs its own public URL at config or build time (origin allowlists, OAuth redirect URIs, CORS, base URLs), but Mitos assigns the subdomain dynamically as `<label>.<expose-domain>`, so the app cannot hardcode it. This is part 1 of #476: the URL injection plus `mitos.yaml` templating.

The resolved public URL becomes known in `runservice.Run` (`https://<label>.<exposeDomain>`). The golden pool is shared across a tenant's forks and is built once, so it gets the stable per-pool URL `https://<pool>.<domain>` at build time, which reaches a `run.ready` gated serving workload that starts during the snapshot build (the OpenClaw gateway case). The per-fork Sandbox gets its own per-instance URL `https://<label>.<domain>` in `Spec.Env`, for exec sessions and processes started after the fork. For a single-instance app these coincide.

Mechanisms:
- `MITOS_PUBLIC_URL` injected into the golden `Template.Env` (and the captured-running workload env), and into the per-fork `Sandbox.Spec.Env`.
- `${MITOS_PUBLIC_URL}` substitution over `run.command`, `run.env`, and `workdir`: one well-defined braced token only, no shell or arbitrary variable expansion (no injection surface). A bare `$MITOS_PUBLIC_URL` is not substituted; an empty URL injects nothing and leaves the token literal.
- The value is a non-secret URL, never a credential, so it is safe to bake into the shareable golden snapshot. Threat-model note added.

Threaded the per-pool canonical URL into `GoldenPool(namespace, publicURL)` and the per-instance URL into `Provision(..., publicURL)`; `runservice.Run` computes both.

## Verification

Commands run in the worktree:

- `go build ./...`: clean.
- `go test ./internal/runmanifest/ ./internal/runservice/`: PASS (new tests: `TestExpandPublicURL`, `TestGoldenPoolInjectsPublicURL`, `TestGoldenPoolNoURLLeavesLiteral`, `TestProvisionInjectsPublicURL`, `TestProvisionNoURLNoInjection`, `TestRunThreadsPublicURL`; all pre-existing tests still PASS). TDD: tests written first, confirmed RED (signature/symbol compile failures), then GREEN.
- `go vet ./internal/runmanifest/ ./internal/runservice/ ./internal/controller/`: clean.
- `gofmt -l internal/runmanifest/ internal/runservice/`: empty.
- `golangci-lint run --timeout=5m ./internal/runmanifest/... ./internal/runservice/...`: exit 0.
- `GOOS=linux golangci-lint run --timeout=5m ./internal/runmanifest/... ./internal/runservice/...`: exit 0 (authoritative).
- em/en dash scan over all touched files: clean.
- envtest: assets installed via `setup-envtest use 1.31`; the full `./internal/controller/` suite is slow and exceeded a 2 minute bound, but the relevant subset `go test ./internal/controller/ -run 'AutoUpdate|Workload|RunWith'` PASSED (4.8s). No controller production code changed in this PR.

## Model Used

Claude (subagent) via Claude Code

## Summary

Implements part 1 of #476: inject `MITOS_PUBLIC_URL` into the build and run env and add `${MITOS_PUBLIC_URL}` `mitos.yaml` templating over `run.command` / `run.env` / config. Docs updated in `docs/preview-urls.md` (new "Self-configuring with MITOS_PUBLIC_URL" section) and `docs/threat-model.md` (non-secret URL, bounded substitution, no new exposure surface).

Tracked follow-up (part 2, out of scope here): the auth bridge, forwarding the caller's verified Mitos Expose identity into the app via forward-auth headers and an optional signed identity assertion (deep SSO). It moves a trusted identity surface and needs its own threat-model delta and a named human reviewer.

Refs #476