### PR TITLE
fix(console): first-run snippets use the hosted surface, not cluster-mode AgentRun

### DIFF
--- a/web/app/src/views/firstrun/content.test.ts
+++ b/web/app/src/views/firstrun/content.test.ts
@@ -68,3 +68,33 @@ describe('FIRST_RUN entries: no em or en dashes', () => {
     expect(DASH_RE.test(entry.watchFor)).toBe(false)
   })
 })
+
+describe('snippets use the hosted surface a new signup can actually run', () => {
+  // AgentRun is the CLUSTER-mode client: it loads a kubeconfig and cannot work
+  // for a hosted signup, whose only credential is MITOS_API_KEY. The first-run
+  // snippet must use the hosted entry points (mitos.create / SandboxServer) or
+  // every new user's first copy-paste dies on ConfigException.
+  it('python snippets never use the cluster-mode AgentRun client', () => {
+    for (const entry of FIRST_RUN) {
+      expect(entry.snippets.python).not.toContain('AgentRun')
+      expect(entry.snippets.python).toContain('mitos.create(')
+    }
+  })
+
+  it('typescript snippets use SandboxServer from the @mitos/sdk package', () => {
+    for (const entry of FIRST_RUN) {
+      expect(entry.snippets.typescript).not.toContain('AgentRun')
+      expect(entry.snippets.typescript).toContain('SandboxServer')
+      expect(entry.snippets.typescript).toContain('@mitos/sdk')
+    }
+  })
+
+  it('cli snippets only use flags the mitos CLI actually has', () => {
+    for (const entry of FIRST_RUN) {
+      // sandbox create has --pool, not --ready; fork has --count, not --exec.
+      expect(entry.snippets.cli).not.toContain('--ready')
+      expect(entry.snippets.cli).not.toContain('--exec')
+      expect(entry.snippets.cli).toContain('--pool')
+    }
+  })
+})

--- a/web/app/src/views/firstrun/content.ts
+++ b/web/app/src/views/firstrun/content.ts
@@ -21,98 +21,101 @@ export type FirstRunContent = {
 }
 
 // Rollouts: warm sandbox forked into a swarm, one task per fork.
+// Hosted surface: mitos.create / SandboxServer resolve MITOS_API_KEY and
+// default to https://api.mitos.run; the cluster-mode AgentRun client needs a
+// kubeconfig a hosted signup does not have.
 const ROLLOUTS = {
   python: `\
-from mitos import AgentRun
+import mitos
 
-sb = AgentRun().sandbox("python", ready=True)
+sb = mitos.create("python")
 swarm = sb.fork(8)
 for run in swarm:
-    run.exec(["python", "rollout.py"])
+    run.exec("python rollout.py")
 `,
   typescript: `\
-import { AgentRun } from "mitos"
+import { SandboxServer } from "@mitos/sdk"
 
-const sb = await new AgentRun().sandbox("python", { ready: true })
+const sb = await new SandboxServer().fork("python")
 const swarm = await sb.fork(8)
-await Promise.all(swarm.map((run) => run.exec(["python", "rollout.py"])))
+await Promise.all(swarm.map((run) => run.exec("python rollout.py")))
 `,
   cli: `\
-mitos sandbox create --ready python
-mitos fork <sandbox-id> --count 8 \\
-  --exec "python rollout.py"
+mitos sandbox create --pool python
+mitos fork <sandbox-id> --count 8
+mitos exec <fork-id> python rollout.py
 `,
 }
 
 // Code execution: boot a warm microVM and exec a single command.
 const CODE_EXEC = {
   python: `\
-from mitos import AgentRun
+import mitos
 
-sb = AgentRun().sandbox("python", ready=True)
-result = sb.exec(["python", "-c", "print('hello from the sandbox')"])
+sb = mitos.create("python")
+result = sb.exec("python3 -c 'print(40 + 2)'")
 print(result.stdout)
 `,
   typescript: `\
-import { AgentRun } from "mitos"
+import { SandboxServer } from "@mitos/sdk"
 
-const sb = await new AgentRun().sandbox("python", { ready: true })
-const result = await sb.exec(["python", "-c", "print('hello from the sandbox')"])
+const sb = await new SandboxServer().fork("python")
+const result = await sb.exec("python3 -c 'print(40 + 2)'")
 console.log(result.stdout)
 `,
   cli: `\
-mitos sandbox create --ready python
-mitos exec <sandbox-id> python -c "print('hello from the sandbox')"
+mitos sandbox create --pool python
+mitos exec <sandbox-id> python3 -c 'print(40 + 2)'
 `,
 }
 
 // Evals: fork one sandbox per test case, no shared state.
 const EVALS = {
   python: `\
-from mitos import AgentRun
+import mitos
 
-sb = AgentRun().sandbox("python", ready=True)
+sb = mitos.create("python")
 cases = sb.fork(len(prompts))
 for run, prompt in zip(cases, prompts):
-    run.exec(["python", "eval_one.py", "--prompt", prompt])
+    run.exec(f"python eval_one.py --prompt {prompt}")
 `,
   typescript: `\
-import { AgentRun } from "mitos"
+import { SandboxServer } from "@mitos/sdk"
 
-const sb = await new AgentRun().sandbox("python", { ready: true })
+const sb = await new SandboxServer().fork("python")
 const cases = await sb.fork(prompts.length)
 await Promise.all(
-  cases.map((run, i) => run.exec(["python", "eval_one.py", "--prompt", prompts[i]]))
+  cases.map((run, i) => run.exec(\`python eval_one.py --prompt \${prompts[i]}\`))
 )
 `,
   cli: `\
-mitos sandbox create --ready python
-mitos fork <sandbox-id> --count <n> \\
-  --exec "python eval_one.py --prompt <prompt>"
+mitos sandbox create --pool python
+mitos fork <sandbox-id> --count <n>
+mitos exec <fork-id> python eval_one.py --prompt <prompt>
 `,
 }
 
 // Default: generic swarm pattern.
 const DEFAULT_SNIPPETS = {
   python: `\
-from mitos import AgentRun
+import mitos
 
-sb = AgentRun().sandbox("python", ready=True)
+sb = mitos.create("python")
 swarm = sb.fork(4)
 for run in swarm:
-    run.exec(["python", "task.py"])
+    run.exec("python task.py")
 `,
   typescript: `\
-import { AgentRun } from "mitos"
+import { SandboxServer } from "@mitos/sdk"
 
-const sb = await new AgentRun().sandbox("python", { ready: true })
+const sb = await new SandboxServer().fork("python")
 const swarm = await sb.fork(4)
-await Promise.all(swarm.map((run) => run.exec(["python", "task.py"])))
+await Promise.all(swarm.map((run) => run.exec("python task.py")))
 `,
   cli: `\
-mitos sandbox create --ready python
-mitos fork <sandbox-id> --count 4 \\
-  --exec "python task.py"
+mitos sandbox create --pool python
+mitos fork <sandbox-id> --count 4
+mitos exec <fork-id> python task.py
 `,
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the console first-run screen is the aha moment of the hosted journey.
> - Asked whether the onboarding screen's python examples had actually been executed, I ran the literal snippet from content.ts with a fresh hosted key and no kubeconfig: it dies on ConfigException before ever using the key.
> - Root cause: all four use-case entries use AgentRun, the CLUSTER-mode client whose constructor loads a kubeconfig; the hosted surface is mitos.create / SandboxServer. The TypeScript tab also imports a package name that does not exist (the npm package is @mitos/sdk) and the CLI tab uses flags the CLI does not have (--ready, --exec).
> - The verify screen promises one snippet that works first try; the very next screen handed every hosted user a dead end in all three tabs (journey rule 6).
> - This pull request rewrites all 12 snippets to the hosted surfaces and adds tests that lock AgentRun out and the hosted entry points in.
> - The benefit is the first code a new user copies actually runs against api.mitos.run with the key they were just handed.

## Linked Issues or Issue Description

Closes #603. Same direct-vs-cluster confusion previously fixed in SKILL.md during the #323 epic.

## What Changed

- web/app/src/views/firstrun/content.ts: python snippets use import mitos / mitos.create("python") / string exec; typescript snippets use SandboxServer from "@mitos/sdk"; cli snippets use the real verbs and flags (sandbox create --pool, fork --count, exec). Comment documents WHY the cluster client cannot appear here.
- web/app/src/views/firstrun/content.test.ts: new suite asserting, for every entry, python contains mitos.create( and never AgentRun; typescript contains SandboxServer and @mitos/sdk and never AgentRun; cli has --pool and neither --ready nor --exec (all red before the fix).

## Verification

- [x] Literal OLD python snippet reproduced the failure against production (ConfigException, key never consulted)
- [x] Literal NEW python snippets run verbatim against api.mitos.run with a fresh onboarding key: code-exec prints 42; the default swarm forks 4 and execs each
- [x] cd web/app: vitest run (272 passed), tsc --noEmit clean, vite build clean
- [x] CLI flags cross-checked against internal/agentcli (sandbox create --pool; fork --count; no --ready/--exec); TS entry cross-checked against sdk/typescript README hosted quickstart

## Risks

Low risk: content-only change in the console SPA plus tests. No API or component logic touched.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
