### PR TITLE
fix(firecracker): normalize template artifact ownership after the jailed build

### DIFF
--- a/internal/firecracker/template.go
+++ b/internal/firecracker/template.go
@@ -523,6 +523,15 @@ func (tm *TemplateManager) CreateTemplate(id string, cfg VMConfig, initCommands 
 		return nil, fmt.Errorf("sync snapshot vmstate file: %w", err)
 	}
 
+	// Hand the canonical template tree back to the daemon before the caller
+	// records its digest: the jailed build flips artifact ownership to the
+	// per-VM jailed uid, which the husk VMM cannot open (#583, see
+	// normalizeTemplateArtifacts). A template that fails normalization must
+	// never be registered or marked verified.
+	if err := normalizeTemplateArtifacts(workDir); err != nil {
+		return nil, fmt.Errorf("normalize template artifact ownership: %w", err)
+	}
+
 	// Get snapshot size
 	memInfo, err := os.Stat(memFile)
 	if err != nil {
@@ -539,6 +548,45 @@ func (tm *TemplateManager) CreateTemplate(id string, cfg VMConfig, initCommands 
 		CreationTimeMs: float64(elapsed.Milliseconds()),
 		SnapshotSize:   memInfo.Size(),
 	}, nil
+}
+
+// normalizeTemplateArtifacts hands every file under the canonical template
+// tree back to the daemon's own uid/gid with world-readable modes (files
+// 0o644, dirs 0o755) after the jailed build VM is done with it.
+//
+// Why this exists (#583): in jailer mode the build hardlinks the canonical
+// rootfs into the per-VM chroot and chownIntoJail flips the SHARED inode to
+// the jailed uid; it must, because the deprivileged build VM writes the
+// rootfs. The snapshot mem and vmstate are likewise created inside the jail
+// and hardlinked out still owned by the jailed uid. Left that way, the husk
+// VMM (uid 0 with ALL capabilities dropped, so no CAP_DAC_OVERRIDE) fails
+// EACCES opening the rootfs O_RDWR at /snapshot/load and the warm pool
+// crashloops. The bug was latent while the data dir and the chroot base sat
+// on different filesystems: prepareChroot's EXDEV fallback copied instead of
+// hardlinking, so the chown hit the jail-private copy. Consolidating both
+// onto one filesystem made the hardlink succeed and unmasked it.
+//
+// Chowning to the daemon's own euid keeps this a no-op in non-jailed and
+// non-root paths (mock engine, unit tests) while restoring root ownership on
+// a production forkd.
+func normalizeTemplateArtifacts(root string) error {
+	uid, gid := os.Geteuid(), os.Getegid()
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		mode := os.FileMode(0o644)
+		if d.IsDir() {
+			mode = 0o755
+		}
+		if err := os.Chown(path, uid, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", path, err)
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("chmod %s: %w", path, err)
+		}
+		return nil
+	})
 }
 
 // DeleteTemplate removes a template and its snapshot files.

--- a/internal/firecracker/template_owner_test.go
+++ b/internal/firecracker/template_owner_test.go
@@ -1,0 +1,108 @@
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// The jailed build VM hardlinks the canonical template rootfs into its chroot
+// and chownIntoJail flips the SHARED inode to the per-VM jailed uid (it must:
+// the deprivileged build VM writes the rootfs during the build). Left that
+// way, the husk VMM (uid 0 with ALL capabilities dropped, so no
+// CAP_DAC_OVERRIDE) fails EACCES opening the rootfs O_RDWR at /snapshot/load
+// (#583). normalizeTemplateArtifacts is the correct-by-construction repair at
+// the end of CreateTemplate: every canonical template artifact is handed back
+// to the daemon's own uid with world-readable modes before the template can
+// be registered or digest-recorded.
+
+func TestNormalizeTemplateArtifactsResetsModes(t *testing.T) {
+	root := t.TempDir()
+	snapDir := filepath.Join(root, "snapshot")
+	if err := os.MkdirAll(snapDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	files := []string{
+		filepath.Join(root, "rootfs.ext4"),
+		filepath.Join(snapDir, "mem"),
+		filepath.Join(snapDir, "vmstate"),
+	}
+	for _, f := range files {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := normalizeTemplateArtifacts(root); err != nil {
+		t.Fatalf("normalizeTemplateArtifacts: %v", err)
+	}
+
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o644 {
+			t.Errorf("%s mode = %o, want 0644", f, got)
+		}
+		st := info.Sys().(*syscall.Stat_t)
+		if int(st.Uid) != os.Geteuid() || int(st.Gid) != os.Getegid() {
+			t.Errorf("%s owned %d:%d, want %d:%d", f, st.Uid, st.Gid, os.Geteuid(), os.Getegid())
+		}
+	}
+	for _, d := range []string{root, snapDir} {
+		info, err := os.Stat(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o755 {
+			t.Errorf("%s mode = %o, want 0755", d, got)
+		}
+	}
+}
+
+// Root-gated regression for the exact production failure: a hardlink of the
+// canonical rootfs chowned to a jailed uid flips the shared inode, and
+// normalization restores it. Requires CAP_CHOWN, so it runs only as root
+// (the KVM e2e runner); everywhere else it skips.
+func TestNormalizeTemplateArtifactsRestoresJailFlippedOwner(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to chown to a foreign uid")
+	}
+	root := t.TempDir()
+	rootfs := filepath.Join(root, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jail := t.TempDir()
+	link := filepath.Join(jail, "rootfs.ext4")
+	if err := os.Link(rootfs, link); err != nil {
+		t.Fatal(err)
+	}
+	// What chownIntoJail does to the build VM's chroot hardlink.
+	if err := os.Chown(link, 64000, 64000); err != nil {
+		t.Fatal(err)
+	}
+	st := statT(t, rootfs)
+	if st.Uid != 64000 {
+		t.Fatalf("precondition: shared inode not flipped (uid=%d)", st.Uid)
+	}
+
+	if err := normalizeTemplateArtifacts(root); err != nil {
+		t.Fatalf("normalizeTemplateArtifacts: %v", err)
+	}
+	st = statT(t, rootfs)
+	if int(st.Uid) != 0 || int(st.Gid) != 0 {
+		t.Errorf("rootfs owned %d:%d after normalize, want 0:0", st.Uid, st.Gid)
+	}
+}
+
+func statT(t *testing.T, path string) *syscall.Stat_t {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Sys().(*syscall.Stat_t)
+}


### PR DESCRIPTION
## Summary

Fixes #583: every hosted fork hung Pending because the python warm pool could not fill; every husk pod CrashLoopBackOff'd with Firecracker failing snapshot restore:

```
Block: Virtio backend error: Error manipulating the backing file: Permission denied (os error 13) /var/lib/mitos/templates/python/rootfs.ext4
```

## Root cause (proven on the prod node, not SELinux)

The node-level evidence sweep (cluster-ops `mitos-avc-diag`) ruled out both #583 suspects and found the real one:

- SELinux on the Talos KVM node is `enabled, permissive` with ZERO AVC denials across a live activation window; permissive cannot produce EACCES.
- The template hostPath mount is `ro=false`; not a mount-mode regression (an RO mount yields EROFS anyway).
- The canonical template artifacts were owned `64000:64000` mode `0644` with link count 2.

Mechanism: in jailer mode the build hardlinks the canonical `rootfs.ext4` into the per-VM chroot and `chownIntoJail` flips the SHARED inode to the jailed uid (it must: the deprivileged build VM writes the rootfs). The snapshot `mem`/`vmstate` are created inside the jail and hardlinked out with the same ownership. The husk VMM is uid 0 with ALL capabilities dropped, so it has no `CAP_DAC_OVERRIDE`: its `O_RDWR` open of the rootfs at `/snapshot/load` falls in the world class of `0644` and fails EACCES. Reads (mem, vmstate, `O_RDONLY`) keep working, which is why the failure appears only at the rootfs open.

Why it only broke now: the bug was latent behind `prepareChroot`'s EXDEV fallback. While `/var/lib/mitos` sat on its own tiny partition, the chroot hardlink crossed filesystems and fell back to a COPY, so the chown hit the jail-private copy. The prod data-dir consolidation put the data dir and chroot base on one filesystem; the hardlink started succeeding and every rebuilt template came out husk-unusable.

## What changed

- `normalizeTemplateArtifacts` (internal/firecracker/template.go): after the snapshot is settled and synced, hand the whole canonical template tree back to the daemon's own uid/gid, files `0o644`, dirs `0o755`. Called before CreateTemplate returns, so the caller can never digest-record or register a template the husk cannot open. Failure is fatal to the build.
- Chowning to the daemon's own euid keeps this a no-op for the mock engine and non-root test paths.

## Verification

- `go test ./internal/firecracker/` passes; new `TestNormalizeTemplateArtifactsResetsModes` plus a root-gated `TestNormalizeTemplateArtifactsRestoresJailFlippedOwner` that reproduces the exact hardlink+chown flip and asserts normalization repairs it (runs on the KVM CI runner; skips without root).
- `go vet` native and `GOOS=linux`; `gofmt` clean.
- Prod hypothesis test: chowning the live template back to `0:0` (cluster-ops `mitos-fix-template-owner`) took the pool from 8 CrashLoopBackOff husks to 10/10 Running with zero restarts, and the hosted onboarding snippet (signup, create, fork HTTP 201 Ready, exec `hello`) passes end to end.

## Reviewer note

`internal/firecracker` is a security-sensitive path and requires a named human reviewer before merge. Until this ships, any template rebuild on prod re-breaks the pool and cluster-ops `mitos-fix-template-owner` re-fixes it; #584 (controller-driven self-healing rebuild) builds on this so rebuilds become correct-by-construction and automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Thinking Path

The issue framed two suspects (SELinux label vs mount mode) on the premise that a uid 0 process cannot hit DAC EACCES. The node evidence sweep falsified both: SELinux is permissive with zero AVC denials, and the mount is read-write. That forced re-examining the premise; the husk container drops ALL capabilities, so uid 0 has no CAP_DAC_OVERRIDE and IS subject to permission bits. The on-disk state (owner 64000, link count 2) then pointed straight at the build jail's chownIntoJail on a hardlinked inode. The remaining question, why this ever worked, fell to prepareChroot's EXDEV copy fallback: the data-dir consolidation put the chroot base and the template dir on one filesystem, so the hardlink began succeeding and the latent flip became fatal. The fix normalizes ownership at the exact point the build stops needing jailed-uid access and before the template can be registered, which is the narrowest correct-by-construction seam; a mitigation op proved the mechanism on prod before this code was written.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.
