### PR TITLE
feat(canary): synthetic canary probing the fork+exec path with alerts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -400,6 +400,7 @@ jobs:
       - run: docker build -f Dockerfile.facade -t mitos-facade:ci .
       - run: docker build -f Dockerfile.console -t mitos-console:ci .
       - run: docker build -f Dockerfile.gateway -t mitos-gateway:ci .
+      - run: docker build -f Dockerfile.canary -t mitos-canary:ci .
       # The computer-use template image (headless Chromium + CDP relay, issue
       # #314). Build context is the repository root because the relay is compiled
       # from source. Smoke that the multi-stage build works, the launcher brings

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,6 +54,8 @@ jobs:
             dockerfile: Dockerfile.console
           - name: mitos-gateway
             dockerfile: Dockerfile.gateway
+          - name: mitos-canary
+            dockerfile: Dockerfile.canary
           - name: mitos-frontdoor
             dockerfile: Dockerfile.frontdoor
           - name: mitos-computer-use

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,0 +1,20 @@
+FROM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS builder
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -o mitos-canary ./cmd/mitos-canary/
+
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+
+LABEL org.opencontainers.image.title="mitos-canary" \
+      org.opencontainers.image.description="Mitos synthetic canary: continuously forks and execs a sandbox to prove the user-facing path and export it as Prometheus metrics." \
+      org.opencontainers.image.source="https://github.com/mitos-run/mitos" \
+      org.opencontainers.image.url="https://mitos.run" \
+      org.opencontainers.image.documentation="https://mitos.run/docs" \
+      org.opencontainers.image.vendor="Mitos" \
+      org.opencontainers.image.licenses="Apache-2.0"
+COPY --from=builder /build/mitos-canary /mitos-canary
+ENTRYPOINT ["/mitos-canary"]

--- a/cmd/mitos-canary/main.go
+++ b/cmd/mitos-canary/main.go
@@ -1,0 +1,284 @@
+// Command mitos-canary continuously exercises the full user-facing sandbox path
+// (auth -> gateway -> controller -> forkd -> fork -> exec -> terminate) against a
+// live mitos install and exports the result as Prometheus metrics.
+//
+// It is the synthetic probe behind the production alerts: when a real user
+// would get fork_unavailable, the canary sees it first and mitos_canary_up goes
+// to 0. The canary reuses the exact HostedBackend the CLI and SDKs use, so it
+// fails the same way a customer would, not through a privileged side channel.
+//
+// Liveness vs platform health are deliberately separate. /healthz reports only
+// whether the probe LOOP is alive (so Kubernetes restarts a wedged canary and
+// self-heals it), never whether the platform is healthy: a platform outage must
+// NOT crash-loop the canary, or we would lose the very metrics the alerts read.
+// Platform health lives in mitos_canary_up and the alerting rules on top of it.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"mitos.run/mitos/internal/agentcli"
+)
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:], os.Getenv)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mitos-canary:", err)
+		os.Exit(2)
+	}
+
+	reg := prometheus.NewRegistry()
+	m := newMetrics(reg)
+
+	// A dedicated http client with a sane timeout so a hung gateway cannot wedge
+	// a probe forever; the per-cycle context is the primary bound.
+	backend := agentcli.NewHostedBackend(cfg.baseURL, cfg.apiKey, &http.Client{Timeout: cfg.cycleTimeout})
+
+	h := &health{stalenessWindow: cfg.stalenessWindow}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	srv := newServer(cfg.listenAddr, reg, h)
+	go func() {
+		log.Printf("mitos-canary: serving /metrics /healthz /readyz on %s", cfg.listenAddr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("mitos-canary: http server error: %v", err)
+			stop()
+		}
+	}()
+
+	log.Printf("mitos-canary: probing template %q every %s (exec timeout %ds, cycle timeout %s)",
+		cfg.pool, cfg.interval, cfg.execTimeout, cfg.cycleTimeout)
+	runLoop(ctx, backend, m, h, cfg)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
+	log.Print("mitos-canary: stopped")
+}
+
+// config is the resolved canary configuration.
+type config struct {
+	baseURL         string        // gateway/API base; empty lets HostedBackend resolve in-cluster
+	apiKey          string        // bearer token; never logged
+	pool            string        // template name to fork each cycle
+	interval        time.Duration // time between cycle starts
+	execTimeout     int           // per-exec timeout in seconds
+	cycleTimeout    time.Duration // whole-cycle deadline
+	listenAddr      string        // metrics/health listen address
+	stalenessWindow time.Duration // /healthz fails if the loop has not ticked within this window
+}
+
+// parseConfig resolves flags with environment-variable defaults. getenv is
+// injected so the resolution is unit-testable. The api key is read from
+// MITOS_API_KEY or, preferred for secret mounts, the file at MITOS_API_KEY_FILE.
+func parseConfig(args []string, getenv func(string) string) (config, error) {
+	fs := flag.NewFlagSet("mitos-canary", flag.ContinueOnError)
+	baseURL := fs.String("base-url", getenv("MITOS_BASE_URL"), "gateway/API base URL; empty resolves the in-cluster gateway")
+	pool := fs.String("pool", envOr(getenv, "MITOS_CANARY_POOL", "python"), "template name to fork each cycle")
+	interval := fs.Duration("interval", envDurationOr(getenv, "MITOS_CANARY_INTERVAL", 60*time.Second), "time between probe cycles")
+	execTimeout := fs.Int("exec-timeout", envIntOr(getenv, "MITOS_CANARY_EXEC_TIMEOUT", 30), "per-exec timeout in seconds")
+	cycleTimeout := fs.Duration("cycle-timeout", envDurationOr(getenv, "MITOS_CANARY_CYCLE_TIMEOUT", 120*time.Second), "whole-cycle deadline")
+	listenAddr := fs.String("listen", envOr(getenv, "MITOS_CANARY_LISTEN", ":9102"), "metrics/health listen address")
+	staleness := fs.Duration("staleness-window", envDurationOr(getenv, "MITOS_CANARY_STALENESS", 0), "liveness fails if the loop has not ticked within this window (default 3x interval)")
+	apiKeyFile := fs.String("api-key-file", getenv("MITOS_API_KEY_FILE"), "path to a file containing the api key (preferred over the env var)")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+
+	apiKey := getenv("MITOS_API_KEY")
+	if *apiKeyFile != "" {
+		raw, err := os.ReadFile(*apiKeyFile)
+		if err != nil {
+			return config{}, fmt.Errorf("read api key file: %w", err)
+		}
+		apiKey = strings.TrimSpace(string(raw))
+	}
+	if apiKey == "" {
+		return config{}, errors.New("no api key: set MITOS_API_KEY or MITOS_API_KEY_FILE (a mitos_live_ token scoped to the canary org)")
+	}
+	if *interval <= 0 {
+		return config{}, fmt.Errorf("interval must be positive, got %s", *interval)
+	}
+	window := *staleness
+	if window <= 0 {
+		// Default: three missed ticks means the loop is wedged.
+		window = 3 * *interval
+	}
+	return config{
+		baseURL:         *baseURL,
+		apiKey:          apiKey,
+		pool:            *pool,
+		interval:        *interval,
+		execTimeout:     *execTimeout,
+		cycleTimeout:    *cycleTimeout,
+		listenAddr:      *listenAddr,
+		stalenessWindow: window,
+	}, nil
+}
+
+// runLoop probes immediately, then on every interval tick, until ctx is done.
+// It owns the consecutive-failure gauge and the liveness heartbeat.
+func runLoop(ctx context.Context, api sandboxAPI, m *metrics, h *health, cfg config) {
+	ticker := time.NewTicker(cfg.interval)
+	defer ticker.Stop()
+
+	var consecFail int
+	once := func() {
+		h.tick() // heartbeat first: a probe that hangs still proves the loop was alive here
+		nonce := newNonce()
+		cctx, cancel := context.WithTimeout(ctx, cfg.cycleTimeout)
+		defer cancel()
+
+		res := runProbe(cctx, api, m, cfg.pool, nonce, cfg.execTimeout)
+		if res.OK {
+			consecFail = 0
+			log.Printf("mitos-canary: cycle ok (template=%s)", cfg.pool)
+		} else {
+			consecFail++
+			// res.Err comes from HostedBackend, which already redacts the api key.
+			log.Printf("mitos-canary: cycle FAILED at %s (consecutive=%d): %v", res.Phase, consecFail, res.Err)
+		}
+		m.consecFail.Set(float64(consecFail))
+		h.ready()
+	}
+
+	once()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			once()
+		}
+	}
+}
+
+// newNonce returns a per-cycle unique token embedded in the exec so a stale or
+// proxied response cannot be mistaken for a fresh guest round-trip.
+func newNonce() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is effectively impossible; fall back to a fixed
+		// marker rather than panic, verification still requires an exact match.
+		return "canary-fixed"
+	}
+	return "canary-" + hex.EncodeToString(b[:])
+}
+
+// health tracks the probe loop's liveness and first-cycle readiness. It is safe
+// for concurrent use by the loop goroutine and the HTTP handlers.
+type health struct {
+	mu              sync.Mutex
+	lastTick        time.Time
+	started         bool
+	stalenessWindow time.Duration
+}
+
+// tick records that the loop is alive at the top of a cycle.
+func (h *health) tick() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastTick = time.Now()
+}
+
+// ready marks that at least one cycle has completed, so metrics are populated.
+func (h *health) ready() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.started = true
+}
+
+// live reports whether the loop has ticked within the staleness window. It is
+// the liveness signal: false means the loop wedged and the pod should restart.
+func (h *health) live() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.lastTick.IsZero() {
+		return true // not started probing yet; give it until the first tick
+	}
+	return time.Since(h.lastTick) < h.stalenessWindow
+}
+
+// isReady reports whether the first cycle has completed.
+func (h *health) isReady() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.started
+}
+
+// newServer builds the metrics/health HTTP server. /healthz is liveness (loop
+// alive), /readyz is readiness (first cycle done), /metrics is the scrape target.
+func newServer(addr string, reg *prometheus.Registry, h *health) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		if h.live() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("probe loop stalled"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if h.isReady() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ready"))
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("first cycle not complete"))
+	})
+	return &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+}
+
+// envOr returns the environment value for key or def when unset/empty.
+func envOr(getenv func(string) string, key, def string) string {
+	if v := getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// envIntOr parses the environment value for key or returns def.
+func envIntOr(getenv func(string) string, key string, def int) int {
+	if v := getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// envDurationOr parses the environment value for key or returns def.
+func envDurationOr(getenv func(string) string, key string, def time.Duration) time.Duration {
+	if v := getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/cmd/mitos-canary/main_test.go
+++ b/cmd/mitos-canary/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// envFunc builds a getenv func over a map for deterministic config tests.
+func envFunc(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	cfg, err := parseConfig(nil, envFunc(map[string]string{"MITOS_API_KEY": "mitos_live_test"}))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.pool != "python" {
+		t.Errorf("default pool = %q, want python", cfg.pool)
+	}
+	if cfg.interval != 60*time.Second {
+		t.Errorf("default interval = %s, want 60s", cfg.interval)
+	}
+	if cfg.listenAddr != ":9102" {
+		t.Errorf("default listen = %q, want :9102", cfg.listenAddr)
+	}
+	// Default staleness window is three intervals.
+	if cfg.stalenessWindow != 3*time.Minute {
+		t.Errorf("default staleness = %s, want 3m", cfg.stalenessWindow)
+	}
+}
+
+func TestParseConfigRequiresAPIKey(t *testing.T) {
+	_, err := parseConfig(nil, envFunc(nil))
+	if err == nil {
+		t.Fatal("expected an error when no api key is set")
+	}
+}
+
+func TestParseConfigAPIKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+	if err := os.WriteFile(keyPath, []byte("  mitos_live_fromfile\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := parseConfig([]string{"--api-key-file", keyPath}, envFunc(nil))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.apiKey != "mitos_live_fromfile" {
+		t.Errorf("api key = %q, want trimmed mitos_live_fromfile", cfg.apiKey)
+	}
+}
+
+func TestParseConfigFlagsOverrideEnv(t *testing.T) {
+	env := map[string]string{
+		"MITOS_API_KEY":         "mitos_live_test",
+		"MITOS_CANARY_POOL":     "node",
+		"MITOS_CANARY_INTERVAL": "30s",
+	}
+	cfg, err := parseConfig([]string{"--pool", "python", "--interval", "10s"}, envFunc(env))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.pool != "python" {
+		t.Errorf("flag pool should override env: got %q", cfg.pool)
+	}
+	if cfg.interval != 10*time.Second {
+		t.Errorf("flag interval should override env: got %s", cfg.interval)
+	}
+}
+
+func TestParseConfigRejectsNonPositiveInterval(t *testing.T) {
+	_, err := parseConfig([]string{"--interval", "0s"}, envFunc(map[string]string{"MITOS_API_KEY": "x"}))
+	if err == nil {
+		t.Fatal("expected an error for a non-positive interval")
+	}
+}

--- a/cmd/mitos-canary/probe.go
+++ b/cmd/mitos-canary/probe.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"mitos.run/mitos/internal/agentcli"
+)
+
+// reapTimeout bounds the best-effort Terminate that cleans up each probe's
+// sandbox. It uses its own context so a cancelled cycle context (deadline hit
+// mid-exec) still gets a chance to reap the sandbox and not leak it.
+const reapTimeout = 30 * time.Second
+
+// sandboxAPI is the minimal slice of the sandbox backend the canary probe
+// needs. *agentcli.HostedBackend satisfies it directly; the unit test supplies
+// a fake so the probe logic is exercised without a live cluster.
+type sandboxAPI interface {
+	Create(ctx context.Context, pool string) (string, error)
+	Exec(ctx context.Context, sandboxID, command string, timeoutSec int) (agentcli.ExecResult, error)
+	Terminate(ctx context.Context, sandboxID string) error
+}
+
+// probePhase names one step of a probe cycle. It doubles as the {phase} metric
+// label value, so the names are stable and lowercase.
+type probePhase string
+
+const (
+	phaseCreate    probePhase = "create"
+	phaseExec      probePhase = "exec"
+	phaseVerify    probePhase = "verify"
+	phaseTerminate probePhase = "terminate"
+	phaseCycle     probePhase = "cycle"
+)
+
+// probeResult is the outcome of one full probe cycle. Phase is the step that
+// decided the outcome: the failing step on failure, or phaseVerify on success
+// (the last step of the user-facing path). Err is nil on success and always
+// carries a redacted, actionable message on failure.
+type probeResult struct {
+	Phase probePhase
+	OK    bool
+	Err   error
+}
+
+// metrics holds the canary's Prometheus collectors. Constructed against an
+// explicit registry so tests get an isolated one and never touch the global
+// default registerer.
+type metrics struct {
+	probeTotal    *prometheus.CounterVec   // {phase,result} attempts per phase
+	probeDuration *prometheus.HistogramVec // {phase} wall-clock per phase
+	cycleDuration prometheus.Histogram     // full create->verify->terminate cycle
+	lastSuccess   prometheus.Gauge         // unix time of the last fully-green cycle
+	up            prometheus.Gauge         // 1 if the last cycle passed, else 0
+	consecFail    prometheus.Gauge         // consecutive failed cycles (0 when green)
+}
+
+// newMetrics registers the canary collectors on reg and returns them.
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		probeTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "mitos_canary_probe_total",
+			Help: "Canary probe attempts by phase and result (success|failure).",
+		}, []string{"phase", "result"}),
+		probeDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "mitos_canary_probe_duration_seconds",
+			Help:    "Wall-clock duration of each canary probe phase.",
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120},
+		}, []string{"phase"}),
+		cycleDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "mitos_canary_cycle_duration_seconds",
+			Help:    "Wall-clock duration of a full canary cycle (create, exec, verify, terminate).",
+			Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300},
+		}),
+		lastSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "mitos_canary_last_success_timestamp_seconds",
+			Help: "Unix timestamp of the last fully successful canary cycle.",
+		}),
+		up: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "mitos_canary_up",
+			Help: "1 if the most recent canary cycle passed end to end, else 0.",
+		}),
+		consecFail: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "mitos_canary_consecutive_failures",
+			Help: "Number of consecutive failed canary cycles; 0 when the last cycle was green.",
+		}),
+	}
+	reg.MustRegister(m.probeTotal, m.probeDuration, m.cycleDuration, m.lastSuccess, m.up, m.consecFail)
+	return m
+}
+
+// resultLabel maps success to the stable metric label values.
+func resultLabel(ok bool) string {
+	if ok {
+		return "success"
+	}
+	return "failure"
+}
+
+// observe runs fn, records its duration under the phase histogram and bumps the
+// {phase,result} counter, then returns fn's value and error. Generic so each
+// phase keeps its natural return type.
+func observe[T any](m *metrics, phase probePhase, fn func() (T, error)) (T, error) {
+	start := time.Now()
+	v, err := fn()
+	m.probeDuration.WithLabelValues(string(phase)).Observe(time.Since(start).Seconds())
+	m.probeTotal.WithLabelValues(string(phase), resultLabel(err == nil)).Inc()
+	return v, err
+}
+
+// runProbe executes one full canary cycle against api and records every metric
+// for it: create a sandbox from pool, exec `echo <nonce>`, verify the nonce
+// round-tripped with a zero exit code, then terminate. Terminate always runs
+// once a sandbox exists, even when an earlier phase failed, so the canary never
+// leaks sandboxes. The returned probeResult reflects the user-facing path
+// (create, exec, verify); a terminate-only failure is recorded in metrics but
+// does not by itself mark the cycle down, since the fork path still worked.
+func runProbe(ctx context.Context, api sandboxAPI, m *metrics, pool, nonce string, execTimeoutSec int) probeResult {
+	cycleStart := time.Now()
+	res := doProbe(ctx, api, m, pool, nonce, execTimeoutSec)
+
+	m.cycleDuration.Observe(time.Since(cycleStart).Seconds())
+	m.probeTotal.WithLabelValues(string(phaseCycle), resultLabel(res.OK)).Inc()
+	if res.OK {
+		m.up.Set(1)
+		m.lastSuccess.SetToCurrentTime()
+	} else {
+		m.up.Set(0)
+	}
+	return res
+}
+
+// doProbe is the cycle body without the cycle-level metric bookkeeping, split
+// out so runProbe stays readable.
+func doProbe(ctx context.Context, api sandboxAPI, m *metrics, pool, nonce string, execTimeoutSec int) probeResult {
+	id, err := observe(m, phaseCreate, func() (string, error) {
+		return api.Create(ctx, pool)
+	})
+	if err != nil {
+		return probeResult{Phase: phaseCreate, OK: false, Err: fmt.Errorf("create sandbox from template %q: %w", pool, err)}
+	}
+	// Once a sandbox exists, always reap it: a cancelled cycle context must not
+	// leave a live sandbox behind.
+	defer reap(api, m, id)
+
+	out, err := observe(m, phaseExec, func() (agentcli.ExecResult, error) {
+		return api.Exec(ctx, id, "echo "+nonce, execTimeoutSec)
+	})
+	if err != nil {
+		return probeResult{Phase: phaseExec, OK: false, Err: fmt.Errorf("exec in sandbox %s: %w", id, err)}
+	}
+
+	// Verify: the nonce we sent must come back, proving the exec actually ran in
+	// the guest rather than a proxy returning an empty 200.
+	ok := strings.Contains(out.Stdout, nonce) && out.ExitCode == 0
+	m.probeTotal.WithLabelValues(string(phaseVerify), resultLabel(ok)).Inc()
+	if !ok {
+		return probeResult{
+			Phase: phaseVerify,
+			OK:    false,
+			Err:   fmt.Errorf("canary nonce did not round-trip (exit=%d): the sandbox exec path is not returning guest output", out.ExitCode),
+		}
+	}
+	return probeResult{Phase: phaseVerify, OK: true}
+}
+
+// reap terminates a probe's sandbox on a fresh, bounded context so cleanup runs
+// even when the cycle context was already cancelled. Failures are recorded in
+// metrics (a rising terminate-failure counter means leaked sandboxes) but never
+// abort the caller.
+func reap(api sandboxAPI, m *metrics, id string) {
+	ctx, cancel := context.WithTimeout(context.Background(), reapTimeout)
+	defer cancel()
+	_, _ = observe(m, phaseTerminate, func() (struct{}, error) {
+		return struct{}{}, api.Terminate(ctx, id)
+	})
+}

--- a/cmd/mitos-canary/probe_test.go
+++ b/cmd/mitos-canary/probe_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"mitos.run/mitos/internal/agentcli"
+)
+
+// fakeAPI is a scriptable sandboxAPI. Each phase can be told to fail, and it
+// records the calls it saw so tests can assert cleanup happened.
+type fakeAPI struct {
+	createErr     error
+	createID      string
+	execErr       error
+	execOut       agentcli.ExecResult
+	echoBackNonce bool // when true, Exec returns the nonce it was asked to echo (exit 0)
+	terminateErr  error
+
+	created    int
+	execed     int
+	terminated int
+	lastCmd    string
+}
+
+func (f *fakeAPI) Create(context.Context, string) (string, error) {
+	f.created++
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	id := f.createID
+	if id == "" {
+		id = "sbx-test"
+	}
+	return id, nil
+}
+
+func (f *fakeAPI) Exec(_ context.Context, _, command string, _ int) (agentcli.ExecResult, error) {
+	f.execed++
+	f.lastCmd = command
+	if f.execErr != nil {
+		return agentcli.ExecResult{}, f.execErr
+	}
+	if f.echoBackNonce {
+		// Mimic `echo <nonce>`: stdout is the argument after "echo ".
+		return agentcli.ExecResult{ExitCode: 0, Stdout: strings.TrimPrefix(command, "echo ") + "\n"}, nil
+	}
+	return f.execOut, nil
+}
+
+func (f *fakeAPI) Terminate(context.Context, string) error {
+	f.terminated++
+	return f.terminateErr
+}
+
+func newTestMetrics(t *testing.T) *metrics {
+	t.Helper()
+	return newMetrics(prometheus.NewRegistry())
+}
+
+func TestRunProbeSuccess(t *testing.T) {
+	f := &fakeAPI{echoBackNonce: true}
+	m := newTestMetrics(t)
+
+	res := runProbe(context.Background(), f, m, "python", "canary-abc123", 30)
+
+	if !res.OK {
+		t.Fatalf("expected success, got failure at %s: %v", res.Phase, res.Err)
+	}
+	if res.Phase != phaseVerify {
+		t.Errorf("success phase = %s, want %s", res.Phase, phaseVerify)
+	}
+	if f.created != 1 || f.execed != 1 || f.terminated != 1 {
+		t.Errorf("call counts create=%d exec=%d terminate=%d, want 1/1/1", f.created, f.execed, f.terminated)
+	}
+	if !strings.Contains(f.lastCmd, "canary-abc123") {
+		t.Errorf("exec command %q did not carry the nonce", f.lastCmd)
+	}
+	if got := testutil.ToFloat64(m.up); got != 1 {
+		t.Errorf("mitos_canary_up = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.lastSuccess); got == 0 {
+		t.Error("last-success timestamp was not set on a green cycle")
+	}
+}
+
+func TestRunProbeCreateFailsNoTerminate(t *testing.T) {
+	f := &fakeAPI{createErr: errors.New("fork_unavailable")}
+	m := newTestMetrics(t)
+
+	res := runProbe(context.Background(), f, m, "python", "canary-x", 30)
+
+	if res.OK {
+		t.Fatal("expected failure when create fails")
+	}
+	if res.Phase != phaseCreate {
+		t.Errorf("failure phase = %s, want %s", res.Phase, phaseCreate)
+	}
+	if f.execed != 0 {
+		t.Error("exec should not run after a failed create")
+	}
+	if f.terminated != 0 {
+		t.Error("terminate should not run when no sandbox was created")
+	}
+	if got := testutil.ToFloat64(m.up); got != 0 {
+		t.Errorf("mitos_canary_up = %v, want 0", got)
+	}
+}
+
+func TestRunProbeExecFailsStillTerminates(t *testing.T) {
+	f := &fakeAPI{execErr: errors.New("exec stream closed")}
+	m := newTestMetrics(t)
+
+	res := runProbe(context.Background(), f, m, "python", "canary-x", 30)
+
+	if res.OK || res.Phase != phaseExec {
+		t.Fatalf("expected exec-phase failure, got ok=%v phase=%s", res.OK, res.Phase)
+	}
+	if f.terminated != 1 {
+		t.Error("sandbox must be terminated even when exec fails, to avoid leaks")
+	}
+}
+
+func TestRunProbeVerifyFailsOnMissingNonce(t *testing.T) {
+	// Exec succeeds at the transport level but returns the wrong output: the
+	// exec path is broken even though create/exec did not error.
+	f := &fakeAPI{execOut: agentcli.ExecResult{ExitCode: 0, Stdout: "unrelated\n"}}
+	m := newTestMetrics(t)
+
+	res := runProbe(context.Background(), f, m, "python", "canary-abc123", 30)
+
+	if res.OK || res.Phase != phaseVerify {
+		t.Fatalf("expected verify-phase failure, got ok=%v phase=%s", res.OK, res.Phase)
+	}
+	if f.terminated != 1 {
+		t.Error("sandbox must be terminated after a verify failure")
+	}
+}
+
+func TestRunProbeVerifyFailsOnNonzeroExit(t *testing.T) {
+	// The nonce is present but the command reported a non-zero exit.
+	f := &fakeAPI{execOut: agentcli.ExecResult{ExitCode: 7, Stdout: "canary-abc123\n"}}
+	m := newTestMetrics(t)
+
+	res := runProbe(context.Background(), f, m, "python", "canary-abc123", 30)
+
+	if res.OK || res.Phase != phaseVerify {
+		t.Fatalf("expected verify-phase failure on non-zero exit, got ok=%v phase=%s", res.OK, res.Phase)
+	}
+}
+
+func TestRunProbeTerminateFailureDoesNotFailCycle(t *testing.T) {
+	// The user-facing path (create, exec, verify) works; only cleanup fails.
+	// The cycle stays green because a fork/exec worked; the leak is visible via
+	// the terminate failure counter, not by marking the platform down.
+	f := &fakeAPI{echoBackNonce: true, terminateErr: errors.New("terminate 500")}
+	m := newTestMetrics(t)
+
+	res := runProbe(context.Background(), f, m, "python", "canary-abc123", 30)
+
+	if !res.OK {
+		t.Fatalf("terminate-only failure should not fail the cycle, got failure at %s: %v", res.Phase, res.Err)
+	}
+	got := testutil.ToFloat64(m.probeTotal.WithLabelValues(string(phaseTerminate), "failure"))
+	if got != 1 {
+		t.Errorf("terminate failure counter = %v, want 1", got)
+	}
+}
+
+func TestHealthLiveness(t *testing.T) {
+	h := &health{stalenessWindow: 50 * time.Millisecond}
+
+	// Before the first tick, liveness is true (still starting up).
+	if !h.live() {
+		t.Error("expected live before first tick")
+	}
+	if h.isReady() {
+		t.Error("expected not-ready before first cycle")
+	}
+
+	h.tick()
+	h.ready()
+	if !h.live() {
+		t.Error("expected live right after a tick")
+	}
+	if !h.isReady() {
+		t.Error("expected ready after first cycle")
+	}
+
+	// Force the tick to be stale.
+	h.mu.Lock()
+	h.lastTick = time.Now().Add(-time.Second)
+	h.mu.Unlock()
+	if h.live() {
+		t.Error("expected not-live when the loop has not ticked within the staleness window")
+	}
+}

--- a/deploy/charts/mitos/templates/canary.yaml
+++ b/deploy/charts/mitos/templates/canary.yaml
@@ -1,0 +1,150 @@
+{{- if .Values.canary.enabled }}
+# Synthetic canary: continuously exercises the full user-facing sandbox path
+# (auth -> gateway -> controller -> forkd -> fork -> exec -> terminate) with the
+# same HostedBackend the SDKs use, and exports the result as Prometheus metrics.
+# When a real user would get fork_unavailable, the canary sees it first and
+# mitos_canary_up drops to 0. Opt-in via canary.enabled: it needs a scoped API
+# key, so it stays off for a default self-hosted install until an operator wires
+# the secret below.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mitos-canary
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: canary
+spec:
+  # Exactly one canary: a second would double the synthetic load and split the
+  # up signal. The probe is stateless, so a restart just resumes probing.
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mitos.selectorLabels" (dict "root" . "component" "canary") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mitos.selectorLabels" (dict "root" . "component" "canary") | nindent 8 }}
+      annotations:
+        # Fallback scrape path for prometheus.io/scrape-style discovery. Clusters
+        # running the Prometheus Operator use the ServiceMonitor below instead.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.canary.metricsPort | quote }}
+        prometheus.io/path: "/metrics"
+    spec:
+      {{- include "mitos.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: canary
+          image: {{ include "mitos.image" (dict "root" . "image" .Values.canary.image) }}
+          imagePullPolicy: {{ .Values.canary.image.pullPolicy }}
+          args:
+            - --listen=:{{ .Values.canary.metricsPort }}
+            - --pool={{ .Values.canary.pool }}
+            - --interval={{ .Values.canary.interval }}
+            - --exec-timeout={{ .Values.canary.execTimeoutSeconds }}
+            - --cycle-timeout={{ .Values.canary.cycleTimeout }}
+            {{- if .Values.canary.baseURL }}
+            - --base-url={{ .Values.canary.baseURL }}
+            {{- end }}
+            - --api-key-file=/etc/mitos-canary/api-key
+          env:
+            # Let HostedBackend resolve the in-cluster gateway automatically when
+            # no explicit base URL is set. The gateway Service injects
+            # MITOS_GATEWAY_SERVICE_HOST/PORT into pods in its namespace.
+            - name: MITOS_CANARY_STALENESS
+              value: {{ .Values.canary.stalenessWindow | quote }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.canary.metricsPort }}
+          resources:
+            {{- toYaml .Values.canary.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          # Liveness is loop-alive only: a platform outage keeps the loop ticking
+          # and exporting mitos_canary_up=0, so it must NOT restart the pod (that
+          # would lose the very metrics the alerts read). /healthz fails only when
+          # the probe loop itself wedges.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: api-key
+              mountPath: /etc/mitos-canary
+              readOnly: true
+      volumes:
+        - name: api-key
+          secret:
+            # A scoped mitos_live_ token under the key `api-key`. Create it out of
+            # band (or via canary.apiKey below) so the token never lands in
+            # values or git.
+            secretName: {{ .Values.canary.apiKeySecretName }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mitos-canary
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: canary
+spec:
+  selector:
+    {{- include "mitos.selectorLabels" (dict "root" . "component" "canary") | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.canary.metricsPort }}
+      targetPort: metrics
+{{- if and .Values.canary.apiKey (not .Values.canary.apiKeySecretExternal) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.canary.apiKeySecretName }}
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: canary
+type: Opaque
+stringData:
+  api-key: {{ .Values.canary.apiKey | quote }}
+{{- end }}
+{{- if and .Values.canary.serviceMonitor.enabled .Values.monitoring.enabled }}
+---
+# ServiceMonitor for clusters running the Prometheus Operator. Selected by the
+# operator via the release label, same convention as the PrometheusRule.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mitos-canary
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: canary
+    release: {{ .Values.monitoring.prometheusRuleRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mitos.selectorLabels" (dict "root" . "component" "canary") | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.canary.serviceMonitor.interval }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/mitos/templates/monitoring-prometheusrule.yaml
+++ b/deploy/charts/mitos/templates/monitoring-prometheusrule.yaml
@@ -130,4 +130,61 @@ spec:
               is {{`{{ printf "%.1f" $value }}`}}s over 10m, sustained for 15m.
               Deficit nodes are pulling the snapshot slowly from a holder; check CAS
               bandwidth and holder load. Populated only on the multi-node path.
+{{- if .Values.canary.enabled }}
+
+    - name: mitos-canary
+      rules:
+        - alert: CanaryDown
+          # The synthetic canary's last full cycle (create, exec, verify) failed.
+          # This is the closest signal to "a real user cannot fork right now": it
+          # rides the same HostedBackend path the SDKs use.
+          expr: |
+            mitos_canary_up == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Synthetic canary cannot fork and exec a sandbox"
+            description: >
+              The mitos canary's last full cycle failed for 5m: create, exec, or
+              output verification did not succeed against the live gateway. A real
+              user would see fork_unavailable or a broken exec right now. Check
+              the warm pool, forkd readiness, and the gateway before customers do.
+            runbook_url: "https://github.com/mitos-run/mitos/blob/main/docs/runbooks/CanaryDown.md"
+
+        - alert: CanaryStale
+          # No successful cycle for 15m even if up briefly flapped: the canary is
+          # either wedged or the path has been failing the whole window.
+          expr: |
+            time() - mitos_canary_last_success_timestamp_seconds > 900
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Synthetic canary has had no successful cycle for 15m"
+            description: >
+              The mitos canary has not completed a green cycle in over 15m. Either
+              the probe loop is wedged (the pod should have restarted; check its
+              liveness) or the sandbox path has been failing the whole window.
+              Treat as a user-facing outage until proven otherwise.
+            runbook_url: "https://github.com/mitos-run/mitos/blob/main/docs/runbooks/CanaryDown.md"
+
+        - alert: CanarySandboxLeak
+          # The user path works but cleanup keeps failing: the canary is leaking
+          # sandboxes every cycle. Not user-facing, but it accumulates cost and
+          # eventually exhausts capacity.
+          expr: |
+            sum(rate(mitos_canary_probe_total{phase="terminate",result="failure"}[15m])) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Canary is leaking sandboxes (terminate keeps failing)"
+            description: >
+              The canary's terminate step has been failing for 30m, so every
+              cycle leaks a sandbox. The fork path still works, but leaked
+              sandboxes accumulate cost and can exhaust capacity. Check the
+              terminate/DELETE path and reap any orphaned canary sandboxes.
+            runbook_url: "https://github.com/mitos-run/mitos/blob/main/docs/runbooks/CanaryDown.md"
+{{- end }}
 {{- end }}

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -229,6 +229,59 @@ facade:
       memory: "256Mi"
       cpu: "500m"
 
+# Synthetic canary (Deployment): continuously forks and execs a sandbox through
+# the same HostedBackend the SDKs use, and exports mitos_canary_up plus per-phase
+# metrics. Opt-in: it needs a scoped API key, so it stays off until an operator
+# supplies one (canary.apiKey or a pre-created secret named by apiKeySecretName).
+canary:
+  # Gate the whole canary (Deployment, Service, ServiceMonitor, optional Secret).
+  enabled: false
+  image:
+    repository: mitos-canary
+    tag: ""
+    pullPolicy: IfNotPresent
+  # Template the canary forks each cycle. Must be a template the server can build
+  # on demand; the first cycle warms it. Keep it small for a fast, cheap probe.
+  pool: python
+  # Time between probe cycles.
+  interval: 60s
+  # Per-exec timeout, seconds.
+  execTimeoutSeconds: 30
+  # Whole-cycle deadline (create, exec, verify, terminate).
+  cycleTimeout: 120s
+  # Liveness fails if the probe loop has not ticked within this window (roughly
+  # three intervals): the loop is wedged and the pod should restart. A platform
+  # outage does NOT trip this; it keeps ticking and exporting up=0.
+  stalenessWindow: 3m
+  # Container port for /metrics, /healthz, /readyz.
+  metricsPort: 9102
+  # API base URL. Leave empty to auto-resolve the in-cluster gateway (tests the
+  # control plane). Set to https://api.mitos.run to probe the full external path
+  # including ingress and TLS.
+  baseURL: ""
+  # Name of the Secret holding the api key under the key `api-key`.
+  apiKeySecretName: mitos-canary-api-key
+  # When true, the Secret is assumed to exist already (created out of band) and
+  # the chart never renders it. When false and apiKey is set below, the chart
+  # renders the Secret. Leave apiKey empty and this false to supply the Secret
+  # yourself without the chart touching it.
+  apiKeySecretExternal: false
+  # A scoped mitos_live_ token. Prefer leaving this empty and creating the Secret
+  # out of band (GitOps sealed-secret, external-secrets, or kubectl) so the token
+  # never lands in values or git. Set only for a quick local install.
+  apiKey: ""
+  serviceMonitor:
+    # Render a ServiceMonitor (needs the Prometheus Operator and monitoring.enabled).
+    enabled: true
+    interval: 30s
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "250m"
+
 # Monitoring artifacts: the PrometheusRule and the Grafana dashboard ConfigMap.
 # Opt-in; requires the Prometheus Operator CRDs and a Grafana sidecar.
 monitoring:

--- a/docs/runbooks/CanaryDown.md
+++ b/docs/runbooks/CanaryDown.md
@@ -1,0 +1,91 @@
+# Runbook: CanaryDown (and CanaryStale, CanarySandboxLeak)
+
+## Signal
+
+- **CanaryDown**: `mitos_canary_up == 0` sustained for 5m.
+- **CanaryStale**: `time() - mitos_canary_last_success_timestamp_seconds > 900`
+  (no green cycle for 15m) sustained for 5m.
+- **CanarySandboxLeak**: `rate(mitos_canary_probe_total{phase="terminate",result="failure"}[15m]) > 0`
+  sustained for 30m.
+
+The synthetic canary (`cmd/mitos-canary`, deployed as the `mitos-canary`
+Deployment) runs one cycle every `canary.interval`: it forks a sandbox from the
+`canary.pool` template, execs `echo <nonce>`, verifies the nonce round-trips
+with a zero exit code, then terminates the sandbox. It uses the exact
+`HostedBackend` the SDKs use, so it fails the same way a customer would. This is
+the closest signal to "a real user cannot fork right now".
+
+`mitos_canary_up` is 1 only when the last full cycle passed create, exec, and
+verify. It does NOT include terminate: a cleanup failure surfaces as
+CanarySandboxLeak instead, because the user-facing fork path still worked.
+
+## Liveness vs platform health
+
+The canary's own `/healthz` (liveness) reports only whether the probe LOOP is
+alive, never platform health. A real outage keeps the loop ticking and exporting
+`mitos_canary_up=0`, and must NOT crash-loop the canary pod, or we lose the very
+metrics these alerts read. So:
+
+- Canary pod restarting or CrashLooping -> the canary itself is broken (bad api
+  key, unreachable gateway at startup, config). Fix the canary.
+- Canary pod healthy but `mitos_canary_up=0` -> the PLATFORM path is broken.
+  Follow the diagnosis below; do not restart the canary.
+
+## Likely causes (CanaryDown / CanaryStale)
+
+Read `mitos_canary_probe_total{phase,result}` to see which phase fails:
+
+- **phase=create failing**: the fork path is down. Warm pool starved, forkd not
+  Ready, controller not placing claims, or the template cannot build. This is
+  the same condition a user sees as `fork_unavailable`. Cross-check
+  `WarmPoolStarved`, `ClaimsPendingSustained`, `ClaimErrorRateHigh`.
+- **phase=exec failing**: fork works but the exec path is broken. Gateway ->
+  forkd :9091 -> vsock -> guest agent. Check forkd HTTP health and the guest
+  agent.
+- **phase=verify failing** (create + exec returned but the nonce did not
+  round-trip): the exec path is returning empty or wrong output, e.g. a proxy
+  answering 200 without reaching the guest. Check the gateway routing and the
+  guest agent exec stream.
+- **Canary pod not Running / not Ready**: a bad or expired api key, or the
+  gateway was unreachable. Check the pod and its logs (secret values are never
+  logged; look for the phase and the redacted cause).
+
+## Diagnosis
+
+- `kubectl -n mitos get deploy,pod -l app.kubernetes.io/component=canary` and
+  `kubectl -n mitos logs deploy/mitos-canary` (the per-cycle log names the failing
+  phase and a redacted cause).
+- Which phase: `sum by (phase,result) (rate(mitos_canary_probe_total[10m]))`.
+- Latency by phase: `histogram_quantile(0.95, sum by (le,phase) (rate(mitos_canary_probe_duration_seconds_bucket[10m])))`.
+- Confirm it is platform-wide, not canary-only: try the same path yourself with
+  the SDK or `mitos sandbox create --pool <canary.pool>` against the gateway. If
+  you also get `fork_unavailable`, it is the platform.
+- Check the dependencies the canary rides: forkd readiness
+  (`kubectl -n mitos get pods -l app.kubernetes.io/component=forkd`), the warm
+  pool (`WarmPoolStarved`), the gateway, and the account/auth service (a create
+  starts with auth).
+
+## Remediation
+
+- create failing: restore the warm pool and forkd (see `WarmPoolStarved` and
+  `ClaimsPendingSustained` runbooks); confirm at least one KVM node is Ready.
+- exec/verify failing: check forkd :9091 and the guest agent; restart the
+  affected forkd if a node is wedged.
+- Canary pod broken: rotate/repair the api key secret
+  (`canary.apiKeySecretName`), confirm the gateway is reachable, redeploy.
+
+## CanarySandboxLeak
+
+The fork path works but terminate keeps failing, so every cycle leaks a
+sandbox. Not user-facing, but it accumulates cost and can exhaust capacity.
+
+- Check the terminate/DELETE path: `mitos_canary_probe_total{phase="terminate",result="failure"}`.
+- List and reap orphaned canary sandboxes: `mitos sandbox ls` (or the hosted
+  dashboard) and terminate leftovers. The GC's orphan sweep also reaps them; a
+  concurrent `OrphanSweepSpike` is expected while this fires.
+
+## Escalation
+
+If create failures trace to snapshot builds or KVM with no obvious node cause,
+escalate to the `internal/fork` / `internal/firecracker` on-call (snapshot build
+path, security-sensitive).


### PR DESCRIPTION
Part of #579 (production hardening), item 1: a synthetic canary plus alerting.

## Summary

Adds `cmd/mitos-canary`, a synthetic probe that continuously exercises the full user-facing sandbox path (auth, gateway, controller, forkd, fork, exec, verify, terminate) using the same `internal/agentcli` `HostedBackend` the SDKs use, and exports the result as Prometheus metrics. When a real user would get `fork_unavailable`, the canary sees it first and `mitos_canary_up` drops to 0.

Each cycle:
1. forks a sandbox from the `canary.pool` template,
2. execs `echo <per-cycle-nonce>`,
3. verifies the nonce round-trips with a zero exit code (proving real guest output, not a proxy 200),
4. terminates the sandbox (always, once one exists, so the canary never leaks).

Metrics: `mitos_canary_up`, `mitos_canary_last_success_timestamp_seconds`, `mitos_canary_consecutive_failures`, and per-phase `mitos_canary_probe_total{phase,result}` / `mitos_canary_probe_duration_seconds{phase}`.

Deploy (all opt-in): chart component gated by `canary.enabled` (Deployment + Service + optional ServiceMonitor, api key mounted from a Secret), a `mitos-canary` alert group in the PrometheusRule (`CanaryDown`, `CanaryStale`, `CanarySandboxLeak`), a runbook, `Dockerfile.canary`, and the CI + publish image wiring.

## Thinking Path

The onboarding-to-fork chain broke in production in ways whose symptom was far from the cause (a full data dir surfaced only as a generic `fork_unavailable`). The fix for that class is not another point patch but a probe that rides the exact customer path and fails the same way a customer would, so we detect it before customers do rather than through a privileged health check that stays green while the real path is broken.

Key design decisions:
- **Reuse `HostedBackend`**, not a bespoke client: the canary must fail identically to the SDKs, including auth and gateway routing.
- **Verify the nonce round-trips**: a create+exec that returns an empty 200 (proxy answered, guest never ran) must count as a failure, so the probe checks the exact nonce and the exit code, not just the absence of a transport error.
- **Liveness is loop-alive only, never platform health.** A platform outage keeps the loop ticking and exporting `up=0`; if `/healthz` reported platform health, Kubernetes would crash-loop the canary during the exact outage we need it to report, losing the metrics. So `/healthz` fails only when the probe loop itself wedges (no tick within ~3 intervals); platform health lives in `mitos_canary_up` and the alerts.
- **Terminate failure does not fail the cycle.** The fork path worked; a cleanup failure is a leak, surfaced by `CanarySandboxLeak`, not a user-facing outage.
- **Opt-in.** It needs a scoped api key, so it stays off for a default self-hosted install until an operator wires the Secret; the community install stays clean with no dead config.

## Verification

- `go test ./cmd/mitos-canary/`: ok. Tests cover every phase outcome (create/exec/verify/terminate), the missing-nonce and non-zero-exit verify failures, the terminate-failure-does-not-fail-cycle rule, liveness staleness, and config resolution (env, flag override, api-key-file, validation).
- `go vet ./cmd/mitos-canary/`: clean.
- `golangci-lint run` and `GOOS=linux golangci-lint run` on the package: clean.
- `gofmt -l`: clean. No em or en dashes in any added file.
- Native and `GOOS=linux GOARCH=amd64` builds of the binary: OK.
- `helm lint deploy/charts/mitos`: 0 failed. `helm template` with `canary.enabled=true monitoring.enabled=true` renders the Deployment, Service, ServiceMonitor, PrometheusRule, and Secret; the api key appears exactly once (in the Secret, never in args or env).
- `promtool check rules` on the rendered PrometheusRule groups: SUCCESS, 9 rules (including the 3 canary alerts).

## Model Used

Claude Opus 4.8 (1M context).