### PR TITLE
feat(saas): hosted pause and resume via the sandbox lifecycle proxy

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -88,6 +88,13 @@ Exposed as:
 
 - `POST /v1/pause` and `POST /v1/resume` on forkd and the standalone
   sandbox-server, body `{"sandbox": "<id>"}`.
+- `POST /v1/pause` and `POST /v1/resume` on the hosted gateway, same body; the
+  gateway resolves the sandbox org-scoped and proxies the call to that
+  sandbox's runtime endpoint with the per-sandbox token. Hosted pause today
+  records the idle-hold state (the paused sandbox is never idle-reaped),
+  exactly like the standalone server: the hosted runtime endpoint sets no
+  engine pauser, so the live memory snapshot under pause is the KVM-gated
+  follow-up.
 - `sandbox.pause()` / `sandbox.resume()` in the Python SDK (sync and async) and
   `sandbox.pause()` / `sandbox.resume()` in the TypeScript SDK.
 

--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -448,6 +448,176 @@ func TestProxyUnknownSandboxIsNotFound(t *testing.T) {
 	}
 }
 
+// ----- pause / resume lifecycle proxy (#601) -----
+
+// TestPauseResumeForwardToSandboxEndpoint asserts sandbox.pause and
+// sandbox.resume POST the daemon lifecycle routes on the org-owned sandbox
+// endpoint with the per-sandbox bearer token and the body {"sandbox": <name>},
+// and pass the upstream 2xx status and body through.
+func TestPauseResumeForwardToSandboxEndpoint(t *testing.T) {
+	cases := []struct {
+		op       string
+		route    string
+		upstream string
+	}{
+		{op: "sandbox.pause", route: "/v1/pause", upstream: `{"status":"paused"}`},
+		{op: "sandbox.resume", route: "/v1/resume", upstream: `{"status":"running"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.op, func(t *testing.T) {
+			var gotMethod, gotPath, gotAuth, gotBody string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				b, _ := io.ReadAll(r.Body)
+				gotBody = string(b)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.upstream))
+			}))
+			defer srv.Close()
+			endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+			sb, secret := readySandbox(orgA, "sb-hold", endpoint, "the-real-token")
+			c := newFakeClient(t, sb, secret)
+			cp := New(c, WithHTTPClient(srv.Client()))
+
+			resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+				OrgID: orgA, Op: tc.op, Path: tc.route, Body: []byte(`{"sandbox":"sb-hold"}`),
+			})
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+			if resp.Status != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+			}
+			if string(resp.Body) != tc.upstream {
+				t.Errorf("body = %q, want the upstream body %q", resp.Body, tc.upstream)
+			}
+			if gotMethod != http.MethodPost {
+				t.Errorf("upstream method = %q, want POST", gotMethod)
+			}
+			if gotPath != tc.route {
+				t.Errorf("upstream path = %q, want %q", gotPath, tc.route)
+			}
+			if gotAuth != "Bearer the-real-token" {
+				t.Errorf("upstream Authorization = %q, want the per-sandbox token", gotAuth)
+			}
+			if gotBody != `{"sandbox":"sb-hold"}` {
+				t.Errorf("upstream body = %q, want {\"sandbox\":\"sb-hold\"}", gotBody)
+			}
+		})
+	}
+}
+
+// TestPauseUpstreamErrorPassesThrough asserts a non-2xx daemon response (for
+// example a failed engine pause) is passed through with its status and body,
+// so the caller sees the daemon's actionable error, not a generic one.
+func TestPauseUpstreamErrorPassesThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"pause sandbox: snapshot failed"}`))
+	}))
+	defer srv.Close()
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+	sb, secret := readySandbox(orgA, "sb-err", endpoint, "tok")
+	c := newFakeClient(t, sb, secret)
+	cp := New(c, WithHTTPClient(srv.Client()))
+
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.pause", Path: "/v1/pause", Body: []byte(`{"sandbox":"sb-err"}`),
+	})
+	if resp.Status != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want the upstream 500 passed through; body = %s", resp.Status, resp.Body)
+	}
+	if !strings.Contains(string(resp.Body), "snapshot failed") {
+		t.Errorf("body = %q, want the upstream error body passed through", resp.Body)
+	}
+}
+
+// TestPauseCrossOrgIsNotFoundAndNeverReachesEndpoint asserts org A cannot pause
+// org B's sandbox: not_found, the endpoint is never hit, AND the response is
+// indistinguishable from a sandbox that does not exist at all (no oracle).
+func TestPauseCrossOrgIsNotFoundAndNeverReachesEndpoint(t *testing.T) {
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+	sb, secret := readySandbox(orgB, "sb-bheld", endpoint, "tok")
+	c := newFakeClient(t, sb, secret)
+	cp := New(c, WithHTTPClient(srv.Client()))
+
+	cross, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.pause", Path: "/v1/pause", Body: []byte(`{"sandbox":"sb-bheld"}`),
+	})
+	if cross.Status != http.StatusNotFound {
+		t.Fatalf("cross-org pause: status = %d, want 404", cross.Status)
+	}
+	if reached {
+		t.Fatal("cross-org pause REACHED the sandbox endpoint; the boundary failed")
+	}
+
+	// A truly missing id must be byte-for-byte indistinguishable modulo the id.
+	missing, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.pause", Path: "/v1/pause", Body: []byte(`{"sandbox":"sb-ghost"}`),
+	})
+	if missing.Status != cross.Status {
+		t.Errorf("missing-id status = %d, cross-org status = %d; the two must not differ (oracle)", missing.Status, cross.Status)
+	}
+	crossBody := strings.ReplaceAll(string(cross.Body), "sb-bheld", "<id>")
+	missingBody := strings.ReplaceAll(string(missing.Body), "sb-ghost", "<id>")
+	if crossBody != missingBody {
+		t.Errorf("cross-org body %q differs from missing-id body %q; a probe can map ids", crossBody, missingBody)
+	}
+}
+
+// TestPauseNotReadySandboxIsClearError asserts pausing a sandbox with no
+// runtime endpoint yet returns an actionable error, mirroring the runtime
+// proxy's not-ready behavior.
+func TestPauseNotReadySandboxIsClearError(t *testing.T) {
+	sb, secret := readySandbox(orgA, "sb-cold", "", "tok")
+	sb.Status.Phase = v1.SandboxPending
+	sb.Status.Endpoint = ""
+	c := newFakeClient(t, sb, secret)
+	cp := New(c)
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.pause", Path: "/v1/pause", Body: []byte(`{"sandbox":"sb-cold"}`),
+	})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404-style not-ready error; body = %s", resp.Status, resp.Body)
+	}
+	if !strings.Contains(string(resp.Body), "not Ready") {
+		t.Errorf("error body not actionable about readiness: %s", resp.Body)
+	}
+}
+
+// TestPauseBodyWithoutSandboxIsInvalidInput asserts a pause or resume body that
+// does not name a sandbox (missing field, empty value, or invalid JSON) is a
+// 400 invalid_input with remediation, not a forwarded request.
+func TestPauseBodyWithoutSandboxIsInvalidInput(t *testing.T) {
+	c := newFakeClient(t)
+	cp := New(c)
+	for _, body := range []string{`{}`, `{"sandbox":""}`, `not json`, ``} {
+		for _, op := range []string{"sandbox.pause", "sandbox.resume"} {
+			resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{
+				OrgID: orgA, Op: op, Path: "/v1/pause", Body: []byte(body),
+			})
+			if resp.Status != http.StatusBadRequest {
+				t.Errorf("%s body=%q: status = %d, want 400; body = %s", op, body, resp.Status, resp.Body)
+			}
+			if !strings.Contains(string(resp.Body), "invalid_input") {
+				t.Errorf("%s body=%q: error code missing invalid_input: %s", op, body, resp.Body)
+			}
+		}
+	}
+}
+
 // TestTokenNeverAppearsInErrorOrNonCreateResponse asserts the per-sandbox token
 // is returned ONLY on create: status and list responses, and every error body,
 // are scanned and must not contain it.

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -44,6 +44,10 @@ func (k *K8sControlPlane) Forward(ctx context.Context, req saas.ForwardRequest) 
 		return k.terminate(ctx, req)
 	case "sandbox.runtime":
 		return k.proxy(ctx, req)
+	case "sandbox.pause":
+		return k.lifecycle(ctx, req, "/v1/pause")
+	case "sandbox.resume":
+		return k.lifecycle(ctx, req, "/v1/resume")
 	case "template.ensure":
 		return k.ensureTemplate(ctx, req)
 	case "template.list":

--- a/internal/saas/controlplane/lifecycle.go
+++ b/internal/saas/controlplane/lifecycle.go
@@ -1,0 +1,97 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// maxLifecycleRespBytes bounds a buffered lifecycle response body. The daemon
+// pause/resume replies are tiny JSON objects; the cap only guards against a
+// misbehaving endpoint.
+const maxLifecycleRespBytes = 1 << 20 // 1 MiB
+
+// lifecycleBody names the sandbox a pause or resume acts on. It mirrors the
+// daemon request shape (internal/daemon/lifecycle_api.go): the id rides in the
+// JSON body, not the path, which is why these ops cannot share the Connect
+// runtime proxy.
+type lifecycleBody struct {
+	Sandbox string `json:"sandbox"`
+}
+
+// lifecycle forwards a pause or resume (route "/v1/pause" or "/v1/resume") to
+// the org-owned sandbox's runtime endpoint. The sandbox id comes from the JSON
+// body; the sandbox is read org-scoped with the org-label re-check, so a
+// missing or cross-org id collapses to not_found and is NEVER forwarded. The
+// request presented upstream carries the per-sandbox bearer token (never
+// logged, never echoed) and the body {"sandbox": <resolved name>}; the
+// upstream status and body are passed through so the daemon's own error stays
+// actionable.
+func (k *K8sControlPlane) lifecycle(ctx context.Context, req saas.ForwardRequest, route string) (saas.ForwardResponse, error) {
+	var body lifecycleBody
+	if err := json.Unmarshal(req.Body, &body); err != nil || body.Sandbox == "" {
+		return errResp(apierr.Get(apierr.CodeInvalidInput).
+			WithCause(`the request body does not name a sandbox; send {"sandbox": "<id>"} with the id of the sandbox to act on`)), nil
+	}
+
+	// Org-scoped read with the org-label re-check: a missing or cross-org sandbox
+	// collapses to not_found and never reaches the endpoint.
+	sb, ok := k.getOwned(ctx, req.OrgID, body.Sandbox)
+	if !ok {
+		return notFound(body.Sandbox), nil
+	}
+	if sb.Status.Endpoint == "" {
+		return errResp(apierr.Get(apierr.CodeNotFound).
+			WithCause(fmt.Sprintf("sandbox %q has no runtime endpoint yet; it is not Ready", body.Sandbox))), nil
+	}
+
+	token, err := k.readToken(ctx, sb.Namespace, sb.Name)
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).
+			WithCause("the per-sandbox access token secret could not be read")), nil
+	}
+
+	// The upstream body carries the control-plane-resolved sandbox name, never a
+	// client-supplied value the resolution did not verify.
+	payload, err := json.Marshal(map[string]string{"sandbox": sb.Name})
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).
+			WithCause("could not encode the lifecycle request")), nil
+	}
+	outReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+sb.Status.Endpoint+route, bytes.NewReader(payload))
+	if err != nil {
+		return errResp(apierr.Get(apierr.CodeInternal).
+			WithCause("could not build the lifecycle proxy request")), nil
+	}
+	outReq.Header.Set("Content-Type", "application/json")
+	outReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := k.httpClient.Do(outReq)
+	if err != nil {
+		return errResp(withStatus(apierr.Get(apierr.CodeInternal).
+			WithCause("the sandbox runtime endpoint could not be reached"), http.StatusBadGateway)), nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxLifecycleRespBytes))
+	if err != nil {
+		return errResp(withStatus(apierr.Get(apierr.CodeInternal).
+			WithCause("the sandbox runtime endpoint response could not be read"), http.StatusBadGateway)), nil
+	}
+
+	header := http.Header{}
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		header.Set("Content-Type", ct)
+	}
+	return saas.ForwardResponse{
+		Status: resp.StatusCode,
+		Header: header,
+		Body:   respBody,
+	}, nil
+}

--- a/internal/saas/gateway.go
+++ b/internal/saas/gateway.go
@@ -168,6 +168,15 @@ func opFromPath(method, path string) string {
 	// {"pool":"<name>"} or {"image":"<name>"}. The create handler resolves all three.
 	case p == "fork" && method == http.MethodPost:
 		return "sandbox.create"
+	// Pause and resume: the SDK calls POST /v1/pause and POST /v1/resume with the
+	// body {"sandbox":"<id>"} (issue #601). Both are mutating lifecycle verbs, so
+	// the requiredScopeFor default (the sandboxes scope) is correct. The control
+	// plane proxies them to the per-sandbox runtime endpoint, which already serves
+	// the routes (internal/daemon/lifecycle_api.go).
+	case p == "pause" && method == http.MethodPost:
+		return "sandbox.pause"
+	case p == "resume" && method == http.MethodPost:
+		return "sandbox.resume"
 	default:
 		return "sandbox." + strings.ToLower(method)
 	}

--- a/internal/saas/gateway_test.go
+++ b/internal/saas/gateway_test.go
@@ -471,6 +471,75 @@ func TestGatewayExistingSandboxesPathStillWorks(t *testing.T) {
 	}
 }
 
+// TestGatewayPauseMapsToSandboxPause asserts POST /v1/pause (the SDK
+// sandbox.pause() call, body {"sandbox": "<id>"}) routes as the "sandbox.pause"
+// op with the org taken from the verified key. Before #601 it fell through to
+// "sandbox.post", which the control plane rejects as an unknown operation.
+func TestGatewayPauseMapsToSandboxPause(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	f.cp.respBody = []byte(`{"status":"paused"}`)
+	rec := doRequest(f.gw, http.MethodPost, "/v1/pause", f.rawA, `{"sandbox":"sb-x"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(f.cp.got) != 1 {
+		t.Fatalf("control plane saw %d requests, want 1", len(f.cp.got))
+	}
+	if f.cp.got[0].Op != "sandbox.pause" {
+		t.Errorf("op = %q, want sandbox.pause", f.cp.got[0].Op)
+	}
+	if f.cp.got[0].OrgID != "org-a" {
+		t.Errorf("OrgID = %q, want org-a (must come from the verified key)", f.cp.got[0].OrgID)
+	}
+}
+
+// TestGatewayResumeMapsToSandboxResume asserts POST /v1/resume routes as the
+// "sandbox.resume" op with the org taken from the verified key.
+func TestGatewayResumeMapsToSandboxResume(t *testing.T) {
+	f := newGatewayFixture(t, nil)
+	f.cp.respBody = []byte(`{"status":"running"}`)
+	rec := doRequest(f.gw, http.MethodPost, "/v1/resume", f.rawA, `{"sandbox":"sb-x"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if len(f.cp.got) != 1 {
+		t.Fatalf("control plane saw %d requests, want 1", len(f.cp.got))
+	}
+	if f.cp.got[0].Op != "sandbox.resume" {
+		t.Errorf("op = %q, want sandbox.resume", f.cp.got[0].Op)
+	}
+	if f.cp.got[0].OrgID != "org-a" {
+		t.Errorf("OrgID = %q, want org-a (must come from the verified key)", f.cp.got[0].OrgID)
+	}
+}
+
+// TestGatewayPauseResumeRequireSandboxScope asserts pause and resume are
+// MUTATING ops: a read-only key is rejected with forbidden and never reaches
+// the control plane.
+func TestGatewayPauseResumeRequireSandboxScope(t *testing.T) {
+	store := NewMemStore()
+	newTestOrg(t, store, "org-a")
+	keys := NewKeyService(store)
+	created, err := keys.CreateKey(context.Background(), CreateKeyRequest{OrgID: "org-a", Scopes: []string{ScopeReadOnly}})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	cp := &fakeControlPlane{respBody: []byte(`{}`)}
+	gw := NewGateway(keys, nil, cp, nil)
+	for _, path := range []string{"/v1/pause", "/v1/resume"} {
+		rec := doRequest(gw, http.MethodPost, path, created.RawKey, `{"sandbox":"sb-x"}`)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s: status = %d, want 403 for a read-only key", path, rec.Code)
+		}
+		if code := decodeErr(t, rec); code != "forbidden" {
+			t.Errorf("%s: error code = %q, want forbidden", path, code)
+		}
+	}
+	if len(cp.got) != 0 {
+		t.Error("control plane reached despite a read-only key on pause/resume")
+	}
+}
+
 // TestGatewayTemplatesPathStillWorks is a regression guard: the /v1/templates POST
 // path added in #520 must still route as template.ensure after the /v1/fork case
 // is added.


### PR DESCRIPTION
## Thinking Path

> 1. Reproduced the gap: the SDK sends POST /v1/pause and /v1/resume with body {"sandbox": "<id>"} (sdk/python/mitos/direct.py), but opFromPath had no case for them, so they fell to "sandbox.post" and the control plane rejected them as an unknown operation.
> 2. Confirmed the per-sandbox hosted runtime endpoint already serves both routes: husk-stub builds daemon.NewSandboxAPI, whose mux mounts POST /v1/pause and /v1/resume and validates the per-sandbox bearer, exactly like hosted exec and files.
> 3. Ruled out reusing the Connect runtime proxy: it only carries /sandbox.v1.Sandbox/ methods and resolves the id from the header or path, while pause/resume carry the id in the JSON body; a small dedicated lifecycle proxy is the honest shape.
> 4. Wrote the failing tests first: gateway op-mapping, scope enforcement, and control-plane forwarding with bearer, body, cross-org, not-ready, and invalid-input cases; all red on main.
> 5. Implemented the two opFromPath cases (the requiredScopeFor default already demands the sandboxes scope for these mutating verbs) and the Forward switch routes.
> 6. Implemented lifecycle(): unmarshal the body, resolve the sandbox org-scoped through getOwned (org-label re-check, not_found collapse), read the per-sandbox token, POST the route upstream, pass the upstream status and body through.
> 7. Updated docs/lifecycle.md with the hosted routes and the honest semantics note, then verified: full saas test suite, go build, both lint invocations, and the dash scan.

## Linked Issues or Issue Description

Closes #601

## What Changed

- `internal/saas/gateway.go`: opFromPath maps POST /v1/pause to `sandbox.pause` and POST /v1/resume to `sandbox.resume`. Both are mutating ops, so the existing requiredScopeFor default (the sandboxes scope) applies unchanged; a read-only key is rejected with forbidden.
- `internal/saas/controlplane/forward.go`: the Forward switch routes both ops to the new lifecycle handler.
- `internal/saas/controlplane/lifecycle.go` (new): resolves the sandbox id from the JSON body, reads the sandbox org-scoped with the org-label re-check (a missing or cross-org id collapses to not_found with no oracle difference), rejects an empty or invalid body as invalid_input with remediation, mirrors the runtime proxy's not-ready error when the endpoint is empty, then POSTs `http://<endpoint>/v1/pause` or `/v1/resume` with the per-sandbox bearer token and the body `{"sandbox": <resolved name>}`. The upstream status and body pass through, so the daemon's own actionable error reaches the caller. The token is never logged and never echoed.
- `docs/lifecycle.md`: documents the two hosted routes.
- Tests: `internal/saas/gateway_test.go` (op mapping, org from the verified key, read-only scope rejected) and `internal/saas/controlplane/controlplane_test.go` (upstream method, path, bearer, body; 2xx and error passthrough; cross-org vs missing id oracle equality; missing endpoint; body without a sandbox).

Honest semantics note: hosted pause today records the idle-hold state (the paused sandbox is never idle-reaped), exactly like the standalone sandbox-server, because the hosted per-sandbox runtime endpoint sets no EnginePauser (`internal/daemon/lifecycle_api.go`). The live memory snapshot under pause is the KVM-gated follow-up.

## Verification

- Tests written first and red on main (unknown operation), green after: `go test ./internal/saas/...` all packages ok.
- `go build ./...` clean.
- `~/go/bin/golangci-lint run --timeout=5m internal/saas/...` and `GOOS=linux ~/go/bin/golangci-lint run --timeout=5m internal/saas/...` both clean.
- Dash scan over every changed file: no em or en dashes.

## Risks

- The lifecycle proxy buffers the upstream response (capped at 1 MiB); the daemon replies are tiny JSON objects, so no streaming path is affected.
- Cross-tenant boundary: the id resolution reuses getOwned, the same org-label re-check every owned-object lookup uses; the oracle-equality test pins that a cross-org probe is indistinguishable from a missing id.
- No secret surface change: the per-sandbox token is read from the same controller-owned Secret as the runtime proxy and never appears in logs or responses.

## Model Used

Claude Fable 5 (model id claude-fable-5), via Claude Code.

## Checklist

- [x] Tests land in the same commit as the behavior change (TDD, red first)
- [x] Docs updated in the same PR (docs/lifecycle.md)
- [x] No threat-model delta: no new listener, credential, or trust boundary; the change reuses the existing org-scoped lookup and per-sandbox token plane
- [x] No benchmark run needed: the fork hot path is untouched
- [x] Both golangci-lint invocations clean
- [x] No em or en dashes in any changed file or this PR body
- [x] DCO sign-off on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
