### PR TITLE
fix(console): first-run snippets are self-contained and produce real output

### DIFF
--- a/web/app/src/views/firstrun/content.test.ts
+++ b/web/app/src/views/firstrun/content.test.ts
@@ -100,4 +100,16 @@ describe('snippets use the hosted surface a new signup can actually run', () => 
       expect(entry.snippets.cli).not.toMatch(/\nmitos exec /)
     }
   })
+
+  it('snippets are self-contained: no references to files the snippet never creates', () => {
+    // A fresh sandbox has no task.py / rollout.py / eval_one.py, and hosted
+    // fork re-forks the template, so a file staged in the parent does not
+    // reach the children either. A pasted snippet must produce real output,
+    // not a swarm of "can't open file" exits.
+    for (const entry of FIRST_RUN) {
+      for (const runtime of ['python', 'typescript', 'cli'] as const) {
+        expect(entry.snippets[runtime]).not.toMatch(/\w+\.(py|js)\b/)
+      }
+    }
+  })
 })

--- a/web/app/src/views/firstrun/content.ts
+++ b/web/app/src/views/firstrun/content.ts
@@ -30,20 +30,23 @@ import mitos
 
 sb = mitos.create("python")
 swarm = sb.fork(8)
-for run in swarm:
-    run.exec("python rollout.py")
+for i, run in enumerate(swarm):
+    print(run.exec(f"python3 -c 'print({i} ** 2)'").stdout.strip())
 `,
   typescript: `\
 import { SandboxServer } from "@mitos/sdk"
 
 const sb = await new SandboxServer().fork("python")
 const swarm = await sb.fork(8)
-await Promise.all(swarm.map((run) => run.exec("python rollout.py")))
+const results = await Promise.all(
+  swarm.map((run, i) => run.exec(\`python3 -c 'print(\${i} ** 2)'\`))
+)
+results.forEach((r) => console.log(r.stdout.trim()))
 `,
   cli: `\
 mitos sandbox create --pool python
 mitos fork <sandbox-id> --count 8
-mitos sandbox exec <fork-id> python rollout.py
+mitos sandbox exec <fork-id> python3 -c 'print(42)'
 `,
 }
 
@@ -74,24 +77,27 @@ const EVALS = {
   python: `\
 import mitos
 
+prompts = ["2 + 2", "10 * 4.2"]
 sb = mitos.create("python")
 cases = sb.fork(len(prompts))
 for run, prompt in zip(cases, prompts):
-    run.exec(f"python eval_one.py --prompt {prompt}")
+    print(run.exec(f"python3 -c 'print({prompt})'").stdout.strip())
 `,
   typescript: `\
 import { SandboxServer } from "@mitos/sdk"
 
+const prompts = ["2 + 2", "10 * 4.2"]
 const sb = await new SandboxServer().fork("python")
 const cases = await sb.fork(prompts.length)
-await Promise.all(
-  cases.map((run, i) => run.exec(\`python eval_one.py --prompt \${prompts[i]}\`))
+const results = await Promise.all(
+  cases.map((run, i) => run.exec(\`python3 -c 'print(\${prompts[i]})'\`))
 )
+results.forEach((r) => console.log(r.stdout.trim()))
 `,
   cli: `\
 mitos sandbox create --pool python
 mitos fork <sandbox-id> --count <n>
-mitos sandbox exec <fork-id> python eval_one.py --prompt <prompt>
+mitos sandbox exec <fork-id> python3 -c 'print(2 + 2)'
 `,
 }
 
@@ -102,20 +108,23 @@ import mitos
 
 sb = mitos.create("python")
 swarm = sb.fork(4)
-for run in swarm:
-    run.exec("python task.py")
+for i, run in enumerate(swarm):
+    print(run.exec(f"python3 -c 'print({i} ** 2)'").stdout.strip())
 `,
   typescript: `\
 import { SandboxServer } from "@mitos/sdk"
 
 const sb = await new SandboxServer().fork("python")
 const swarm = await sb.fork(4)
-await Promise.all(swarm.map((run) => run.exec("python task.py")))
+const results = await Promise.all(
+  swarm.map((run, i) => run.exec(\`python3 -c 'print(\${i} ** 2)'\`))
+)
+results.forEach((r) => console.log(r.stdout.trim()))
 `,
   cli: `\
 mitos sandbox create --pool python
 mitos fork <sandbox-id> --count 4
-mitos sandbox exec <fork-id> python task.py
+mitos sandbox exec <fork-id> python3 -c 'print(42)'
 `,
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the console first-run screen promises a snippet that works first try.
> - #604/#606 moved the snippets to the hosted surface, but the swarm snippets still exec'd task.py / rollout.py / eval_one.py, files a fresh sandbox does not contain: every fork exits 2 with can't-open-file and the user sees nothing work.
> - Staging the file in the parent before forking would not fix it: hosted fork re-forks the template (#596), so children never inherit parent writes.
> - The only honest shape today is fully self-contained: fork, run inline code in each child, print the result.
> - This pull request rewrites the rollouts, evals, and default snippets (python, typescript, cli) to inline commands with visible output, and adds a test rejecting references to files a snippet never creates.
> - The benefit is a pasted snippet produces real output on the spot: eight isolated microVMs printing their own computation IS the aha.

## Linked Issues or Issue Description

Related: #603, #604, #606 (the first-run snippet fixes this completes), #596 (why parent-staged files cannot be used).

## What Changed

- web/app/src/views/firstrun/content.ts: rollouts forks 8 and each child prints i squared; evals defines an inline prompts list and evaluates one per fork; default forks 4 likewise; cli tabs exec an inline python3 -c. code-execution was already self-contained.
- web/app/src/views/firstrun/content.test.ts: new test asserting no snippet references a .py/.js file it never creates (red before the fix).

## Verification

- [x] All four python snippets extracted verbatim from content.ts and executed against api.mitos.run with a fresh onboarding key: outputs 0 1 4 9 16 25 36 49 / 42 / 4 42.0 / 0 1 4 9, all sandboxes terminated clean
- [x] cd web/app: vitest run (273 passed), vite build clean
- [x] Rapid back-to-back runs tripped the gateway per-window rate limit as designed; rerun after the window confirmed both remaining snippets

## Risks

Low risk: console content strings plus a test.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, agentic coding via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
