### PR TITLE
feat(sdk): one-import Daytona-compat shim (mitos.daytona) + migration doc

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -35,6 +35,7 @@ reaches the same native ops: `exec`, `run_code`, `files`, and `fork`.
 | From | How | Doc |
 |---|---|---|
 | E2B | one-import shim `from mitos.e2b import Sandbox` | [../migrating-from-e2b.md](../migrating-from-e2b.md) |
+| Daytona | one-import shim `from mitos.daytona import Daytona` | [../migrating-from-daytona.md](../migrating-from-daytona.md) |
 
 ## The honest Codex note
 

--- a/docs/migrating-from-daytona.md
+++ b/docs/migrating-from-daytona.md
@@ -1,0 +1,139 @@
+# Migrating from Daytona
+
+`mitos.daytona` is a one-way migration bridge for teams leaving Daytona for a
+SELF-HOSTED sandbox runtime. Daytona moved its runtime to a private codebase, so
+the open path many teams adopted is closed. The promise here is "change one
+import":
+
+```python
+# before
+from daytona import Daytona, CreateSandboxFromSnapshotParams
+# after
+from mitos.daytona import Daytona, CreateSandboxFromSnapshotParams
+```
+
+The shim presents Daytona's client and `Sandbox` surface over the standalone
+Mitos sandbox-server REST API (no Kubernetes required). It is an adapter over the
+native `DirectSandbox` surface, not a re-implementation, and it has no dependency
+on the `daytona` package. Most scripts run unchanged.
+
+## Why self-host
+
+- Your agents' code, data, and credentials run on infrastructure you control.
+- The runtime is open source under Apache-2.0, a license that cannot be revoked
+  on the code already released.
+- The same snapshot-fork engine, exec, files, and code-interpreter surface you
+  get from the native SDK, behind Daytona's method names. Plus `fork(n)`, which
+  Daytona does not have.
+
+## Quickstart
+
+Point the client at a sandbox-server you run (for example the local mock engine,
+`mitos dev up`, or a real KVM deployment):
+
+```python
+from mitos.daytona import Daytona, DaytonaConfig, CreateSandboxFromSnapshotParams
+
+daytona = Daytona(DaytonaConfig(api_url="http://localhost:8080"))
+sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="python"))
+
+# run a shell command
+response = sandbox.process.exec("echo hello", cwd="/workspace")
+print(response.result, response.exit_code)
+
+# run code in the stateful kernel
+run = sandbox.process.code_run("print(1 + 1)")
+print(run.result)
+
+# files
+sandbox.fs.upload_file(b"{}", "/tmp/data.json")
+print(sandbox.fs.download_file("/tmp/data.json"))
+sandbox.fs.create_folder("/tmp/out", "0755")
+
+# a signed preview URL for a guest port
+link = sandbox.get_preview_link(3000)
+print(link.url, link.token)
+
+# stop / start (pause / resume) and delete
+sandbox.stop()
+sandbox.start()
+daytona.delete(sandbox)
+```
+
+Auth resolves exactly like `mitos.create`: pass `api_key=` / `api_url=` on the
+`DaytonaConfig`, or set `MITOS_API_KEY` / `MITOS_BASE_URL`. The standalone server
+is tokenless and ignores the key; the hosted front door verifies the same header
+with no code change.
+
+## Reconnect and list
+
+```python
+sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="python"))
+again = daytona.get(sandbox.id)
+
+for s in daytona.list():
+    print(s.id)
+```
+
+`get` reattaches to a running sandbox by id; an unknown id raises the typed
+`NotFoundError`.
+
+## Support table
+
+Every Daytona verb the shim exposes, what it maps to, and whether it works today
+against the standalone sandbox-server.
+
+| Daytona verb | Mitos op | Status |
+|---|---|---|
+| `Daytona(config)` | hold `api_key` / `api_url` | Supported |
+| `daytona.create(params)` | `mitos.create` / `DirectSandbox` | Supported |
+| `daytona.get(id)` | `SandboxServer.list_sandboxes` lookup | Supported |
+| `daytona.list()` | `SandboxServer.list_sandboxes` | Supported |
+| `daytona.delete(sandbox)` | `DirectSandbox.terminate` | Supported |
+| `daytona.start(sandbox)` | `DirectSandbox.resume` | Supported |
+| `daytona.stop(sandbox)` | `DirectSandbox.pause` | Supported |
+| `sandbox.process.exec(cmd, cwd, env, timeout)` | `DirectSandbox.exec` | Supported (needs a guest agent) |
+| `sandbox.process.code_run(code, params, timeout)` | `DirectSandbox.run_code` | Supported (needs a guest agent) |
+| `sandbox.fs.upload_file(file, remote_path)` | `DirectSandbox.files.write` | Supported (needs a guest agent) |
+| `sandbox.fs.download_file(remote_path[, local_path])` | `DirectSandbox.files.read_bytes` | Supported (needs a guest agent) |
+| `sandbox.fs.list_files(path)` | `DirectSandbox.files.list` | Supported (needs a guest agent) |
+| `sandbox.fs.create_folder(path, mode)` | `DirectSandbox.files.mkdir` | Supported (needs a guest agent) |
+| `sandbox.fs.delete_file(path)` | `DirectSandbox.files.remove` | Supported (needs a guest agent) |
+| `sandbox.fs.get_file_info(path)` | `DirectSandbox.files.list` lookup | Supported (needs a guest agent) |
+| `sandbox.get_preview_link(port)` | preview URLs | Supported (needs the preview proxy deployed) |
+
+"needs a guest agent" means the op runs end-to-end only against a real guest over
+vsock (a KVM deployment, or `mitos dev up` with the engine). The bare mock-engine
+sandbox-server answers the create / get / list / delete / start / stop lifecycle
+but cannot run process / fs, which is why the test suite proves those against a
+fake target and runs them end-to-end in the KVM CI job.
+
+## The vocabulary renames
+
+- `fs.upload_file` / `fs.download_file` map onto `files.write` / `files.read`.
+- `fs.create_folder` maps onto `files.mkdir`; `fs.delete_file` onto `files.remove`.
+- `start` / `stop` map onto the native `resume` / `pause`.
+
+`DirectSandbox.exec` is shell based and takes no `cwd` / `env` argument, so
+`process.exec(cmd, cwd=..., env=...)` folds those into the command
+(`export K=V; cd DIR; CMD`) rather than dropping them. `env_vars` and `labels` on
+create are accepted for signature parity and not applied today (no server slot
+yet).
+
+## get_preview_link returns a signed preview URL
+
+`sandbox.get_preview_link(port)` returns a `PortPreviewUrl` with `.url` and
+`.token`, served by the per-sandbox preview reverse proxy. The server mints the
+URL (the signing secret stays server-side) and the token expires, so treat the
+URL value as a credential. A server that does not expose the preview proxy raises
+a typed `AgentRunError` from the call rather than fabricating a URL that would not
+resolve.
+
+## What you gain beyond Daytona parity
+
+The underlying `DirectSandbox` (reachable via `sandbox.sandbox`, also surfaced as
+`sandbox.fork(n)`) exposes a Mitos superpower Daytona does not: `fork(n)` for
+branching a warm, mid-task machine into many copies at fork(2) speeds, plus
+`pause` / `resume` and an interactive `pty`. The shim keeps your Daytona script
+working; reach for the fork when you want best-of-N, evals, or tree search from
+one shared starting state.

--- a/sdk/python/mitos/daytona.py
+++ b/sdk/python/mitos/daytona.py
@@ -1,0 +1,551 @@
+"""Daytona-compat shim: ``mitos.daytona``.
+
+A ONE-WAY migration bridge for teams leaving Daytona's cloud for a SELF-HOSTED
+sandbox runtime. Daytona moved its runtime to a private codebase; this shim lets
+a Daytona-style script keep running by changing one import:
+
+    # before
+    from daytona import Daytona, CreateSandboxFromSnapshotParams
+    # after
+    from mitos.daytona import Daytona, CreateSandboxFromSnapshotParams
+
+Like ``mitos.e2b``, this is an ADAPTER over the native ``DirectSandbox`` /
+``SandboxServer`` surface, not engine work and not a re-implementation. It has NO
+dependency on the ``daytona`` package and imports it NEVER. The class and
+namespace shapes (``daytona.create()``, ``sandbox.process.code_run``,
+``sandbox.fs.upload_file``, ``sandbox.get_preview_link``) mirror Daytona's object
+model so the import swap is the only change.
+
+Daytona verb -> mitos op (and whether it works TODAY against the standalone server):
+
+    Daytona(config)                  -> hold api_key + base_url            works today
+    daytona.create(params)           -> mitos.create() / DirectSandbox     works today
+    daytona.get(id)                  -> SandboxServer.list_sandboxes lookup works today
+    daytona.list()                   -> SandboxServer.list_sandboxes       works today
+    daytona.delete(sandbox)          -> DirectSandbox.terminate            works today
+    daytona.start(sandbox)           -> DirectSandbox.resume               works today
+    daytona.stop(sandbox)            -> DirectSandbox.pause                 works today
+    sandbox.process.exec(cmd, ...)   -> DirectSandbox.exec                 needs guest agent
+    sandbox.process.code_run(code)   -> DirectSandbox.run_code             needs guest agent
+    sandbox.fs.upload_file(...)      -> DirectSandbox.files.write          needs guest agent
+    sandbox.fs.download_file(...)    -> DirectSandbox.files.read_bytes     needs guest agent
+    sandbox.fs.list_files(path)      -> DirectSandbox.files.list           needs guest agent
+    sandbox.fs.create_folder(path)   -> DirectSandbox.files.mkdir          needs guest agent
+    sandbox.fs.delete_file(path)     -> DirectSandbox.files.remove         needs guest agent
+    sandbox.fs.get_file_info(path)   -> DirectSandbox.files.list (lookup)  needs guest agent
+    sandbox.get_preview_link(port)   -> DirectSandbox.get_host             works (proxy deployed)
+
+"works today" vs "needs guest agent": the create / get / list / delete /
+start / stop lifecycle answers on the bare mock-engine sandbox-server (no KVM).
+process / fs need a real guest agent over vsock, so they are proven against a
+fake target in the unit tests and run end-to-end in the KVM CI job; this exactly
+mirrors the E2B shim (``mitos.e2b``).
+
+``DirectSandbox.exec`` is shell based and takes no ``cwd`` / ``env`` argument, so
+Daytona's ``process.exec(cmd, cwd=..., env=...)`` folds those into the command
+(``export K=V; cd DIR; CMD``) rather than dropping them. ``env_vars`` / ``labels``
+on create are accepted for signature parity and not applied today (no server
+slot yet), the same honest stance the E2B shim takes for E2B's ``metadata``.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import shlex
+from typing import Any, List, Optional
+from urllib.parse import parse_qs, urlsplit
+
+from mitos.direct import DirectSandbox, SandboxServer, create as _create
+from mitos.errors import NotFoundError
+from mitos.types import FileInfo, Network
+
+
+def _create_direct(
+    image: str = "python",
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    id: Optional[str] = None,
+    network: Optional[Network] = None,
+) -> DirectSandbox:
+    """The single seam that builds a native ``DirectSandbox``.
+
+    Factored out so tests can patch it to a fake target and exercise the shim
+    without a server, the same pattern ``mitos.e2b`` uses."""
+    return _create(image, api_key=api_key, base_url=base_url, id=id, network=network)
+
+
+# --------------------------------------------------------------------------
+# Config + create params: Daytona's input shapes, accepted for parity.
+# --------------------------------------------------------------------------
+
+
+class DaytonaConfig:
+    """Daytona's ``DaytonaConfig``.
+
+    Holds the credentials the ``Daytona`` client uses. ``api_url`` is Daytona's
+    name for the server base; it maps onto the Mitos ``base_url``. Extra Daytona
+    fields (``target``, ``organization_id``, ...) are accepted and ignored so a
+    Daytona config literal constructs unchanged."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+        server_url: Optional[str] = None,
+        target: Optional[str] = None,
+        **_ignored: Any,
+    ):
+        self.api_key = api_key
+        # Daytona has used both api_url and server_url across versions; accept
+        # either and prefer api_url.
+        self.api_url = api_url or server_url
+        self.target = target
+
+
+class CreateSandboxBaseParams:
+    """Daytona's create-params shape.
+
+    Captures the fields a Mitos sandbox can honor (``language`` selects the
+    code_run default; ``image`` / ``snapshot`` name a base image) and accepts the
+    rest (``env_vars``, ``labels``, ``resources``, ...) for parity. ``env_vars``
+    and ``labels`` are held but not applied today (no server slot yet)."""
+
+    def __init__(
+        self,
+        language: str = "python",
+        image: Optional[str] = None,
+        snapshot: Optional[str] = None,
+        env_vars: Optional[dict[str, str]] = None,
+        labels: Optional[dict[str, str]] = None,
+        **_ignored: Any,
+    ):
+        self.language = language or "python"
+        self.image = image
+        self.snapshot = snapshot
+        self.env_vars = env_vars or {}
+        self.labels = labels or {}
+
+    def _image(self) -> str:
+        """The base image to create from: an explicit image / snapshot wins,
+        else fall back to the language name (Mitos resolves a default)."""
+        return self.image or self.snapshot or self.language or "python"
+
+
+# Daytona has shipped several names for the same input across versions. Alias
+# them all to the one base shape so any of these imports constructs unchanged.
+CreateSandboxFromSnapshotParams = CreateSandboxBaseParams
+CreateSandboxFromImageParams = CreateSandboxBaseParams
+CreateSandboxParams = CreateSandboxBaseParams
+
+
+class CodeRunParams:
+    """Daytona's ``CodeRunParams`` (``argv`` / ``env`` for a code_run).
+
+    Accepted for parity; ``env`` is folded into the run when given, ``argv`` is
+    held but not forwarded (Mitos run_code has no argv channel)."""
+
+    def __init__(
+        self,
+        argv: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+        **_ignored: Any,
+    ):
+        self.argv = argv or []
+        self.env = env or {}
+
+
+# --------------------------------------------------------------------------
+# Result shapes: Daytona's return objects, so caller code reads them unchanged.
+# --------------------------------------------------------------------------
+
+
+class ExecutionArtifacts:
+    """Daytona's ``ExecutionArtifacts``: ``stdout`` plus optional ``charts``.
+
+    Mitos does not parse matplotlib charts out of a plain exec, so ``charts`` is
+    ``None``; ``stdout`` mirrors ``ExecuteResponse.result``."""
+
+    def __init__(self, stdout: str = "", charts: Optional[list] = None):
+        self.stdout = stdout
+        self.charts = charts
+
+    def __repr__(self) -> str:
+        return f"ExecutionArtifacts(stdout={self.stdout!r})"
+
+
+class ExecuteResponse:
+    """Daytona's ``ExecuteResponse``: ``exit_code``, ``result``, ``artifacts``."""
+
+    def __init__(
+        self, exit_code: int, result: str, artifacts: Optional[ExecutionArtifacts] = None
+    ):
+        self.exit_code = exit_code
+        self.result = result
+        self.artifacts = artifacts
+
+    def __repr__(self) -> str:
+        return f"ExecuteResponse(exit_code={self.exit_code}, result={self.result!r})"
+
+
+class PortPreviewUrl:
+    """Daytona's ``get_preview_link`` return: ``url`` plus an access ``token``.
+
+    Mitos mints a single signed preview URL with the token embedded as a query
+    param; this surfaces both the full URL and the parsed token so Daytona code
+    reading ``.url`` / ``.token`` works unchanged."""
+
+    def __init__(self, url: str, token: str = ""):
+        self.url = url
+        self.token = token
+
+    def __repr__(self) -> str:
+        return f"PortPreviewUrl(url={self.url!r})"
+
+
+# --------------------------------------------------------------------------
+# Namespaces on a sandbox: process + fs, mirroring Daytona's object model.
+# --------------------------------------------------------------------------
+
+
+class Process:
+    """Daytona's ``sandbox.process`` namespace: ``exec`` and ``code_run``.
+
+    Maps onto ``DirectSandbox.exec`` / ``DirectSandbox.run_code``.
+
+    needs a guest agent: works end-to-end only against a real guest (proven
+    against a fake target in tests, run on KVM in CI)."""
+
+    def __init__(self, sandbox: DirectSandbox, language: str = "python"):
+        self._sb = sandbox
+        self._language = language
+
+    def exec(
+        self,
+        command: str,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        timeout: Optional[int] = None,
+    ) -> ExecuteResponse:
+        """Daytona ``process.exec(command, cwd, env, timeout)`` -> ``exec``.
+
+        ``DirectSandbox.exec`` is shell based and takes no ``cwd`` / ``env``, so
+        both are folded into the command (``export K=V; cd DIR; CMD``) rather
+        than silently dropped. Returns a Daytona ``ExecuteResponse``."""
+        full = self._wrap(command, cwd, env)
+        res = self._sb.exec(full, timeout=timeout if timeout is not None else 30)
+        return ExecuteResponse(
+            exit_code=res.exit_code,
+            result=res.stdout,
+            artifacts=ExecutionArtifacts(stdout=res.stdout, charts=None),
+        )
+
+    @staticmethod
+    def _wrap(
+        command: str, cwd: Optional[str], env: Optional[dict[str, str]]
+    ) -> str:
+        """Fold cwd / env into a single shell command.
+
+        env is exported and cwd is changed into before the command runs, so the
+        Daytona semantics survive even though the native exec has no slot for
+        them. Values are shell quoted."""
+        parts: list[str] = []
+        for k, v in (env or {}).items():
+            parts.append(f"export {k}={shlex.quote(str(v))};")
+        if cwd:
+            parts.append(f"cd {shlex.quote(cwd)};")
+        parts.append(command)
+        return " ".join(parts)
+
+    def code_run(
+        self,
+        code: str,
+        params: Optional[CodeRunParams] = None,
+        timeout: Optional[int] = None,
+    ) -> ExecuteResponse:
+        """Daytona ``process.code_run(code, params, timeout)`` -> ``run_code``.
+
+        Runs in the sandbox's stateful kernel (Daytona's stateful mode). The rich
+        Mitos ``Execution`` is flattened to Daytona's ``ExecuteResponse``: stdout
+        logs become ``result`` / ``artifacts.stdout``, a structured kernel error
+        yields a non-zero ``exit_code``."""
+        ex = self._sb.run_code(
+            code,
+            language=self._language,
+            timeout=timeout if timeout is not None else 60,
+        )
+        stdout = "".join(ex.logs.get("stdout", []))
+        # Daytona's result is the run's output; prefer the REPL value, fall back
+        # to buffered stdout.
+        result = ex.text or stdout
+        exit_code = 1 if ex.error is not None else 0
+        return ExecuteResponse(
+            exit_code=exit_code,
+            result=result,
+            artifacts=ExecutionArtifacts(stdout=stdout, charts=None),
+        )
+
+
+class FileSystem:
+    """Daytona's ``sandbox.fs`` namespace.
+
+    Maps onto ``DirectSandbox.files.*``. Vocabulary renames: Daytona's
+    ``upload_file`` / ``download_file`` -> ``write`` / ``read``,
+    ``create_folder`` -> ``mkdir``, ``delete_file`` -> ``remove``.
+
+    needs a guest agent: works end-to-end only against a real guest."""
+
+    def __init__(self, sandbox: DirectSandbox):
+        self._sb = sandbox
+
+    def upload_file(
+        self, file: str | bytes, remote_path: str, timeout: int = 30 * 60
+    ) -> None:
+        """Daytona ``fs.upload_file(file, remote_path)`` -> ``files.write``.
+
+        Daytona overloads ``file``: raw ``bytes`` are written verbatim; a ``str``
+        is treated as a LOCAL path whose contents are read and uploaded (the
+        Daytona local-path overload)."""
+        if isinstance(file, (bytes, bytearray)):
+            self._sb.files.write(remote_path, bytes(file))
+        elif isinstance(file, str):
+            with open(file, "rb") as fh:
+                self._sb.files.write(remote_path, fh.read())
+        else:
+            raise TypeError(
+                "upload_file(file, remote_path): file must be bytes (content) "
+                "or str (a local path to read), not "
+                f"{type(file).__name__}"
+            )
+
+    def download_file(
+        self, remote_path: str, local_path: Optional[str] = None, timeout: int = 30 * 60
+    ) -> Optional[bytes]:
+        """Daytona ``fs.download_file(remote_path[, local_path])`` -> ``files.read_bytes``.
+
+        Returns the bytes when no ``local_path`` is given (Daytona's bytes
+        overload); writes them to ``local_path`` and returns ``None`` otherwise."""
+        data = self._sb.files.read_bytes(remote_path)
+        if local_path is None:
+            return data
+        with open(local_path, "wb") as fh:
+            fh.write(data)
+        return None
+
+    def list_files(self, path: str = "/") -> List[FileInfo]:
+        """Daytona ``fs.list_files(path)`` -> ``files.list``.
+
+        Returns Mitos ``FileInfo`` rows. The fields Daytona code reads most
+        (``name``, ``is_dir``, ``size``, ``mode``) are present; Daytona's
+        ``owner`` / ``group`` / ``permissions`` extras are not populated."""
+        return self._sb.files.list(path)
+
+    def create_folder(self, path: str, mode: str = "0755") -> None:
+        """Daytona ``fs.create_folder(path, mode)`` -> ``files.mkdir``.
+
+        ``mode`` is accepted for signature parity; the native ``mkdir`` applies
+        the server default."""
+        self._sb.files.mkdir(path)
+
+    def delete_file(self, path: str, recursive: bool = False) -> None:
+        """Daytona ``fs.delete_file(path)`` -> ``files.remove``."""
+        self._sb.files.remove(path)
+
+    def get_file_info(self, path: str) -> FileInfo:
+        """Daytona ``fs.get_file_info(path)`` -> a single ``FileInfo``.
+
+        Mitos has no stat RPC, so this lists the parent directory and returns the
+        matching entry. A path with no matching entry raises the typed
+        ``NotFoundError``."""
+        parent = posixpath.dirname(path.rstrip("/")) or "/"
+        name = posixpath.basename(path.rstrip("/"))
+        for entry in self._sb.files.list(parent):
+            if entry.name == name:
+                return entry
+        raise NotFoundError(
+            f"no file or directory at {path!r}",
+            code="not_found",
+            cause=f"{name!r} was not present in the listing of {parent!r}",
+            remediation=(
+                "Check the path exists with fs.list_files(parent), or create it "
+                "with fs.upload_file / fs.create_folder first."
+            ),
+            status=404,
+        )
+
+
+# --------------------------------------------------------------------------
+# Sandbox: Daytona's per-sandbox handle, backed by a native DirectSandbox.
+# --------------------------------------------------------------------------
+
+
+class Sandbox:
+    """Daytona's ``Sandbox`` handle, backed by a Mitos sandbox.
+
+    Wraps a ready ``DirectSandbox`` and exposes Daytona's namespaces and methods:
+    ``process`` (``exec`` / ``code_run``), ``fs`` (``upload_file`` /
+    ``download_file`` / ``list_files`` / ``create_folder`` / ``delete_file`` /
+    ``get_file_info``), ``get_preview_link``, ``start`` / ``stop`` / ``delete``,
+    and ``id``.
+    """
+
+    def __init__(self, sandbox: DirectSandbox, language: str = "python"):
+        self._sb = sandbox
+        self._language = language
+        self.process = Process(sandbox, language)
+        self.fs = FileSystem(sandbox)
+
+    @property
+    def id(self) -> str:
+        """Daytona's ``sandbox.id``."""
+        return self._sb.id
+
+    @property
+    def sandbox(self) -> DirectSandbox:
+        """The native ``DirectSandbox`` (the full SDK surface, including
+        ``fork``, ``pause`` / ``resume``, and ``pty``)."""
+        return self._sb
+
+    def get_preview_link(self, port: int) -> PortPreviewUrl:
+        """Daytona ``sandbox.get_preview_link(port)`` -> preview URL.
+
+        Delegates to the native ``DirectSandbox.get_host`` and splits the signed
+        token out of the URL so both ``.url`` and ``.token`` are populated."""
+        url = self._sb.get_host(port)
+        token = ""
+        try:
+            qs = parse_qs(urlsplit(url).query)
+            token = (qs.get("token") or [""])[0]
+        except Exception:  # noqa: BLE001 - a malformed URL just yields no token.
+            token = ""
+        return PortPreviewUrl(url=url, token=token)
+
+    def fork(self, n: int = 1) -> List["Sandbox"]:
+        """Not in Daytona's surface: a Mitos superpower exposed for convenience.
+
+        Forks this sandbox into ``n`` independent copies, each wrapped as a
+        Daytona ``Sandbox``."""
+        return [Sandbox(child, self._language) for child in self._sb.fork(n)]
+
+    def start(self, timeout: Optional[float] = 60) -> None:
+        """Daytona ``sandbox.start()`` -> ``DirectSandbox.resume``."""
+        self._sb.resume()
+
+    def stop(self, timeout: Optional[float] = 60, force: bool = False) -> None:
+        """Daytona ``sandbox.stop()`` -> ``DirectSandbox.pause``."""
+        self._sb.pause()
+
+    def delete(self, timeout: Optional[float] = 60) -> None:
+        """Daytona ``sandbox.delete()`` -> ``DirectSandbox.terminate``."""
+        self._sb.terminate()
+
+    def __enter__(self) -> "Sandbox":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.delete()
+
+    def __repr__(self) -> str:
+        return f"Sandbox(id={self._sb.id!r})"
+
+
+# --------------------------------------------------------------------------
+# Daytona: the client. Owns auth and the create / get / list / delete verbs.
+# --------------------------------------------------------------------------
+
+
+class Daytona:
+    """Daytona's top-level client, backed by the Mitos standalone server.
+
+    Drop-in for ``from daytona import Daytona`` against a SELF-HOSTED Mitos
+    sandbox-server. Auth resolves exactly like ``mitos.create``: from the
+    ``DaytonaConfig`` (``api_key`` / ``api_url``), else ``MITOS_API_KEY`` /
+    ``MITOS_BASE_URL``.
+
+        from mitos.daytona import Daytona, CreateSandboxFromSnapshotParams
+
+        daytona = Daytona()
+        sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="python"))
+        sandbox.process.code_run("print(1 + 1)")
+        daytona.delete(sandbox)
+    """
+
+    def __init__(self, config: Optional[DaytonaConfig] = None):
+        cfg = config or DaytonaConfig()
+        self._api_key = cfg.api_key
+        self._base_url = cfg.api_url
+
+    def create(
+        self,
+        params: Optional[CreateSandboxBaseParams] = None,
+        timeout: Optional[float] = 60,
+    ) -> Sandbox:
+        """Daytona ``daytona.create(params)`` -> ``mitos.create``.
+
+        Returns a READY Daytona ``Sandbox`` over the standalone server / hosted
+        control plane (no Kubernetes). ``language`` sets the code_run default and
+        ``image`` / ``snapshot`` selects the base; ``env_vars`` / ``labels`` are
+        accepted and not applied today.
+
+        works today against the bare mock server."""
+        params = params or CreateSandboxBaseParams()
+        sb = _create_direct(
+            params._image(), api_key=self._api_key, base_url=self._base_url
+        )
+        return Sandbox(sb, language=params.language)
+
+    def get(self, sandbox_id: str) -> Sandbox:
+        """Daytona ``daytona.get(id)`` -> reattach to a RUNNING sandbox by id.
+
+        The standalone server has no get-one endpoint, so this finds the id in
+        ``list_sandboxes`` and rebuilds a handle. An unknown id raises the typed
+        ``NotFoundError``.
+
+        works today against the bare mock server."""
+        server = SandboxServer.from_auth(api_key=self._api_key, base_url=self._base_url)
+        for info in server.list_sandboxes():
+            if info.get("id") == sandbox_id:
+                return Sandbox(self._rebuild(server, info))
+        raise NotFoundError(
+            f"no running sandbox with id {sandbox_id!r}",
+            code="not_found",
+            cause="the id was not present in the server's running-sandbox listing",
+            remediation=(
+                "List running sandboxes with daytona.list() and use one of those "
+                "ids, or create a new sandbox with daytona.create(...)."
+            ),
+            status=404,
+        )
+
+    def list(self) -> List[Sandbox]:
+        """Daytona ``daytona.list()`` -> ``SandboxServer.list_sandboxes``.
+
+        Returns the running sandboxes as Daytona ``Sandbox`` handles.
+
+        works today against the bare mock server."""
+        server = SandboxServer.from_auth(api_key=self._api_key, base_url=self._base_url)
+        return [Sandbox(self._rebuild(server, info)) for info in server.list_sandboxes()]
+
+    @staticmethod
+    def _rebuild(server: SandboxServer, info: dict) -> DirectSandbox:
+        """Rebuild a native ``DirectSandbox`` handle from a listing row, the same
+        reattach the E2B shim's ``connect`` uses."""
+        return DirectSandbox(
+            id=info["id"],
+            template=info.get("template_id", ""),
+            endpoint=info.get("endpoint", ""),
+            server_url=server.url,
+            fork_time_ms=info.get("fork_time_ms", 0.0),
+            api_key=server._api_key,
+        )
+
+    def delete(self, sandbox: Sandbox, timeout: Optional[float] = 60) -> None:
+        """Daytona ``daytona.delete(sandbox)`` -> ``DirectSandbox.terminate``."""
+        sandbox.delete(timeout=timeout)
+
+    def start(self, sandbox: Sandbox, timeout: Optional[float] = 60) -> None:
+        """Daytona ``daytona.start(sandbox)`` -> ``DirectSandbox.resume``."""
+        sandbox.start(timeout=timeout)
+
+    def stop(self, sandbox: Sandbox, timeout: Optional[float] = 60) -> None:
+        """Daytona ``daytona.stop(sandbox)`` -> ``DirectSandbox.pause``."""
+        sandbox.stop(timeout=timeout)

--- a/sdk/python/tests/test_daytona_compat.py
+++ b/sdk/python/tests/test_daytona_compat.py
@@ -1,0 +1,343 @@
+"""Tests for the Daytona-compat shim ``mitos.daytona``.
+
+The shim is a one-way migration bridge for teams leaving Daytona's cloud for a
+SELF-HOSTED sandbox runtime: "change one import" and a Daytona-style script runs
+against a standalone Mitos sandbox-server. Like ``mitos.e2b`` this is an ADAPTER
+over the existing ``DirectSandbox`` / ``SandboxServer`` surface, not engine work.
+
+Two layers, mirroring the E2B shim tests (test_e2b_compat.py):
+
+  1. A DAYTONA-STYLE script run UNCHANGED against ``mitos.daytona`` on a fake
+     target (the mock-engine sandbox-server cannot answer process / fs without a
+     vsock guest agent). The fake proves create / process.* / fs.* /
+     get_preview_link / delete map onto the native ops correctly.
+
+  2. An integration smoke test against the mock-engine sandbox-server (no KVM)
+     for the create / get / list / delete lifecycle the shim wraps.
+
+No hard dependency on the ``daytona`` package: this suite never imports it.
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+from mitos.daytona import (
+    CreateSandboxFromSnapshotParams,
+    Daytona,
+    DaytonaConfig,
+    Sandbox,
+)
+from mitos.errors import AgentRunError, NotFoundError
+from mitos.types import Execution, ExecResult, FileInfo, Result
+
+
+# --------------------------------------------------------------------------
+# Fakes: a target that quacks like DirectSandbox but touches no server / KVM.
+# --------------------------------------------------------------------------
+
+
+class _FakeFiles:
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.writes: list[tuple[str, object]] = []
+        self.removed: list[str] = []
+        self.mkdirs: list[str] = []
+
+    def read(self, path: str) -> str:
+        return self.read_bytes(path).decode("utf-8", "replace")
+
+    def read_bytes(self, path: str) -> bytes:
+        return self.store[path]
+
+    def write(self, path: str, content, mode: int = 0o644):
+        raw = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        self.store[path] = raw
+        self.writes.append((path, raw))
+
+    def list(self, path: str = "/"):
+        return [FileInfo(name="a.txt", is_dir=False, size=3, mode=0o644)]
+
+    def exists(self, path: str) -> bool:
+        return path in self.store
+
+    def remove(self, path: str) -> None:
+        self.removed.append(path)
+        self.store.pop(path, None)
+
+    def mkdir(self, path: str) -> None:
+        self.mkdirs.append(path)
+
+
+class _FakeSandbox:
+    """Implements the surface the shim drives: exec, run_code, files,
+    get_host, fork, pause, resume, terminate."""
+
+    def __init__(self, id: str = "fake-1", run_code_error=None):
+        self.id = id
+        self.template = "python"
+        self.files = _FakeFiles()
+        self.exec_calls: list[tuple[str, int]] = []
+        self.run_code_calls: list[tuple[str, str, int]] = []
+        self._run_code_error = run_code_error
+        self.paused = False
+        self.resumed = False
+        self.terminated = False
+
+    def exec(self, command: str, timeout: int = 30) -> ExecResult:
+        self.exec_calls.append((command, timeout))
+        return ExecResult(
+            exit_code=0, stdout=f"ran:{command}", stderr="", exec_time_ms=1.5
+        )
+
+    def run_code(
+        self,
+        code: str,
+        language: str = "python",
+        timeout: int = 60,
+        on_stdout=None,
+        on_stderr=None,
+        on_result=None,
+    ) -> Execution:
+        self.run_code_calls.append((code, language, timeout))
+        result = Result(data={"text/plain": "42"}, is_main_result=True)
+        return Execution(
+            text="42",
+            logs={"stdout": ["hi\n"], "stderr": []},
+            results=[result],
+            error=self._run_code_error,
+        )
+
+    def get_host(self, port: int = 80) -> str:
+        return f"https://{self.id}.preview.example.com/?token=tok&port={port}"
+
+    def fork(self, n: int = 1, id=None):
+        return [_FakeSandbox(id=f"child-{i}") for i in range(n)]
+
+    def pause(self) -> None:
+        self.paused = True
+
+    def resume(self) -> None:
+        self.resumed = True
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+
+# --------------------------------------------------------------------------
+# 1. The DAYTONA-STYLE script, run UNCHANGED against mitos.daytona on a fake.
+# --------------------------------------------------------------------------
+
+
+def test_daytona_style_script_runs_unchanged(monkeypatch, tmp_path):
+    """A Daytona user's script: only the import changed. Every method name and
+    signature is Daytona's; the body is what a Daytona tutorial would show."""
+    fake = _FakeSandbox()
+    # daytona.create() builds a DirectSandbox; patch that one seam so the script
+    # never touches a server. Everything else exercises the real shim.
+    monkeypatch.setattr("mitos.daytona._create_direct", lambda *a, **k: fake)
+
+    # --- this block is verbatim Daytona surface ---
+    daytona = Daytona(DaytonaConfig(api_key="dtn_x", api_url="http://localhost:8080"))
+    sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="python"))
+
+    # process.exec -> exec
+    response = sandbox.process.exec("echo hello")
+    assert response.exit_code == 0
+    assert response.result == "ran:echo hello"
+    assert response.artifacts.stdout == "ran:echo hello"
+
+    # process.code_run -> rich run mapped to ExecuteResponse
+    run = sandbox.process.code_run("1 + 1")
+    assert run.exit_code == 0
+    assert run.result == "42"
+
+    # fs.upload_file / download_file / list_files / create_folder / delete_file
+    sandbox.fs.upload_file(b"data", "/tmp/x.txt")
+    assert sandbox.fs.download_file("/tmp/x.txt") == b"data"
+    listing = sandbox.fs.list_files("/tmp")
+    assert listing[0].name == "a.txt"
+    info = sandbox.fs.get_file_info("/tmp/a.txt")
+    assert info.name == "a.txt"
+    sandbox.fs.create_folder("/tmp/sub", "0755")
+    sandbox.fs.delete_file("/tmp/x.txt")
+
+    # get_preview_link(port) -> a signed preview URL plus token
+    link = sandbox.get_preview_link(3000)
+    assert link.url.startswith("https://") and "port=3000" in link.url
+    assert link.token == "tok"
+
+    # delete -> terminate
+    daytona.delete(sandbox)
+    # --- end verbatim Daytona surface ---
+
+    assert fake.exec_calls == [("echo hello", 30)]
+    assert fake.run_code_calls == [("1 + 1", "python", 60)]
+    assert fake.files.writes == [("/tmp/x.txt", b"data")]
+    assert fake.files.mkdirs == ["/tmp/sub"]
+    assert fake.files.removed == ["/tmp/x.txt"]
+    assert fake.terminated is True
+
+
+def test_exec_folds_cwd_and_env_into_command():
+    """DirectSandbox.exec has no cwd / env slot, so the shim folds them into the
+    shell command rather than dropping them."""
+    fake = _FakeSandbox()
+    sb = Sandbox(fake)
+    sb.process.exec("ls", cwd="/workspace/app", env={"TOKEN": "s3cret"})
+    (cmd, _timeout) = fake.exec_calls[0]
+    assert "export TOKEN=s3cret;" in cmd
+    assert "cd /workspace/app;" in cmd
+    assert cmd.endswith("ls")
+
+
+def test_code_run_error_maps_to_nonzero_exit():
+    """A structured kernel error yields a non-zero ExecuteResponse.exit_code."""
+    from mitos.types import ExecutionError
+
+    fake = _FakeSandbox(
+        run_code_error=ExecutionError(name="ValueError", value="boom", traceback=[])
+    )
+    sb = Sandbox(fake)
+    run = sb.process.code_run("raise ValueError('boom')")
+    assert run.exit_code == 1
+
+
+def test_upload_file_bytes_and_local_path(tmp_path):
+    """upload_file accepts raw bytes (content) or a str (a local path to read)."""
+    fake = _FakeSandbox()
+    sb = Sandbox(fake)
+
+    sb.fs.upload_file(b"raw-bytes", "/remote/a.bin")
+    assert fake.files.store["/remote/a.bin"] == b"raw-bytes"
+
+    local = tmp_path / "local.txt"
+    local.write_bytes(b"from-disk")
+    sb.fs.upload_file(str(local), "/remote/b.txt")
+    assert fake.files.store["/remote/b.txt"] == b"from-disk"
+
+
+def test_download_file_returns_bytes_or_writes_local(tmp_path):
+    fake = _FakeSandbox()
+    fake.files.store["/remote/c.txt"] = b"payload"
+    sb = Sandbox(fake)
+
+    assert sb.fs.download_file("/remote/c.txt") == b"payload"
+
+    out = tmp_path / "out.txt"
+    assert sb.fs.download_file("/remote/c.txt", str(out)) is None
+    assert out.read_bytes() == b"payload"
+
+
+def test_get_file_info_missing_raises_not_found():
+    fake = _FakeSandbox()
+    sb = Sandbox(fake)
+    with pytest.raises(NotFoundError) as ei:
+        sb.fs.get_file_info("/tmp/does-not-exist.txt")
+    assert ei.value.code == "not_found"
+
+
+def test_get_preview_link_parses_token():
+    sb = Sandbox(_FakeSandbox(id="sb-x"))
+    link = sb.get_preview_link(8080)
+    assert link.url == "https://sb-x.preview.example.com/?token=tok&port=8080"
+    assert link.token == "tok"
+
+
+def test_start_stop_map_to_resume_pause():
+    fake = _FakeSandbox()
+    sb = Sandbox(fake)
+    sb.stop()
+    sb.start()
+    assert fake.paused is True
+    assert fake.resumed is True
+
+
+def test_context_manager_deletes():
+    fake = _FakeSandbox()
+    with Sandbox(fake) as sb:
+        assert sb.id == "fake-1"
+    assert fake.terminated is True
+
+
+def test_fork_returns_wrapped_sandboxes():
+    """fork is a Mitos superpower exposed on the Daytona handle for convenience;
+    it returns Daytona Sandbox wrappers, not raw DirectSandboxes."""
+    sb = Sandbox(_FakeSandbox())
+    children = sb.fork(3)
+    assert len(children) == 3
+    assert all(isinstance(c, Sandbox) for c in children)
+
+
+# --------------------------------------------------------------------------
+# 2. create / get / list / delete against the mock-engine server (no KVM).
+# --------------------------------------------------------------------------
+
+
+SERVER_URL = "http://localhost:18085"
+server_process = None
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    global server_process
+    result = subprocess.run(
+        ["go", "build", "-o", "/tmp/sandbox-server-daytona-test", "./cmd/sandbox-server/"],
+        cwd=os.path.join(os.path.dirname(__file__), "..", "..", ".."),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Could not build sandbox-server: {result.stderr.decode()}")
+
+    server_process = subprocess.Popen(
+        ["/tmp/sandbox-server-daytona-test", "--mock", "--addr", ":18085"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(1)
+    yield SERVER_URL
+    server_process.terminate()
+    server_process.wait(timeout=5)
+
+
+def _client(base_url: str) -> Daytona:
+    return Daytona(DaytonaConfig(api_url=base_url))
+
+
+def test_create_and_delete_lifecycle(mock_server):
+    """daytona.create -> a READY handle -> delete, on the mock server. Proves the
+    shim drives the standalone (no-Kubernetes) path. process / fs need a vsock
+    guest agent the mock server lacks (covered by the fake above and KVM CI)."""
+    daytona = _client(mock_server)
+    sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="daytona-python"))
+    assert sandbox.id
+    daytona.delete(sandbox)
+
+
+def test_get_reattaches_to_running_sandbox(mock_server):
+    daytona = _client(mock_server)
+    sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="daytona-get"))
+    try:
+        again = daytona.get(sandbox.id)
+        assert again.id == sandbox.id
+    finally:
+        daytona.delete(sandbox)
+
+
+def test_get_unknown_id_raises_not_found(mock_server):
+    daytona = _client(mock_server)
+    with pytest.raises(AgentRunError) as ei:
+        daytona.get("does-not-exist")
+    assert ei.value.code == "not_found"
+
+
+def test_list_returns_running_sandboxes(mock_server):
+    daytona = _client(mock_server)
+    sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="daytona-list"))
+    try:
+        ids = [s.id for s in daytona.list()]
+        assert sandbox.id in ids
+    finally:
+        daytona.delete(sandbox)


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs and a standalone sandbox-server.
> - The Python SDK already ships a one-import E2B compat shim (mitos.e2b) as a migration bridge onto the native DirectSandbox surface.
> - Daytona moved its OSS runtime development to a private codebase in June 2026, closing the open self-host path many teams had adopted; those teams need a landing spot that does not require a rewrite.
> - Mitos is exactly that landing spot (Apache-2.0, self-hosted, same exec / files / code-interpreter surface plus fork(n)), but only if the switching cost is one line.
> - This pull request adds mitos.daytona: a Daytona-compat shim mirroring the mitos.e2b pattern, plus docs/migrating-from-daytona.md and the Daytona row in the integrations README.
> - The benefit is a genuine one-import migration for Daytona users onto self-hosted Mitos, with an honest support table for what works on which deployment.

## Linked Issues or Issue Description

No tracked issue. Problem: teams leaving Daytona's now-closed OSS runtime have no low-friction way onto Mitos; a Daytona-shaped script (daytona.create, sandbox.process.code_run, sandbox.fs.upload_file, get_preview_link) would need a full rewrite against the native SDK. This shim removes that cost the same way mitos.e2b did for E2B.

## What Changed

- New sdk/python/mitos/daytona.py: Daytona, DaytonaConfig, CreateSandbox*Params aliases, Sandbox with process / fs namespaces, ExecuteResponse / ExecutionArtifacts / PortPreviewUrl result shapes; all backed by the native DirectSandbox / SandboxServer with no dependency on the daytona package.
- process.exec folds cwd / env into the shell command instead of dropping them; code_run runs in the stateful kernel and flattens the Mitos Execution to Daytona's ExecuteResponse.
- get_preview_link delegates to get_host and splits the signed token out so both .url and .token read unchanged; fork(n) is surfaced beyond parity.
- env_vars / labels on create are accepted for signature parity and documented as not applied today (same honest stance as the E2B shim's metadata).
- New docs/migrating-from-daytona.md: the one-import swap, quickstart, full support table, vocabulary renames.
- docs/integrations/README.md: Daytona row in the migrations table next to E2B.

## Verification

- [x] cd sdk/python && PYTHONPATH=. python3 -m pytest tests/test_daytona_compat.py (14 passed)
- [x] cd sdk/python && PYTHONPATH=. python3 -m pytest tests/ (329 passed, 1 skipped; full SDK suite on this base)
- [x] perl dash scan over the four touched files: clean
- [x] pyproject packages = ["mitos"] already ships the new module (same as mitos.e2b)

## Risks

Low risk: pure additive Python module + docs; no engine, controller, or daemon changes. The shim never imports the daytona package, so no upstream coupling. process / fs paths need a real guest agent, which the docs and docstrings state explicitly.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
