### PR TITLE
fix(saas): mint label-safe org ids; surface api server validation errors

### DIFF
--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -12,11 +12,14 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/saas"
@@ -879,4 +882,42 @@ func flipWhenCreatedInNs(t *testing.T, c client.Client, ns string, mutate func(*
 		}
 	}()
 	return func() { once.Do(func() { close(done) }) }
+}
+
+// TestCreateApiServerInvalidSurfacesValidationCause asserts that when the api
+// server rejects the sandbox OBJECT as invalid (for example an org id that is
+// not a valid label value, #593), the error surfaced to the caller carries the
+// validation message and does not claim their request body was malformed JSON.
+func TestCreateApiServerInvalidSurfacesValidationCause(t *testing.T) {
+	base := fakeclient.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithStatusSubresource(&v1.Sandbox{}).
+		Build()
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			return apierrors.NewInvalid(
+				v1.GroupVersion.WithKind("Sandbox").GroupKind(), obj.GetName(),
+				field.ErrorList{field.Invalid(
+					field.NewPath("metadata", "labels"), "bad_",
+					"a valid label must be an empty string or consist of alphanumeric characters")})
+		},
+	})
+	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
+
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"default"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", resp.Status, resp.Body)
+	}
+	body := string(resp.Body)
+	if strings.Contains(body, "invalid_json") || strings.Contains(body, "not valid JSON") {
+		t.Errorf("error blames the caller's JSON for an object validation failure: %s", body)
+	}
+	if !strings.Contains(body, "metadata.labels") {
+		t.Errorf("error body missing the api server validation detail: %s", body)
+	}
 }

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -166,8 +166,12 @@ func (k *K8sControlPlane) create(ctx context.Context, req saas.ForwardRequest) (
 		case isNamespaceMissing(err, ns):
 			return errResp(namespaceMissingErr(req.OrgID, ns)), nil
 		case apierrors.IsInvalid(err), apierrors.IsBadRequest(err):
-			return errResp(apierr.Get(apierr.CodeInvalidJSON).
-				WithCause("the sandbox spec was rejected by the api server as invalid")), nil
+			// The caller's JSON decoded fine; the OBJECT the gateway built from
+			// it failed api server validation (for example an org id that is not
+			// a valid label value, #593). Surface the validation message instead
+			// of blaming the request body, per the LLM-legible error rule (#28).
+			return errResp(apierr.Get(apierr.CodeInvalidInput).
+				WithCause("the api server rejected the sandbox object as invalid: " + err.Error())), nil
 		default:
 			return errResp(apierr.Get(apierr.CodeInternal).
 				WithCause("could not create the sandbox object")), nil

--- a/internal/saas/id_safety_test.go
+++ b/internal/saas/id_safety_test.go
@@ -1,0 +1,25 @@
+package saas
+
+import (
+	"regexp"
+	"testing"
+)
+
+// Org ids are stamped on Sandbox objects as a Kubernetes label value and, in
+// org-tenancy mode, embedded in the org namespace name. Both are stricter than
+// base64url: a label value must begin and end alphanumeric, and an RFC1123
+// name segment must be lowercase alphanumerics and hyphens only. Ids must
+// satisfy the strictest consumer so no org can be born unable to create a
+// sandbox (#593).
+func TestRandomIDIsLabelValueAndRFC1123Safe(t *testing.T) {
+	rfc1123 := regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+	for i := 0; i < 4096; i++ {
+		id := randomID()
+		if len(id) < 16 {
+			t.Fatalf("randomID() = %q: too short to stay collision resistant", id)
+		}
+		if !rfc1123.MatchString(id) {
+			t.Fatalf("randomID() = %q: not a valid k8s label value / RFC1123 name segment", id)
+		}
+	}
+}

--- a/internal/saas/keys.go
+++ b/internal/saas/keys.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base32"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -225,7 +226,12 @@ func randomSecret() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// randomID returns a short opaque url-safe id used for accounts, orgs, and keys.
+// randomID returns a short opaque id used for accounts, orgs, and keys. The
+// alphabet is lowercase base32 ([a-z2-7]) because org ids reach Kubernetes:
+// they are stamped on Sandbox objects as the tenant label value (must begin
+// and end alphanumeric) and, in org-tenancy mode, embedded in the org
+// namespace name (RFC1123: lowercase only). base64url ids gave ~6% of orgs a
+// leading or trailing '-'/'_' that no sandbox create could ever pass (#593).
 func randomID() string {
 	b := make([]byte, 12)
 	if _, err := rand.Read(b); err != nil {
@@ -233,5 +239,5 @@ func randomID() string {
 		// than panic so the process stays up. This never carries a secret.
 		return fmt.Sprintf("id-%d", time.Now().UnixNano())
 	}
-	return base64.RawURLEncoding.EncodeToString(b)
+	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b))
 }

--- a/internal/saas/pgstore/migrations/0006_label_safe_org_ids.sql
+++ b/internal/saas/pgstore/migrations/0006_label_safe_org_ids.sql
@@ -1,0 +1,28 @@
+-- Rewrite org ids that begin or end with '-' or '_' to a label-safe form by
+-- replacing the offending edge character with '0' (#593). Org ids minted by
+-- the old base64url randomID could carry those edge characters, and the
+-- gateway stamps every Sandbox with the org id as a Kubernetes label VALUE,
+-- which must begin and end alphanumeric: an affected org could never create a
+-- sandbox. New ids are lowercase base32 and always safe; this migration heals
+-- the ids minted before the fix.
+--
+-- The same transform is applied to every table that carries an org id; these
+-- tables have no FK constraints between them, so order does not matter. A
+-- collision between a rewritten id and an existing one would violate the orgs
+-- primary key and abort the migration for the operator to resolve; with
+-- 16-character ids the probability is negligible.
+
+UPDATE orgs SET id = regexp_replace(id, '^[-_]|[-_]$', '0', 'g')
+	WHERE id ~ '^[-_]|[-_]$';
+UPDATE memberships SET org_id = regexp_replace(org_id, '^[-_]|[-_]$', '0', 'g')
+	WHERE org_id ~ '^[-_]|[-_]$';
+UPDATE api_keys SET org_id = regexp_replace(org_id, '^[-_]|[-_]$', '0', 'g')
+	WHERE org_id ~ '^[-_]|[-_]$';
+UPDATE credit_ledger SET org_id = regexp_replace(org_id, '^[-_]|[-_]$', '0', 'g')
+	WHERE org_id ~ '^[-_]|[-_]$';
+UPDATE usage_records SET org_id = regexp_replace(org_id, '^[-_]|[-_]$', '0', 'g')
+	WHERE org_id ~ '^[-_]|[-_]$';
+UPDATE spend_caps SET org_id = regexp_replace(org_id, '^[-_]|[-_]$', '0', 'g')
+	WHERE org_id ~ '^[-_]|[-_]$';
+UPDATE accounts SET personal_org_id = regexp_replace(personal_org_id, '^[-_]|[-_]$', '0', 'g')
+	WHERE personal_org_id ~ '^[-_]|[-_]$';


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the hosted SaaS fronts this with a gateway that turns API calls into Sandbox objects.
> - During the production launch verification I onboarded a fresh user end to end and the very first `create` failed 400 with "request body is not valid JSON" despite a contract-perfect body.
> - Root cause: `randomID` mints org ids as base64url, the gateway stamps the org id on every Sandbox as a Kubernetes label value, and a label value must begin and end alphanumeric; about 6% of orgs draw an id with a leading or trailing '-'/'_' and can never create a sandbox (2 of the first 8 real prod orgs were affected).
> - A second defect hid the first: the gateway mapped api server Invalid/BadRequest to invalid_json, sending the caller to debug their own request body.
> - This pull request mints label-safe and RFC1123-safe ids (lowercase base32), heals existing unsafe org ids with a migration, and surfaces the api server validation message as invalid_input.
> - The benefit is that no new signup can be born broken, existing broken orgs self-heal on rollout, and any future object rejection tells the caller the truth.

## Linked Issues or Issue Description

Closes #593. Related: the misleading error mapping violated the LLM-legible error rule (#28); #571/#570 are the launch verification that surfaced it.

## What Changed

- `internal/saas/keys.go`: `randomID` now encodes the same 12 random bytes as lowercase base32 ([a-z2-7], 20 chars), valid as a k8s label value and as an RFC1123 name segment (org-tenancy namespace names included).
- `internal/saas/pgstore/migrations/0006_label_safe_org_ids.sql`: rewrites the offending edge characters of existing org ids to '0' across orgs, memberships, api_keys, credit_ledger, usage_records, spend_caps, and accounts.personal_org_id.
- `internal/saas/controlplane/forward.go`: api server Invalid/BadRequest on create now maps to `invalid_input` and carries the validation message, instead of `invalid_json` blaming the request body.
- Tests: property test that `randomID` output is label/RFC1123 safe (4096 draws); controlplane test that an api-server-invalid create surfaces the validation detail and does not claim malformed JSON.

## Verification

- [x] go test ./internal/saas/... (all packages pass; both new tests were red before the fix)
- [x] go build ./...
- [x] golangci-lint run --timeout=5m internal/saas/... AND GOOS=linux golangci-lint run --timeout=5m internal/saas/... (clean)
- [x] Production evidence: applying the same id transform manually to the 2 affected prod orgs immediately fixed create/fork against api.mitos.run (see #593)

## Risks

Low risk. Id shape changes from 16 base64url chars to 20 lowercase base32 chars: ids are opaque strings everywhere (stores key them as text, no length constraint). The migration touches only rows whose org id has an unsafe edge character; a primary-key collision aborts the whole migration transactionally (probability ~2^-90). Key SECRETS are unchanged (still base64url; they never reach Kubernetes).

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
