### PR TITLE
fix(console): first-run cli snippets use the real verb, mitos sandbox exec

### DIFF
--- a/web/app/src/views/firstrun/content.test.ts
+++ b/web/app/src/views/firstrun/content.test.ts
@@ -95,6 +95,9 @@ describe('snippets use the hosted surface a new signup can actually run', () => 
       expect(entry.snippets.cli).not.toContain('--ready')
       expect(entry.snippets.cli).not.toContain('--exec')
       expect(entry.snippets.cli).toContain('--pool')
+      // There is no top-level `mitos exec` verb; the real one is
+      // `mitos sandbox exec` (internal/agentcli/cli.go dispatch).
+      expect(entry.snippets.cli).not.toMatch(/\nmitos exec /)
     }
   })
 })

--- a/web/app/src/views/firstrun/content.ts
+++ b/web/app/src/views/firstrun/content.ts
@@ -43,7 +43,7 @@ await Promise.all(swarm.map((run) => run.exec("python rollout.py")))
   cli: `\
 mitos sandbox create --pool python
 mitos fork <sandbox-id> --count 8
-mitos exec <fork-id> python rollout.py
+mitos sandbox exec <fork-id> python rollout.py
 `,
 }
 
@@ -65,7 +65,7 @@ console.log(result.stdout)
 `,
   cli: `\
 mitos sandbox create --pool python
-mitos exec <sandbox-id> python3 -c 'print(40 + 2)'
+mitos sandbox exec <sandbox-id> python3 -c 'print(40 + 2)'
 `,
 }
 
@@ -91,7 +91,7 @@ await Promise.all(
   cli: `\
 mitos sandbox create --pool python
 mitos fork <sandbox-id> --count <n>
-mitos exec <fork-id> python eval_one.py --prompt <prompt>
+mitos sandbox exec <fork-id> python eval_one.py --prompt <prompt>
 `,
 }
 
@@ -115,7 +115,7 @@ await Promise.all(swarm.map((run) => run.exec("python task.py")))
   cli: `\
 mitos sandbox create --pool python
 mitos fork <sandbox-id> --count 4
-mitos exec <fork-id> python task.py
+mitos sandbox exec <fork-id> python task.py
 `,
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the console first-run screen shows CLI snippets a new user copies verbatim.
> - #604 rewrote the first-run snippets from the cluster-mode client to the hosted surface, and cross-checked the create/fork flags, but wrote the exec line as a top-level `mitos exec`.
> - The CLI dispatch (internal/agentcli/cli.go) has no top-level exec verb: the real form is `mitos sandbox exec <id> <command...>`; only fork has a top-level alias (#311).
> - A copied snippet would exit 2 with the usage text, a small dead end in the exact surface #604 was fixing.
> - This pull request corrects the four cli snippets to `mitos sandbox exec` and adds a test that rejects a top-level `mitos exec` line.
> - The benefit is the cli tab of the first-run screen now runs verbatim, like the python and typescript tabs.

## Linked Issues or Issue Description

Related: #603 (the first-run snippet fix this corrects), #604.

## What Changed

- web/app/src/views/firstrun/content.ts: `mitos exec` -> `mitos sandbox exec` in all four use-case cli snippets.
- web/app/src/views/firstrun/content.test.ts: asserts no snippet contains a top-level `mitos exec` line (red before the fix).

## Verification

- [x] cd web/app && npx vitest run src/views/firstrun/ (58 passed; the new assertion was red before the fix)
- [x] Verb list cross-checked against internal/agentcli/cli.go dispatch (run, sandbox, fork, ws, template, auth, dev, doctor)

## Risks

Low risk: console content string change plus a test.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
