### PR TITLE
feat(monitoring): scrape control-plane metrics via PodMonitors

### DIFF
--- a/deploy/charts/mitos/templates/monitoring-podmonitors.yaml
+++ b/deploy/charts/mitos/templates/monitoring-podmonitors.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.podMonitors.enabled }}
+# PodMonitors for the control-plane components that export the metrics the
+# PrometheusRule alerts on (mitos_claim_*, mitos_pool_*, mitos_fork_* from the
+# controller and forkd). Without these, a Prometheus Operator scrapes nothing
+# from mitos (it does NOT honor the prometheus.io/scrape pod annotations), so the
+# alert rules would evaluate on absent series and never fire. PodMonitors are
+# used rather than ServiceMonitors because neither the controller Deployment nor
+# the forkd DaemonSet fronts its metrics port with a Service; both expose a named
+# `metrics` container port that a PodMonitor scrapes directly.
+#
+# Both endpoints are plain HTTP: the controller runs controller-runtime metrics
+# with no secure serving, and forkd's :9091 is the plaintext operational mux.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mitos-controller
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+    # Selected by a Prometheus Operator configured to match this release label,
+    # the same convention as the PrometheusRule.
+    release: {{ .Values.monitoring.prometheusRuleRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mitos.selectorLabels" (dict "root" . "component" "controller") | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.monitoring.podMonitors.interval }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mitos-forkd
+  namespace: {{ include "mitos.namespace" . }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+    release: {{ .Values.monitoring.prometheusRuleRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mitos.selectorLabels" (dict "root" . "component" "forkd") | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.monitoring.podMonitors.interval }}
+{{- end }}

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -232,10 +232,17 @@ facade:
 # Monitoring artifacts: the PrometheusRule and the Grafana dashboard ConfigMap.
 # Opt-in; requires the Prometheus Operator CRDs and a Grafana sidecar.
 monitoring:
-  # Gate both the PrometheusRule and the dashboard ConfigMap.
+  # Gate the PrometheusRule, the dashboard ConfigMap, and the PodMonitors.
   enabled: false
   # Label value selected by the Prometheus Operator ruleSelector for the rule.
   prometheusRuleRelease: prometheus
+  # PodMonitors that make the control-plane metrics the alerts depend on actually
+  # get scraped. A Prometheus Operator does NOT honor prometheus.io/scrape pod
+  # annotations, so without these the alert rules evaluate on absent series.
+  podMonitors:
+    # Render PodMonitors for the controller and forkd (needs monitoring.enabled).
+    enabled: true
+    interval: 30s
 
 # Namespace the workloads install into.
 namespace:


### PR DESCRIPTION
Part of #579 (production hardening): make the alerting real in prod.

## Summary

The chart already renders a PrometheusRule with alerts on `mitos_claim_*`, `mitos_pool_*`, and `mitos_fork_*`, but **nothing was scraping those series**. Neither the controller Deployment nor the forkd DaemonSet fronts its metrics port with a Service, and a Prometheus Operator (kube-prometheus-stack) does not honor the `prometheus.io/scrape` pod annotations the chart set. So the alert rules evaluated on absent series and could never fire: the whole alerting story was decorative in a prod cluster.

This adds PodMonitors for the controller and forkd, gated by `monitoring.enabled` plus a new `monitoring.podMonitors` toggle, selected by the same `release` label as the PrometheusRule.

## Thinking Path

While wiring the synthetic canary (#580) I traced how its `CanaryDown` alert would actually reach Prometheus in prod and found the gap: the mitos control plane is not scraped at all. The existing alerts have been shipping green-by-absence.

- **PodMonitor, not ServiceMonitor**: both components expose only a named `metrics` container port with no fronting Service (only console and gateway have Services, and neither exposes metrics). A PodMonitor scrapes the pods directly with no new Service.
- **Plain HTTP is safe here**: the controller runs controller-runtime metrics with no secure serving (`metricsserver.Options{BindAddress}` only), and forkd's `:9091` is documented as the plaintext operational mux, so no TLS/bearer config is needed on the scrape.
- **Same `release` label convention** as the PrometheusRule, so an operator already selecting the mitos rules picks these up with no extra config.
- **Opt-in and off by default**, consistent with the rest of the monitoring block; a default self-hosted install renders nothing new.

## Verification

- `helm lint deploy/charts/mitos`: 0 failed.
- `helm template --set monitoring.enabled=true` renders both PodMonitors with the correct selectors (`app.kubernetes.io/component: controller|forkd`), the `metrics` port, `/metrics` path, and the `release` label.
- `helm template` with monitoring off (the default) renders zero PodMonitors.
- No em or en dashes in any changed file.

## Model Used

Claude Opus 4.8 (1M context).