### PR TITLE
fix(deploy): inject /dev/vhost-vsock into forkd via the device plugin

### DIFF
--- a/cmd/kvm-device-plugin/main.go
+++ b/cmd/kvm-device-plugin/main.go
@@ -40,6 +40,13 @@ const defaultKVMDevicePath = "/host-dev/kvm"
 // device count.
 const defaultDeviceCount = 100
 
+// defaultDevicePaths is the set of host device nodes injected into a container
+// requesting mitos.run/kvm. /dev/vhost-vsock is REQUIRED alongside /dev/kvm and
+// /dev/net/tun: forkd is non-privileged and receives devices only from this
+// plugin, so omitting vhost-vsock makes every fork boot a VM whose guest-agent
+// vsock transport never comes up, and the fork hangs. Do not drop it.
+const defaultDevicePaths = "/dev/kvm,/dev/net/tun,/dev/vhost-vsock"
+
 func main() {
 	var (
 		resourceName  string
@@ -50,7 +57,7 @@ func main() {
 	)
 	flag.StringVar(&resourceName, "resource-name", "mitos.run/kvm", "Extended resource name the plugin advertises; pods request it under resources.limits")
 	flag.IntVar(&deviceCount, "device-count", 0, "Number of synthetic device slots to advertise when /dev/kvm is present; 0 means auto (a sane default). /dev/kvm is shareable, so this is a soft per-node concurrency cap, not a physical device count")
-	flag.StringVar(&devicePaths, "device-paths", "/dev/kvm,/dev/net/tun", "Comma-separated host device nodes injected into a requesting container on Allocate (each at the same container path, rw)")
+	flag.StringVar(&devicePaths, "device-paths", defaultDevicePaths, "Comma-separated host device nodes injected into a requesting container on Allocate (each at the same container path, rw). Includes /dev/vhost-vsock: forkd is non-privileged and needs the host vsock device to build the guest-agent transport, so a fork without it boots a VM that never reaches Ready and hangs.")
 	flag.StringVar(&kubeletDir, "kubelet-dir", "/var/lib/kubelet/device-plugins", "Kubelet device-plugins directory: the plugin serves its socket here and dials the kubelet registry socket (kubelet.sock) here")
 	flag.StringVar(&kvmDevicePath, "kvm-device-path", defaultKVMDevicePath, "Container path the plugin stat(2)s to decide whether KVM is present; the DaemonSet mounts the host /dev read-only here (not over the container /dev)")
 	flag.Parse()

--- a/cmd/kvm-device-plugin/main_test.go
+++ b/cmd/kvm-device-plugin/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The forkd pod is non-privileged and receives its devices only from this
+// plugin. /dev/vhost-vsock must stay in the default set: dropping it is exactly
+// the regression that left the host with the device but the forkd pod without
+// it, so every fork booted a VM whose guest-agent vsock transport never came up
+// and the fork hung. This guards that default against a silent removal.
+func TestDefaultDevicePathsIncludeVhostVsock(t *testing.T) {
+	got := strings.Split(defaultDevicePaths, ",")
+	for _, required := range []string{"/dev/kvm", "/dev/net/tun", "/dev/vhost-vsock"} {
+		if !slices.Contains(got, required) {
+			t.Errorf("defaultDevicePaths %q is missing required device %q", defaultDevicePaths, required)
+		}
+	}
+}

--- a/deploy/charts/mitos/templates/device-plugin-daemonset.yaml
+++ b/deploy/charts/mitos/templates/device-plugin-daemonset.yaml
@@ -38,7 +38,10 @@ spec:
             - --resource-name=mitos.run/kvm
             # 0 = auto: advertise a sane slot count (100) where /dev/kvm exists.
             - --device-count=0
-            - --device-paths=/dev/kvm,/dev/net/tun
+            # /dev/vhost-vsock is required: forkd is non-privileged and gets its
+            # devices only from this plugin, so without it a fork boots a VM whose
+            # guest-agent vsock transport never comes up and the fork hangs.
+            - --device-paths=/dev/kvm,/dev/net/tun,/dev/vhost-vsock
             - --kubelet-dir=/var/lib/kubelet/device-plugins
             # Probe the host /dev/kvm at /host-dev/kvm: the host /dev is mounted
             # read-only at /host-dev, NOT over the container's own /dev.

--- a/deploy/charts/mitos/templates/forkd-daemonset.yaml
+++ b/deploy/charts/mitos/templates/forkd-daemonset.yaml
@@ -100,7 +100,7 @@ spec:
           # --enable-networking), scoped to forkd's own pod netns; DAC_OVERRIDE so
           # the builder can reopen the template rootfs.ext4 it wrote after the
           # jailer chowned the shared inode to the per-VM uid, #426).
-          # /dev/kvm and /dev/net/tun come from the device plugin (mitos.run/kvm),
+          # /dev/kvm, /dev/net/tun, and /dev/vhost-vsock come from the device plugin (mitos.run/kvm),
           # not a privileged hostPath. allowPrivilegeEscalation: false and the
           # seccomp profile complete the hardening. The base capability set and
           # privileged: false are fixed; forkd.seccompProfile and
@@ -158,7 +158,7 @@ spec:
           hostPath:
             path: {{ .Values.forkd.dataDir }}
             type: DirectoryOrCreate
-        # /dev/kvm and /dev/net/tun are injected by the device plugin
+        # /dev/kvm, /dev/net/tun, and /dev/vhost-vsock are injected by the device plugin
         # (mitos.run/kvm) on Allocate, NOT a privileged hostPath CharDevice.
         # Created by the controller's PKI bootstrap (EnsurePKI) at startup.
         - name: tls

--- a/deploy/daemon/daemonset.yaml
+++ b/deploy/daemon/daemonset.yaml
@@ -134,7 +134,7 @@ spec:
           #   - DAC_OVERRIDE: reopen the template rootfs.ext4 the builder itself
           #     wrote, after the jailer chowned the shared inode to the per-VM
           #     uid, so a rebuild does not fail with EACCES (#426).
-          # /dev/kvm and /dev/net/tun come from the device plugin (mitos.run/kvm),
+          # /dev/kvm, /dev/net/tun, and /dev/vhost-vsock come from the device plugin (mitos.run/kvm),
           # NOT a privileged hostPath, so the device cgroup is scoped by the
           # kubelet. allowPrivilegeEscalation: false and seccompProfile
           # RuntimeDefault complete the hardening (privileged: true had disabled
@@ -159,7 +159,7 @@ spec:
             requests:
               memory: "1Gi"
               cpu: "500m"
-              # The device plugin injects /dev/kvm and /dev/net/tun on Allocate;
+              # The device plugin injects /dev/kvm, /dev/net/tun, and /dev/vhost-vsock on Allocate;
               # requesting the extended resource is what replaces privileged: true
               # for device access.
               mitos.run/kvm: "1"
@@ -197,7 +197,7 @@ spec:
           hostPath:
             path: /var/lib/mitos
             type: DirectoryOrCreate
-        # /dev/kvm and /dev/net/tun are injected by the device plugin
+        # /dev/kvm, /dev/net/tun, and /dev/vhost-vsock are injected by the device plugin
         # (mitos.run/kvm) on Allocate, NOT a privileged hostPath CharDevice.
         # Created by the controller's PKI bootstrap (EnsurePKI) at startup.
         - name: tls


### PR DESCRIPTION
## Summary

Root cause of the hosted create/fork outage. forkd runs `privileged: false` and receives host devices only from the kvm-device-plugin, whose `--device-paths` was `/dev/kvm,/dev/net/tun`. `/dev/vhost-vsock` was never injected, so the forkd pod could not open the host vsock device even though the node had it. A fork then boots a microVM whose guest-agent vsock transport never comes up, the sandbox never reaches Ready, and the fork hangs to the gateway timeout (a client read timeout). In prod the node had `/dev/vhost-vsock` (talosctl confirmed) but the forkd pod did not.

## Changes

- Add `/dev/vhost-vsock` to the device-plugin device set: the `defaultDevicePaths` constant in `cmd/kvm-device-plugin/main.go` and the chart arg in `device-plugin-daemonset.yaml`, so it is injected on Allocate alongside `/dev/kvm` and `/dev/net/tun`.
- Add a regression test guarding the default set.
- Correct the now-inaccurate "kvm and tun come from the device plugin" comments in the forkd DaemonSet templates.

## Thinking Path

The forkd pod diagnostic showed `/dev/kvm` and `/dev/net/tun` present but `/dev/vhost-vsock` missing, while talosctl showed the device present on the node. That host-vs-pod split ruled out a missing kernel module and pointed at device injection. The kvm-device-plugin injects exactly its `--device-paths` list on Allocate, and that list omitted vhost-vsock, so forkd (non-privileged, no hostPath /dev) never received it. Adding it to the injected set is the minimal durable fix.

## Verification

- `go test ./cmd/kvm-device-plugin/...` passes, including the new `TestDefaultDevicePathsIncludeVhostVsock`.
- The device-plugin Allocate returns a DeviceSpec per configured path, so the added device is bind-mounted into forkd on the next allocation. The node already carries `/dev/vhost-vsock`, and a companion machineconfig change keeps the module loaded across reboots.

## Model Used

Claude Opus 4.8 (1M context), via Claude Code.

## Follow-up (prevention, separate)

- forkd should fail its readiness probe when a required device (`/dev/vhost-vsock`, `/dev/kvm`, `/dev/net/tun`) is absent, so a missing device takes the node out of rotation with a structured error instead of hanging every fork.
- A synthetic create+fork canary against the hosted endpoint with alerting would catch any fork regression in minutes.

Fixes the outage tracked in #571.