### PR TITLE
feat(sdk): fork-native subagent hook with graceful off-mitos fallback

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -283,6 +283,46 @@ The ordered steps (copy / run / env / workdir) map onto the CRD
 steps are reused. See the [docs](https://mitos.run) for the CLI
 (`mitos template build` / `push`) and the cache semantics.
 
+## Fork-native subagents
+
+When a multi-agent harness runs INSIDE a mitos sandbox, spawning a subagent IS
+forking the current warm sandbox: the child is a copy-on-write snapshot of the
+live parent, so it starts warm with the parent's state, with no cold boot and no
+external orchestrator round-trip. `mitos.subagent` is the small hook that does
+this, with a graceful no-op fallback when the code is not on mitos.
+
+```python
+import mitos.subagent as sub
+
+result = sub.spawn_subagent(3, label="researcher")
+if result.on_mitos:
+    for child in result.children:
+        print("warm subagent:", child.sandbox_id)   # forked from this sandbox
+else:
+    print("off mitos:", result.reason)              # fall back to your normal spawn
+```
+
+- Detection signal: the in-guest self-service socket advertised at
+  `$MITOS_SOCKET` (see `mitos.guest`). The host sets it at claim time only inside
+  a mitos sandbox, so its presence is the honest "am I running inside mitos"
+  check. `sub.is_on_mitos()` is that pure check; `sub.current_sandbox()` returns
+  the sandbox's own identity (or `None` off mitos).
+- On mitos: `spawn_subagent(n, label=...)` routes the spawn through the
+  budget-gated self-fork on that socket (`mitos.guest.fork`), no network egress
+  and no API credentials, and returns a `SubagentResult` with `on_mitos=True` and
+  a `SubagentHandle` per warm child.
+- Off mitos: it returns `on_mitos=False` with an explanatory `reason`, does NOT
+  call fork, and never raises. The fallback path is first-class so a harness
+  using this hook does not break off-platform.
+
+Honest scope: the warm fork needs a running mitos sandbox context. The
+budget-gated self-fork is wired progressively by the guest agent; where it is not
+yet enabled the socket returns its remediation as a `mitos.guest.GuestError`,
+which is a real on-mitos error rather than the off-mitos fallback. The handles
+carry the child sandbox names; driving a child from another process needs
+control-plane credentials, which is a documented follow-up. See
+`examples/fork_native_subagent.py`.
+
 ## Integrations
 
 Framework adapters live under `mitos.integrations`. Each maps a framework's

--- a/sdk/python/examples/README.md
+++ b/sdk/python/examples/README.md
@@ -28,6 +28,7 @@ pip install mitos-run        # import name stays `mitos`
 | `best_of_n.py` | Best-of-N | Fork one warm sandbox into N, run attempts in parallel, keep the winner. | direct |
 | `rl_evals.py` | RL / evals | A SWE-bench-style harness that forks many environments from one golden state. | direct |
 | `background_agent.py` | Background agent | Task in, PR out: a durable workspace pushed to a rendezvous git remote on terminate. | operator |
+| `fork_native_subagent.py` | Fork-native subagents | Spawning a subagent = forking the current warm sandbox; graceful no-op off mitos. | in-guest |
 
 Other examples in this directory: `quickstart.py` (the README hero),
 `direct.py` (the minimal standalone smoke test, executed end to end on real KVM
@@ -93,6 +94,23 @@ python3 background_agent.py
 Honest gap: the SDK has no first-class helper for `spec.git.paths` yet, so this
 example sets it by patching the Workspace CRD through the Kubernetes client
 `AgentRun` already loaded. A `spec.git` helper is a follow-up.
+
+### fork_native_subagent.py
+
+In-guest path. When a multi-agent harness runs inside a mitos sandbox, spawning a
+subagent IS forking the current warm sandbox via the in-guest self-service socket
+(`$MITOS_SOCKET`, `mitos.guest`). `mitos.subagent.spawn_subagent(n, label=...)`
+returns warm `SubagentHandle`s on mitos and a graceful no-op `SubagentResult`
+(`on_mitos=False`) off mitos, so the harness never breaks off-platform. Run it on
+your laptop and it prints the fallback; run it inside a sandbox and it forks.
+
+```
+python3 fork_native_subagent.py
+```
+
+Honest scope: the budget-gated self-fork is wired progressively by the guest
+agent, and driving a child from another process needs control-plane credentials;
+both are documented follow-ups.
 
 ## What CI verifies (and what it does not)
 

--- a/sdk/python/examples/fork_native_subagent.py
+++ b/sdk/python/examples/fork_native_subagent.py
@@ -1,0 +1,86 @@
+"""Fork-native subagents: spawning a subagent IS forking the current sandbox.
+
+Use case hook: a multi-agent harness wants to spawn a subagent. When the harness
+itself runs INSIDE a mitos sandbox, the differentiated move is to spawn that
+subagent by forking the current warm sandbox: the child is a copy-on-write
+snapshot of the live parent, so it starts warm with the parent's state, with no
+cold boot and no external orchestrator round-trip. When the harness is NOT on
+mitos, there is nothing to fork, so the hook returns a graceful no-op fallback
+and the harness uses its normal (cold) spawn path. The fallback is first-class:
+the hook never raises just because the code is off-platform.
+
+    import mitos.subagent as sub
+
+    result = sub.spawn_subagent(3, label="researcher")
+    if result.on_mitos:
+        for child in result.children:
+            ...        # drive each warm subagent
+    else:
+        ...            # off mitos: spawn subagents the normal way
+
+Detection signal: the in-guest self-service socket advertised at $MITOS_SOCKET
+(mitos.guest). The host sets it at claim time only inside a mitos sandbox, so its
+presence is the honest "am I running inside mitos" check. The fork is routed over
+that socket (mitos.guest.fork): no network egress, no API credentials.
+
+Honest scope: the warm fork needs a running mitos sandbox context. Off mitos
+(running this on your laptop), spawn_subagent returns on_mitos=False, which is
+exactly what this example prints. The budget-gated self-fork is wired
+progressively by the guest agent (issue #25); where it is not yet enabled the
+socket returns its remediation as a mitos.guest.GuestError, which is a real
+on-mitos error rather than the off-mitos fallback.
+
+Run::
+
+    python3 fork_native_subagent.py      # off mitos: prints the fallback
+    # inside a mitos sandbox: forks the current warm sandbox into subagents
+
+Byte-compiled and import-checked by the sdk-examples CI job; not executed there
+(no VM, and this is import-safe regardless of platform). The asserts below run at
+import time as a real API-surface check.
+"""
+
+import mitos
+import mitos.subagent as sub
+from mitos.subagent import SubagentHandle, SubagentResult
+
+# Drift guard: assert the surface the example uses, so a rename fails import.
+assert callable(sub.spawn_subagent)
+assert callable(sub.is_on_mitos)
+assert callable(sub.current_sandbox)
+assert {"on_mitos", "children", "reason"} <= set(SubagentResult.__dataclass_fields__)
+assert hasattr(SubagentResult, "first")  # the convenience property
+assert {"sandbox_id", "label", "on_mitos"} <= set(SubagentHandle.__dataclass_fields__)
+assert mitos.subagent is sub  # exported from the package root
+
+
+def spawn_research_team(n: int = 3) -> SubagentResult:
+    """Spawn n research subagents. On mitos each is a warm fork of this very
+    sandbox; off mitos this is a no-op fallback the caller can branch on."""
+    return sub.spawn_subagent(n, label="researcher")
+
+
+def main() -> None:
+    me = sub.current_sandbox()
+    if me is not None:
+        print(f"running inside mitos sandbox: {me.sandbox_id}")
+    else:
+        print("not running inside a mitos sandbox")
+
+    result = spawn_research_team(3)
+    if result.on_mitos:
+        print(f"spawned {len(result.children)} warm subagents by forking the current sandbox:")
+        for child in result.children:
+            print(f"  warm subagent {child.sandbox_id} (label={child.label!r})")
+        # A real harness would now drive each child (exec, run_code, ...). Driving
+        # a child from another process needs control-plane credentials; that
+        # reconnect helper is a documented follow-up.
+    else:
+        print(f"fork-native spawn unavailable: {result.reason}")
+        print("falling back to the normal subagent spawn path here.")
+
+    print("fork_native_subagent example OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/mitos/__init__.py
+++ b/sdk/python/mitos/__init__.py
@@ -1,4 +1,4 @@
-from mitos import guest
+from mitos import guest, subagent
 from mitos.aio import AsyncAgentRun, AsyncSandbox
 from mitos.client import AgentRun
 from mitos.direct import DirectSandbox, SandboxServer, create
@@ -51,4 +51,5 @@ __all__ = [
     "ForkPolicy",
     "Network",
     "guest",
+    "subagent",
 ]

--- a/sdk/python/mitos/subagent.py
+++ b/sdk/python/mitos/subagent.py
@@ -1,0 +1,138 @@
+"""Fork-native subagent spawning (issue #340), the differentiated hook.
+
+A multi-agent harness asks for a subagent. On mitos, spawning a subagent IS
+forking the current warm sandbox: the child boots from a copy-on-write snapshot
+of the live parent, so it inherits the parent's warm state with no cold start and
+no external orchestrator round-trip. Off mitos there is nothing to fork, so the
+call returns a graceful no-op fallback and the harness drops back to its normal
+(cold) spawn path. The fallback is first-class: ``spawn_subagent`` never raises
+just because the code is not running on mitos.
+
+    import mitos.subagent as sub
+
+    result = sub.spawn_subagent(3, label="researcher")
+    if result.on_mitos:
+        for child in result.children:
+            print("warm subagent:", child.sandbox_id)
+    else:
+        # not on mitos: spawn subagents the normal way
+        ...
+
+DETECTION SIGNAL: the in-guest self-service socket advertised at ``$MITOS_SOCKET``
+(see ``mitos.guest``). The host sets it at claim time only inside a mitos
+sandbox, so its presence is the honest "am I running inside mitos" signal. The
+fork itself goes through the budget-gated self-fork on that socket
+(``mitos.guest.fork``), which needs no network egress and no API credentials.
+
+HONEST SCOPE: the warm fork requires a running mitos sandbox context. The
+budget-gated self-fork is wired progressively by the guest agent (issue #25);
+where it is not yet enabled the socket returns its remediation, which surfaces as
+a ``mitos.guest.GuestError``. That is a real on-mitos error (with an actionable
+message), distinct from the off-mitos fallback this module guarantees. The
+returned handles carry the child sandbox names; driving a child from a different
+process needs control-plane credentials and is a documented follow-up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from mitos import guest
+
+
+@dataclass(frozen=True)
+class SubagentHandle:
+    """A handle to a warm child subagent forked from the current sandbox.
+
+    ``sandbox_id`` is the child's sibling name as returned by the self-service
+    fork. ``on_mitos`` is always True for a real warm child (it is only ever
+    constructed on the on-mitos path); it is carried so callers can branch on the
+    handle alone.
+    """
+
+    sandbox_id: str
+    label: str = ""
+    on_mitos: bool = True
+
+
+@dataclass(frozen=True)
+class SubagentResult:
+    """The outcome of :func:`spawn_subagent`.
+
+    ``on_mitos`` True means warm-fork children were spawned and ``children``
+    holds their handles. ``on_mitos`` False is the graceful off-mitos fallback:
+    ``children`` is empty and ``reason`` explains why (so a harness can log it and
+    fall back to its normal spawn path). The result is truthy iff it spawned warm
+    children, so ``if spawn_subagent(...):`` reads naturally.
+    """
+
+    on_mitos: bool
+    children: Tuple[SubagentHandle, ...] = ()
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.on_mitos
+
+    @property
+    def first(self) -> Optional[SubagentHandle]:
+        """The first warm child, or None on the off-mitos fallback."""
+        return self.children[0] if self.children else None
+
+
+# Message used for the off-mitos fallback. Actionable per the LLM-legible error
+# rule (issue #28): it names the signal and what to do, without raising.
+_OFF_MITOS_REASON = (
+    "not running inside a mitos sandbox ($MITOS_SOCKET is unset), so there is no "
+    "warm sandbox to fork; fall back to your normal subagent spawn path. To get "
+    "warm fork-native subagents, run this harness inside a mitos sandbox."
+)
+
+
+def is_on_mitos() -> bool:
+    """Return True when running inside a mitos sandbox.
+
+    The signal is the in-guest self-service socket advertised at ``$MITOS_SOCKET``
+    (``mitos.guest.socket_path``), which the host sets only inside a sandbox. This
+    is a pure environment check: it does not open the socket.
+    """
+    return guest.socket_path() is not None
+
+
+def current_sandbox() -> Optional[guest.Identity]:
+    """Return the calling sandbox's own identity, or None when not on mitos.
+
+    On mitos this reads the sandbox's own identity over ``$MITOS_SOCKET``
+    (``mitos.guest.identity``). Off mitos it returns None rather than raising, so
+    a harness can probe "what sandbox am I" without a guard.
+    """
+    if not is_on_mitos():
+        return None
+    return guest.identity()
+
+
+def spawn_subagent(n: int = 1, *, label: str = "") -> SubagentResult:
+    """Spawn ``n`` subagents by forking the current warm sandbox.
+
+    On mitos (detected via ``$MITOS_SOCKET``) this routes the spawn through a
+    budget-gated self-fork (``mitos.guest.fork``) and returns a
+    :class:`SubagentResult` with ``on_mitos=True`` and a handle per warm child.
+
+    Off mitos (the signal is absent) it returns a :class:`SubagentResult` with
+    ``on_mitos=False`` and an explanatory ``reason``, and does NOT call fork. It
+    never raises in that case: the fallback path is first-class so a harness using
+    this hook does not break off-platform.
+
+    On mitos, a genuine fork error (for example the self-fork not yet being
+    enabled by the guest agent, issue #25) surfaces as a
+    ``mitos.guest.GuestError`` with its remediation; that is intentionally not
+    swallowed, because it is a real on-mitos failure rather than the off-mitos
+    fallback.
+    """
+    if not is_on_mitos():
+        return SubagentResult(on_mitos=False, children=(), reason=_OFF_MITOS_REASON)
+    names = guest.fork(n, label=label)
+    children = tuple(
+        SubagentHandle(sandbox_id=name, label=label, on_mitos=True) for name in names
+    )
+    return SubagentResult(on_mitos=True, children=children)

--- a/sdk/python/tests/test_subagent.py
+++ b/sdk/python/tests/test_subagent.py
@@ -1,0 +1,119 @@
+"""Fork-native subagent hook (mitos.subagent), issue #340.
+
+A multi-agent harness asks for a subagent. On mitos, spawning a subagent IS
+forking the current warm sandbox via the in-guest self-service socket
+($MITOS_SOCKET, see mitos.guest). Off mitos, there is nothing to fork, so the
+call returns a graceful no-op fallback and never raises.
+
+These tests do not boot a VM. The on-mitos detection signal is the presence of
+$MITOS_SOCKET; the fork itself is routed through mitos.guest.fork, which is
+replaced with a spy so we can assert it is (and is not) called.
+"""
+
+import mitos.guest as guest
+import mitos.subagent as sub
+
+
+# ---------------------------------------------------------------------------
+# Detection: is_on_mitos reflects the $MITOS_SOCKET self-identification signal.
+# ---------------------------------------------------------------------------
+
+
+def test_is_on_mitos_true_when_socket_env_set(monkeypatch):
+    monkeypatch.setenv("MITOS_SOCKET", "/run/mitos.sock")
+    assert sub.is_on_mitos() is True
+
+
+def test_is_on_mitos_false_when_socket_env_absent(monkeypatch):
+    monkeypatch.delenv("MITOS_SOCKET", raising=False)
+    assert sub.is_on_mitos() is False
+
+
+# ---------------------------------------------------------------------------
+# On mitos: spawn_subagent routes through a fork of the current sandbox.
+# ---------------------------------------------------------------------------
+
+
+def test_on_mitos_routes_spawn_through_fork(monkeypatch):
+    """Inside a sandbox, spawn_subagent forks the current warm sandbox via the
+    guest self-service socket and returns handles to the warm children."""
+    monkeypatch.setenv("MITOS_SOCKET", "/run/mitos.sock")
+    calls = []
+
+    def fake_fork(n=1, label=""):
+        calls.append((n, label))
+        return ["sb-child-a", "sb-child-b"]
+
+    monkeypatch.setattr(guest, "fork", fake_fork)
+
+    result = sub.spawn_subagent(2, label="researcher")
+
+    assert calls == [(2, "researcher")]  # fork WAS called, with our args
+    assert result.on_mitos is True
+    assert [c.sandbox_id for c in result.children] == ["sb-child-a", "sb-child-b"]
+    assert all(c.on_mitos and c.label == "researcher" for c in result.children)
+    assert result.first is not None and result.first.sandbox_id == "sb-child-a"
+    assert bool(result) is True
+
+
+def test_on_mitos_default_n_is_one(monkeypatch):
+    monkeypatch.setenv("MITOS_SOCKET", "/run/mitos.sock")
+    calls = []
+
+    def fake_fork(n=1, label=""):
+        calls.append((n, label))
+        return ["sb-only"]
+
+    monkeypatch.setattr(guest, "fork", fake_fork)
+
+    result = sub.spawn_subagent()
+    assert calls == [(1, "")]
+    assert len(result.children) == 1
+
+
+# ---------------------------------------------------------------------------
+# Off mitos: graceful fallback. No fork, no raise, first-class result.
+# ---------------------------------------------------------------------------
+
+
+def test_off_mitos_returns_fallback_and_does_not_fork(monkeypatch):
+    """Outside a sandbox (no $MITOS_SOCKET) spawn_subagent returns a no-op
+    fallback, never calls fork, and never raises, so a harness using it does not
+    break off-platform."""
+    monkeypatch.delenv("MITOS_SOCKET", raising=False)
+    calls = []
+    monkeypatch.setattr(guest, "fork", lambda *a, **k: calls.append(True) or [])
+
+    result = sub.spawn_subagent(3, label="x")
+
+    assert calls == []  # fork was NOT called
+    assert result.on_mitos is False
+    assert result.children == ()
+    assert result.first is None
+    assert bool(result) is False
+    assert result.reason  # carries an explanation of the off-mitos fallback
+
+
+def test_off_mitos_never_raises_even_with_large_n(monkeypatch):
+    monkeypatch.delenv("MITOS_SOCKET", raising=False)
+    # Must not raise; the fallback path is first-class.
+    result = sub.spawn_subagent(100)
+    assert result.on_mitos is False
+
+
+# ---------------------------------------------------------------------------
+# current_sandbox(): graceful self-identification.
+# ---------------------------------------------------------------------------
+
+
+def test_current_sandbox_off_mitos_is_none(monkeypatch):
+    monkeypatch.delenv("MITOS_SOCKET", raising=False)
+    assert sub.current_sandbox() is None
+
+
+def test_current_sandbox_on_mitos_returns_identity(monkeypatch):
+    monkeypatch.setenv("MITOS_SOCKET", "/run/mitos.sock")
+    ident = guest.Identity(sandbox_id="sb-self", pool="p1")
+    monkeypatch.setattr(guest, "identity", lambda: ident)
+    got = sub.current_sandbox()
+    assert got is not None and got.sandbox_id == "sb-self"


### PR DESCRIPTION
## Thinking Path

Issue #340 piece 2: a fork-native subagent hook so a multi-agent harness auto-detects it is running inside a mitos sandbox and spawns subagents by forking the current warm sandbox, with a graceful no-op fallback off-platform.

Self-identification signal used: `$MITOS_SOCKET`, the in-guest self-service socket advertised by the guest agent (`mitos.guest`). The host sets this env var at claim time only inside a mitos sandbox (it mirrors `guestsock.SocketEnvVar` on the Go side), so its presence is the honest "am I running inside mitos" check. This signal already exists in the runtime and SDK (`mitos.guest.socket_path()` / `info()` / `identity()` / `fork()`); I did not invent a mechanism. The fork is routed over that same socket via `mitos.guest.fork`, so no network egress and no API credentials are needed.

New surface (`mitos.subagent`, also exported as `mitos.subagent`):
- `spawn_subagent(n=1, label="") -> SubagentResult`. On mitos: routes through `guest.fork` and returns a `SubagentHandle` per warm child. Off mitos: returns `SubagentResult(on_mitos=False, reason=...)`, does NOT call fork, and never raises.
- `is_on_mitos() -> bool`: pure env check on `$MITOS_SOCKET`.
- `current_sandbox() -> Optional[guest.Identity]`: own identity on mitos, `None` off mitos (no raise).
- `SubagentResult` (truthy iff warm children spawned, `.first`, `.children`, `.reason`) and `SubagentHandle` (`sandbox_id`, `label`, `on_mitos`).

Honest scope: the warm fork needs a running mitos sandbox context. The budget-gated self-fork is wired progressively by the guest agent, so where it is not yet enabled the socket returns its remediation as a `mitos.guest.GuestError`. That is a real on-mitos error and is intentionally not swallowed (it is distinct from the off-mitos fallback). The handles carry child sandbox names; driving a child from another process needs control-plane credentials, a documented follow-up. End-to-end warm-fork is therefore NOT claimed here; the SDK surface, detection, and routing are.

Piece 1 (the Run-with-Mitos button + mitos.yaml manifest + repo-harness autodetect) is out of scope and tracked as a follow-up.

## Verification

TDD: failing test first (`ModuleNotFoundError: No module named 'mitos.subagent'`), then green.

Commands and results (run from `sdk/python`):
- `PYTHONPATH=. python3 -m pytest tests/test_subagent.py -q` -> `8 passed`
- `PYTHONPATH=. python3 -m pytest tests/ -q` -> `309 passed, 1 skipped`
- `python3 -m py_compile sdk/python/examples/*.py` -> OK
- sdk-examples-style import-check over every `sdk/python/examples/*.py` -> all `import OK` (including `fork_native_subagent.py`, whose module-level drift-guard asserts run)
- README python-fence byte-compile over `README.md` and `sdk/python/README.md` -> `checked 23 python fences; failures=0`
- Dash scan (U+2014 / U+2013) over all changed files -> none found

Tests assert: on-mitos routes the spawn through `fork` (fork called with `(n, label)`, warm child handles returned); off-mitos returns the fallback, does NOT call fork, and does NOT raise.

## Model Used

Claude (subagent) via Claude Code

Closes part of #340 (piece 2). Piece 1 is a follow-up.
