### PR TITLE
feat(console): route /waitlist and show a calm not-configured add-credits state

### DIFF
--- a/internal/frontdoor/router.go
+++ b/internal/frontdoor/router.go
@@ -29,6 +29,10 @@ var marketingSegments = map[string]bool{
 	"compare":   true,
 	"blog":      true,
 	"about":     true,
+	// /waitlist is the public post-signup "you are on the list" marketing page.
+	// No session required: visitors land here after joining the waitlist and must
+	// be able to read it without being redirected to the console.
+	"waitlist": true,
 	// Astro emits its bundled CSS/JS under /_astro/ (the build.assets default).
 	// The console's Vite bundle lives under /assets/, so /assets is owned by the
 	// console (see authSegments), NOT marketing. Routing /assets to marketing

--- a/internal/frontdoor/router_test.go
+++ b/internal/frontdoor/router_test.go
@@ -27,6 +27,9 @@ func TestDecide(t *testing.T) {
 		{"/blog", "marketing", false, false},
 		{"/blog/post-1", "marketing", false, false},
 		{"/about", "marketing", false, false},
+		// /waitlist is the public post-signup "you are on the list" marketing
+		// page; no session required.
+		{"/waitlist", "marketing", false, false},
 		{"/assets/x.js", "console", false, false},
 		{"/_astro/x.css", "marketing", false, false},
 		{"/og-image.png", "marketing", false, false},

--- a/internal/saas/console/console.go
+++ b/internal/saas/console/console.go
@@ -483,6 +483,11 @@ type BillingView struct {
 	SoftCapCents  int64                 `json:"soft_cap_cents"`
 	HardCapCents  int64                 `json:"hard_cap_cents"`
 	LedgerEntries []ledgerEntryView     `json:"ledger_entries"`
+	// TopUpAvailable is true when the prepaid credit top-up provider is
+	// configured (a non-empty TopUpProductID). When false the SPA shows a calm
+	// "adding credits is not available yet" state instead of offering a checkout
+	// that would fail. The signup credit and balance are unaffected either way.
+	TopUpAvailable bool `json:"topup_available"`
 }
 
 func (c *Console) handleBilling(w http.ResponseWriter, r *http.Request) {
@@ -492,6 +497,9 @@ func (c *Console) handleBilling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	view := BillingView{OrgID: orgID, Status: billing.StatusActive}
+	// A top-up is available exactly when the product ID is configured, matching
+	// the topup.go guard that returns 400 on an empty product ID.
+	view.TopUpAvailable = c.deps.TopUpProductID != ""
 	if c.deps.Billing.Status != nil {
 		st, err := c.deps.Billing.Status.Status(r.Context(), orgID)
 		if err != nil {

--- a/internal/saas/console/console_test.go
+++ b/internal/saas/console/console_test.go
@@ -391,6 +391,50 @@ func TestBillingBobSeesOwnSuspendedStatus(t *testing.T) {
 	}
 }
 
+// TestBillingTopUpAvailableTrue asserts that when the Console is built with a
+// non-empty TopUpProductID, GET /console/billing returns topup_available: true.
+func TestBillingTopUpAvailableTrue(t *testing.T) {
+	f := newFixture(t)
+	// Override the console to add a product ID (the default fixture leaves it empty).
+	f.con = New(Deps{
+		Accounts:    f.con.deps.Accounts,
+		Usage:       f.usage,
+		Billing:     BillingReader{Ledger: f.ledger, Status: f.status, Caps: f.caps, Rates: billing.DefaultRates()},
+		Sandboxes:   f.sandboxes,
+		Templates:   f.templates,
+		Audit:       f.audit,
+		Instruments: f.instr,
+		Logs:        NewAuthorizingLogStreamer(f.sandboxes, f.rawlogs),
+		Now:         func() time.Time { return time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC) },
+		TopUpProductID: "prod_test123",
+	})
+	w := f.req(t, "GET", "/console/billing", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var v BillingView
+	decode(t, w, &v)
+	if !v.TopUpAvailable {
+		t.Errorf("topup_available = false, want true when TopUpProductID is set")
+	}
+}
+
+// TestBillingTopUpAvailableFalse asserts that when the Console is built with an
+// empty TopUpProductID (the default), GET /console/billing returns topup_available: false.
+func TestBillingTopUpAvailableFalse(t *testing.T) {
+	// The default fixture leaves TopUpProductID empty.
+	f := newFixture(t)
+	w := f.req(t, "GET", "/console/billing", "", f.aliceAcct, f.aliceOrg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var v BillingView
+	decode(t, w, &v)
+	if v.TopUpAvailable {
+		t.Errorf("topup_available = true, want false when TopUpProductID is empty")
+	}
+}
+
 // --- Live sandboxes ---
 
 func TestSandboxListReturnsOnlyCallerOrg(t *testing.T) {

--- a/web/app/src/api.ts
+++ b/web/app/src/api.ts
@@ -74,7 +74,7 @@ export type CreateKeyResult = { org_id: string; raw_key: string; key: KeyView }
 export type AuditEvent = { org_id: string; actor_id: string; action: string; target: string; detail: string; at: string }
 export type TemplateView = { name: string; org_id: string; description: string; image: string; updated_at: string }
 export type UsageResponse = { org_id: string; records: unknown[]; totals: Record<string, number>; cost: Record<string, number> }
-export type BillingView = { org_id: string; status: string; balance_cents: number; spend_cents: number; soft_cap_cents: number; hard_cap_cents: number; ledger_entries: Array<{ ts?: string; cents?: number; reason?: string }> }
+export type BillingView = { org_id: string; status: string; balance_cents: number; spend_cents: number; soft_cap_cents: number; hard_cap_cents: number; ledger_entries: Array<{ ts?: string; cents?: number; reason?: string }>; topup_available: boolean }
 
 export type Role = 'owner' | 'admin' | 'billing' | 'member' | 'viewer'
 export type MemberView = { account_id: string; org_id: string; role: Role; created_at: string }

--- a/web/app/src/views/Billing.a11y.test.tsx
+++ b/web/app/src/views/Billing.a11y.test.tsx
@@ -27,6 +27,7 @@ const billingPayload = {
   ledger_entries: [
     { ts: '2026-06-01T00:00:00Z', cents: 5000, reason: 'signup credit' },
   ],
+  topup_available: true,
 }
 
 beforeEach(() => {

--- a/web/app/src/views/Billing.test.tsx
+++ b/web/app/src/views/Billing.test.tsx
@@ -27,6 +27,7 @@ const billingPayload = {
   ledger_entries: [
     { ts: '2026-06-01T00:00:00Z', cents: 5000, reason: 'signup credit' },
   ],
+  topup_available: true,
 }
 
 function mockFetch(postResponse?: object) {
@@ -315,5 +316,38 @@ describe('Add credits section', () => {
     expect(screen.getByText(/valid dollar amount/i)).toBeInTheDocument()
     expect(topupSpy).not.toHaveBeenCalled()
     expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows a calm not-available note and no add-credits controls when topup_available is false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input).split('?')[0]
+      const method = (init?.method ?? 'GET').toUpperCase()
+      if (url.endsWith('/console/capabilities')) {
+        return Promise.resolve(new Response(JSON.stringify(caps), { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (url.endsWith('/console/billing') && method === 'GET') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ ...billingPayload, topup_available: false }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        )
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }))
+    })
+    await renderAt('/billing', caps)
+    await waitFor(() => expect(screen.getByText(/adding credits is not available yet/i)).toBeInTheDocument())
+    // Tier buttons and Add credits submit button must not be rendered.
+    expect(screen.queryByRole('button', { name: '$10.00' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add credits/i })).not.toBeInTheDocument()
+  })
+
+  it('shows the active add-credits controls when topup_available is true', async () => {
+    // billingPayload already sets topup_available: true; the global beforeEach
+    // uses mockFetch() which serves it, so no additional setup is needed.
+    await renderAt('/billing', caps)
+    await waitFor(() => expect(screen.getByRole('button', { name: '$10.00' })).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /add credits/i })).toBeInTheDocument()
+    expect(screen.queryByText(/adding credits is not available yet/i)).not.toBeInTheDocument()
   })
 })

--- a/web/app/src/views/Billing.tsx
+++ b/web/app/src/views/Billing.tsx
@@ -213,48 +213,56 @@ export function Billing() {
           </form>
 
           <h2 style={{ marginBottom: 'var(--space-4)' }}>Add credits</h2>
-          <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
-            Buy prepaid credits for this org. Choose a tier or enter a custom amount.
-          </p>
-          {/* Single shared aria-live region for all top-up errors (preset and custom). */}
-          {topUpError && (
-            <span
-              role="alert"
-              aria-live="assertive"
-              style={{ display: 'block', fontSize: 'var(--step--1)', color: 'var(--amber)', marginBottom: 'var(--space-3)' }}
-            >
-              {topUpError}
-            </span>
+          {data.topup_available ? (
+            <>
+              <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-4)' }}>
+                Buy prepaid credits for this org. Choose a tier or enter a custom amount.
+              </p>
+              {/* Single shared aria-live region for all top-up errors (preset and custom). */}
+              {topUpError && (
+                <span
+                  role="alert"
+                  aria-live="assertive"
+                  style={{ display: 'block', fontSize: 'var(--step--1)', color: 'var(--amber)', marginBottom: 'var(--space-3)' }}
+                >
+                  {topUpError}
+                </span>
+              )}
+              <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', marginBottom: 'var(--space-4)' }}>
+                {TOPUP_TIERS.map(({ cents, label }) => (
+                  <button key={cents} className="btn" disabled={topUpPending} onClick={() => void startTopUp(cents)}>
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <form onSubmit={onCustomTopUpSubmit} noValidate style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 360, marginBottom: 'var(--space-6)' }}>
+                <div>
+                  <label htmlFor="custom-topup-dollars" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
+                    Custom amount (dollars)
+                  </label>
+                  <input
+                    id="custom-topup-dollars"
+                    type="number"
+                    min={0.01}
+                    step="0.01"
+                    placeholder="0"
+                    value={customTopUp}
+                    onChange={(e) => { setCustomTopUp(e.target.value); setTopUpError(null) }}
+                    style={{ width: '140px' }}
+                  />
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+                  <button type="submit" className="btn btn-primary" disabled={topUpPending}>
+                    Add credits
+                  </button>
+                </div>
+              </form>
+            </>
+          ) : (
+            <p className="t-dim" style={{ fontSize: 'var(--step--1)', marginBottom: 'var(--space-6)' }}>
+              Adding credits is not available yet. Please check back soon.
+            </p>
           )}
-          <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', marginBottom: 'var(--space-4)' }}>
-            {TOPUP_TIERS.map(({ cents, label }) => (
-              <button key={cents} className="btn" disabled={topUpPending} onClick={() => void startTopUp(cents)}>
-                {label}
-              </button>
-            ))}
-          </div>
-          <form onSubmit={onCustomTopUpSubmit} noValidate style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 360, marginBottom: 'var(--space-6)' }}>
-            <div>
-              <label htmlFor="custom-topup-dollars" style={{ display: 'block', marginBottom: 'var(--space-1)' }}>
-                Custom amount (dollars)
-              </label>
-              <input
-                id="custom-topup-dollars"
-                type="number"
-                min={0.01}
-                step="0.01"
-                placeholder="0"
-                value={customTopUp}
-                onChange={(e) => { setCustomTopUp(e.target.value); setTopUpError(null) }}
-                style={{ width: '140px' }}
-              />
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
-              <button type="submit" className="btn btn-primary" disabled={topUpPending}>
-                Add credits
-              </button>
-            </div>
-          </form>
 
           <h2 style={{ marginBottom: 'var(--space-3)' }}>Ledger</h2>
           {data.ledger_entries.length === 0 ? (


### PR DESCRIPTION
Two small go-live follow-ups on top of the merged hosted journey (#567).

## 1. Route /waitlist to the marketing site
The website adds a public `/waitlist` page (mitos-run/website#65), but `waitlist` was not a reserved front-door segment, so `Decide("/waitlist")` fell through to the org-slug branch and routed to the console with a session requirement, which would black-hole the public page. Adds `waitlist` to `marketingSegments` (public, no session) with a router test.

## 2. Calm "add credits not available yet" state when top-up is off
While the Paddle top-up provider is unconfigured, the free signup credit still works, but clicking Add credits hit a generic "checkout could not be started" error with no hint that it was simply not configured. Now the billing read reports `topup_available` (true exactly when `TopUpProductID` is set, matching the existing 400 guard in `topup.go`), and the Billing view renders a calm "Adding credits is not available yet. Please check back soon." instead of the tier and custom-amount controls. The active checkout flow and the runtime error path are unchanged for when top-up IS configured. Balance and the signup credit are unaffected either way.

## Thinking Path
Both items surfaced while wiring the gated go-live: the website CTA flip needs a reachable marketing `/waitlist` (front-door routing gap), and the user wants users to start on their free credit with a graceful, honest add-credits state while Paddle stays off. The topup_available signal is derived from the same `TopUpProductID` the top-up handler already guards on, so server and client agree on one condition; the SPA gates only the affordance, keeping the runtime error path for genuine failures when top-up is live.

## Verification
`go test ./internal/frontdoor/ ./internal/saas/console/` and `go vet` clean; SPA `pnpm test` (269 pass, 60 files) and `pnpm build` (tsc + vite) clean. Full required CI runs on this PR. Note: a full local `go build ./...` was blocked by a low-disk condition on the dev machine, not by these changes; the touched packages build and vet cleanly and CI builds on clean runners.

## Model Used
Claude Opus 4.8 (1M context) as the orchestrator; a Claude Sonnet 4.6 subagent for the implementation, reviewed against the diff.
