### PR TITLE
fix(saas): sandboxes scope implies read-only so default keys can list

### DIFF
--- a/internal/saas/keys_test.go
+++ b/internal/saas/keys_test.go
@@ -219,3 +219,35 @@ func TestSaltChangesHash(t *testing.T) {
 		t.Error("different salts produced the same hash")
 	}
 }
+
+// TestSandboxesScopeImpliesReadOnly: the default onboarding key carries only
+// the sandboxes scope; the gateway's read-only ops (sandbox.list,
+// sandbox.status, template.list) require the read scope. Full lifecycle access
+// must imply read access or every default key is locked out of listing its own
+// sandboxes (#599).
+func TestSandboxesScopeImpliesReadOnly(t *testing.T) {
+	store := NewMemStore()
+	svc := NewKeyService(store)
+	ctx := context.Background()
+	newTestOrg(t, store, "org-scope")
+
+	created, err := svc.CreateKey(ctx, CreateKeyRequest{
+		OrgID: "org-scope", Name: "default", Scopes: []string{ScopeSandboxes},
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	if _, err := svc.Verify(ctx, created.RawKey, ScopeReadOnly); err != nil {
+		t.Errorf("a sandboxes-scoped key must satisfy the read-only scope, got %v", err)
+	}
+
+	readOnly, err := svc.CreateKey(ctx, CreateKeyRequest{
+		OrgID: "org-scope", Name: "ro", Scopes: []string{ScopeReadOnly},
+	})
+	if err != nil {
+		t.Fatalf("CreateKey ro: %v", err)
+	}
+	if _, err := svc.Verify(ctx, readOnly.RawKey, ScopeSandboxes); !errors.Is(err, ErrKeyScope) {
+		t.Errorf("a read-only key must NOT satisfy the sandboxes scope, got %v", err)
+	}
+}

--- a/internal/saas/model.go
+++ b/internal/saas/model.go
@@ -152,10 +152,18 @@ func (k ApiKey) IsRevoked() bool {
 	return !k.RevokedAt.IsZero()
 }
 
-// HasScope reports whether the key carries the named scope.
+// HasScope reports whether the key carries the named scope. The full
+// lifecycle scope implies read-only access: a key that may create and
+// terminate sandboxes may also list them; without the implication the default
+// onboarding key (sandboxes only) is locked out of the gateway's read-only
+// ops (#599). The reverse does not hold: a read-only key never satisfies a
+// mutating requirement.
 func (k ApiKey) HasScope(scope string) bool {
 	for _, s := range k.Scopes {
 		if s == scope {
+			return true
+		}
+		if scope == ScopeReadOnly && s == ScopeSandboxes {
 			return true
 		}
 	}


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the hosted gateway fronts the sandbox lifecycle behind scoped API keys.
> - The production e2e sweep drove every SDK surface with a freshly onboarded default key and GET /v1/sandboxes came back 403 while create, exec, fork, and terminate all worked.
> - Root cause: requiredScopeFor maps read-only ops to the read scope and its comment promises either scope satisfies a read-only op, but ApiKey.HasScope was an exact match, so a sandboxes-scoped key never satisfied a read requirement.
> - Every default onboarding key carries only the sandboxes scope, so every new user is locked out of listing their own sandboxes: a silent dead end in the journey.
> - This pull request makes the sandboxes scope imply the read-only scope in HasScope, with tests proving the implication and its non-reversibility.
> - The benefit is that the documented scope semantics and the enforced semantics agree, and list/status work for the key the funnel hands out.

## Linked Issues or Issue Description

Closes #599. Found during the production launch e2e verification (see #572, #593 for the sweep's other findings).

## What Changed

- internal/saas/model.go: HasScope treats ScopeSandboxes as implying ScopeReadOnly; a read-only key still never satisfies a mutating requirement.
- internal/saas/keys_test.go: TestSandboxesScopeImpliesReadOnly proves a ["sandboxes"] key passes Verify for the read scope and a ["read"] key fails Verify for the sandboxes scope (red before the fix).

## Verification

- [x] go test ./internal/saas/... (new test red before, green after)
- [x] golangci-lint run --timeout=5m internal/saas/... AND GOOS=linux golangci-lint run (clean)
- [x] Live 403 reproduced against api.mitos.run with a fresh default key before the fix

## Risks

Low risk: the implication only widens read-only access for keys that already hold full lifecycle access, which is strictly less power than they already have. No change for read-only keys.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
