### PR TITLE
feat(doctor): add data-dir free-space check; document data-disk selection

### DIFF
--- a/deploy/talos/README.md
+++ b/deploy/talos/README.md
@@ -18,8 +18,9 @@ Firecracker requires hardware virtualization exposed to the OS as `/dev/kvm`.
 ## Files
 
 - `worker-kvm.yaml`: a patch over the generated worker config. Loads the KVM /
-  vsock / tun kernel modules, labels the node `mitos.run/kvm=true`, and
-  mounts a data partition at `/var/lib/mitos`.
+  vsock / tun kernel modules and labels the node `mitos.run/kvm=true`. forkd's
+  data dir `/var/lib/mitos` defaults to the node's `/var` (the ephemeral
+  partition); a dedicated data disk is optional and commented out in the patch.
 - `controlplane.yaml`: a tiny optional patch over the generated control-plane
   config (just a role label). A stock Talos control plane needs no KVM.
 
@@ -32,12 +33,20 @@ Firecracker requires hardware virtualization exposed to the OS as `/dev/kvm`.
 - **Node label** (`machine.nodeLabels: mitos.run/kvm: "true"`): the forkd
   DaemonSet in `deploy/daemon/daemonset.yaml` has `nodeSelector
   mitos.run/kvm: "true"`, so forkd only schedules onto labeled KVM workers.
-- **Data partition** at `/var/lib/mitos`: this is forkd's `--data-dir`.
-  Snapshots, rootfs images, and the jailer chroot base all live here and must
-  share one filesystem so forkd can hard-link them into each per-VM chroot
-  (forkd refuses to start if they straddle filesystems). On a Hetzner AX node
-  this is usually the second NVMe; set `machine.disks[].device` to match
-  (commonly `/dev/nvme1n1`).
+- **Data dir** `/var/lib/mitos`: forkd's `--data-dir`. Snapshots, rootfs
+  images, and the jailer chroot base all live here and must share one filesystem
+  so forkd can hard-link them into each per-VM chroot (forkd refuses to start if
+  they straddle filesystems). By default this is a directory on the node's
+  `/var` (the Talos ephemeral partition, which normally spans the whole system
+  disk), so nothing extra is needed. Size the system disk for your template set
+  (tens of GB per template plus warm-pool snapshots).
+  A dedicated data disk is optional (the commented `machine.disks` block). If
+  you use one, point `device` at the FREE data disk, NOT the OS disk: verify
+  with `talosctl -n <node> get disks` (or `lsblk`), and wipe any leftover
+  partition table first. Talos will not repartition a disk with no free space,
+  so a stale partition table can silently mount `/var/lib/mitos` on a tiny
+  leftover partition; the template build then fails with `no space left on
+  device` and every fork times out. `mitos doctor` flags an undersized data dir.
 
 ## Usage
 

--- a/deploy/talos/worker-kvm.yaml
+++ b/deploy/talos/worker-kvm.yaml
@@ -39,13 +39,26 @@ machine:
   # guest-agent vsock from vhost_vsock, and tap devices from tun. Add
   # machine.sysctls here only if a future networking change needs one.
   #
-  # Mount a dedicated data partition at /var/lib/mitos, the forkd dataDir
-  # (--data-dir in deploy/daemon/daemonset.yaml). Snapshot, rootfs, and the
-  # jailer chroot base all live here and must share one filesystem so forkd can
-  # hard-link them into each per-VM chroot. Point device at the actual data
-  # disk on the Hetzner AX node (commonly the second NVMe, e.g. /dev/nvme1n1);
-  # adjust per machine.
-  disks:
-    - device: /dev/nvme1n1
-      partitions:
-        - mountpoint: /var/lib/mitos
+  # forkd's data dir (--data-dir, default /var/lib/mitos) holds template rootfs
+  # images, snapshots, and the per-VM jailer chroot base, which must share one
+  # filesystem so forkd can hard-link them into each chroot. By DEFAULT it lives
+  # on the node's /var (the Talos EPHEMERAL partition, which normally spans the
+  # whole system disk), so no machine.disks entry is needed and there is nothing
+  # to misconfigure. Size the system disk for your template set: tens of GB per
+  # template plus the warm-pool snapshots.
+  #
+  # A dedicated data disk (the block below, commented out) is OPTIONAL, for
+  # isolation or extra capacity. If you add one, get the device RIGHT: point
+  # `device` at the FREE data disk, NOT the OS/system disk. Verify with
+  # `talosctl -n <node> get disks` (or lsblk), and WIPE any leftover partition
+  # table from a prior OS first. A reset box often keeps old partitions, and
+  # Talos will NOT repartition a disk with no free space, so machine.disks can
+  # silently land /var/lib/mitos on a tiny leftover partition (we hit a ~100MB
+  # one); the template build then fails with "no space left on device" and every
+  # fork times out as fork_unavailable. `mitos doctor` has a data-dir-space check
+  # that catches this before it bites.
+  #
+  # disks:
+  #   - device: /dev/nvmeXn1   # the FREE data disk, NOT the OS disk; wipe it first
+  #     partitions:
+  #       - mountpoint: /var/lib/mitos

--- a/docs/platforms/host-prerequisites.md
+++ b/docs/platforms/host-prerequisites.md
@@ -80,12 +80,29 @@ root filesystem is itself an overlay, fails the snapshotter at image-pull time
 with an opaque mount error. The fix is a real block-backed root filesystem
 (ext4/xfs); it is not a containerd configuration tweak.
 
+### 3. data dir too small, or on the wrong disk
+
+forkd's `--data-dir` (default `/var/lib/mitos`) holds template rootfs images,
+snapshots, and the per-VM jailer chroot base. If it sits on an undersized or
+full filesystem, the template build fails with `no space left on device`, the
+husk warm pool never fills, and every sandbox create/fork times out. The SDK
+sees only a generic `fork_unavailable`, so the symptom is far from the cause.
+
+The common trap is a dedicated data disk pointed at the wrong device. On a bare
+metal box that was reset but whose old partition table was not wiped, Talos (or
+any partitioner) will not repartition a disk with no free space, so a
+`machine.disks` mount can silently land `/var/lib/mitos` on a tiny leftover
+partition (we hit a 100MB one) while the real disk sits unused. Keep the data
+dir on the system `/var` unless you deliberately add a wiped, correctly chosen
+data disk. Budget tens of GB per template plus the warm-pool snapshots. `mitos
+doctor` fails the `data-dir-space` check when free space is below the minimum.
+
 ## One-shot verify
 
 Run `mitos doctor` on each candidate node (or as an in-cluster Job). It checks
-`/dev/kvm`, the required kernel modules, the staged guest kernel, the minted PKI
-secrets, the image pull secret, and the privileged PodSecurity label, and prints
-an actionable remediation per failing check:
+`/dev/kvm`, the required kernel modules, the staged guest kernel, free space on
+the data dir, the minted PKI secrets, the image pull secret, and the privileged
+PodSecurity label, and prints an actionable remediation per failing check:
 
 ```bash
 mitos doctor                 # node + cluster preflight, exits non-zero on any failure

--- a/internal/agentcli/doctor.go
+++ b/internal/agentcli/doctor.go
@@ -64,6 +64,11 @@ type DoctorProbe interface {
 	// GuestKernelStaged reports whether the guest kernel image is staged at the
 	// path forkd boots from, and returns that path for the remediation message.
 	GuestKernelStaged(ctx context.Context) (present bool, path string, err error)
+	// DataDirFree reports the free bytes on the filesystem backing forkd's data
+	// dir (--data-dir, default /var/lib/mitos) and returns that path for the
+	// report. Template rootfs images, snapshots, and per-VM jailer chroots all
+	// live here; a too-small or full data dir makes the build fail with ENOSPC.
+	DataDirFree(ctx context.Context) (freeBytes uint64, path string, err error)
 	// PKISecretPresent reports whether the named PKI Secret exists in the install
 	// namespace. It reads presence only, never the Secret contents.
 	PKISecretPresent(ctx context.Context, name string) (bool, error)
@@ -98,11 +103,48 @@ func RunDoctorChecks(ctx context.Context, probe DoctorProbe) []CheckResult {
 	results = append(results,
 		checkUserfaultfd(ctx, probe),
 		checkGuestKernel(ctx, probe),
+		checkDataDirSpace(ctx, probe),
 		checkPKI(ctx, probe),
 		checkPullSecret(ctx, probe),
 		checkPSA(ctx, probe),
 	)
 	return results
+}
+
+// dataDirMinFreeBytes is the floor below which forkd cannot reliably build a
+// template snapshot: a single template rootfs.ext4 is hundreds of MB to a few
+// GB, and the husk warm pool holds several plus their jailer chroots. Below
+// this the build fails with "no space left on device" and every fork times out
+// with a generic fork_unavailable, so the symptom the caller sees (a fork
+// timeout) is far from the cause (a full data dir). This check names the cause.
+const dataDirMinFreeBytes = 5 << 30 // 5 GiB
+
+// checkDataDirSpace fails when forkd's data dir has too little free space to
+// build a template. A probe error (e.g. the dir does not exist off a KVM node,
+// or statfs is unavailable) is a WARN, not a FAIL, so `mitos doctor` still runs
+// on a workstation without falsely blocking.
+func checkDataDirSpace(ctx context.Context, probe DoctorProbe) CheckResult {
+	free, path, err := probe.DataDirFree(ctx)
+	res := CheckResult{Name: "data-dir-space"}
+	if path == "" {
+		path = defaultKernelPath[:strings.LastIndex(defaultKernelPath, "/")]
+	}
+	remediation := fmt.Sprintf("forkd's data dir %s holds template rootfs images, snapshots, and per-VM jailer chroots; below ~%d GiB free the template build fails with \"no space left on device\" and every fork times out (surfaced to the SDK as a generic fork_unavailable). Point --data-dir at a real, adequately sized filesystem: check df -h %s, and on bare metal make sure it is the DATA disk, not a small leftover partition (a reset box can leave forkd on a ~100MB EFI/boot partition of the OS disk while the real disk sits unused). See docs/platforms/host-prerequisites.md.", path, dataDirMinFreeBytes>>30, path)
+	if err != nil {
+		res.Status = CheckWarn
+		res.Detail = fmt.Sprintf("could not stat data dir %s: %v", path, err)
+		res.Remediation = remediation
+		return res
+	}
+	if free < dataDirMinFreeBytes {
+		res.Status = CheckFail
+		res.Detail = fmt.Sprintf("data dir %s has %d MiB free, below the %d GiB minimum", path, free>>20, dataDirMinFreeBytes>>30)
+		res.Remediation = remediation
+		return res
+	}
+	res.Status = CheckPass
+	res.Detail = fmt.Sprintf("data dir %s has %d GiB free", path, free>>30)
+	return res
 }
 
 func checkKVM(ctx context.Context, probe DoctorProbe) CheckResult {

--- a/internal/agentcli/doctor_probe.go
+++ b/internal/agentcli/doctor_probe.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +33,9 @@ type realProbe struct {
 	// leaves them at the Linux defaults.
 	modulesPath string
 	kvmPath     string
+	// dataDirPath is forkd's --data-dir (the directory of kernelPath), the
+	// filesystem the data-dir-space check statfs's.
+	dataDirPath string
 }
 
 // DoctorProbeConfig configures the real probe.
@@ -64,6 +69,7 @@ func NewRealProbe(cfg DoctorProbeConfig) DoctorProbe {
 		kernelPath:  kp,
 		modulesPath: "/proc/modules",
 		kvmPath:     "/dev/kvm",
+		dataDirPath: filepath.Dir(kp),
 	}
 }
 
@@ -119,6 +125,19 @@ func (p *realProbe) GuestKernelStaged(context.Context) (bool, string, error) {
 	}
 	// A staged kernel is a regular, non-empty file.
 	return info.Mode().IsRegular() && info.Size() > 0, p.kernelPath, nil
+}
+
+// DataDirFree statfs's the filesystem backing forkd's data dir and returns the
+// bytes available to an unprivileged writer (Bavail, not Bfree). Off a KVM node
+// the dir usually does not exist, which statfs reports as an error; the check
+// folds that into a WARN so a workstation run is not falsely blocked.
+func (p *realProbe) DataDirFree(context.Context) (uint64, string, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(p.dataDirPath, &st); err != nil {
+		return 0, p.dataDirPath, err
+	}
+	// Bsize and Bavail widths differ across platforms; convert explicitly.
+	return uint64(st.Bavail) * uint64(st.Bsize), p.dataDirPath, nil
 }
 
 func (p *realProbe) PKISecretPresent(ctx context.Context, name string) (bool, error) {

--- a/internal/agentcli/doctor_test.go
+++ b/internal/agentcli/doctor_test.go
@@ -3,6 +3,7 @@ package agentcli
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 	"testing"
 )
@@ -23,6 +24,9 @@ type fakeProbe struct {
 	psaLabelValue string
 	namespace     string
 	userfaultfd   bool
+	dataDirFree   uint64
+	dataDirPath   string
+	dataDirErr    error
 }
 
 func (f *fakeProbe) Userfaultfd(context.Context) (bool, error) { return f.userfaultfd, nil }
@@ -35,6 +39,10 @@ func (f *fakeProbe) KernelModuleLoaded(_ context.Context, name string) (bool, er
 
 func (f *fakeProbe) GuestKernelStaged(context.Context) (present bool, path string, err error) {
 	return f.kernelStaged, f.kernelPath, nil
+}
+
+func (f *fakeProbe) DataDirFree(context.Context) (uint64, string, error) {
+	return f.dataDirFree, f.dataDirPath, f.dataDirErr
 }
 
 func (f *fakeProbe) PKISecretPresent(_ context.Context, name string) (bool, error) {
@@ -70,6 +78,8 @@ func healthyProbe() *fakeProbe {
 		psaLabelValue: "privileged",
 		namespace:     "mitos",
 		userfaultfd:   true,
+		dataDirFree:   50 << 30, // 50 GiB, well above the minimum
+		dataDirPath:   "/var/lib/mitos",
 	}
 }
 
@@ -107,6 +117,44 @@ func TestDoctorUserfaultfdPresentPasses(t *testing.T) {
 		if r.Name == "userfaultfd" && r.Status != CheckPass {
 			t.Errorf("userfaultfd present should pass, got %s: %s", r.Status, r.Detail)
 		}
+	}
+}
+
+// TestDoctorDataDirSpaceLowFails proves the preflight names an undersized data
+// dir: when forkd's --data-dir sits on a tiny partition (the real-world case: a
+// reset bare-metal box left /var/lib/mitos on a ~100MB leftover partition of the
+// OS disk), template builds fail with ENOSPC and every fork times out with a
+// generic fork_unavailable. doctor must FAIL and point at the data disk so the
+// operator does not have to trace a fork timeout back to a full filesystem.
+func TestDoctorDataDirSpaceLowFails(t *testing.T) {
+	p := healthyProbe()
+	p.dataDirFree = 88 << 20 // 88 MiB, the observed misprovisioned case
+	r := findCheck(t, RunDoctorChecks(context.Background(), p), "data-dir-space")
+	if r.Status != CheckFail {
+		t.Errorf("an 88 MiB data dir should FAIL, got %s: %s", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Remediation, "--data-dir") || !strings.Contains(r.Remediation, "DATA disk") {
+		t.Errorf("remediation should point at --data-dir and the data disk, got: %s", r.Remediation)
+	}
+}
+
+// TestDoctorDataDirSpacePasses proves an amply sized data dir passes.
+func TestDoctorDataDirSpacePasses(t *testing.T) {
+	r := findCheck(t, RunDoctorChecks(context.Background(), healthyProbe()), "data-dir-space")
+	if r.Status != CheckPass {
+		t.Errorf("a 50 GiB data dir should pass, got %s: %s", r.Status, r.Detail)
+	}
+}
+
+// TestDoctorDataDirSpaceProbeErrorWarns proves a statfs error (e.g. the data dir
+// does not exist off a KVM node, so a workstation run cannot check it) is a
+// non-blocking WARN, not a FAIL, so `mitos doctor` still runs off-node.
+func TestDoctorDataDirSpaceProbeErrorWarns(t *testing.T) {
+	p := healthyProbe()
+	p.dataDirErr = os.ErrNotExist
+	r := findCheck(t, RunDoctorChecks(context.Background(), p), "data-dir-space")
+	if r.Status != CheckWarn {
+		t.Errorf("a statfs error should WARN (off-node run), got %s: %s", r.Status, r.Detail)
 	}
 }
 


### PR DESCRIPTION
## Summary

A misprovisioned forkd data dir fails invisibly. When `/var/lib/mitos` sits on a too-small or full filesystem, the template snapshot build fails with `no space left on device`, the husk warm pool never fills, and every sandbox create/fork times out. The SDK sees only a generic `fork_unavailable`, so there is no thread from symptom back to cause.

This is a real failure we hit on a bare-metal node: a reset box kept a stale partition table, so the Talos `machine.disks` mount landed `/var/lib/mitos` on a ~100MB leftover partition of the OS disk while the actual data disk sat unused. forkd had 88MB to build a template rootfs of hundreds of MB.

## Changes

- **New `data-dir-space` doctor check** (`internal/agentcli/doctor.go`, `doctor_probe.go`): statfs's forkd's `--data-dir` and FAILS below a 5 GiB floor. A statfs error (dir absent off a KVM node, e.g. a workstation run) is a non-blocking WARN so `mitos doctor` still runs off-node. Remediation names `--data-dir`, the data disk, and the reset-box partition trap.
- **Docs / reference config**: `deploy/talos/worker-kvm.yaml` now defaults the data dir to the node `/var` (the ephemeral partition, normally the whole system disk) and demotes the dedicated data disk to an optional, commented block with a loud warning to point at the FREE disk (not the OS disk) and wipe stale partitions first. `deploy/talos/README.md` and `docs/platforms/host-prerequisites.md` carry the same guidance and reference the new check.

## Thinking Path

The root cause of the incident was infra (a per-machine disk-layout mismatch), not mitos code, but the *symptom* is a mitos observability gap: a fork timeout with the real reason (ENOSPC on the data dir) buried in a controller ERROR log. The durable fix is to name the cause at preflight and to stop the reference config from steering self-hosters into the trap. A dedicated data disk is now opt-in and clearly guarded; the default (data dir on `/var`) has nothing to misconfigure.

## Verification

- `go build ./internal/agentcli/` native + `GOOS=linux`: exit 0.
- `go test ./internal/agentcli/` passes, including new `TestDoctorDataDirSpaceLowFails` (88 MiB -> FAIL), `TestDoctorDataDirSpacePasses` (50 GiB -> PASS), `TestDoctorDataDirSpaceProbeErrorWarns` (statfs error -> WARN).
- `gofmt` clean on all changed Go files; no em or en dashes.

## Model Used

Claude Opus 4.8 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)