### PR TITLE
feat(compose): Harbor compose provider contract (per-service ops, fail-closed backend)

### DIFF
--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,0 +1,75 @@
+# Compose provider contract
+
+Status: the host-side contract is DEFINED and unit-proven. The in-guest backend
+that actually runs `docker compose` is a separate, hardware/kernel gated
+follow-up and does NOT exist yet. Nothing here claims that a compose stack runs
+end to end today.
+
+## Why
+
+Mitos runs one workload per microVM today. Many agent evaluation harnesses
+(Harbor: Terminal-Bench, SWE-Bench, and similar) define their environment as a
+`docker-compose.yaml`: a main agent container plus sidecars (databases, mock
+servers, MCP servers). To be a valid compose provider for that task class, a
+provider must advertise a `docker_compose` capability and implement per-service
+operations against arbitrary services, not just the main one, plus collect hooks
+that gather sidecar artifacts at teardown (for example a `pg_dump` from a
+database sidecar before grading).
+
+This is the compose epic. The work is sequenced:
+
+- A0 guest kernel with container features built in (`=Y`) plus `iptables-legacy`.
+- A1 in-guest privileged `dockerd` plus `docker compose` on a dedicated overlay2
+  device (main plus sidecars).
+- A2 (this contract) the Harbor compose provider contract: `docker_compose=true`,
+  per-service exec/copy/stop, collect hooks.
+- A3 warm-image compose snapshots.
+- A4 live-fork a warm compose stack (the differentiator).
+
+A0 and A1 are hardware/kernel gated and out of scope here. This page documents
+only A2, the contract.
+
+## What is defined and proven today
+
+`internal/compose` is the host-side contract and router for the per-service
+operations. It provides:
+
+- `Capabilities{DockerCompose bool}`, advertised true ONLY when a working backend
+  is wired. With no backend, the flag is false: the capability is never claimed
+  dishonestly.
+- Typed per-service requests addressing a named compose service: `ServiceExec`,
+  `ServiceDownloadFile`, `ServiceDownloadDir` (with exclusions), `ServiceIsDir`,
+  `StopService`.
+- `CollectHook` plus `Collect`, which run each teardown hook against its sidecar,
+  gather every hook's output independently, and never abort the batch on a single
+  hook's failure (each hook's error is recorded in its own result).
+- Input validation that runs BEFORE any backend dispatch:
+  - service names are constrained to `^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$` (no
+    slashes, no leading dot, no `..`, no whitespace), so a service name can never
+    escape into a path element;
+  - container paths must be absolute with no `..` segment, mirroring the
+    traversal defense on the sandbox file APIs.
+- A `Backend` interface that abstracts the actual compose execution, and an
+  `UnavailableBackend` default that fails closed.
+
+The contract, routing, validation, traversal rejection, collect orchestration,
+and the fail-closed path are all unit-tested against a mock backend in
+`internal/compose/compose_test.go`. These tests need no KVM, no dockerd, and no
+running guest.
+
+## What is gated (not done here)
+
+The real `Backend` is the in-guest privileged `dockerd` plus `docker compose`
+(issues #489 and #490). It does not exist yet. Until it is wired:
+
+- `UnavailableBackend` is the default;
+- `Capabilities().DockerCompose` reports `false`;
+- every per-service operation returns `ErrBackendUnavailable`, an error that
+  names the missing backend and tells the operator to enable it.
+
+So per-service compose operations cannot drive any execution today. They fail
+closed with a clear, actionable error. When the in-guest backend lands under
+#489 and #490, it implements the `Backend` interface and the same contract,
+routing, validation, and collect orchestration carry over unchanged. The threat
+model row for the resulting exec and file-read surface (`docs/threat-model.md`,
+section 3) is re-derived at that point.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -907,6 +907,46 @@ threat properties carry over unchanged:
   in-guest privilege separation). It adds no new host-side privilege. The auditor
   records an `exec_ws` op with the `pty` flag only, never terminal contents.
 
+### Compose provider contract surface (per-service exec/copy/stop, issue #491)
+
+The Harbor compose provider contract (`internal/compose`) defines the per-service
+operations an external compose driver (Harbor) addresses at a named compose
+service in a multi-container sandbox: `ServiceExec`, `ServiceDownloadFile`,
+`ServiceDownloadDir`, `ServiceIsDir`, `StopService`, and collect hooks that gather
+sidecar artifacts at teardown. When the in-guest backend lands (issues #489 and
+#490) this is a NEW exec and file-read surface, the per-service analog of the
+exec/files rows above: a caller can run a command in, and read bytes out of, an
+arbitrary compose service container, not just the main service.
+
+The contract is shipped fail-closed and validation-first ahead of that backend:
+
+- No backend today. The real backend is the in-guest privileged dockerd plus
+  docker compose, which does not exist yet and is a separate, hardware/kernel
+  gated follow-up (#489, #490). Until it is wired, `UnavailableBackend` is the
+  default: `Capabilities().DockerCompose` reports false (the capability is never
+  advertised dishonestly) and every operation fails closed with
+  `ErrBackendUnavailable`, which carries actionable remediation. So the contract
+  cannot drive any execution today; there is no live exec or egress surface to
+  exploit. Status: fail-closed by construction.
+- Input validation is the boundary half and runs BEFORE any backend dispatch.
+  Service names are constrained to `^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$`
+  (`validateServiceName`), which forbids slashes, leading dots, `..`, and
+  whitespace, so a service name can never be mistaken for or escape into a path
+  element. Container paths must be absolute with no `..` segment
+  (`validateContainerPath`), mirroring the traversal defense on the sandbox file
+  APIs. An invalid request returns a validation error and the backend is never
+  reached (asserted in `internal/compose` tests). Status: mitigated at the
+  contract boundary; the in-guest containment of the execution itself is gated on
+  #490 and will get its own row when that backend ships.
+- Collect orchestration gathers each hook's output independently and never
+  aborts the batch on a single failure, so a failing sidecar hook cannot suppress
+  the rest of the teardown artifacts; each hook's error is recorded per result.
+
+When #490 wires a real backend, this row must be re-derived: per-service exec and
+file-read carry the same in-guest-unconfined residual as the exec/files surface
+(isolation is the microVM boundary, not in-guest privilege separation), plus the
+intra-VM compose bridge between services.
+
 ## 4. Sandbox → network
 
 See `docs/networking.md` for the full design (tap-per-sandbox, nftables

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -1,0 +1,258 @@
+// Package compose defines the Harbor compose provider contract for a mitos
+// sandbox (issue #491, part of the compose epic #487).
+//
+// Harbor models a multi-service evaluation environment as a docker-compose
+// stack: one main service the agent execs into, plus sidecars (databases, mock
+// servers, MCP servers). Harbor's provider surface advertises an
+// EnvironmentCapabilities.docker_compose flag and per-service operations
+// (service exec, file/dir download, is-dir, stop) plus collect hooks that gather
+// sidecar artifacts at teardown (for example a pg_dump from a database sidecar
+// before grading).
+//
+// This package is the host-side CONTRACT and ROUTER for those operations:
+//
+//   - typed per-service request types,
+//   - input validation (service names and container paths, traversal rejected
+//     the same way the sandbox file APIs reject it),
+//   - a Provider that validates every request and dispatches it to a Backend,
+//   - collect-hook orchestration that gathers every hook's output and never
+//     aborts the batch on a single failure,
+//   - an honest capability advertisement (docker_compose is true only when a
+//     working backend is wired).
+//
+// The ACTUAL compose execution lives behind the Backend interface. The real
+// backend is the in-guest privileged dockerd + docker compose, which is a
+// separate, hardware/kernel-gated follow-up (issues #489 and #490) and does NOT
+// exist yet. Until it is wired, UnavailableBackend is the default: it advertises
+// docker_compose=false and fails closed with ErrBackendUnavailable on every
+// operation. The contract, routing, validation, and collect orchestration in
+// this package are therefore unit-tested against a mock backend; nothing here
+// claims that compose runs end to end.
+package compose
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrBackendUnavailable is returned by every per-service operation when no
+// working compose backend is wired into the sandbox. It carries actionable
+// remediation per the LLM-legible error rule.
+var ErrBackendUnavailable = errors.New(
+	"compose backend unavailable: in-guest docker compose is not running in this sandbox. " +
+		"Enable the in-guest privileged dockerd plus docker compose backend (compose epic A1, issues #489 and #490) " +
+		"before driving per-service compose operations",
+)
+
+// serviceNamePattern constrains a compose service name. Compose service names
+// are short identifiers; this pattern forbids dots as the first character,
+// slashes, whitespace, and `..` segments, so a validated name can never escape
+// into a host or container path or be mistaken for a path element.
+var serviceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$`)
+
+// Capabilities mirrors the subset of Harbor's EnvironmentCapabilities that this
+// contract governs. DockerCompose is advertised true only when a working
+// backend is wired, so the flag is never claimed dishonestly.
+type Capabilities struct {
+	DockerCompose bool
+}
+
+// ServiceExecRequest addresses an exec at a named compose service's container.
+type ServiceExecRequest struct {
+	// Service is the compose service name (for example "db" or "mock-server").
+	Service string
+	// Command is the argv to run inside the service container. Must be non-empty.
+	Command []string
+	// WorkDir, when set, is an absolute path inside the container.
+	WorkDir string
+}
+
+// ServiceStopRequest stops a named compose service.
+type ServiceStopRequest struct {
+	// Service is the compose service name to stop.
+	Service string
+	// TimeoutSeconds is the optional graceful-stop timeout passed to the backend.
+	TimeoutSeconds int
+}
+
+// ExecResult is the outcome of a per-service exec.
+type ExecResult struct {
+	ExitCode int
+	Stdout   []byte
+	Stderr   []byte
+}
+
+// CollectHook describes one artifact-collection step to run against a sidecar at
+// teardown (for example a pg_dump before grading).
+type CollectHook struct {
+	// Name labels the collected artifact in the results.
+	Name string
+	// Service is the compose service the hook runs against.
+	Service string
+	// Command is the argv to run; its stdout is the collected artifact.
+	Command []string
+	// WorkDir, when set, is an absolute path inside the container.
+	WorkDir string
+}
+
+// CollectResult is one CollectHook's outcome. Err is non-nil when that hook
+// failed validation or its backend exec failed; the rest of the batch still
+// runs (collect-on-teardown gathers everything it can).
+type CollectResult struct {
+	Name     string
+	Service  string
+	ExitCode int
+	Output   []byte
+	Err      error
+}
+
+// Backend is the per-service compose execution surface. The real implementation
+// is the in-guest privileged dockerd plus docker compose (issues #489 and #490);
+// it does not exist yet, so UnavailableBackend is the wired default and the mock
+// backend stands in for the contract's unit tests.
+type Backend interface {
+	// Available reports whether a working compose runtime is present. It gates
+	// the docker_compose capability so the flag is advertised honestly.
+	Available() bool
+	ServiceExec(ctx context.Context, req ServiceExecRequest) (ExecResult, error)
+	ServiceDownloadFile(ctx context.Context, service, path string) ([]byte, error)
+	ServiceDownloadDir(ctx context.Context, service, path string, exclusions []string) ([]byte, error)
+	ServiceIsDir(ctx context.Context, service, path string) (bool, error)
+	StopService(ctx context.Context, req ServiceStopRequest) error
+}
+
+// Provider validates inputs and routes per-service operations to a Backend. It
+// is the contract Harbor (or any external compose driver) builds against.
+type Provider struct {
+	backend Backend
+}
+
+// NewProvider wraps a Backend. A nil backend behaves as no compose support:
+// Capabilities reports docker_compose=false and operations fail closed.
+func NewProvider(b Backend) *Provider {
+	return &Provider{backend: b}
+}
+
+// Capabilities advertises docker_compose only when a working backend is wired.
+func (p *Provider) Capabilities() Capabilities {
+	return Capabilities{DockerCompose: p.backend != nil && p.backend.Available()}
+}
+
+func (p *Provider) backendOrUnavailable() Backend {
+	if p.backend == nil {
+		return UnavailableBackend{}
+	}
+	return p.backend
+}
+
+// ServiceExec validates the request and runs it against the addressed service.
+func (p *Provider) ServiceExec(ctx context.Context, req ServiceExecRequest) (ExecResult, error) {
+	if err := validateServiceName(req.Service); err != nil {
+		return ExecResult{}, err
+	}
+	if len(req.Command) == 0 {
+		return ExecResult{}, fmt.Errorf("invalid exec for service %q: command must be a non-empty argv", req.Service)
+	}
+	if req.WorkDir != "" {
+		if err := validateContainerPath(req.WorkDir); err != nil {
+			return ExecResult{}, fmt.Errorf("invalid workdir: %w", err)
+		}
+	}
+	return p.backendOrUnavailable().ServiceExec(ctx, req)
+}
+
+// ServiceDownloadFile validates inputs and downloads a file from a service.
+func (p *Provider) ServiceDownloadFile(ctx context.Context, service, path string) ([]byte, error) {
+	if err := validateServiceName(service); err != nil {
+		return nil, err
+	}
+	if err := validateContainerPath(path); err != nil {
+		return nil, err
+	}
+	return p.backendOrUnavailable().ServiceDownloadFile(ctx, service, path)
+}
+
+// ServiceDownloadDir validates inputs and downloads a directory (as a stream)
+// from a service, honoring the exclusion patterns.
+func (p *Provider) ServiceDownloadDir(ctx context.Context, service, path string, exclusions []string) ([]byte, error) {
+	if err := validateServiceName(service); err != nil {
+		return nil, err
+	}
+	if err := validateContainerPath(path); err != nil {
+		return nil, err
+	}
+	return p.backendOrUnavailable().ServiceDownloadDir(ctx, service, path, exclusions)
+}
+
+// ServiceIsDir validates inputs and reports whether path is a directory in a
+// service container.
+func (p *Provider) ServiceIsDir(ctx context.Context, service, path string) (bool, error) {
+	if err := validateServiceName(service); err != nil {
+		return false, err
+	}
+	if err := validateContainerPath(path); err != nil {
+		return false, err
+	}
+	return p.backendOrUnavailable().ServiceIsDir(ctx, service, path)
+}
+
+// StopService validates the request and stops the addressed service.
+func (p *Provider) StopService(ctx context.Context, req ServiceStopRequest) error {
+	if err := validateServiceName(req.Service); err != nil {
+		return err
+	}
+	return p.backendOrUnavailable().StopService(ctx, req)
+}
+
+// Collect runs every hook in order and returns one CollectResult per hook. A
+// hook that fails validation or whose backend exec errors records its error in
+// its result; the remaining hooks still run, so a single bad sidecar never loses
+// the rest of the teardown artifacts.
+func (p *Provider) Collect(ctx context.Context, hooks []CollectHook) []CollectResult {
+	results := make([]CollectResult, 0, len(hooks))
+	for _, h := range hooks {
+		res := CollectResult{Name: h.Name, Service: h.Service}
+		out, err := p.ServiceExec(ctx, ServiceExecRequest{
+			Service: h.Service,
+			Command: h.Command,
+			WorkDir: h.WorkDir,
+		})
+		if err != nil {
+			res.Err = fmt.Errorf("collect hook %q on service %q: %w", h.Name, h.Service, err)
+		} else {
+			res.ExitCode = out.ExitCode
+			res.Output = out.Stdout
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+// validateServiceName rejects a compose service name that could escape into a
+// path or is otherwise malformed (empty, traversal, slashes, whitespace).
+func validateServiceName(s string) error {
+	if !serviceNamePattern.MatchString(s) {
+		return fmt.Errorf("invalid compose service name %q: names must be 1-63 characters of [a-zA-Z0-9_.-] starting with a letter or digit (no slashes, no dots leading, no '..', no whitespace)", s)
+	}
+	return nil
+}
+
+// validateContainerPath requires an absolute container path with no `..`
+// segment, mirroring the traversal defense on the sandbox file APIs.
+func validateContainerPath(p string) error {
+	if p == "" {
+		return errors.New("path must not be empty")
+	}
+	if !strings.HasPrefix(p, "/") {
+		return fmt.Errorf("path %q must be absolute (start with '/')", p)
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return fmt.Errorf("path %q must not contain a '..' segment", p)
+		}
+	}
+	return nil
+}

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -1,0 +1,303 @@
+package compose
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// recordingBackend is the mock compose backend used to prove the contract,
+// routing, validation, and collect orchestration WITHOUT a real in-guest
+// docker compose (that backend is the gated follow-up, issue #490).
+type recordingBackend struct {
+	available bool
+
+	execCalls []ServiceExecRequest
+	stopCalls []ServiceStopRequest
+	dlFile    []string // "service:path"
+	dlDir     []string // "service:path"
+	isDir     []string // "service:path"
+
+	execResult ExecResult
+	execErr    error
+	isDirVal   bool
+}
+
+func (b *recordingBackend) Available() bool { return b.available }
+
+func (b *recordingBackend) ServiceExec(_ context.Context, req ServiceExecRequest) (ExecResult, error) {
+	b.execCalls = append(b.execCalls, req)
+	if b.execErr != nil {
+		return ExecResult{}, b.execErr
+	}
+	return b.execResult, nil
+}
+
+func (b *recordingBackend) ServiceDownloadFile(_ context.Context, service, path string) ([]byte, error) {
+	b.dlFile = append(b.dlFile, service+":"+path)
+	return []byte("file-bytes"), nil
+}
+
+func (b *recordingBackend) ServiceDownloadDir(_ context.Context, service, path string, _ []string) ([]byte, error) {
+	b.dlDir = append(b.dlDir, service+":"+path)
+	return []byte("tar-bytes"), nil
+}
+
+func (b *recordingBackend) ServiceIsDir(_ context.Context, service, path string) (bool, error) {
+	b.isDir = append(b.isDir, service+":"+path)
+	return b.isDirVal, nil
+}
+
+func (b *recordingBackend) StopService(_ context.Context, req ServiceStopRequest) error {
+	b.stopCalls = append(b.stopCalls, req)
+	return nil
+}
+
+func newAvailableProvider() (*Provider, *recordingBackend) {
+	b := &recordingBackend{available: true, execResult: ExecResult{ExitCode: 0, Stdout: []byte("ok")}}
+	return NewProvider(b), b
+}
+
+func TestCapabilitiesReflectBackendAvailability(t *testing.T) {
+	p, _ := newAvailableProvider()
+	if !p.Capabilities().DockerCompose {
+		t.Fatal("available backend must advertise docker_compose=true")
+	}
+
+	pu := NewProvider(UnavailableBackend{})
+	if pu.Capabilities().DockerCompose {
+		t.Fatal("unavailable backend must advertise docker_compose=false (honest capability)")
+	}
+
+	if NewProvider(nil).Capabilities().DockerCompose {
+		t.Fatal("nil backend must advertise docker_compose=false")
+	}
+}
+
+func TestServiceExecRoutesToBackend(t *testing.T) {
+	p, b := newAvailableProvider()
+	res, err := p.ServiceExec(context.Background(), ServiceExecRequest{
+		Service: "db",
+		Command: []string{"psql", "-c", "select 1"},
+		WorkDir: "/var/lib",
+	})
+	if err != nil {
+		t.Fatalf("ServiceExec: %v", err)
+	}
+	if string(res.Stdout) != "ok" {
+		t.Fatalf("stdout = %q", res.Stdout)
+	}
+	if len(b.execCalls) != 1 || b.execCalls[0].Service != "db" {
+		t.Fatalf("backend not called once with service db: %+v", b.execCalls)
+	}
+}
+
+func TestServiceExecRejectsBadServiceNameBeforeBackend(t *testing.T) {
+	bad := []string{"", "../etc", "svc/../x", "a b", "/abs", ".hidden", strings.Repeat("a", 100)}
+	for _, name := range bad {
+		p, b := newAvailableProvider()
+		_, err := p.ServiceExec(context.Background(), ServiceExecRequest{Service: name, Command: []string{"echo"}})
+		if err == nil {
+			t.Fatalf("service %q: expected validation error", name)
+		}
+		if len(b.execCalls) != 0 {
+			t.Fatalf("service %q: backend must not be called on invalid input", name)
+		}
+	}
+}
+
+func TestServiceExecRejectsEmptyCommand(t *testing.T) {
+	p, b := newAvailableProvider()
+	_, err := p.ServiceExec(context.Background(), ServiceExecRequest{Service: "db", Command: nil})
+	if err == nil {
+		t.Fatal("expected error on empty command")
+	}
+	if len(b.execCalls) != 0 {
+		t.Fatal("backend must not be called on empty command")
+	}
+}
+
+func TestServiceExecRejectsBadWorkDir(t *testing.T) {
+	p, b := newAvailableProvider()
+	_, err := p.ServiceExec(context.Background(), ServiceExecRequest{
+		Service: "db", Command: []string{"echo"}, WorkDir: "rel/../path",
+	})
+	if err == nil {
+		t.Fatal("expected error on traversal workdir")
+	}
+	if len(b.execCalls) != 0 {
+		t.Fatal("backend must not be called on invalid workdir")
+	}
+}
+
+func TestDownloadFileRoutesAndValidatesPath(t *testing.T) {
+	p, b := newAvailableProvider()
+	got, err := p.ServiceDownloadFile(context.Background(), "db", "/data/dump.sql")
+	if err != nil {
+		t.Fatalf("download file: %v", err)
+	}
+	if string(got) != "file-bytes" {
+		t.Fatalf("bytes = %q", got)
+	}
+	if len(b.dlFile) != 1 || b.dlFile[0] != "db:/data/dump.sql" {
+		t.Fatalf("backend dlFile = %+v", b.dlFile)
+	}
+
+	for _, bad := range []string{"", "relative/path", "/data/../../etc/passwd", "/a/../b"} {
+		p2, b2 := newAvailableProvider()
+		if _, err := p2.ServiceDownloadFile(context.Background(), "db", bad); err == nil {
+			t.Fatalf("path %q: expected validation error", bad)
+		} else if len(b2.dlFile) != 0 {
+			t.Fatalf("path %q: backend must not be called", bad)
+		}
+	}
+}
+
+func TestDownloadDirRoutesWithExclusions(t *testing.T) {
+	p, b := newAvailableProvider()
+	got, err := p.ServiceDownloadDir(context.Background(), "db", "/var/lib/data", []string{"*.tmp"})
+	if err != nil {
+		t.Fatalf("download dir: %v", err)
+	}
+	if string(got) != "tar-bytes" {
+		t.Fatalf("bytes = %q", got)
+	}
+	if len(b.dlDir) != 1 || b.dlDir[0] != "db:/var/lib/data" {
+		t.Fatalf("backend dlDir = %+v", b.dlDir)
+	}
+
+	p2, b2 := newAvailableProvider()
+	if _, err := p2.ServiceDownloadDir(context.Background(), "db", "/a/../b", nil); err == nil {
+		t.Fatal("expected traversal rejection")
+	} else if len(b2.dlDir) != 0 {
+		t.Fatal("backend must not be called on traversal")
+	}
+}
+
+func TestIsDirRoutesAndValidates(t *testing.T) {
+	p, b := newAvailableProvider()
+	b.isDirVal = true
+	ok, err := p.ServiceIsDir(context.Background(), "db", "/data")
+	if err != nil || !ok {
+		t.Fatalf("isdir = %v, %v", ok, err)
+	}
+	if len(b.isDir) != 1 {
+		t.Fatalf("backend isDir = %+v", b.isDir)
+	}
+
+	p2, b2 := newAvailableProvider()
+	if _, err := p2.ServiceIsDir(context.Background(), "bad/name", "/data"); err == nil {
+		t.Fatal("expected service-name rejection")
+	} else if len(b2.isDir) != 0 {
+		t.Fatal("backend must not be called on invalid service")
+	}
+}
+
+func TestStopServiceRoutesAndValidates(t *testing.T) {
+	p, b := newAvailableProvider()
+	if err := p.StopService(context.Background(), ServiceStopRequest{Service: "mock"}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if len(b.stopCalls) != 1 || b.stopCalls[0].Service != "mock" {
+		t.Fatalf("backend stopCalls = %+v", b.stopCalls)
+	}
+
+	p2, b2 := newAvailableProvider()
+	if err := p2.StopService(context.Background(), ServiceStopRequest{Service: "../x"}); err == nil {
+		t.Fatal("expected validation error")
+	} else if len(b2.stopCalls) != 0 {
+		t.Fatal("backend must not be called on invalid service")
+	}
+}
+
+func TestCollectOrchestratesAllHooksAndContinuesOnFailure(t *testing.T) {
+	b := &recordingBackend{available: true, execResult: ExecResult{ExitCode: 0, Stdout: []byte("dump")}}
+	p := NewProvider(b)
+
+	hooks := []CollectHook{
+		{Name: "pgdump", Service: "db", Command: []string{"pg_dump", "app"}},
+		{Name: "bad-service", Service: "../evil", Command: []string{"cat"}},
+		{Name: "requests", Service: "mock", Command: []string{"cat", "/log/requests.json"}},
+	}
+	results := p.Collect(context.Background(), hooks)
+	if len(results) != 3 {
+		t.Fatalf("want 3 results, got %d", len(results))
+	}
+	// Hook 0 ran on the backend and succeeded.
+	if results[0].Name != "pgdump" || results[0].Err != nil || string(results[0].Output) != "dump" {
+		t.Fatalf("hook 0 unexpected: %+v", results[0])
+	}
+	// Hook 1 had an invalid service name; validation error, backend not hit.
+	if results[1].Err == nil {
+		t.Fatal("hook 1 must carry a validation error")
+	}
+	// Hook 2 still ran despite hook 1 failing (collect-on-teardown gathers all).
+	if results[2].Name != "requests" || results[2].Err != nil {
+		t.Fatalf("hook 2 unexpected: %+v", results[2])
+	}
+	// Only the two valid hooks reached the backend.
+	if len(b.execCalls) != 2 {
+		t.Fatalf("backend exec calls = %d, want 2 (invalid hook skipped)", len(b.execCalls))
+	}
+}
+
+func TestCollectRecordsBackendErrorPerHook(t *testing.T) {
+	sentinel := errors.New("boom")
+	b := &recordingBackend{available: true, execErr: sentinel}
+	p := NewProvider(b)
+	results := p.Collect(context.Background(), []CollectHook{{Name: "x", Service: "db", Command: []string{"echo"}}})
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("expected per-hook backend error, got %+v", results)
+	}
+	if !errors.Is(results[0].Err, sentinel) {
+		t.Fatalf("error must wrap backend error, got %v", results[0].Err)
+	}
+}
+
+func TestUnavailableBackendFailsClosed(t *testing.T) {
+	p := NewProvider(UnavailableBackend{})
+
+	if _, err := p.ServiceExec(context.Background(), ServiceExecRequest{Service: "db", Command: []string{"echo"}}); !errors.Is(err, ErrBackendUnavailable) {
+		t.Fatalf("ServiceExec err = %v, want ErrBackendUnavailable", err)
+	}
+	if _, err := p.ServiceDownloadFile(context.Background(), "db", "/data/x"); !errors.Is(err, ErrBackendUnavailable) {
+		t.Fatalf("DownloadFile err = %v", err)
+	}
+	if _, err := p.ServiceDownloadDir(context.Background(), "db", "/data", nil); !errors.Is(err, ErrBackendUnavailable) {
+		t.Fatalf("DownloadDir err = %v", err)
+	}
+	if _, err := p.ServiceIsDir(context.Background(), "db", "/data"); !errors.Is(err, ErrBackendUnavailable) {
+		t.Fatalf("IsDir err = %v", err)
+	}
+	if err := p.StopService(context.Background(), ServiceStopRequest{Service: "db"}); !errors.Is(err, ErrBackendUnavailable) {
+		t.Fatalf("StopService err = %v", err)
+	}
+
+	// Collect over an unavailable backend records the fail-closed error per hook,
+	// it does not panic or silently drop hooks.
+	results := p.Collect(context.Background(), []CollectHook{{Name: "x", Service: "db", Command: []string{"echo"}}})
+	if len(results) != 1 || !errors.Is(results[0].Err, ErrBackendUnavailable) {
+		t.Fatalf("Collect over unavailable backend = %+v", results)
+	}
+}
+
+func TestUnavailableValidationStillRunsFirst(t *testing.T) {
+	// Even fail-closed, an invalid request is a validation error (input is the
+	// problem), not the backend-unavailable error.
+	p := NewProvider(UnavailableBackend{})
+	_, err := p.ServiceExec(context.Background(), ServiceExecRequest{Service: "../x", Command: []string{"echo"}})
+	if err == nil || errors.Is(err, ErrBackendUnavailable) {
+		t.Fatalf("invalid input must fail validation before backend dispatch, got %v", err)
+	}
+}
+
+func TestErrBackendUnavailableCarriesRemediation(t *testing.T) {
+	msg := ErrBackendUnavailable.Error()
+	if !strings.Contains(strings.ToLower(msg), "docker compose") {
+		t.Fatalf("error must name the missing backend: %q", msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "enable") {
+		t.Fatalf("error must carry actionable remediation: %q", msg)
+	}
+}

--- a/internal/compose/unavailable.go
+++ b/internal/compose/unavailable.go
@@ -1,0 +1,41 @@
+package compose
+
+import "context"
+
+// UnavailableBackend is the fail-closed default Backend. It represents a sandbox
+// where the in-guest privileged dockerd plus docker compose runtime (issues #489
+// and #490) is not present, which is the case today: that backend is a separate,
+// hardware/kernel-gated follow-up. Every operation returns ErrBackendUnavailable
+// and Available reports false, so the Provider advertises docker_compose=false
+// and never claims compose works when it does not.
+type UnavailableBackend struct{}
+
+var _ Backend = UnavailableBackend{}
+
+// Available reports false: no compose runtime is wired.
+func (UnavailableBackend) Available() bool { return false }
+
+// ServiceExec fails closed.
+func (UnavailableBackend) ServiceExec(context.Context, ServiceExecRequest) (ExecResult, error) {
+	return ExecResult{}, ErrBackendUnavailable
+}
+
+// ServiceDownloadFile fails closed.
+func (UnavailableBackend) ServiceDownloadFile(context.Context, string, string) ([]byte, error) {
+	return nil, ErrBackendUnavailable
+}
+
+// ServiceDownloadDir fails closed.
+func (UnavailableBackend) ServiceDownloadDir(context.Context, string, string, []string) ([]byte, error) {
+	return nil, ErrBackendUnavailable
+}
+
+// ServiceIsDir fails closed.
+func (UnavailableBackend) ServiceIsDir(context.Context, string, string) (bool, error) {
+	return false, ErrBackendUnavailable
+}
+
+// StopService fails closed.
+func (UnavailableBackend) StopService(context.Context, ServiceStopRequest) error {
+	return ErrBackendUnavailable
+}


### PR DESCRIPTION
## Thinking Path

Feasibility decision: #491 (the Harbor compose provider contract) depends on A1
(#490, in-guest privileged dockerd plus docker compose), which is hardware/kernel
gated and out of scope. The honest, testable slice is the host-side contract and
router with the actual compose execution behind a Backend interface. That seam
lets the contract, per-service routing, input validation, traversal rejection,
collect-hook orchestration, and the fail-closed path be unit-proven against a
mock backend, with no KVM, no dockerd, and no running guest. Per operating
principle #1 (no unverified claims), nothing here claims a compose stack runs end
to end.

Testable and proven here (internal/compose):
- Capabilities{DockerCompose}, advertised true ONLY when a working backend is
  wired (false today, never claimed dishonestly).
- Typed per-service requests: ServiceExec, ServiceDownloadFile,
  ServiceDownloadDir (with exclusions), ServiceIsDir, StopService.
- CollectHook plus Collect: each teardown hook runs against its sidecar, every
  hook's output is gathered independently, and the batch never aborts on a single
  hook failure (per-hook error recorded).
- Validation before any backend dispatch: service-name allowlist
  (^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$, no slashes/leading-dot/`..`/whitespace),
  and absolute container paths with no `..` segment, mirroring the sandbox
  file-API traversal defense.
- Backend interface plus UnavailableBackend default that fails closed with
  ErrBackendUnavailable (actionable remediation).

Gated, not done here (named follow-up): the real Backend is the in-guest
privileged dockerd plus docker compose (#489 and #490). It does not exist yet,
so UnavailableBackend is the wired default and the capability is false. When that
backend lands it implements the Backend interface and the same contract carries
over unchanged.

## Verification

All run in the worktree on this branch.

- go test ./internal/compose/ -count=1 -> ok (mock-backend unit tests: routing,
  service-name and path-traversal rejection, collect orchestration continues on
  failure, fail-closed when no backend, capability honesty).
- go build ./... -> clean.
- gofmt -l internal/compose/ -> empty.
- golangci-lint run --timeout=5m ./internal/compose/ -> clean.
- GOOS=linux golangci-lint run --timeout=5m ./internal/compose/ -> clean.
- grep for em/en dashes across touched files -> none.

## Model Used

Claude (subagent) via Claude Code

## Summary

Defines the host-side Harbor compose provider contract so an external compose
driver can address per-service exec/copy/stop and collect hooks against a
multi-service stack in a sandbox. Ships fail-closed and validation-first ahead of
the in-guest dockerd backend, which is the gated follow-up tracked in #489 and
#490. Adds docs/compose.md and a threat-model row for the per-service exec/file
surface (fail-closed today, re-derived when the backend ships).

Part of #487. Implements the contract half of #491; the in-guest dockerd backend
is tracked in #489 and #490.
