### PR TITLE
feat(saas): self-host operator knobs as first-class Helm values, configurable billing rates

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -95,6 +95,18 @@ func main() {
 		creditLedger = billing.NewMemCreditLedger()
 	}
 
+	// Billing rate table: MITOS_CONSOLE_RATES (a JSON object mapping onto
+	// billing.Rates; Helm value console.billing.rates) REPLACES the built-in
+	// illustrative defaults when set. A malformed value fails startup (fail
+	// closed) rather than silently pricing usage at the wrong rates; the parse
+	// error carries the remediation text. The SAME table prices the billing
+	// view, the drawdown driver, and (via ToPriceList) the display cost
+	// estimate, so they never drift. See docs/saas/pricing.md.
+	rates, err := billing.ParseRatesConfig(os.Getenv("MITOS_CONSOLE_RATES"))
+	if err != nil {
+		log.Fatalf("MITOS_CONSOLE_RATES: %v", err)
+	}
+
 	bill := setupBilling(logger, statusStore, creditLedger)
 
 	// sessionStore is created before console.New so it can be passed into
@@ -134,8 +146,12 @@ func main() {
 			Ledger: creditLedger,
 			Status: statusStore,
 			Caps:   spendCapStore,
-			Rates:  billing.DefaultRates(),
+			Rates:  rates,
 		},
+		// The display price list derives from the SAME configured rate table
+		// the ledger bills with, so the estimate a user sees matches what is
+		// charged.
+		Prices: rates.ToPriceList(),
 		// The active secret backend selected from config (kube / openbao), falling
 		// back to in-memory in dev. Capabilities advertise the same providers.
 		Secrets: buildSecretStore(logger, caps),
@@ -171,18 +187,18 @@ func main() {
 	// dev fallback (nothing real to settle); MITOS_CONSOLE_DRAWDOWN_INTERVAL
 	// overrides (a Go duration, or 0/off to disable). The service is built over
 	// the SAME credit ledger and status store the BFF billing view reads, and
-	// prices with the default rate table (billing.DefaultRates,
-	// docs/saas/pricing.md); a configurable price list is a documented
-	// follow-up. No billing provider is involved: Drawdown only prices the
-	// record and debits prepaid credit, idempotently per (org, sandbox, window).
-	// The driver logs counts only, never balances or costs.
+	// prices with the SAME rate table (billing.DefaultRates unless
+	// MITOS_CONSOLE_RATES overrides it; docs/saas/pricing.md). No billing
+	// provider is involved: Drawdown only prices the record and debits prepaid
+	// credit, idempotently per (org, sandbox, window). The driver logs counts
+	// only, never balances or costs.
 	_, usageLive := usageStore.(*usage.HTTPStore)
 	ddInterval, err := drawdownInterval(os.Getenv("MITOS_CONSOLE_DRAWDOWN_INTERVAL"), usageLive)
 	if err != nil {
 		log.Fatalf("drawdown: %v", err)
 	}
 	if ddInterval > 0 {
-		dd := billing.NewService(billing.Config{Ledger: creditLedger, Status: statusStore, Rates: billing.DefaultRates()})
+		dd := billing.NewService(billing.Config{Ledger: creditLedger, Status: statusStore, Rates: rates})
 		startDrawdownDriver(context.Background(), logger, ddInterval, store, usageStore, dd)
 		logger.Info("usage drawdown driver enabled", "interval", ddInterval.String())
 	} else {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -486,9 +486,21 @@ func main() {
 			if usageAPIToken == "" {
 				logger.Info("WARNING: --usage-api-address is set but MITOS_USAGE_API_TOKEN is empty; the internal usage API will refuse every request (fail closed)")
 			}
+			// Display price list: MITOS_USAGE_PRICELIST (a JSON object mapping
+			// onto usage.PriceList, dollars per unit; Helm value
+			// controller.usage.priceList) REPLACES the illustrative defaults
+			// when set, so the usage API's cost estimate can match the
+			// deployment's configured billing rates instead of drifting from
+			// them. A malformed value fails startup (fail closed); the parse
+			// error carries the remediation text. See docs/saas/pricing.md.
+			prices, err := usage.ParsePriceListConfig(os.Getenv("MITOS_USAGE_PRICELIST"))
+			if err != nil {
+				logger.Error(err, "invalid MITOS_USAGE_PRICELIST")
+				os.Exit(1)
+			}
 			if err := mgr.Add(&controller.UsageAPIRunnable{
 				Store:  usageStore,
-				Prices: usage.DefaultPriceList(),
+				Prices: prices,
 				Addr:   usageAPIAddr,
 				Token:  usageAPIToken,
 			}); err != nil {

--- a/deploy/charts/charttest/console_test.go
+++ b/deploy/charts/charttest/console_test.go
@@ -27,12 +27,25 @@ func chartDir(t *testing.T) string {
 // constraint is satisfied independent of the host's client default.
 func render(t *testing.T, sets ...string) string {
 	t.Helper()
+	return renderFlag(t, "--set", sets...)
+}
+
+// renderJSON is render with --set-json overrides. Plain --set parses only
+// integers as numbers and stringifies floats, so a float value (e.g. a rate of
+// 1.28) needs --set-json to reach the rendered JSON env as a number.
+func renderJSON(t *testing.T, sets ...string) string {
+	t.Helper()
+	return renderFlag(t, "--set-json", sets...)
+}
+
+func renderFlag(t *testing.T, flag string, sets ...string) string {
+	t.Helper()
 	if _, err := exec.LookPath("helm"); err != nil {
 		t.Skip("helm not installed; skipping chart render test")
 	}
 	args := []string{"template", "t", chartDir(t), "--kube-version", "1.31.0"}
 	for _, s := range sets {
-		args = append(args, "--set", s)
+		args = append(args, flag, s)
 	}
 	out, err := exec.Command("helm", args...).CombinedOutput()
 	if err != nil {
@@ -161,6 +174,123 @@ func TestPaddleSecretValuesNeverPlaintext(t *testing.T) {
 			}
 		}
 	}
+}
+
+// Self-host SaaS operator knobs, promoted from extraEnv to first-class values:
+// signup credit, allowlist auto-allow domains, auth connectors, Paddle top-up
+// product/currency, anti-abuse (captcha, disposable-domain allow, per-IP
+// signup velocity), and the billing rate table. Each renders ONLY when set so
+// a default install carries none of the env and the binary defaults apply.
+
+// TestSelfHostKnobsAbsentByDefault asserts the default render carries NONE of
+// the operator-knob env vars, so a fresh install behaves exactly as before.
+func TestSelfHostKnobsAbsentByDefault(t *testing.T) {
+	out := render(t)
+	for _, env := range []string{
+		"MITOS_CONSOLE_SIGNUP_CREDIT_CENTS",
+		"MITOS_CONSOLE_AUTOALLOW_DOMAINS",
+		"MITOS_CONSOLE_AUTH_CONNECTORS",
+		"MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT",
+		"MITOS_CONSOLE_PADDLE_CURRENCY",
+		"MITOS_CONSOLE_FRIENDLY_CAPTCHA_SITEKEY",
+		"MITOS_CONSOLE_FRIENDLY_CAPTCHA_SECRET",
+		"MITOS_CONSOLE_FRIENDLY_CAPTCHA_URL",
+		"MITOS_CONSOLE_DISPOSABLE_ALLOW",
+		"MITOS_CONSOLE_SIGNUP_IP_LIMIT",
+		"MITOS_CONSOLE_SIGNUP_IP_WINDOW",
+		"MITOS_CONSOLE_RATES",
+	} {
+		if strings.Contains(out, env) {
+			t.Fatalf("%s rendered by default; operator knobs must be opt-in", env)
+		}
+	}
+}
+
+// TestSignupCreditAndAllowlistKnobs asserts the signup credit, the auto-allow
+// domain list, and the auth connector list render as env when set (lists are
+// comma-joined, matching the binary's parsers).
+func TestSignupCreditAndAllowlistKnobs(t *testing.T) {
+	out := render(t,
+		"console.signupCreditCents=500",
+		"console.autoAllowDomains={corp.example.com,partner.io}",
+		"console.authConnectors={github,google}",
+	)
+	mustEnv(t, out, "MITOS_CONSOLE_SIGNUP_CREDIT_CENTS", "500")
+	mustEnv(t, out, "MITOS_CONSOLE_AUTOALLOW_DOMAINS", "corp.example.com,partner.io")
+	mustEnv(t, out, "MITOS_CONSOLE_AUTH_CONNECTORS", "github,google")
+}
+
+// TestPaddleTopUpKnobs asserts the top-up product id and currency render when
+// billing is enabled and set; both are plain config, not secrets.
+func TestPaddleTopUpKnobs(t *testing.T) {
+	out := render(t,
+		"console.billing.enabled=true",
+		"console.billing.paddle.topUpProduct=pro_topup",
+		"console.billing.paddle.currency=USD",
+	)
+	mustEnv(t, out, "MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT", "pro_topup")
+	mustEnv(t, out, "MITOS_CONSOLE_PADDLE_CURRENCY", "USD")
+}
+
+// TestPaddleTopUpKnobsGatedByBilling asserts the top-up env stays absent while
+// billing is off even when the values are set, matching the other Paddle env.
+func TestPaddleTopUpKnobsGatedByBilling(t *testing.T) {
+	out := render(t, "console.billing.paddle.topUpProduct=pro_topup")
+	if strings.Contains(out, "MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT") {
+		t.Fatal("MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT rendered with billing disabled")
+	}
+}
+
+// TestAntiAbuseKnobs asserts the captcha sitekey renders as plain env, the
+// captcha SECRET rides a secretKeyRef ONLY, and the disposable-allow and
+// velocity knobs render comma-joined / verbatim.
+func TestAntiAbuseKnobs(t *testing.T) {
+	out := render(t,
+		"console.antiAbuse.friendlyCaptcha.siteKey=FCSITE123",
+		"console.antiAbuse.friendlyCaptcha.secretRef.name=mitos-captcha",
+		"console.antiAbuse.friendlyCaptcha.url=https://eu-api.friendlycaptcha.eu",
+		"console.antiAbuse.disposableAllowDomains={mailinator.com}",
+		"console.antiAbuse.signupIPLimit=20",
+		"console.antiAbuse.signupIPWindow=30m",
+	)
+	mustEnv(t, out, "MITOS_CONSOLE_FRIENDLY_CAPTCHA_SITEKEY", "FCSITE123")
+	mustNamedSecretKeyRef(t, out, "MITOS_CONSOLE_FRIENDLY_CAPTCHA_SECRET", "mitos-captcha", "friendly-captcha-secret")
+	mustEnv(t, out, "MITOS_CONSOLE_FRIENDLY_CAPTCHA_URL", "https://eu-api.friendlycaptcha.eu")
+	mustEnv(t, out, "MITOS_CONSOLE_DISPOSABLE_ALLOW", "mailinator.com")
+	mustEnv(t, out, "MITOS_CONSOLE_SIGNUP_IP_LIMIT", "20")
+	mustEnv(t, out, "MITOS_CONSOLE_SIGNUP_IP_WINDOW", "30m")
+}
+
+// TestSignupIPLimitZeroRenders asserts an explicit 0 renders (it disables the
+// per-IP cap in the binary), which is distinct from unset (binary default 10).
+func TestSignupIPLimitZeroRenders(t *testing.T) {
+	out := render(t, "console.antiAbuse.signupIPLimit=0")
+	mustEnv(t, out, "MITOS_CONSOLE_SIGNUP_IP_LIMIT", "0")
+}
+
+// TestCaptchaRequiresBothSiteKeyAndSecret asserts a half-configured captcha
+// (sitekey without a secret ref) renders NO captcha env, mirroring the binary,
+// which activates verification only when both are present.
+func TestCaptchaRequiresBothSiteKeyAndSecret(t *testing.T) {
+	out := render(t, "console.antiAbuse.friendlyCaptcha.siteKey=FCSITE123")
+	for _, env := range []string{"MITOS_CONSOLE_FRIENDLY_CAPTCHA_SITEKEY", "MITOS_CONSOLE_FRIENDLY_CAPTCHA_SECRET"} {
+		if strings.Contains(out, env) {
+			t.Fatalf("%s rendered without a captcha secret ref; captcha env requires both siteKey and secretRef.name", env)
+		}
+	}
+}
+
+// TestConsoleRatesRenderAsJSONEnv asserts console.billing.rates renders as ONE
+// JSON object in MITOS_CONSOLE_RATES, with the keys the binary's strict parser
+// accepts. Not gated by billing.enabled: the rate table also prices the credit
+// drawdown and the display estimate.
+func TestConsoleRatesRenderAsJSONEnv(t *testing.T) {
+	out := renderJSON(t,
+		`console.billing.rates={"vcpu_second_milli_cents":1.28,"egress_gib_milli_cents":9000}`,
+	)
+	mustContain(t, out, "- name: MITOS_CONSOLE_RATES")
+	mustContain(t, out, `\"vcpu_second_milli_cents\":1.28`)
+	mustContain(t, out, `\"egress_gib_milli_cents\":9000`)
 }
 
 // TestConsoleExtraEnv asserts arbitrary console.extraEnv entries pass through, so

--- a/deploy/charts/charttest/controller_test.go
+++ b/deploy/charts/charttest/controller_test.go
@@ -127,3 +127,31 @@ func TestUsageMeteringConsoleURLOverride(t *testing.T) {
 	dep := consoleDeployment(t, render(t, sets...))
 	mustEnv(t, dep, "MITOS_USAGE_API_URL", "http://usage.internal:9000")
 }
+
+// TestUsagePriceListAbsentByDefault asserts MITOS_USAGE_PRICELIST is not
+// rendered by default, even with the collector on: unset means the binary's
+// illustrative default price list applies.
+func TestUsagePriceListAbsentByDefault(t *testing.T) {
+	for _, out := range []string{render(t), render(t, usageEnabledSets()...)} {
+		if strings.Contains(out, "MITOS_USAGE_PRICELIST") {
+			t.Fatal("MITOS_USAGE_PRICELIST rendered without controller.usage.priceList set")
+		}
+	}
+}
+
+// TestUsagePriceListRendersAsJSONEnv asserts controller.usage.priceList renders
+// as ONE JSON object in MITOS_USAGE_PRICELIST on the controller container, with
+// the keys the binary's strict parser accepts. Requires the collector: the env
+// only matters when the internal usage API runs.
+func TestUsagePriceListRendersAsJSONEnv(t *testing.T) {
+	sets := []string{
+		`controller.usage.collector=true`,
+		`controller.usage.tokenSecret.name="mitos-usage"`,
+		`database.dsnSecretRef.name="mitos-db"`,
+		`controller.usage.priceList={"vcpu_second":0.5,"egress_gib":0.09}`,
+	}
+	dep := controllerDeployment(t, renderJSON(t, sets...))
+	mustContain(t, dep, "- name: MITOS_USAGE_PRICELIST")
+	mustContain(t, dep, `\"vcpu_second\":0.5`)
+	mustContain(t, dep, `\"egress_gib\":0.09`)
+}

--- a/deploy/charts/mitos/README.md
+++ b/deploy/charts/mitos/README.md
@@ -162,6 +162,19 @@ already optional, so a missing secret never blocks forkd from starting.
 | `imagePullSecret.dockerconfigjson` | `{"auths":{}}` base64 | Base64 dockerconfigjson value used when `create=true`. |
 | `imagePullSecrets` | `[]` | Pull-secret names attached to every workload pod. Empty by default (public images); populate for a private mirror. |
 | `commonLabels` | `{}` | Extra labels merged onto every resource. |
+| `controller.usage.priceList` | `{}` | Display price list for the internal usage API (`MITOS_USAGE_PRICELIST`, dollars per unit, rendered as one JSON env). Non-empty REPLACES the illustrative defaults; unknown keys or negative values fail controller startup. Keep consistent with `console.billing.rates`. |
+| `console.signupCreditCents` | `0` | Signup credit for a newly verified org in integer cents (`MITOS_CONSOLE_SIGNUP_CREDIT_CENTS`). 0 renders no env (binary default applies). |
+| `console.autoAllowDomains` | `[]` | Email domains whose signups bypass manual allowlist approval (`MITOS_CONSOLE_AUTOALLOW_DOMAINS`, comma-joined). Empty renders no env; the binary defaults to `mitos.run`. |
+| `console.authConnectors` | `[]` | Social-login connectors advertised at `GET /auth/connectors` (`MITOS_CONSOLE_AUTH_CONNECTORS`). Known values: `github`, `google`. |
+| `console.antiAbuse.friendlyCaptcha.siteKey` | `""` | Friendly Captcha sitekey (`MITOS_CONSOLE_FRIENDLY_CAPTCHA_SITEKEY`). Captcha env renders only when both the sitekey and the secret ref are set. |
+| `console.antiAbuse.friendlyCaptcha.secretRef` | `name: ""`, `key: friendly-captcha-secret` | Existing Secret holding the Friendly Captcha API secret, injected via secretKeyRef ONLY (`MITOS_CONSOLE_FRIENDLY_CAPTCHA_SECRET`). |
+| `console.antiAbuse.friendlyCaptcha.url` | `""` | Verification API base URL override (`MITOS_CONSOLE_FRIENDLY_CAPTCHA_URL`). |
+| `console.antiAbuse.disposableAllowDomains` | `[]` | Email domains exempted from the disposable-domain blocklist (`MITOS_CONSOLE_DISPOSABLE_ALLOW`, comma-joined). |
+| `console.antiAbuse.signupIPLimit` | `""` | Per-IP signup velocity cap (`MITOS_CONSOLE_SIGNUP_IP_LIMIT`). Empty renders no env (binary default 10 per 1h); `"0"` disables the cap. |
+| `console.antiAbuse.signupIPWindow` | `""` | Velocity window as a Go duration (`MITOS_CONSOLE_SIGNUP_IP_WINDOW`), e.g. `30m`. |
+| `console.billing.paddle.topUpProduct` | `""` | Paddle product id for prepaid credit top-up checkout (`MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT`). Empty disables the affordance. |
+| `console.billing.paddle.currency` | `""` | ISO currency code for top-up checkout (`MITOS_CONSOLE_PADDLE_CURRENCY`). Empty uses the binary default (EUR). |
+| `console.billing.rates` | `{}` | Billing rate table (`MITOS_CONSOLE_RATES`, milli-cents per unit, rendered as one JSON env). Non-empty REPLACES the illustrative defaults entirely; unknown keys or negative values fail console startup. Use a values file or `--set-json` for fractional values. See `docs/saas/pricing.md`. |
 
 ## Security notes
 

--- a/deploy/charts/mitos/templates/console.yaml
+++ b/deploy/charts/mitos/templates/console.yaml
@@ -124,6 +124,63 @@ spec:
             - name: MITOS_CONSOLE_BILLING
               value: {{ .Values.console.billing.enabled | quote }}
             {{- /*
+            Self-host operator knobs, first-class values (previously only
+            reachable via extraEnv). Each renders ONLY when set, so a default
+            install carries no extra env and the binary defaults apply. None of
+            these values is a secret; the captcha secret below is the one
+            exception and rides a secretKeyRef.
+            */}}
+            {{- if .Values.console.signupCreditCents }}
+            - name: MITOS_CONSOLE_SIGNUP_CREDIT_CENTS
+              value: {{ .Values.console.signupCreditCents | quote }}
+            {{- end }}
+            {{- with .Values.console.autoAllowDomains }}
+            - name: MITOS_CONSOLE_AUTOALLOW_DOMAINS
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.console.authConnectors }}
+            - name: MITOS_CONSOLE_AUTH_CONNECTORS
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.console.antiAbuse }}
+            {{- if and .friendlyCaptcha.siteKey .friendlyCaptcha.secretRef.name }}
+            - name: MITOS_CONSOLE_FRIENDLY_CAPTCHA_SITEKEY
+              value: {{ .friendlyCaptcha.siteKey | quote }}
+            - name: MITOS_CONSOLE_FRIENDLY_CAPTCHA_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .friendlyCaptcha.secretRef.name | quote }}
+                  key: {{ .friendlyCaptcha.secretRef.key | default "friendly-captcha-secret" | quote }}
+            {{- if .friendlyCaptcha.url }}
+            - name: MITOS_CONSOLE_FRIENDLY_CAPTCHA_URL
+              value: {{ .friendlyCaptcha.url | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .disposableAllowDomains }}
+            - name: MITOS_CONSOLE_DISPOSABLE_ALLOW
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if ne (toString .signupIPLimit) "" }}
+            - name: MITOS_CONSOLE_SIGNUP_IP_LIMIT
+              value: {{ .signupIPLimit | quote }}
+            {{- end }}
+            {{- if ne (toString .signupIPWindow) "" }}
+            - name: MITOS_CONSOLE_SIGNUP_IP_WINDOW
+              value: {{ .signupIPWindow | quote }}
+            {{- end }}
+            {{- end }}
+            {{- /*
+            Billing rate table (docs/saas/pricing.md): the values map renders as
+            ONE JSON env value the binary parses strictly (unknown keys and
+            negative rates fail startup). Not gated by billing.enabled: the
+            rate table also prices the credit drawdown and the display cost
+            estimate, which run regardless of the provider surface.
+            */}}
+            {{- with .Values.console.billing.rates }}
+            - name: MITOS_CONSOLE_RATES
+              value: {{ toJson . | quote }}
+            {{- end }}
+            {{- /*
             Paddle (Merchant of Record) selection. The provider switches to Paddle
             only when BOTH the API key and the webhook signing secret are present;
             otherwise the binary keeps the Stripe default. Both are SECRETS,
@@ -153,6 +210,19 @@ spec:
             {{- if .Values.console.billing.paddle.baseURL }}
             - name: MITOS_CONSOLE_PADDLE_BASE_URL
               value: {{ .Values.console.billing.paddle.baseURL | quote }}
+            {{- end }}
+            {{- /*
+            Prepaid top-up checkout (Paddle only). The product id and currency
+            are plain config, not secrets; an empty product id disables the
+            affordance in the binary, so nothing renders until it is set.
+            */}}
+            {{- if .Values.console.billing.paddle.topUpProduct }}
+            - name: MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT
+              value: {{ .Values.console.billing.paddle.topUpProduct | quote }}
+            {{- end }}
+            {{- if .Values.console.billing.paddle.currency }}
+            - name: MITOS_CONSOLE_PADDLE_CURRENCY
+              value: {{ .Values.console.billing.paddle.currency | quote }}
             {{- end }}
             {{- end }}
             - name: MITOS_CONSOLE_OIDC_ISSUER

--- a/deploy/charts/mitos/templates/controller-deployment.yaml
+++ b/deploy/charts/mitos/templates/controller-deployment.yaml
@@ -100,6 +100,16 @@ spec:
             {{- if .Values.controller.usage.collector }}
             {{- include "mitos.database.env" . | nindent 12 }}
             {{- include "mitos.usageToken.env" . | nindent 12 }}
+            {{- /*
+            Display price list for the internal usage API: the values map
+            renders as ONE JSON env value the binary parses strictly (unknown
+            keys and negative rates fail startup). Empty renders nothing and
+            the illustrative defaults apply. Not a secret.
+            */}}
+            {{- with .Values.controller.usage.priceList }}
+            - name: MITOS_USAGE_PRICELIST
+              value: {{ toJson . | quote }}
+            {{- end }}
             {{- end }}
             {{- with .Values.controller.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -99,8 +99,9 @@ controller:
   # orgTenancy the org derives from the per-org namespace; a single-tenant
   # (shared namespace) hosted deployment relies on the claim-time org label the
   # controller copies from the Sandbox object the gateway stamped. Credit
-  # drawdown prices records with the built-in default rate table
-  # (billing.DefaultRates); a configurable price list is a documented follow-up.
+  # drawdown prices records with the billing rate table (billing.DefaultRates
+  # unless console.billing.rates overrides it); the usage API's display price
+  # list is configurable below via priceList.
   usage:
     # Run the collector and serve the internal usage API.
     collector: false
@@ -117,6 +118,24 @@ controller:
     tokenSecret:
       name: ""
       key: "usage-api-token"
+    # Display price list for the internal usage API (MITOS_USAGE_PRICELIST), a
+    # map rendered as one JSON env value. When non-empty it REPLACES the
+    # built-in illustrative defaults ENTIRELY: an omitted key is a zero (free)
+    # rate, and an unknown key or a negative value fails controller startup
+    # (fail closed). Values are account-currency dollars per unit. Keep it
+    # consistent with console.billing.rates (milli-cents = dollars x 100000)
+    # so the display estimate and the billed cost never drift; see
+    # docs/saas/pricing.md. Set it in a values file or via --set-json: plain
+    # --set turns a fractional value into a string, which the strict parser
+    # rejects at startup. Example:
+    #
+    #   priceList:
+    #     vcpu_second: 0.0000128
+    #     mem_gib_second: 0.0000016
+    #     storage_gib_hour: 0.0001
+    #     egress_gib: 0.09
+    #     gpu_second: 0.0006
+    priceList: {}
   # Extra args appended verbatim to the controller container args.
   extraArgs: []
   # Extra env vars appended verbatim to the controller container. FORKD_NAMESPACE
@@ -425,6 +444,56 @@ console:
   # public self-serve untrusted multi-tenancy does not switch on until the
   # production gates pass; this is server-controlled, never a client flag.
   signup: false
+  # Free credit granted to a newly verified signup, in integer CENTS
+  # (MITOS_CONSOLE_SIGNUP_CREDIT_CENTS). 0 (the default) renders no env, so the
+  # binary's built-in default applies. Example: 500 grants $5.00.
+  signupCreditCents: 0
+  # Email domains whose signups bypass the manual allowlist approval
+  # (MITOS_CONSOLE_AUTOALLOW_DOMAINS, rendered comma-joined). Empty renders no
+  # env; the binary then defaults to ["mitos.run"]. A self-host deployment
+  # normally sets its own domain here, for example ["corp.example.com"].
+  autoAllowDomains: []
+  # Social-login connectors advertised at GET /auth/connectors
+  # (MITOS_CONSOLE_AUTH_CONNECTORS, rendered comma-joined). Known values:
+  # github, google; the binary silently drops anything else. Empty renders no
+  # env, so the SPA shows no social-login buttons.
+  authConnectors: []
+  # Signup anti-abuse knobs. Everything defaults off/empty so a self-host
+  # install renders none of these and the binary defaults apply.
+  antiAbuse:
+    # Friendly Captcha server-side verification. Active only when BOTH the
+    # sitekey and the secret ref are set; with either absent the signup handler
+    # passes through unchanged. The secret is injected via secretKeyRef ONLY,
+    # never as a plaintext value. Create the Secret out of band, for example:
+    #
+    #   kubectl create secret generic mitos-captcha \
+    #     --namespace mitos \
+    #     --from-literal=friendly-captcha-secret='...'
+    friendlyCaptcha:
+      # The public Friendly Captcha sitekey
+      # (MITOS_CONSOLE_FRIENDLY_CAPTCHA_SITEKEY). Not a secret.
+      siteKey: ""
+      # Reference an existing Secret holding the Friendly Captcha API secret
+      # (MITOS_CONSOLE_FRIENDLY_CAPTCHA_SECRET).
+      secretRef:
+        # Name of the Secret in the release namespace. Empty omits the env.
+        name: ""
+        # Key within that Secret holding the API secret.
+        key: "friendly-captcha-secret"
+      # Verification API base URL override (MITOS_CONSOLE_FRIENDLY_CAPTCHA_URL).
+      # Empty uses the binary's built-in default endpoint.
+      url: ""
+    # Email domains exempted from the disposable-email-domain blocklist
+    # (MITOS_CONSOLE_DISPOSABLE_ALLOW, rendered comma-joined), for staff or
+    # partner domains the embedded blocklist wrongly flags. Empty renders no
+    # env (no exemptions).
+    disposableAllowDomains: []
+    # Per-IP signup velocity cap (MITOS_CONSOLE_SIGNUP_IP_LIMIT and
+    # MITOS_CONSOLE_SIGNUP_IP_WINDOW). Empty renders no env; the binary then
+    # defaults to 10 signups per 1h per IP. Set signupIPLimit to "0" to disable
+    # the cap entirely; signupIPWindow is a Go duration string, e.g. "30m".
+    signupIPLimit: ""
+    signupIPWindow: ""
   # Browser-session OIDC. Self-host points this at the operator's issuer
   # (Dex/Keycloak/Google); hosted points it at our IdP.
   oidc:
@@ -497,6 +566,32 @@ console:
       # Paddle API host. Default is live; set to https://sandbox-api.paddle.com
       # for the sandbox. Empty uses the binary's built-in live default.
       baseURL: ""
+      # Paddle product id used for prepaid credit top-up checkout
+      # (MITOS_CONSOLE_PADDLE_TOPUP_PRODUCT). Not a secret. Empty renders no
+      # env and disables the top-up affordance (the endpoint returns 400).
+      topUpProduct: ""
+      # ISO currency code for top-up checkout (MITOS_CONSOLE_PADDLE_CURRENCY),
+      # for example "USD". Empty renders no env; the binary then defaults to
+      # EUR.
+      currency: ""
+    # Billing rate table override (MITOS_CONSOLE_RATES), a map rendered as one
+    # JSON env value. When non-empty it REPLACES the built-in illustrative
+    # defaults ENTIRELY: an omitted key is a zero (free) rate, and an unknown
+    # key or a negative value fails console startup (fail closed). All values
+    # are MILLI-cents (thousandths of a cent) per unit. The same table prices
+    # the credit drawdown, the billing view, and the display cost estimate.
+    # Keep controller.usage.priceList consistent with it (milli-cents =
+    # dollars x 100000); see docs/saas/pricing.md. Set it in a values file or
+    # via --set-json: plain --set turns a fractional value like 1.28 into a
+    # string, which the strict parser rejects at startup. Example:
+    #
+    #   rates:
+    #     vcpu_second_milli_cents: 1.28
+    #     mem_gib_second_milli_cents: 0.16
+    #     storage_gib_hour_milli_cents: 10
+    #     egress_gib_milli_cents: 9000
+    #     gpu_second_milli_cents: 60
+    rates: {}
   # Public self-serve onboarding (issue #215): the unauthenticated signup +
   # verify endpoints and the verification email. The public endpoints are mounted
   # only when console.signup is true (the #208 gate); this block configures HOW

--- a/docs/saas/pricing.md
+++ b/docs/saas/pricing.md
@@ -53,16 +53,46 @@ This keeps the directional economics honest and removes the abuse subsidy.
 
 Rates live as a structured config (`billing.Rates`), quoted in MILLI-cents per
 unit (thousandths of a cent) so a single per-second tick does not round to zero.
-The values in `billing.DefaultRates()` are ILLUSTRATIVE and CONFIGURABLE
-placeholders, NOT published prices (the no-unverified-claims rule). A hosted
-deployment overrides them from config. Only the SHAPE (decoupled per-second
-compute, storage GiB-hours, metered egress) is committed here.
+The values in `billing.DefaultRates()` are ILLUSTRATIVE placeholders, NOT
+published prices (the no-unverified-claims rule). A deployment overrides them
+from config (below). Only the SHAPE (decoupled per-second compute, storage
+GiB-hours, metered egress) is committed here.
+
+#### Configuring the rates
+
+The console reads `MITOS_CONSOLE_RATES`: a single JSON object mapping onto
+`billing.Rates` (parsed by `billing.ParseRatesConfig`), for example:
+
+    MITOS_CONSOLE_RATES='{"vcpu_second_milli_cents":1.28,"mem_gib_second_milli_cents":0.16,"storage_gib_hour_milli_cents":10,"egress_gib_milli_cents":9000,"gpu_second_milli_cents":60}'
+
+Semantics:
+
+- Unset (or empty) uses `billing.DefaultRates()`, exactly as before.
+- When set, the object REPLACES the default table ENTIRELY: an omitted key is a
+  zero (free) rate, never the default for that key.
+- Unknown keys, malformed JSON, and negative rates FAIL console startup with an
+  actionable error (fail closed); a bad override never silently falls back to
+  the defaults and bills at the wrong rates.
+
+The Helm chart exposes it as `console.billing.rates` (a map rendered to the
+JSON env value; use a values file or `--set-json`, since plain `--set`
+stringifies fractional numbers). The SAME parsed table prices the console
+billing view, the credit-drawdown driver, and (via `Rates.ToPriceList`) the
+display-cost estimate, so what a user sees, what draws down, and what would be
+billed never drift.
+
+The controller's internal usage API has the matching display-side override:
+`MITOS_USAGE_PRICELIST` (a JSON object mapping onto `usage.PriceList`, dollars
+per unit; Helm value `controller.usage.priceList`), with the same strict
+fail-closed parsing. Keep the two consistent: milli-cents per unit = dollars
+per unit x 100000.
 
 `billing.DefaultRates()` mirrors the magnitude of the placeholder
 `usage.DefaultPriceList` re-expressed in milli-cents, and `billing.FromPriceList`
-is the single bridge between the two so the usage API's display-cost estimate
-and the real billing rates derive from one table and never drift. This is the
-reconciliation of the `PriceList` placeholder to the billing model.
+/ `Rates.ToPriceList` are the bridges between the two so the usage API's
+display-cost estimate and the real billing rates derive from one table and
+never drift. This is the reconciliation of the `PriceList` placeholder to the
+billing model.
 
 Directional competitor figures (Modal, Daytona, E2B published per-second or
 per-resource prices) may be cited as vendor-published when comparing the model's
@@ -102,7 +132,9 @@ cannot silently drift.
 
 - Signup credit (`GrantSignupCredit`): the free credit at signup. The default is
   $100 (`DefaultSignupCredit`), within the $100-$200 self-serve bar.
-  Illustrative and configurable.
+  Illustrative and configurable: `MITOS_CONSOLE_SIGNUP_CREDIT_CENTS` (Helm
+  value `console.signupCreditCents`) overrides it per deployment in integer
+  cents, e.g. 500 grants $5.00.
 - Top-ups (`TopUp`): prepaid purchases on a Daytona-style ladder
   (`TopUpLadder`: $10/$25/$50/$100/$250, illustrative). Added after the payment
   clears.

--- a/internal/saas/billing/pricing.go
+++ b/internal/saas/billing/pricing.go
@@ -62,21 +62,24 @@ const (
 // Rates is the structured, configurable per-unit price table: the decoupled
 // per-second compute model in one place. The values in DefaultRates are
 // ILLUSTRATIVE and CONFIGURABLE, never published prices (the no-unverified-
-// claims rule). A hosted deployment overrides them from config; only the SHAPE
-// (decoupled vCPU + RAM per second, storage GiB-hours, metered egress) is
-// committed here. All rates are in account-currency MINOR UNITS (cents) per
-// unit so the cost computation stays in integer money end to end.
+// claims rule). A hosted deployment overrides them from config (the
+// MITOS_CONSOLE_RATES env parsed by ParseRatesConfig; the Helm value
+// console.billing.rates); only the SHAPE (decoupled vCPU + RAM per second,
+// storage GiB-hours, metered egress) is committed here. All rates are in
+// account-currency MINOR UNITS (cents) per unit so the cost computation stays
+// in integer money end to end. The json tags are the ParseRatesConfig wire
+// keys.
 type Rates struct {
 	// VCPUSecondMilliCents and the rest are quoted in MILLI-cents per unit
 	// (thousandths of a cent) because a single vCPU-second costs a tiny fraction
 	// of a cent; quoting in cents would round every per-second tick to zero. The
 	// CostCents accumulation sums milli-cents across all usage, then divides to
 	// cents once at the end, so sub-cent rates accumulate exactly.
-	VCPUSecondMilliCents     float64
-	MemGiBSecondMilliCents   float64
-	StorageGiBHourMilliCents float64
-	EgressGiBMilliCents      float64
-	GPUSecondMilliCents      float64
+	VCPUSecondMilliCents     float64 `json:"vcpu_second_milli_cents"`
+	MemGiBSecondMilliCents   float64 `json:"mem_gib_second_milli_cents"`
+	StorageGiBHourMilliCents float64 `json:"storage_gib_hour_milli_cents"`
+	EgressGiBMilliCents      float64 `json:"egress_gib_milli_cents"`
+	GPUSecondMilliCents      float64 `json:"gpu_second_milli_cents"`
 }
 
 // DefaultRates returns the illustrative, configurable default rate table. These

--- a/internal/saas/billing/ratesconfig.go
+++ b/internal/saas/billing/ratesconfig.go
@@ -1,0 +1,77 @@
+package billing
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"mitos.run/mitos/internal/usage"
+)
+
+// ratesRemediation is the actionable remediation text every ParseRatesConfig
+// error carries (the LLM-legible error rule): what shape is expected, the exact
+// allowed keys, the unit, and an example. It never echoes any secret; the rate
+// table itself is configuration, not a secret.
+const ratesRemediation = "set MITOS_CONSOLE_RATES (Helm: console.billing.rates) to a single JSON object " +
+	"whose only keys are vcpu_second_milli_cents, mem_gib_second_milli_cents, " +
+	"storage_gib_hour_milli_cents, egress_gib_milli_cents, and gpu_second_milli_cents, " +
+	"each a non-negative number in MILLI-cents (thousandths of a cent) per unit, " +
+	`for example {"vcpu_second_milli_cents":1.28,"egress_gib_milli_cents":9000}; ` +
+	"an omitted key is a zero (free) rate; unset the variable to use the built-in illustrative defaults"
+
+// ParseRatesConfig parses the MITOS_CONSOLE_RATES override into a Rates table.
+//
+//   - An empty or all-whitespace value returns DefaultRates(): no override
+//     configured, the illustrative defaults apply.
+//   - A non-empty value must be a single JSON object mapping onto Rates; it
+//     REPLACES the default table entirely (an omitted key is a zero, i.e. free,
+//     rate; it never falls back to the default for that key).
+//   - Unknown keys, malformed JSON, trailing data, and negative rates are
+//     REJECTED with an actionable error so the caller fails startup (fail
+//     closed) instead of silently billing at the wrong rates.
+func ParseRatesConfig(raw string) (Rates, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultRates(), nil
+	}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var r Rates
+	if err := dec.Decode(&r); err != nil {
+		return Rates{}, fmt.Errorf("invalid rates JSON: %w; %s", err, ratesRemediation)
+	}
+	if dec.More() {
+		return Rates{}, fmt.Errorf("invalid rates JSON: trailing data after the object; %s", ratesRemediation)
+	}
+	for _, f := range []struct {
+		key string
+		v   float64
+	}{
+		{"vcpu_second_milli_cents", r.VCPUSecondMilliCents},
+		{"mem_gib_second_milli_cents", r.MemGiBSecondMilliCents},
+		{"storage_gib_hour_milli_cents", r.StorageGiBHourMilliCents},
+		{"egress_gib_milli_cents", r.EgressGiBMilliCents},
+		{"gpu_second_milli_cents", r.GPUSecondMilliCents},
+	} {
+		if f.v < 0 {
+			return Rates{}, fmt.Errorf("invalid rate %s=%v: a negative rate would corrupt the credit ledger; %s", f.key, f.v, ratesRemediation)
+		}
+	}
+	return r, nil
+}
+
+// ToPriceList re-expresses the milli-cents-per-unit Rates as the
+// dollars-per-unit usage.PriceList: the inverse of FromPriceList. It lets the
+// display-cost estimate (the usage API's PriceList) derive from the SAME
+// configured rate table the ledger bills with, so the number a user sees and
+// the number they are charged never drift.
+func (r Rates) ToPriceList() usage.PriceList {
+	const milliCentsPerDollar = 100000.0 // $1 = 100 cents = 100000 milli-cents.
+	return usage.PriceList{
+		VCPUSecond:     r.VCPUSecondMilliCents / milliCentsPerDollar,
+		MemGiBSecond:   r.MemGiBSecondMilliCents / milliCentsPerDollar,
+		StorageGiBHour: r.StorageGiBHourMilliCents / milliCentsPerDollar,
+		EgressGiB:      r.EgressGiBMilliCents / milliCentsPerDollar,
+		GPUSecond:      r.GPUSecondMilliCents / milliCentsPerDollar,
+	}
+}

--- a/internal/saas/billing/ratesconfig_test.go
+++ b/internal/saas/billing/ratesconfig_test.go
@@ -1,0 +1,133 @@
+package billing
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseRatesConfigUnsetUsesDefaults asserts an empty (unset) value falls
+// through to the built-in illustrative defaults, so a deployment that sets no
+// override behaves exactly as before.
+func TestParseRatesConfigUnsetUsesDefaults(t *testing.T) {
+	for _, raw := range []string{"", "   ", "\n\t"} {
+		got, err := ParseRatesConfig(raw)
+		if err != nil {
+			t.Fatalf("ParseRatesConfig(%q) error: %v", raw, err)
+		}
+		if got != DefaultRates() {
+			t.Fatalf("ParseRatesConfig(%q) = %+v, want DefaultRates %+v", raw, got, DefaultRates())
+		}
+	}
+}
+
+// TestParseRatesConfigValidJSONApplies asserts a valid JSON object REPLACES the
+// default table entirely: set keys carry the configured value and omitted keys
+// are zero (an explicitly free dimension), never the default.
+func TestParseRatesConfigValidJSONApplies(t *testing.T) {
+	raw := `{"vcpu_second_milli_cents": 2.5, "egress_gib_milli_cents": 12000}`
+	got, err := ParseRatesConfig(raw)
+	if err != nil {
+		t.Fatalf("ParseRatesConfig(%q) error: %v", raw, err)
+	}
+	want := Rates{VCPUSecondMilliCents: 2.5, EgressGiBMilliCents: 12000}
+	if got != want {
+		t.Fatalf("ParseRatesConfig = %+v, want %+v (full replacement, omitted keys zero)", got, want)
+	}
+}
+
+// TestParseRatesConfigFullTable asserts every key round-trips.
+func TestParseRatesConfigFullTable(t *testing.T) {
+	raw := `{
+		"vcpu_second_milli_cents": 1.28,
+		"mem_gib_second_milli_cents": 0.16,
+		"storage_gib_hour_milli_cents": 10,
+		"egress_gib_milli_cents": 9000,
+		"gpu_second_milli_cents": 60
+	}`
+	got, err := ParseRatesConfig(raw)
+	if err != nil {
+		t.Fatalf("ParseRatesConfig error: %v", err)
+	}
+	if got != DefaultRates() {
+		t.Fatalf("ParseRatesConfig = %+v, want %+v", got, DefaultRates())
+	}
+}
+
+// TestParseRatesConfigInvalidJSONFailsWithRemediation asserts malformed JSON is
+// rejected (fail closed, no silent fallback) and the error carries actionable
+// remediation text naming the allowed keys.
+func TestParseRatesConfigInvalidJSONFailsWithRemediation(t *testing.T) {
+	for _, raw := range []string{"not json", "{", `["vcpu_second_milli_cents"]`, `{"vcpu_second_milli_cents":1.28} trailing`} {
+		_, err := ParseRatesConfig(raw)
+		if err == nil {
+			t.Fatalf("ParseRatesConfig(%q) = nil error, want failure", raw)
+		}
+		if !strings.Contains(err.Error(), "vcpu_second_milli_cents") {
+			t.Fatalf("ParseRatesConfig(%q) error %q lacks remediation text naming the allowed keys", raw, err)
+		}
+	}
+}
+
+// TestParseRatesConfigUnknownFieldFails asserts a typoed key is rejected rather
+// than silently ignored, so a misspelled rate never silently becomes free.
+func TestParseRatesConfigUnknownFieldFails(t *testing.T) {
+	_, err := ParseRatesConfig(`{"vcpu_seconds_milli_cents": 1.28}`)
+	if err == nil {
+		t.Fatal("ParseRatesConfig with an unknown field returned nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "vcpu_second_milli_cents") {
+		t.Fatalf("unknown-field error %q lacks remediation text naming the allowed keys", err)
+	}
+}
+
+// TestParseRatesConfigNegativeRateFails asserts a negative rate is rejected: a
+// negative price is configuration nonsense that would corrupt the ledger.
+func TestParseRatesConfigNegativeRateFails(t *testing.T) {
+	_, err := ParseRatesConfig(`{"egress_gib_milli_cents": -1}`)
+	if err == nil {
+		t.Fatal("ParseRatesConfig with a negative rate returned nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "egress_gib_milli_cents") {
+		t.Fatalf("negative-rate error %q does not name the offending key", err)
+	}
+}
+
+// TestParseRatesConfigZeroRateIsAllowed asserts an explicit zero is a valid,
+// deliberately free dimension (e.g. a self-host deployment with no GPUs).
+func TestParseRatesConfigZeroRateIsAllowed(t *testing.T) {
+	got, err := ParseRatesConfig(`{"gpu_second_milli_cents": 0}`)
+	if err != nil {
+		t.Fatalf("ParseRatesConfig with a zero rate error: %v", err)
+	}
+	if got.GPUSecondMilliCents != 0 {
+		t.Fatalf("GPUSecondMilliCents = %v, want 0", got.GPUSecondMilliCents)
+	}
+}
+
+// TestRatesToPriceListMatchesDefaults asserts ToPriceList (the inverse of
+// FromPriceList) re-derives the display price list from the rate table, so a
+// console's cost estimate and the billed cost come from ONE configured table.
+func TestRatesToPriceListMatchesDefaults(t *testing.T) {
+	got := DefaultRates().ToPriceList()
+	want := DefaultRates()
+	back := FromPriceList(got)
+	fields := []struct {
+		name       string
+		have, wanb float64
+	}{
+		{"VCPUSecondMilliCents", back.VCPUSecondMilliCents, want.VCPUSecondMilliCents},
+		{"MemGiBSecondMilliCents", back.MemGiBSecondMilliCents, want.MemGiBSecondMilliCents},
+		{"StorageGiBHourMilliCents", back.StorageGiBHourMilliCents, want.StorageGiBHourMilliCents},
+		{"EgressGiBMilliCents", back.EgressGiBMilliCents, want.EgressGiBMilliCents},
+		{"GPUSecondMilliCents", back.GPUSecondMilliCents, want.GPUSecondMilliCents},
+	}
+	for _, f := range fields {
+		diff := f.have - f.wanb
+		if diff < 0 {
+			diff = -diff
+		}
+		if f.wanb != 0 && diff/f.wanb > 1e-12 {
+			t.Fatalf("round trip %s = %v, want %v", f.name, f.have, f.wanb)
+		}
+	}
+}

--- a/internal/usage/pricelistconfig.go
+++ b/internal/usage/pricelistconfig.go
@@ -1,0 +1,62 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// priceListRemediation is the actionable remediation text every
+// ParsePriceListConfig error carries: expected shape, the exact allowed keys,
+// the unit, and an example. The price list is configuration, never a secret.
+const priceListRemediation = "set MITOS_USAGE_PRICELIST (Helm: controller.usage.priceList) to a single JSON object " +
+	"whose only keys are vcpu_second, mem_gib_second, storage_gib_hour, egress_gib, and gpu_second, " +
+	"each a non-negative number in account-currency dollars per unit, " +
+	`for example {"vcpu_second":0.0000128,"egress_gib":0.09}; ` +
+	"an omitted key is a zero (free) rate; unset the variable to use the built-in illustrative defaults"
+
+// ParsePriceListConfig parses the MITOS_USAGE_PRICELIST override into a
+// PriceList.
+//
+//   - An empty or all-whitespace value returns DefaultPriceList(): no override
+//     configured, the illustrative defaults apply.
+//   - A non-empty value must be a single JSON object mapping onto PriceList; it
+//     REPLACES the default table entirely (an omitted key is a zero, i.e. free,
+//     rate; it never falls back to the default for that key).
+//   - Unknown keys, malformed JSON, trailing data, and negative rates are
+//     REJECTED with an actionable error so the caller fails startup (fail
+//     closed) instead of silently displaying the wrong cost estimate.
+//
+// Keep this table consistent with the billing rate table (billing.Rates,
+// MITOS_CONSOLE_RATES): milli-cents per unit = dollars per unit x 100000. See
+// docs/saas/pricing.md.
+func ParsePriceListConfig(raw string) (PriceList, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultPriceList(), nil
+	}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var pl PriceList
+	if err := dec.Decode(&pl); err != nil {
+		return PriceList{}, fmt.Errorf("invalid price-list JSON: %w; %s", err, priceListRemediation)
+	}
+	if dec.More() {
+		return PriceList{}, fmt.Errorf("invalid price-list JSON: trailing data after the object; %s", priceListRemediation)
+	}
+	for _, f := range []struct {
+		key string
+		v   float64
+	}{
+		{"vcpu_second", pl.VCPUSecond},
+		{"mem_gib_second", pl.MemGiBSecond},
+		{"storage_gib_hour", pl.StorageGiBHour},
+		{"egress_gib", pl.EgressGiB},
+		{"gpu_second", pl.GPUSecond},
+	} {
+		if f.v < 0 {
+			return PriceList{}, fmt.Errorf("invalid rate %s=%v: a negative rate is not a price; %s", f.key, f.v, priceListRemediation)
+		}
+	}
+	return pl, nil
+}

--- a/internal/usage/pricelistconfig_test.go
+++ b/internal/usage/pricelistconfig_test.go
@@ -1,0 +1,70 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParsePriceListConfigUnsetUsesDefaults asserts an empty (unset) value falls
+// through to the illustrative defaults, so a deployment with no override
+// behaves exactly as before.
+func TestParsePriceListConfigUnsetUsesDefaults(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		got, err := ParsePriceListConfig(raw)
+		if err != nil {
+			t.Fatalf("ParsePriceListConfig(%q) error: %v", raw, err)
+		}
+		if got != DefaultPriceList() {
+			t.Fatalf("ParsePriceListConfig(%q) = %+v, want DefaultPriceList %+v", raw, got, DefaultPriceList())
+		}
+	}
+}
+
+// TestParsePriceListConfigValidJSONApplies asserts a valid JSON object REPLACES
+// the default table entirely: omitted keys are zero (free), never the default.
+func TestParsePriceListConfigValidJSONApplies(t *testing.T) {
+	raw := `{"vcpu_second": 0.00002, "egress_gib": 0.12}`
+	got, err := ParsePriceListConfig(raw)
+	if err != nil {
+		t.Fatalf("ParsePriceListConfig(%q) error: %v", raw, err)
+	}
+	want := PriceList{VCPUSecond: 0.00002, EgressGiB: 0.12}
+	if got != want {
+		t.Fatalf("ParsePriceListConfig = %+v, want %+v (full replacement, omitted keys zero)", got, want)
+	}
+}
+
+// TestParsePriceListConfigInvalidJSONFails asserts malformed JSON is rejected
+// (fail closed) and the error carries remediation text naming the allowed keys.
+func TestParsePriceListConfigInvalidJSONFails(t *testing.T) {
+	for _, raw := range []string{"not json", "{", `{"vcpu_second":0.1} x`} {
+		_, err := ParsePriceListConfig(raw)
+		if err == nil {
+			t.Fatalf("ParsePriceListConfig(%q) = nil error, want failure", raw)
+		}
+		if !strings.Contains(err.Error(), "vcpu_second") {
+			t.Fatalf("ParsePriceListConfig(%q) error %q lacks remediation text naming the allowed keys", raw, err)
+		}
+	}
+}
+
+// TestParsePriceListConfigUnknownFieldFails asserts a typoed key is rejected
+// rather than silently ignored.
+func TestParsePriceListConfigUnknownFieldFails(t *testing.T) {
+	_, err := ParsePriceListConfig(`{"vcpu_seconds": 0.1}`)
+	if err == nil {
+		t.Fatal("ParsePriceListConfig with an unknown field returned nil error, want failure")
+	}
+}
+
+// TestParsePriceListConfigNegativeRateFails asserts a negative display rate is
+// rejected as configuration nonsense.
+func TestParsePriceListConfigNegativeRateFails(t *testing.T) {
+	_, err := ParsePriceListConfig(`{"gpu_second": -0.5}`)
+	if err == nil {
+		t.Fatal("ParsePriceListConfig with a negative rate returned nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "gpu_second") {
+		t.Fatalf("negative-rate error %q does not name the offending key", err)
+	}
+}


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs, with a hosted SaaS and a first-class self-host story sharing one console image.
> - Operating principle 7 says a self-hoster gets a complete product; that includes running mitos as their own SaaS with their own economics.
> - A 2026-07-02 self-host audit found the commercial knobs half-wired: signup credit, email-domain allowlist, Paddle top-up product, auth connectors, and the anti-abuse settings exist only as undocumented env vars behind console.extraEnv, and the billing rate table is compiled in (billing.DefaultRates), so an operator cannot set their own prices without patching Go.
> - The production deployment itself already hand-writes four of these via extraEnv, proving the gap is real.
> - This pull request adds a fail-closed MITOS_CONSOLE_RATES env override (and MITOS_USAGE_PRICELIST for the controller display estimate, derived from one table so they never drift) and promotes all of the above to documented first-class chart values.
> - The benefit is that a platform engineer can configure real SaaS economics from values.yaml alone, with misconfiguration failing startup loudly instead of billing at wrong rates.

## Linked Issues or Issue Description

No existing issue; found by the self-host configurability audit. Problem: `console.extraEnv` was the only path to signup credit, allowlist, top-up, connectors, and abuse knobs, and rates were not configurable at all. Related: #620 (chart hardening follow-ups), #615 (enforcement seams).

## What Changed

- `internal/saas/billing/ratesconfig.go`: `ParseRatesConfig` for `MITOS_CONSOLE_RATES`; empty means `DefaultRates()`, set means full replacement; unknown keys, malformed JSON, trailing data, and negative rates are rejected with remediation text (fail closed at startup). `Rates.ToPriceList()` derives the display price list from the same table.
- `internal/usage/pricelistconfig.go`: `ParsePriceListConfig` for `MITOS_USAGE_PRICELIST` with the same strict semantics; wired in `cmd/controller` replacing the hardcoded `usage.DefaultPriceList()`.
- `cmd/console/main.go`: one parsed rate table now feeds the billing reader, the display prices, and the drawdown driver.
- Chart: first-class values rendering only when set: `console.signupCreditCents`, `console.autoAllowDomains`, `console.authConnectors`, `console.billing.paddle.topUpProduct` and `.currency`, `console.antiAbuse.friendlyCaptcha` (secret via secretKeyRef only), `console.antiAbuse.disposableAllowDomains`, `signupIPLimit`/`signupIPWindow`, `console.billing.rates`, `controller.usage.priceList`.
- 8 new Go unit tests, 9 new charttest render tests, docs: `docs/saas/pricing.md` and 13 new chart README rows.

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/saas/... ./internal/usage/... ./deploy/charts/charttest/... ./cmd/console/... ./cmd/controller/...` all ok
- [x] `golangci-lint run --timeout=5m` (one pre-existing finding in internal/fork untouched by this PR; zero findings in touched files) and `GOOS=linux golangci-lint run --timeout=5m` clean
- [x] helm template smoke: default render unchanged; all-knobs render shows every new env; live binary rejects an unknown rates key at startup with the remediation message

## Risks

Rates override replaces the whole table when set (an omitted key is a free rate, documented); Helm `--set` stringifies floats so values files or `--set-json` are the documented paths. Defaults unchanged: an existing deployment renders byte-identical env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.
