### PR TITLE
feat(guest): mitos-python base image with the run_code kernel baked in

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   publish:
-    # Build, push, cosign keyless-sign, and SBOM-attest the seven Mitos images
+    # Build, push, cosign keyless-sign, and SBOM-attest the Mitos images
     # under ghcr.io/mitos-run (supply chain, issue #35). Keyless signing
     # uses the workflow GitHub OIDC identity (id-token: write); there is NO
     # private key in the repo or in secrets. Each image is pushed by digest and
@@ -58,6 +58,8 @@ jobs:
             dockerfile: Dockerfile.canary
           - name: mitos-frontdoor
             dockerfile: Dockerfile.frontdoor
+          - name: mitos-python
+            dockerfile: Dockerfile.python-base
           - name: mitos-computer-use
             dockerfile: images/computer-use/Dockerfile
     env:

--- a/Dockerfile.python-base
+++ b/Dockerfile.python-base
@@ -1,0 +1,17 @@
+# The hosted "python" sandbox template base image. Plain python:3.12-slim
+# plus the pieces run_code needs in the guest: ipykernel and jupyter_client
+# for the stateful kernel and /opt/mitos/kernel_driver.py, the line-oriented
+# JSON driver the guest agent spawns (guest/agent-rs kernel/driver.rs). The
+# fork engine's OCI path injects only the guest agent into a template image
+# (internal/fork/imagebuild.go), so the kernel pieces must already be in the
+# image; without them run_code fails structured with KernelUnavailable (#572).
+# matplotlib, matplotlib-inline, and pandas match guest/rootfs/build.sh's
+# FULL_ROOTFS=1 set so notebook-style snippets work out of the box.
+FROM mirror.gcr.io/library/python:3.12-slim
+
+RUN pip install --no-cache-dir \
+        ipykernel jupyter_client matplotlib matplotlib-inline pandas \
+    && python3 -m ipykernel install --name python3 --sys-prefix
+
+COPY guest/rootfs/kernel_driver.py /opt/mitos/kernel_driver.py
+RUN chmod 0755 /opt/mitos/kernel_driver.py


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the hosted python pool builds its guest rootfs from a plain OCI image.
> - The fork engine's OCI path (internal/fork/imagebuild.go) injects only the guest agent into that image, so run_code needs ipykernel, jupyter_client, and /opt/mitos/kernel_driver.py to already be inside the image.
> - The prod pool points at plain python:3.12-slim, so every hosted run_code fails structured with KernelUnavailable (#572); exec and files work, only the headline code-interpreter path is down.
> - guest/rootfs/build.sh already defines the FULL_ROOTFS=1 kernel set, but that path is for debootstrap-built rootfs images, not the OCI template path the hosted pool uses.
> - This pull request adds Dockerfile.python-base, a purpose-built hosted python template base (python:3.12-slim + the kernel set + kernel_driver.py), and publishes it as ghcr.io/mitos-run/mitos-python via the existing signed publish matrix.
> - The benefit is that pointing the hosted (or any self-hosted) python pool at mitos-python makes run_code work with full snapshot-fork semantics, closing the last broken quickstart verb.

## Linked Issues or Issue Description

Related: #572 (run_code on the hosted python template fails with KernelUnavailable). The image is the fix's first half; re-pointing the prod SandboxPool template and verifying run_code against api.mitos.run completes it and is tracked there.

## What Changed

- New Dockerfile.python-base: FROM python:3.12-slim (via mirror.gcr.io), pip installs ipykernel, jupyter_client, matplotlib, matplotlib-inline, pandas (the guest/rootfs/build.sh FULL_ROOTFS=1 set), registers the python3 kernelspec, and bakes guest/rootfs/kernel_driver.py at /opt/mitos/kernel_driver.py.
- .github/workflows/publish.yaml: mitos-python added to the signed build matrix; stale "seven images" comment corrected.

## Verification

- [x] docker buildx build --platform linux/amd64 -f Dockerfile.python-base . (builds clean locally; push blocked only by local token scopes)
- [x] Dispatched publish.yaml on this branch (tag python-kernel-1) to build and push via CI
- [ ] Post-merge: re-point the prod python SandboxPool at the image and verify mitos.create("python").run_code("print(1+1)") returns 2 against api.mitos.run (tracked in #572)

## Risks

Low risk: a new image in the publish matrix; no component code changes. GHCR note: the brand-new mitos-python package defaults to private and needs the one-time UI visibility toggle to be anonymously pullable; the prod cluster pulls with the ghcr-pull secret either way.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
