### PR TITLE
feat(saas): durable Postgres usage store for per-org metered usage

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,6 +17,7 @@ import (
 	"mitos.run/mitos/internal/eventfeed"
 	"mitos.run/mitos/internal/kms"
 	"mitos.run/mitos/internal/observability"
+	"mitos.run/mitos/internal/saas/pgstore"
 	"mitos.run/mitos/internal/usage"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,6 +71,7 @@ func main() {
 	var usageCollector bool
 	var usageCollectorInterval time.Duration
 	var usageAPIAddr string
+	var usageDatabaseDSN string
 	var vitalsSampler bool
 	var vitalsSamplerInterval time.Duration
 	var exposeProxyAdminURL string
@@ -99,6 +101,7 @@ func main() {
 	flag.BoolVar(&usageCollector, "usage-collector", false, "Run the live multi-node metering scraper: on a fixed interval, scrape every forkd node's GET /v1/metering, attribute each sandbox to its org via the trusted mitos.run/org husk-pod label, integrate idempotently into per-(org, sandbox, window) usage records, and publish the per-org mitos_usage_*_total Prometheus series. OFF by default so a self-host deployment that does not want metering is unaffected; turn it on for hosted/multi-tenant. The records land in an in-memory store for now (a durable store is a follow-up); the per-org metric is always published on /metrics. The path carries only ids, byte counts, and seconds, never secret values.")
 	flag.DurationVar(&usageCollectorInterval, "usage-collector-interval", 60*time.Second, "Interval between usage metering scrapes when --usage-collector is set. Defaults to the usage window (60s). Only used when --usage-collector is on.")
 	flag.StringVar(&usageAPIAddr, "usage-api-address", "", "Serve the INTERNAL usage API (GET /internal/usage) on this address (for example :8092) so the hosted console can read the SAME per-org usage the collector recorded, without a shared database. Bearer-gated by the MITOS_USAGE_API_TOKEN environment variable (empty token fails closed: every request is refused). Empty address disables the listener. Only meaningful with --usage-collector on. The endpoint is machine-to-machine: the org is taken from the X-Mitos-Org header the console sets after it verified the session, and the store still scopes every read to that org. The path carries only ids, byte counts, and seconds, never secret values.")
+	flag.StringVar(&usageDatabaseDSN, "usage-database-dsn", "", "Postgres DSN for DURABLE per-org usage records (issue #211): when set, the collector upserts billable usage into Postgres so metered consumption survives a controller restart, instead of the in-memory store that is lost on restart. Falls back to the "+pgstore.EnvDSN+" env var. Empty means the in-memory usage store (DEV ONLY; usage is lost on restart). Only used with --usage-collector on. The value is a secret and is never logged.")
 	flag.BoolVar(&vitalsSampler, "vitals-sampler", false, "Run the guest vitals sampler: on a fixed interval, scrape every forkd node's GET /v1/vitals/node, attribute each sandbox to its org via the trusted mitos.run/org husk-pod label, aggregate per (org, pool), and publish the mitos_guest_cpu_steal_percent, mitos_guest_mem_balloon_bytes, mitos_guest_mem_used_bytes, and mitos_guest_process_count Prometheus gauges. cpu_steal is the MAX across the bucket (the worst-starved sandbox); memory and process_count are SUMs (the fleet footprint). OFF by default so a self-host deployment without guest telemetry is unaffected; turn it on for hosted/multi-tenant. The path carries only ids (for org resolution), pool names, and numeric vitals plus the process-list length, never argv, env, process command lines, pids, or secret values.")
 	flag.DurationVar(&vitalsSamplerInterval, "vitals-sampler-interval", 60*time.Second, "Interval between guest vitals samples when --vitals-sampler is set. Defaults to the usage window (60s). Only used when --vitals-sampler is on.")
 	flag.StringVar(&exposeProxyAdminURL, "expose-proxy-admin-url", "", "Expose proxy admin endpoint base URL for route-sync (POST /internal/routes); empty disables")
@@ -440,7 +443,29 @@ func main() {
 		// One shared store: the collector writes per-org usage records into it, and
 		// the internal usage API serves reads of the SAME store to the console, so
 		// the console shows exactly what was collected without a shared database.
-		usageStore := usage.NewMemUsageStore()
+		//
+		// When a usage DSN is configured (issue #211) the store is durable Postgres,
+		// so metered consumption survives a controller restart; otherwise it is the
+		// in-memory store (DEV ONLY, lost on restart). The DSN is a secret and is
+		// never logged: only the chosen backend is.
+		var usageStore usage.UsageStore = usage.NewMemUsageStore()
+		usageDSN := usageDatabaseDSN
+		if usageDSN == "" {
+			usageDSN = os.Getenv(pgstore.EnvDSN)
+		}
+		if usageDSN != "" {
+			pg, err := pgstore.Open(context.Background(), usageDSN)
+			if err != nil {
+				// Never include the DSN in the error.
+				logger.Error(err, "unable to open durable usage store; refusing to fall back to in-memory so usage is not silently lost")
+				os.Exit(1)
+			}
+			defer pg.Close()
+			usageStore = pgstore.NewPgUsageStore(pg.Pool())
+			logger.Info("usage store: durable Postgres (records survive restart)")
+		} else {
+			logger.Info("usage store: in-memory (DEV ONLY, usage is lost on restart; set --usage-database-dsn for durable Postgres)")
+		}
 		if err := mgr.Add(&controller.UsageCollectorRunnable{
 			Registry:   nodeRegistry,
 			Client:     mgr.GetClient(),

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -100,9 +100,25 @@ the same or overlapping samples recomputes the same record value, so:
   re-derives the same records.
 
 The store is the pluggable seam (`UsageStore`), mirroring the accounts `Store`
-pattern. `MemUsageStore` is the tested in-memory default. A durable Postgres
-store is a documented follow-up; the upsert-by-key contract is the seam it
-implements (the natural primary key is `(org_id, sandbox_id, window_start)`).
+pattern. `MemUsageStore` is the tested in-memory reference (lost on restart;
+DEV ONLY). The durable backend is `pgstore.PgUsageStore`
+(`internal/saas/pgstore/usagestore.go`): a Postgres `usage_records` table whose
+primary key is exactly the idempotency key `(org_id, sandbox_id, window_start)`,
+so `UpsertRecord` is an `INSERT ... ON CONFLICT DO UPDATE` that REPLACES the row
+(never adds), and `ListRecords` / `TotalsByOrg` are org-scoped reads. Both stores
+run the SAME behavioral contract (`internal/usage/usagestoretest`), so the
+durable store is proven equivalent to the reference: idempotent upsert, per-org
+isolation, half-open `[from, to)` period bounds, and per-org cumulative totals.
+
+The controller wires the backend behind `--usage-database-dsn` (falling back to
+the `MITOS_DATABASE_DSN` env var): when a DSN is set, the collector and the
+internal usage API use `PgUsageStore` so metered consumption survives a
+controller restart; absent a DSN they use the in-memory store. The DSN is a
+secret and is never logged (only the chosen backend is). A configured-but-
+unreachable DSN fails startup loud rather than silently falling back to a store
+that would lose usage. The `TotalsByOrg` figure for the durable store is a direct
+`SUM` aggregate over the table (there is no eviction to survive, unlike the
+in-memory store's delta-tracked cumulative), so it is the true billing total.
 
 ## CoW reconciliation (no double-count of shared memory)
 
@@ -178,11 +194,13 @@ This usage pipeline produces the auditable records the push consumes.
 
 ## What is a seam / follow-up
 
-- Real multi-node HTTP scrape of `GET /v1/metering` (implements `SampleSource`).
-- Durable Postgres `UsageStore` (implements the upsert-by-key contract).
-- Real `OrgResolver` reading the claim -> org label.
-- Stripe metered-billing push.
+- Real multi-node HTTP scrape of `GET /v1/metering` (implements `SampleSource`): DONE.
+- Durable Postgres `UsageStore` (implements the upsert-by-key contract): DONE
+  (`pgstore.PgUsageStore`, migration `0003_usage_records.sql`).
+- Real `OrgResolver` reading the claim -> org label: DONE.
+- Stripe metered-billing push: implemented in `internal/saas/billing`.
 
-These are seams with tested in-memory or static defaults so the integration,
-idempotency, CoW reconciliation, and org-scoping are fully verifiable on darwin
-without a cluster.
+The in-memory defaults remain so the integration, idempotency, CoW
+reconciliation, and org-scoping are fully verifiable on darwin without a cluster;
+the Postgres store runs the same contract in CI against a Postgres service (set
+`MITOS_TEST_DATABASE_DSN`), and skips locally when no database is configured.

--- a/internal/saas/pgstore/migrations/0003_usage_records.sql
+++ b/internal/saas/pgstore/migrations/0003_usage_records.sql
@@ -1,0 +1,29 @@
+-- Durable, billable usage records so per-org metered consumption survives a
+-- controller restart (issue #211). Mirrors the in-memory usage.MemUsageStore.
+-- The primary key is the integrator's idempotency key (org_id, sandbox_id,
+-- window_start): re-collecting an overlapping or duplicate scrape upserts the
+-- same key with the recomputed value, so a node loss, a controller restart, or a
+-- late scrape can never double-bill a window.
+--
+-- All units are per-window billable totals: vcpu_seconds, mem_gib_seconds, and
+-- storage_gib_hours are the time-integrated rate levels; egress_bytes and
+-- gpu_seconds are the cumulative-counter deltas. The CoW deduplication has
+-- already been applied upstream (usage.SamplesFromReport), so summing these rows
+-- reconstructs the CoW-aware bill, never the naive per-fork double count.
+
+CREATE TABLE usage_records (
+    org_id            TEXT             NOT NULL,
+    sandbox_id        TEXT             NOT NULL,
+    window_start      TIMESTAMPTZ      NOT NULL,
+    vcpu_seconds      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    mem_gib_seconds   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    storage_gib_hours DOUBLE PRECISION NOT NULL DEFAULT 0,
+    egress_bytes      BIGINT           NOT NULL DEFAULT 0,
+    gpu_seconds       BIGINT           NOT NULL DEFAULT 0,
+    PRIMARY KEY (org_id, sandbox_id, window_start)
+);
+
+-- The usage API lists an org's records over a half-open [from, to) window,
+-- ordered by (sandbox_id, window_start); this index serves that org-scoped,
+-- period-bounded read.
+CREATE INDEX usage_records_org_window_idx ON usage_records (org_id, window_start);

--- a/internal/saas/pgstore/usagestore.go
+++ b/internal/saas/pgstore/usagestore.go
@@ -1,0 +1,151 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"mitos.run/mitos/internal/usage"
+)
+
+// PgUsageStore is the durable Postgres implementation of usage.UsageStore. It is
+// the production persistence for billable per-org usage records (issue #211): the
+// controller's collector upserts each (org, sandbox, window) record into it, and
+// the org-scoped usage API serves reads of it, so metered consumption survives a
+// controller restart instead of living only in the in-memory MemUsageStore.
+//
+// The in-memory usage.MemUsageStore is the behavioral reference; this store
+// passes the same usagestoretest contract (idempotent upsert, per-org isolation,
+// half-open period bounds, per-org cumulative totals).
+//
+// All queries are parameterized and org-scoped: ListRecords and TotalsByOrg only
+// ever read the named org's rows, so org A can never see org B's usage. No value
+// is ever interpolated into SQL.
+type PgUsageStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgUsageStore returns a PgUsageStore backed by pool. The schema (the
+// usage_records table) is created by the pgstore migrations Open runs; callers
+// share the pool an Open-ed PgStore exposes via Pool.
+func NewPgUsageStore(pool *pgxpool.Pool) *PgUsageStore { return &PgUsageStore{pool: pool} }
+
+// compile-time assertions that PgUsageStore satisfies the usage contracts.
+var (
+	_ usage.UsageStore     = (*PgUsageStore)(nil)
+	_ usage.TotalsProvider = (*PgUsageStore)(nil)
+)
+
+// UpsertRecord writes rec, REPLACING any existing record for the same
+// (OrgID, SandboxID, Window) key. The ON CONFLICT DO UPDATE makes it idempotent:
+// because usage.Integrate is pure over a window's samples, replaying overlapping
+// or duplicate scrapes recomputes the same value, so a re-upsert is a no-op and a
+// node loss or controller restart can never double-bill a window. The window is
+// stored in UTC so the key is stable regardless of the caller's location.
+func (s *PgUsageStore) UpsertRecord(ctx context.Context, rec usage.UsageRecord) error {
+	const q = `
+        INSERT INTO usage_records
+            (org_id, sandbox_id, window_start, vcpu_seconds, mem_gib_seconds, storage_gib_hours, egress_bytes, gpu_seconds)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT (org_id, sandbox_id, window_start) DO UPDATE SET
+            vcpu_seconds      = EXCLUDED.vcpu_seconds,
+            mem_gib_seconds   = EXCLUDED.mem_gib_seconds,
+            storage_gib_hours = EXCLUDED.storage_gib_hours,
+            egress_bytes      = EXCLUDED.egress_bytes,
+            gpu_seconds       = EXCLUDED.gpu_seconds`
+	_, err := s.pool.Exec(ctx, q,
+		rec.OrgID, rec.SandboxID, rec.Window.UTC(),
+		rec.VCPUSeconds, rec.MemGiBSeconds, rec.StorageGiBHours, rec.EgressBytes, rec.GPUSeconds)
+	if err != nil {
+		return fmt.Errorf("upsert usage record: %w", err)
+	}
+	return nil
+}
+
+// ListRecords returns the org's records whose Window falls in the half-open
+// interval [from, to), sorted by (SandboxID, Window). A zero from means no lower
+// bound; a zero to means no upper bound. It only ever returns the named org's
+// records, never another org's, which is the store-level half of the usage API's
+// cross-org isolation. The returned slice is non-nil even when empty.
+func (s *PgUsageStore) ListRecords(ctx context.Context, orgID string, from, to time.Time) ([]usage.UsageRecord, error) {
+	const q = `
+        SELECT org_id, sandbox_id, window_start, vcpu_seconds, mem_gib_seconds, storage_gib_hours, egress_bytes, gpu_seconds
+        FROM usage_records
+        WHERE org_id = $1
+          AND ($2::timestamptz IS NULL OR window_start >= $2)
+          AND ($3::timestamptz IS NULL OR window_start <  $3)
+        ORDER BY sandbox_id, window_start`
+	rows, err := s.pool.Query(ctx, q, orgID, nullableTime(from), nullableTime(to))
+	if err != nil {
+		return nil, fmt.Errorf("list usage records: %w", err)
+	}
+	defer rows.Close()
+
+	out := []usage.UsageRecord{}
+	for rows.Next() {
+		var r usage.UsageRecord
+		if err := rows.Scan(
+			&r.OrgID, &r.SandboxID, &r.Window,
+			&r.VCPUSeconds, &r.MemGiBSeconds, &r.StorageGiBHours, &r.EgressBytes, &r.GPUSeconds,
+		); err != nil {
+			return nil, fmt.Errorf("scan usage record: %w", err)
+		}
+		r.Window = r.Window.UTC()
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate usage records: %w", err)
+	}
+	return out, nil
+}
+
+// TotalsByOrg returns each org's cumulative usage Totals: the sum of every stored
+// record for that org. Unlike the in-memory store (whose cumulative is a
+// delta-tracked figure that survives in-memory eviction), the durable store keeps
+// every record, so the totals are a direct aggregate over the table and are the
+// true billing system of record. An org with no records is absent from the map.
+//
+// TotalsByOrg has no period bound by design: it is the lifetime cumulative the
+// per-org Prometheus series reads, mirroring usage.MemUsageStore.TotalsByOrg.
+func (s *PgUsageStore) TotalsByOrg() map[string]usage.Totals {
+	const q = `
+        SELECT org_id,
+               COALESCE(SUM(vcpu_seconds), 0),
+               COALESCE(SUM(mem_gib_seconds), 0),
+               COALESCE(SUM(storage_gib_hours), 0),
+               COALESCE(SUM(egress_bytes), 0),
+               COALESCE(SUM(gpu_seconds), 0)
+        FROM usage_records
+        GROUP BY org_id`
+	out := map[string]usage.Totals{}
+	rows, err := s.pool.Query(context.Background(), q)
+	if err != nil {
+		// TotalsByOrg has no error return (it backs a best-effort metric); a query
+		// failure yields an empty snapshot rather than a panic.
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var org string
+		var t usage.Totals
+		if err := rows.Scan(&org, &t.VCPUSeconds, &t.MemGiBSeconds, &t.StorageGiBHours, &t.EgressBytes, &t.GPUSeconds); err != nil {
+			return map[string]usage.Totals{}
+		}
+		out[org] = t
+	}
+	if rows.Err() != nil {
+		return map[string]usage.Totals{}
+	}
+	return out
+}
+
+// nullableTime maps the zero time to a SQL NULL so the "no bound" cases in
+// ListRecords select the IS NULL branch, and a real time to itself in UTC.
+func nullableTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	u := t.UTC()
+	return &u
+}

--- a/internal/saas/pgstore/usagestore_test.go
+++ b/internal/saas/pgstore/usagestore_test.go
@@ -1,0 +1,31 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"mitos.run/mitos/internal/saas/pgstore"
+	"mitos.run/mitos/internal/usage"
+	"mitos.run/mitos/internal/usage/usagestoretest"
+)
+
+// TestPgUsageStoreContract runs the shared UsageStore contract against the
+// durable Postgres implementation, proving it behaves identically to the
+// in-memory reference (idempotent upsert, per-org isolation, period bounds,
+// per-org totals). It skips without MITOS_TEST_DATABASE_DSN; CI sets it against a
+// Postgres service so the durable store is exercised there.
+func TestPgUsageStoreContract(t *testing.T) {
+	dsn := testDSN(t)
+	usagestoretest.RunContract(t, func(t *testing.T) usage.UsageStore {
+		t.Helper()
+		// Open FIRST so the migrations create the schema (idempotent on every
+		// subsequent call), THEN truncate for a clean slate.
+		pg, err := pgstore.Open(context.Background(), dsn)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		truncateTables(t, dsn, "usage_records")
+		t.Cleanup(pg.Close)
+		return pgstore.NewPgUsageStore(pg.Pool())
+	})
+}

--- a/internal/usage/memusagestore_contract_test.go
+++ b/internal/usage/memusagestore_contract_test.go
@@ -1,0 +1,18 @@
+package usage_test
+
+import (
+	"testing"
+
+	"mitos.run/mitos/internal/usage"
+	"mitos.run/mitos/internal/usage/usagestoretest"
+)
+
+// TestMemUsageStoreContract runs the shared UsageStore contract against the
+// in-memory reference implementation. The durable Postgres store runs the SAME
+// contract (internal/saas/pgstore) so the two are proven equivalent.
+func TestMemUsageStoreContract(t *testing.T) {
+	usagestoretest.RunContract(t, func(t *testing.T) usage.UsageStore {
+		t.Helper()
+		return usage.NewMemUsageStore()
+	})
+}

--- a/internal/usage/usagestoretest/contract.go
+++ b/internal/usage/usagestoretest/contract.go
@@ -1,0 +1,214 @@
+// Package usagestoretest holds the shared behavioral contract for
+// usage.UsageStore. It is run against BOTH the in-memory MemUsageStore (the
+// reference implementation) and the durable Postgres PgUsageStore so the durable
+// store is proven equivalent to the reference, behavior for behavior: idempotent
+// upsert, per-org isolation on ListRecords, half-open period bounds, and (for a
+// store that also implements usage.TotalsProvider) per-org cumulative totals.
+//
+// The contract lives in a non-test .go file so both the usage package test and
+// the pgstore package test can import and run it without duplicating assertions,
+// mirroring internal/saas/storetest.
+package usagestoretest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/usage"
+)
+
+// w returns a wall-clock-aligned window start n minutes after a fixed epoch. The
+// epoch is recent so the records stay inside MemUsageStore's default retention
+// horizon (a contract run must not trip eviction).
+func w(n int) time.Time {
+	return time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC).Add(time.Duration(n) * time.Minute)
+}
+
+// RunContract exercises the full usage.UsageStore contract against the store the
+// factory returns. The factory must return a FRESH, empty store on each call so
+// the subtests do not see each other's data. Every subtest gets its own store.
+//
+// A store that additionally implements usage.TotalsProvider is exercised for the
+// per-org cumulative totals contract too; a store that does not is skipped for
+// that subtest.
+func RunContract(t *testing.T, factory func(t *testing.T) usage.UsageStore) {
+	t.Helper()
+
+	t.Run("EmptyStoreListsNoRecords", func(t *testing.T) {
+		s := factory(t)
+		recs, err := s.ListRecords(context.Background(), "org-unknown", time.Time{}, time.Time{})
+		if err != nil {
+			t.Fatalf("ListRecords on empty store: %v", err)
+		}
+		if len(recs) != 0 {
+			t.Fatalf("empty store returned %d records, want 0", len(recs))
+		}
+		if recs == nil {
+			t.Fatalf("ListRecords returned a nil slice; want a non-nil empty slice")
+		}
+	})
+
+	t.Run("UpsertAndListRoundTripSorted", func(t *testing.T) {
+		s := factory(t)
+		ctx := context.Background()
+		// Insert out of order across two sandboxes and two windows; ListRecords must
+		// return them sorted by (SandboxID, Window).
+		recs := []usage.UsageRecord{
+			{OrgID: "org-a", SandboxID: "sb-2", Window: w(1), VCPUSeconds: 2, MemGiBSeconds: 1, StorageGiBHours: 0.5, EgressBytes: 20, GPUSeconds: 3},
+			{OrgID: "org-a", SandboxID: "sb-1", Window: w(1), VCPUSeconds: 1, MemGiBSeconds: 2, StorageGiBHours: 0.25, EgressBytes: 10, GPUSeconds: 1},
+			{OrgID: "org-a", SandboxID: "sb-1", Window: w(0), VCPUSeconds: 4, MemGiBSeconds: 3, StorageGiBHours: 0.1, EgressBytes: 5, GPUSeconds: 0},
+		}
+		for _, r := range recs {
+			if err := s.UpsertRecord(ctx, r); err != nil {
+				t.Fatalf("UpsertRecord: %v", err)
+			}
+		}
+		got, err := s.ListRecords(ctx, "org-a", time.Time{}, time.Time{})
+		if err != nil {
+			t.Fatalf("ListRecords: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("got %d records, want 3", len(got))
+		}
+		// Expected order: (sb-1, w0), (sb-1, w1), (sb-2, w1).
+		wantOrder := []struct {
+			sb  string
+			win time.Time
+		}{{"sb-1", w(0)}, {"sb-1", w(1)}, {"sb-2", w(1)}}
+		for i, want := range wantOrder {
+			if got[i].SandboxID != want.sb || !got[i].Window.Equal(want.win) {
+				t.Fatalf("record[%d] = (%s, %s), want (%s, %s)", i, got[i].SandboxID, got[i].Window, want.sb, want.win)
+			}
+		}
+		// Values for (sb-1, w0) must round trip.
+		r0 := got[0]
+		if r0.VCPUSeconds != 4 || r0.MemGiBSeconds != 3 || r0.StorageGiBHours != 0.1 || r0.EgressBytes != 5 || r0.GPUSeconds != 0 {
+			t.Fatalf("value round trip mismatch for (sb-1, w0): %+v", r0)
+		}
+	})
+
+	t.Run("UpsertIsIdempotentReplaceNotAdd", func(t *testing.T) {
+		s := factory(t)
+		ctx := context.Background()
+		key := usage.UsageRecord{OrgID: "org-a", SandboxID: "sb-1", Window: w(0), VCPUSeconds: 10, EgressBytes: 100, GPUSeconds: 2}
+		// Upsert the same value twice: the store must hold exactly one record with
+		// the unchanged value, never two and never a doubled value.
+		if err := s.UpsertRecord(ctx, key); err != nil {
+			t.Fatalf("UpsertRecord 1: %v", err)
+		}
+		if err := s.UpsertRecord(ctx, key); err != nil {
+			t.Fatalf("UpsertRecord 2 (same value): %v", err)
+		}
+		got, _ := s.ListRecords(ctx, "org-a", time.Time{}, time.Time{})
+		if len(got) != 1 {
+			t.Fatalf("after duplicate upsert: %d records, want 1 (idempotent on (org, sandbox, window))", len(got))
+		}
+		if got[0].VCPUSeconds != 10 || got[0].EgressBytes != 100 || got[0].GPUSeconds != 2 {
+			t.Fatalf("duplicate upsert changed the value: %+v", got[0])
+		}
+		// Upsert a corrected value for the same key: it must REPLACE, not add.
+		corrected := key
+		corrected.VCPUSeconds = 25
+		corrected.EgressBytes = 250
+		if err := s.UpsertRecord(ctx, corrected); err != nil {
+			t.Fatalf("UpsertRecord corrected: %v", err)
+		}
+		got, _ = s.ListRecords(ctx, "org-a", time.Time{}, time.Time{})
+		if len(got) != 1 {
+			t.Fatalf("after corrected upsert: %d records, want 1 (replace not add)", len(got))
+		}
+		if got[0].VCPUSeconds != 25 || got[0].EgressBytes != 250 {
+			t.Fatalf("corrected upsert did not replace: %+v", got[0])
+		}
+	})
+
+	t.Run("ListRecordsIsPerOrgIsolated", func(t *testing.T) {
+		s := factory(t)
+		ctx := context.Background()
+		if err := s.UpsertRecord(ctx, usage.UsageRecord{OrgID: "org-a", SandboxID: "a-sb", Window: w(0), VCPUSeconds: 1}); err != nil {
+			t.Fatalf("upsert org-a: %v", err)
+		}
+		if err := s.UpsertRecord(ctx, usage.UsageRecord{OrgID: "org-b", SandboxID: "b-sb", Window: w(0), VCPUSeconds: 99}); err != nil {
+			t.Fatalf("upsert org-b: %v", err)
+		}
+		a, _ := s.ListRecords(ctx, "org-a", time.Time{}, time.Time{})
+		if len(a) != 1 || a[0].SandboxID != "a-sb" {
+			t.Fatalf("org-a got %+v, want exactly a-sb", a)
+		}
+		for _, r := range a {
+			if r.OrgID != "org-a" {
+				t.Fatalf("cross-org record leaked into org-a list: %+v", r)
+			}
+		}
+		b, _ := s.ListRecords(ctx, "org-b", time.Time{}, time.Time{})
+		if len(b) != 1 || b[0].SandboxID != "b-sb" {
+			t.Fatalf("org-b got %+v, want exactly b-sb", b)
+		}
+	})
+
+	t.Run("ListRecordsHonorsHalfOpenPeriodBounds", func(t *testing.T) {
+		s := factory(t)
+		ctx := context.Background()
+		for i := 0; i < 4; i++ {
+			if err := s.UpsertRecord(ctx, usage.UsageRecord{OrgID: "org-a", SandboxID: "sb", Window: w(i), VCPUSeconds: float64(i)}); err != nil {
+				t.Fatalf("upsert w%d: %v", i, err)
+			}
+		}
+		// [w1, w3): includes w1 and w2, excludes w0 (before from) and w3 (>= to).
+		got, err := s.ListRecords(ctx, "org-a", w(1), w(3))
+		if err != nil {
+			t.Fatalf("ListRecords bounded: %v", err)
+		}
+		if len(got) != 2 || !got[0].Window.Equal(w(1)) || !got[1].Window.Equal(w(2)) {
+			t.Fatalf("bounded [w1,w3) = %+v, want exactly w1 and w2", got)
+		}
+		// Zero from = no lower bound; to = w(1) excludes w1 and later, leaving only w0.
+		got, _ = s.ListRecords(ctx, "org-a", time.Time{}, w(1))
+		if len(got) != 1 || !got[0].Window.Equal(w(0)) {
+			t.Fatalf("[,w1) = %+v, want exactly w0", got)
+		}
+		// Zero to = no upper bound; from = w(2) leaves w2 and w3.
+		got, _ = s.ListRecords(ctx, "org-a", w(2), time.Time{})
+		if len(got) != 2 || !got[0].Window.Equal(w(2)) || !got[1].Window.Equal(w(3)) {
+			t.Fatalf("[w2,) = %+v, want w2 and w3", got)
+		}
+	})
+
+	t.Run("TotalsByOrgCumulativeAndIsolated", func(t *testing.T) {
+		s := factory(t)
+		tp, ok := s.(usage.TotalsProvider)
+		if !ok {
+			t.Skip("store does not implement usage.TotalsProvider")
+		}
+		// org-a: two records across windows; org-b: one record.
+		mustUpsert(t, s, usage.UsageRecord{OrgID: "org-a", SandboxID: "sb", Window: w(0), VCPUSeconds: 3, EgressBytes: 30, GPUSeconds: 1})
+		mustUpsert(t, s, usage.UsageRecord{OrgID: "org-a", SandboxID: "sb", Window: w(1), VCPUSeconds: 4, EgressBytes: 40, GPUSeconds: 2})
+		mustUpsert(t, s, usage.UsageRecord{OrgID: "org-b", SandboxID: "sb", Window: w(0), VCPUSeconds: 100, EgressBytes: 1, GPUSeconds: 0})
+
+		totals := tp.TotalsByOrg()
+		a := totals["org-a"]
+		if a.VCPUSeconds != 7 || a.EgressBytes != 70 || a.GPUSeconds != 3 {
+			t.Fatalf("org-a totals = %+v, want vcpu=7 egress=70 gpu=3", a)
+		}
+		b := totals["org-b"]
+		if b.VCPUSeconds != 100 || b.EgressBytes != 1 {
+			t.Fatalf("org-b totals = %+v, want vcpu=100 egress=1", b)
+		}
+		// A correction to an existing key must move the total by exactly the delta,
+		// not add a second contribution.
+		mustUpsert(t, s, usage.UsageRecord{OrgID: "org-a", SandboxID: "sb", Window: w(0), VCPUSeconds: 5, EgressBytes: 50, GPUSeconds: 1})
+		a = tp.TotalsByOrg()["org-a"]
+		// w0 went 3->5 (vcpu) and 30->50 (egress); w1 unchanged (4, 40).
+		if a.VCPUSeconds != 9 || a.EgressBytes != 90 || a.GPUSeconds != 3 {
+			t.Fatalf("org-a totals after correction = %+v, want vcpu=9 egress=90 gpu=3", a)
+		}
+	})
+}
+
+func mustUpsert(t *testing.T, s usage.UsageStore, r usage.UsageRecord) {
+	t.Helper()
+	if err := s.UpsertRecord(context.Background(), r); err != nil {
+		t.Fatalf("UpsertRecord: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #211 (the durable-storage half).

## Thinking Path

Exists-vs-gap map. The billing-grade usage metering pipeline and the usage API for #211 are already substantially implemented across earlier work (#164, #211, #214):

- Aggregation pipeline: `internal/usage` has `Integrate` (pure, idempotent per-(sandbox, window) rollup with hold-then-gap and reset-aware counters) and `SamplesFromReport` (CoW-aware: each template's shared-once set amortized across forks so the per-org total reconstructs `UsedCoWAware`, never the naive per-fork sum). Source of truth is the existing CoW metering report (`internal/metering`).
- Store seam: `usage.UsageStore` (upsert-by-key idempotency, org-scoped `ListRecords`, `TotalsProvider`) with `MemUsageStore` as the tested in-memory default.
- Usage API: `usage.UsageHandler` (org-scoped, reads org from gateway context, ignores client-named org, RFC3339 period bounds, cost estimate) and `usage.InternalUsageHandler` (bearer-gated M2M), mounted in the console at `/console/usage/api`.

The genuine remaining gap: the store had only an in-memory implementation. The controller's collector wrote billable per-org records into `MemUsageStore`, which is lost on restart. The code itself repeatedly named the durable Postgres store as the unfinished piece: `usage/store.go` ("a durable Postgres store is a documented follow-up"), `saas/store.go` ("issue #211 owns the migrations seam"), `TotalsProvider` ("the durable store will too"), and `docs/saas/usage-pipeline.md` ("Durable Postgres UsageStore" under follow-ups).

The slice built. The durable Postgres `UsageStore`, reusing the existing `pgstore` seam (no new persistence layer):

- `pgstore.PgUsageStore` over a `usage_records` table keyed on `(org_id, sandbox_id, window_start)`, the integrator's idempotency key. `UpsertRecord` is `INSERT ... ON CONFLICT DO UPDATE` (replace, never add). `ListRecords` and `TotalsByOrg` are org-scoped so org A can never read org B. Migration `0003_usage_records.sql`.
- A shared `usagestoretest` contract (mirroring `internal/saas/storetest`) run against BOTH `MemUsageStore` (reference, locally) and `PgUsageStore` (CI): idempotent upsert, per-org isolation, half-open `[from, to)` bounds, empty/period cases, and per-org totals.
- The controller wires it behind `--usage-database-dsn` (fallback `MITOS_DATABASE_DSN`): when set, the collector and internal usage API use the durable store; absent a DSN they use the in-memory store. The DSN is a secret and is never logged; a configured-but-unreachable DSN fails startup loud rather than silently losing usage.

Metering is not re-derived: the existing CoW-aware report and integrator stay the source of truth; this only persists what they produce. Per-tenant isolation holds at the store (every read is `WHERE org_id = $1`).

## Verification

Commands run in the worktree:

- `go build ./...`: clean.
- `go test ./internal/usage/... ./internal/saas/pgstore/... ./internal/metering/... ./internal/saas/`: ok. The `MemUsageStore` contract (`TestMemUsageStoreContract`) is green, proving the contract. The Postgres contract (`TestPgUsageStoreContract`) and the other pgstore integration tests skip locally with no `MITOS_TEST_DATABASE_DSN`; they run in CI against the Postgres service. No local Postgres server or Docker was available, so the durable path is exercised by CI, not locally; stated honestly.
- TDD: wrote the contract plus the failing `pgstore` test first; confirmed RED (the `MemUsageStore` contract passed while `pgstore` failed to compile on the undefined `NewPgUsageStore`), then implemented to GREEN.
- `golangci-lint run --timeout=5m` and `GOOS=linux golangci-lint run --timeout=5m` scoped to `./internal/usage/... ./internal/saas/pgstore/... ./cmd/controller/...`: both clean.
- `gofmt -l` on the touched files: empty.

## Model Used

Claude (subagent) via Claude Code.