### PR TITLE
docs: day-2 lifecycle guide for self-host (upgrade, rollback, backup, uninstall)

### DIFF
--- a/deploy/charts/mitos/README.md
+++ b/deploy/charts/mitos/README.md
@@ -1,9 +1,10 @@
 # Mitos Helm chart
 
 Snapshot-fork sandboxes for AI agents on Kubernetes. This chart installs the
-mitos.run operator: the controller Deployment, the privileged forkd DaemonSet,
-the KVM device plugin, the guest-kernel provisioner, and the six mitos.run CRDs.
-It is a faithful translation of the kustomize manifests under `deploy/`.
+mitos.run operator: the controller Deployment, the forkd DaemonSet, the KVM
+device plugin, the guest-kernel provisioner, the console and gateway front
+door, and the five mitos.run CRDs. It is a faithful translation of the
+kustomize manifests under `deploy/`.
 
 ## Prerequisites
 
@@ -63,13 +64,26 @@ The published chart is indexed on Artifact Hub at
 https://artifacthub.io/packages/helm/mitos/mitos.
 
 The `crds/` directory installs the CRDs before the templated resources. Helm does
-not upgrade or delete CRDs on chart upgrade or uninstall; manage CRD schema
-changes out of band.
+not upgrade or delete CRDs on chart upgrade or uninstall; apply CRD schema
+changes yourself with `kubectl apply` against the manifests in `crds/`. The
+exact procedure is in `docs/platforms/lifecycle.md` (CRD upgrades).
 
 `namespace.create=true` renders a Namespace object with the PodSecurity labels
 for the case where the chart is installed into a DIFFERENT namespace than the one
 it creates; do not combine it with `--create-namespace` for the release namespace
 (see above).
+
+## Upgrading
+
+Read the release notes, apply the CRD manifests for the target version, then
+`helm upgrade` with the same values files you installed with. The full day-2
+runbook (upgrade order, CRD step, rollback semantics, backup and restore of the
+Postgres state, uninstall) is `docs/platforms/lifecycle.md`.
+
+```
+kubectl apply --server-side --force-conflicts -f deploy/charts/mitos/crds/
+helm upgrade mitos mitos/mitos -n mitos --set namespace.create=false -f your-values.yaml
+```
 
 ## Uninstall
 
@@ -77,7 +91,9 @@ it creates; do not combine it with `--create-namespace` for the release namespac
 helm uninstall mitos -n mitos
 ```
 
-CRDs and any data they own are left in place by design.
+CRDs and any data they own are left in place by design. See
+`docs/platforms/lifecycle.md` (Uninstalling) for the safe deletion order and
+full cleanup.
 
 ## Image pull secret
 
@@ -111,50 +127,104 @@ already optional, so a missing secret never blocks forkd from starting.
 
 ## Values
 
+Every per-component `image.tag` defaults to `""`, which resolves to the chart
+`appVersion` (the release the chart shipped with); `global.imageTag` overrides
+all of them at once. `deploy/charts/mitos/values.yaml` is the authoritative,
+fully commented reference; the tables below cover the major knobs.
+
+### Images and core components
+
 | Key | Default | Description |
 | --- | --- | --- |
 | `image.registry` | `ghcr.io/mitos-run` | Registry hosting every Mitos image. |
 | `global.imageTag` | `""` | When set, overrides every per-component image tag. |
 | `controller.image.repository` | `mitos-controller` | Controller image repository. |
-| `controller.image.tag` | `v0.13.0` | Controller image tag. |
+| `controller.image.tag` | `""` | Controller image tag; empty uses the chart `appVersion`. |
 | `controller.image.pullPolicy` | `IfNotPresent` | Controller image pull policy. |
-| `controller.replicas` | `2` | Controller replica count. |
+| `controller.replicas` | `2` | Controller replica count (HA with leader election). |
 | `controller.resources` | requests 128Mi/100m, limits 512Mi/500m | Controller resources. |
 | `controller.enableHuskPods` | `true` | Render `--enable-husk-pods`. |
 | `controller.huskDataDir` | `/var/lib/mitos` | Value for `--husk-data-dir`. |
 | `controller.huskDnsUpstream` | `""` | When set, render `--husk-dns-upstream=<value>`; empty omits the flag. |
 | `controller.kvmResourceName` | `mitos.run/kvm` | KVM extended-resource name husk pods request. |
-| `controller.extraArgs` | `[]` | Extra args appended to the controller container. |
-| `huskStub.image.repository` | `mitos-husk-stub` | Husk stub image repository (passed via `--husk-stub-image`). |
-| `huskStub.image.tag` | `v0.13.0` | Husk stub image tag. |
-| `huskStub.image.pullPolicy` | `IfNotPresent` | Husk stub image pull policy. |
-| `forkd.image.repository` | `mitos-forkd` | forkd image repository. |
-| `forkd.image.tag` | `v0.13.0` | forkd image tag. |
-| `forkd.image.pullPolicy` | `IfNotPresent` | forkd image pull policy. |
-| `forkd.resources` | requests 1Gi/500m, limits 16Gi/8 | forkd resources. |
-| `forkd.dataDir` | `/var/lib/mitos` | forkd `--data-dir` and the data hostPath. |
 | `controller.namespacedSecretsRBAC` | `false` | When true, remove the controller's cluster-wide Secrets grant; it instead binds itself to the `mitos-pool-secrets` ClusterRole per adopted pool namespace (+ a RoleBinding in its own namespace). Leave false until per-pool bindings have reconciled, then flip to narrow Secrets access. Multi-tenancy hardening. |
+| `controller.orgTenancy.enabled` | `false` | Run the OrgReconciler: per-org isolation namespaces with quota, LimitRange, and default-deny NetworkPolicy. Off for single-tenant self-host. |
+| `controller.usage.collector` | `false` | Run the per-org usage metering scraper and the bearer-gated internal usage API the console reads. |
+| `controller.usage.tokenSecret.name` | `""` | Existing Secret holding the usage API bearer token (key `usage-api-token`). Empty renders no token and the API fails closed. |
+| `controller.extraArgs` | `[]` | Extra args appended to the controller container. |
+| `controller.extraEnv` | `[]` | Extra env vars appended to the controller container. |
+| `huskStub.image.repository` | `mitos-husk-stub` | Husk stub image repository (passed via `--husk-stub-image`). |
+| `huskStub.image.tag` | `""` | Husk stub image tag; empty uses the chart `appVersion`. |
+| `forkd.image.repository` | `mitos-forkd` | forkd image repository. |
+| `forkd.image.tag` | `""` | forkd image tag; empty uses the chart `appVersion`. |
+| `forkd.resources` | requests 1Gi/500m, limits 16Gi/8 | forkd resources (includes the `mitos.run/kvm` device resource; do not remove it). |
+| `forkd.dataDir` | `/var/lib/mitos` | forkd `--data-dir` and the data hostPath. |
 | `forkd.enableNetworking` | `true` | Render `--enable-networking`. |
+| `forkd.priorityClassName` | `system-node-critical` | Keeps forkd from kubelet eviction; set `""` to disable. |
+| `forkd.seccompProfile` | `RuntimeDefault` | forkd seccomp profile; hardened runtimes (Talos) need a jailer-compatible profile, see `values/talos.yaml`. |
+| `forkd.extraCapabilities` | `[]` | Capabilities ADDED to forkd's fixed builder set (hardened runtimes only). |
 | `forkd.nodeSelector` | `mitos.run/kvm: "true"` | forkd and kernel-stage nodeSelector. |
 | `forkd.tolerations` | `mitos.run/dedicated` NoSchedule | forkd and kernel-stage tolerations. |
 | `devicePlugin.enabled` | `true` | Render the KVM device plugin DaemonSet. |
 | `devicePlugin.image.repository` | `mitos-kvm-device-plugin` | Device plugin image repository. |
-| `devicePlugin.image.tag` | `v0.13.0` | Device plugin image tag. |
-| `devicePlugin.image.pullPolicy` | `IfNotPresent` | Device plugin image pull policy. |
+| `devicePlugin.image.tag` | `""` | Device plugin image tag; empty uses the chart `appVersion`. |
 | `kernelProvisioner.enabled` | `true` | Render the kernel-stage DaemonSet. |
 | `kernelProvisioner.kernelUrl` | Firecracker CI x86_64 5.10 vmlinux | Guest kernel download URL. |
 | `kernelProvisioner.kernelSha256` | `""` | Expected SHA256 of the kernel. When set, the staged kernel is verified and the init container fails closed on mismatch. Strongly recommended; compute with `curl -fsSL <kernelUrl> \| sha256sum`. |
-| `admissionWebhook.enabled` | `false` | Render the validating webhook that requires a Sandbox creator to be authorized to impersonate `spec.serviceAccount`. Strongly recommended with `controller.workspaceMemorySnapshots` in a multi-tenant cluster. Self-signed cert by default; prefer cert-manager for production rotation. |
+| `admissionWebhook.enabled` | `false` | Render the validating webhook that requires a Sandbox creator to be authorized to impersonate `spec.serviceAccount`. Strongly recommended in a multi-tenant cluster. Self-signed cert by default; prefer cert-manager for production rotation. |
 | `admissionWebhook.failurePolicy` | `Fail` | Webhook failure policy. `Fail` rejects claims if the webhook is unreachable (fail closed); set `Ignore` only if availability outranks the principal guarantee. |
-| `facade.enabled` | `false` | Render the agents.x-k8s.io facade. |
-| `facade.image.repository` | `mitos-facade` | Facade image repository. |
-| `facade.image.tag` | `v0.13.0` | Facade image tag. |
-| `facade.image.pullPolicy` | `IfNotPresent` | Facade image pull policy. |
-| `facade.defaultPool` | `default` | Facade `--default-pool`. |
-| `facade.clusterDomain` | `cluster.local` | Facade `--cluster-domain`. |
-| `facade.resources` | requests 128Mi/100m, limits 256Mi/500m | Facade resources. |
-| `monitoring.enabled` | `false` | Render the PrometheusRule and Grafana dashboard ConfigMap. |
+| `facade.enabled` | `false` | Render the agents.x-k8s.io facade (see `facade.*` in values.yaml for image, pool, and resources). |
+| `monitoring.enabled` | `false` | Render the PrometheusRule, Grafana dashboard ConfigMap, and PodMonitors. |
 | `monitoring.prometheusRuleRelease` | `prometheus` | `release` label the Prometheus Operator selects on. |
+| `canary.enabled` | `false` | Render the synthetic fork/exec canary (needs a scoped API key; see `canary.*` in values.yaml). |
+
+### Console, gateway, and database
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `console.enabled` | `true` | Render the web console (BFF + embedded SPA). |
+| `console.edition` | `community` | `community` (self-host) or `hosted`; a runtime value, never a build fork. |
+| `console.replicas` | `1` | Console replicas. OIDC session state is per-pod in memory, so more than 1 breaks login without a shared session store. |
+| `console.signup` | `false` | Mount the public self-serve signup endpoints. |
+| `console.oidc.issuerURL` | `""` | Browser-session OIDC issuer (Dex/Keycloak/Google/...). |
+| `console.oidc.clientID` | `""` | OIDC client ID. |
+| `console.oidc.clientSecretRef` | `""` | Existing Secret with key `client-secret`. |
+| `console.oidc.redirectURL` | `""` | The registered redirect URI, normally `https://<console-host>/auth/callback`. Required when OIDC is configured. |
+| `console.usage.url` | `""` | Usage API base URL; empty derives the in-cluster Service when `controller.usage.collector` is true. |
+| `console.secrets.kube.enabled` | `true` | Kubernetes-native org secret provider. |
+| `console.secrets.openbao.enabled` | `false` | OpenBao/Vault external secret provider (`address`, `perOrg`). |
+| `console.billing.enabled` | `false` | Billing surface toggle. Off for community: the billing routes never mount. |
+| `console.billing.paddle.apiKeySecretRef` | name `""`, key `api-key` | Existing Secret holding the Paddle API key; with `webhookSecretRef` also set, Paddle is the provider. |
+| `console.billing.paddle.webhookSecretRef` | name `""`, key `webhook-secret` | Existing Secret holding the Paddle webhook signing secret. |
+| `console.onboarding.verifyURL` | `""` | Base URL of the signup verification link; required when SMTP is configured. |
+| `console.onboarding.clusterProvisioning` | `false` | A verified signup creates the Org CR (requires `controller.orgTenancy.enabled`). |
+| `console.onboarding.smtp.host` | `""` | SMTP host for the verification email; empty uses the dev log sender. |
+| `console.onboarding.smtp.credentialsSecretRef` | `""` | Existing Secret with keys `username` and `password`; never inlined. |
+| `console.ingress.enabled` | `false` | Render the console Ingress (`className`, `host`, `annotations`). |
+| `console.extraEnv` | `[]` | Extra env vars appended to the console container. |
+| `gateway.enabled` | `true` | Render the public API gateway (API-key auth, org resolution, forwarding). |
+| `gateway.replicas` | `2` | Gateway replica count. |
+| `gateway.enforce.enabled` | `true` | Quotas, rate limits, size caps, and the abuse kill-switch. Disable only for a trusted single-tenant deployment; the bypass is logged. |
+| `gateway.enforce.trustedProxyHops` | `0` | Trusted reverse-proxy hops for client-IP resolution; `0` does not trust `X-Forwarded-For`. |
+| `gateway.singleTenantNamespace` | `""` | Pin all sandbox operations to one fixed namespace instead of per-org namespaces (QA/single-tenant). |
+| `gateway.ingress.enabled` | `false` | Render the gateway Ingress (`className`, `host`, `annotations`). |
+| `database.dsnSecretRef.name` | `""` | Existing Secret holding the Postgres DSN for the console and gateway (accounts, orgs, API keys, credit ledger). Empty falls back to in-memory storage: DEV ONLY, lost on restart. |
+| `database.dsnSecretRef.key` | `dsn` | Key within that Secret holding the DSN. |
+
+### Telemetry
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `telemetry.enabled` | `false` | Opt-in product telemetry. Off renders no telemetry env at all; see `docs/telemetry.md`. |
+| `telemetry.optOut` | `false` | Force-disable even when enabled; `DO_NOT_TRACK=1` is honored independently. |
+| `telemetry.endpoint` | `""` | Collector URL; required when enabled, empty fails closed. |
+| `telemetry.saltSecretRef` | name `""`, key `salt` | Secret holding the org-id HMAC salt; without it the org id is dropped. |
+| `telemetry.tokenSecretRef` | name `""`, key `token` | Optional collector bearer token Secret. |
+
+### Namespace, pull secrets, labels
+
+| Key | Default | Description |
+| --- | --- | --- |
 | `namespace.name` | `mitos` | Install namespace. |
 | `namespace.create` | `true` | Render the Namespace with PodSecurity labels. |
 | `imagePullSecret.create` | `false` | Render the dockerconfigjson Secret named below. Public images need none; set true only for a private mirror. |
@@ -162,6 +232,18 @@ already optional, so a missing secret never blocks forkd from starting.
 | `imagePullSecret.dockerconfigjson` | `{"auths":{}}` base64 | Base64 dockerconfigjson value used when `create=true`. |
 | `imagePullSecrets` | `[]` | Pull-secret names attached to every workload pod. Empty by default (public images); populate for a private mirror. |
 | `commonLabels` | `{}` | Extra labels merged onto every resource. |
+
+### Optional subsystems (one-line pointers)
+
+Each block is off by default and fully documented inline in `values.yaml`:
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `expose.enabled` | `false` | The preview-proxy for authed wildcard sandbox URLs (`expose.domain`, TLS, OIDC tiers, the `mitos-expose` Secret). |
+| `dex.enabled` | `false` | In-cluster Dex federating GitHub/Google into one OIDC issuer for the console. |
+| `frontdoor.enabled` | `false` | Single-origin reverse proxy routing marketing and console paths. |
+| `edge.enabled` | `false` | Cilium Gateway-API edge resources (Gateway, Certificate, HTTPRoutes). |
+| `marketing.enabled` | `false` | Marketing static-site Deployment behind the frontdoor. |
 
 ## Security notes
 

--- a/docs/platforms/k3s-quickstart.md
+++ b/docs/platforms/k3s-quickstart.md
@@ -175,3 +175,5 @@ console pod must be able to reach that URL.
   single-user Dex with a real identity provider and trusted TLS.
 - For the federated GitHub/Google Dex the chart ships, see the `dex.*` values in
   `deploy/charts/mitos/values.yaml`.
+- For day-2 operations (upgrading, CRD schema changes, rollback, backup,
+  uninstall), see `lifecycle.md`.

--- a/docs/platforms/lifecycle.md
+++ b/docs/platforms/lifecycle.md
@@ -1,0 +1,263 @@
+# Day-2 operations: upgrade, rollback, backup, uninstall
+
+This is the operator lifecycle guide for a self-hosted Mitos install deployed
+with the Helm chart (`deploy/charts/mitos`). It assumes the install path from
+the chart README and `prerequisites.md` and covers everything after that first
+install: upgrading, the CRD step Helm does not do for you, rolling back, backing
+up the state that matters, and uninstalling cleanly.
+
+Versioning: the chart `version` and `appVersion` are bumped together by release
+automation, so a chart release normally ships the matching component images.
+Component release tags are `vX.Y.Z`; the chart release is tagged
+`mitos-<chart-version>` by the chart releaser. Read the release notes at
+https://github.com/mitos-run/mitos/releases before any upgrade.
+
+## Upgrading
+
+The order is: read the release notes, apply the CRDs, then `helm upgrade`.
+
+1. Check the release notes for the target version, and for every version you
+   skip over, for called-out breaking changes.
+
+2. Apply the CRDs for the target version (see CRD upgrades below). Helm will
+   not do this; upgrading the controller against an older CRD schema is not a
+   supported state.
+
+3. Upgrade the release. Pass the same values files you installed with; avoid
+   `--reuse-values`, which suppresses new chart defaults introduced by the
+   upgrade.
+
+   From the HTTP Helm repository:
+
+   ```bash
+   helm repo update
+   helm upgrade mitos mitos/mitos -n mitos \
+     --set namespace.create=false -f your-values.yaml
+   ```
+
+   From the OCI registry:
+
+   ```bash
+   helm upgrade mitos oci://ghcr.io/mitos-run/charts/mitos -n mitos \
+     --version <chart-version> \
+     --set namespace.create=false -f your-values.yaml
+   ```
+
+   From a checkout of the matching release tag:
+
+   ```bash
+   helm upgrade mitos deploy/charts/mitos -n mitos \
+     --set namespace.create=false -f your-values.yaml
+   ```
+
+4. Watch the rollout:
+
+   ```bash
+   kubectl -n mitos rollout status deploy/mitos-controller
+   kubectl -n mitos rollout status ds/mitos-forkd
+   kubectl -n mitos get pods
+   ```
+
+### What happens to running sandboxes during the roll
+
+- **Controller** (Deployment, 2 replicas with leader election): running
+  sandboxes are untouched. The controller holds no in-memory desired state; on
+  restart it rebuilds everything from the CRDs and reconciles within one GC
+  interval (see `docs/failure-gc.md`, "Controller-restart reconciliation").
+  During the leader hand-off new claims and reconciles pause briefly, then
+  resume.
+- **forkd** (DaemonSet, `RollingUpdate` with `maxUnavailable: 1`): one node
+  rolls at a time. In the default husk-pods mode, running sandbox VMs live
+  inside per-sandbox husk pods, not the forkd pod, and exec/file traffic goes
+  to the husk pod's own endpoint, so running sandboxes keep serving through a
+  forkd roll. What pauses on the rolling node until the new forkd pod is Ready:
+  template snapshot builds, peer snapshot distribution, and new raw-mode forks.
+  A restarted forkd re-adopts still-live VMs it launched directly from its
+  on-disk journal (see `docs/failure-gc.md`).
+- **Raw-forkd mode** (`--enable-raw-forkd`, the fallback path): the Firecracker
+  processes are children of the forkd pod, so replacing that pod for an image
+  upgrade tears them down with it. What happens to those Sandbox objects
+  afterwards is not covered by a documented guarantee; treat the survival of
+  running raw-mode sandboxes across a forkd upgrade as undefined and plan the
+  roll for a window where losing them is acceptable.
+- **Console** (1 replica by default): a brief downtime while the pod replaces.
+  Browser sessions are held in pod memory, so users are signed out and sign in
+  again. Accounts, orgs, and API keys live in the Postgres database (when
+  `database.dsnSecretRef` is set) and are unaffected.
+- **Gateway** (2 replicas, rolling): API-key requests keep flowing during the
+  roll. The abuse/billing suspension (kill-switch) store is in-process and does
+  not survive a restart; re-drive any active suspensions after the upgrade.
+- **Warm pools and husk pods** are controller-managed objects, not chart
+  resources; a `helm upgrade` does not restart them.
+
+## CRD upgrades
+
+Helm treats the chart's `crds/` directory specially, and it is worth being
+precise about what that means: the CRDs are installed once, on the first
+`helm install`, and after that Helm never touches them again. `helm upgrade`
+does not apply schema changes to them, `helm rollback` does not revert them,
+and `helm uninstall` does not delete them. This is deliberate upstream Helm
+behavior, because deleting or mishandling a CRD destroys every custom resource
+of that kind cluster-wide. The consequence for you as the operator: every chart
+upgrade that ships a CRD schema change requires you to apply the new CRD
+manifests yourself, before the `helm upgrade`.
+
+The chart ships five CRDs, all in API group `mitos.run/v1`: `sandboxpools`,
+`sandboxes`, `workspaces`, `workspacerevisions`, and `orgs`. The versioned
+manifests live in the repo at `deploy/charts/mitos/crds/` and inside the
+published chart archive under `mitos/crds/`.
+
+From a checkout of the target release tag:
+
+```bash
+git fetch --tags && git checkout v<version>
+kubectl apply --server-side --force-conflicts -f deploy/charts/mitos/crds/
+```
+
+Or from the published chart, without a checkout:
+
+```bash
+helm pull oci://ghcr.io/mitos-run/charts/mitos \
+  --version <chart-version> --untar --untardir /tmp/mitos-chart
+kubectl apply --server-side --force-conflicts -f /tmp/mitos-chart/mitos/crds/
+```
+
+Server-side apply avoids the client-side `last-applied-configuration`
+annotation and its size limit on large CRD manifests; `--force-conflicts` is
+needed because the fields are currently owned by the manager that created the
+CRDs (Helm on first install, or a previous `kubectl apply`). Applying a CRD
+never touches the stored custom resources; it only updates the schema they are
+validated against.
+
+Verify:
+
+```bash
+kubectl get crds | grep mitos.run
+```
+
+## Rolling back
+
+```bash
+helm history mitos -n mitos
+helm rollback mitos <revision> -n mitos
+```
+
+`helm rollback` re-applies the manifests of the target revision as a new
+revision. It rolls back everything the chart templates: the controller, forkd,
+device plugin, kernel provisioner, facade, console, and gateway images and
+their configuration. Those components are stateless or rebuild their state, so
+rolling them back is safe in itself. Two things do NOT roll back with them:
+
+- **CRDs.** A rollback never downgrades CRDs; the newer schema stays in place
+  (the same Helm `crds/` behavior as above). An older controller reading
+  objects with newer optional fields ignores what it does not know, but when it
+  writes an object back it can drop values in fields it never knew about. If
+  the release notes for the version you are leaving call out a breaking CRD
+  change, do not `helm rollback` across it; restore cluster state from backup
+  instead.
+- **The Postgres schema.** The console and gateway apply embedded, forward-only
+  schema migrations at startup, recorded in a `schema_migrations` table. There
+  is no down-migration path, and running an older binary against a schema a
+  newer version migrated is untested; treat it as undefined. The reliable
+  rollback for the database is restoring the pre-upgrade dump (next section),
+  which is why you take one before upgrading.
+
+Node-local template snapshots and CAS content are keyed by content, not by
+chart revision, and are unaffected by a rollback.
+
+## Backing up state
+
+What state lives where:
+
+| State | Lives in | Backup approach |
+| --- | --- | --- |
+| Accounts, orgs, memberships, API keys, sessions, credit ledger, usage records, spend caps, allowlist | The Postgres database referenced by `database.dsnSecretRef` | `pg_dump` (below); managed-Postgres PITR in production |
+| Pool, workspace, revision, and org objects (the declarative config and revision DAG metadata) | CRs in the cluster (etcd) | Cluster backup (etcd snapshots, Velero) or `kubectl get ... -o yaml` exports; GitOps for the specs |
+| Running sandbox state | microVMs on the KVM nodes | Not backupable; sandboxes are ephemeral by design. A re-created Sandbox object does not restore a VM |
+| Template snapshots, CAS chunks, fork CoW state | `forkd.dataDir` (default `/var/lib/mitos`) on each KVM node | None needed: pools rebuild template snapshots from their spec, and snapshot distribution re-fans them out (see `docs/failure-gc.md`) |
+| Workspace revision content | The node CAS under `forkd.dataDir` by default, or an S3-compatible bucket when the Workspace spec configures the S3 store | Node-CAS-backed revisions are node-local data and are lost with the node disk; use the Workspace S3 store for durable workspace content and back the bucket up per your object-store practice |
+| Operator-created Secrets (database DSN, OIDC client secrets, expose secrets, SMTP and billing credentials, telemetry salt) | Kubernetes Secrets in the install namespace | Keep the sources of truth in your secret manager or sealed-secret GitOps flow; they are not derivable from anything else |
+| Control plane PKI (`mitos-ca`, `mitos-forkd-tls`, `mitos-controller-tls`) | Kubernetes Secrets in the install namespace | Self-healing: the controller mints missing PKI Secrets at startup, so no backup is required |
+
+The one store you must treat as production data is the Postgres database: it
+holds every account, organization, API key, and the credit ledger. The chart is
+bring-your-own Postgres by design, and the recommended production path is a
+managed database (RDS, Cloud SQL, Neon, and so on) with point-in-time recovery
+enabled; PITR restores to any moment and needs no dump schedule. A `pg_dump`
+taken before every upgrade is the floor, not the ceiling.
+
+Dump, using the same DSN the cluster uses (the example assumes the Secret name
+from the chart README, `mitos-db`, key `dsn`):
+
+```bash
+DSN=$(kubectl -n mitos get secret mitos-db -o jsonpath='{.data.dsn}' | base64 -d)
+pg_dump --format=custom --no-owner --file="mitos-$(date +%Y%m%d).dump" "$DSN"
+```
+
+Restore. Scale the writers down first so nothing writes mid-restore, then scale
+back up (the console and gateway re-apply their migrations idempotently on
+startup):
+
+```bash
+kubectl -n mitos scale deploy/mitos-console deploy/mitos-gateway --replicas=0
+pg_restore --clean --if-exists --no-owner --dbname="$DSN" mitos-<date>.dump
+kubectl -n mitos scale deploy/mitos-console --replicas=1
+kubectl -n mitos scale deploy/mitos-gateway --replicas=2
+```
+
+If `database.dsnSecretRef` is unset, the console and gateway run on in-memory
+storage: there is nothing to back up and everything is lost on every pod
+restart. That mode is for development only.
+
+## Uninstalling
+
+Delete the workload objects FIRST, while the controller and forkd are still
+running: the Sandbox finalizer reap needs them. Uninstalling the chart first
+leaves Sandbox objects wedged in Terminating with a finalizer no controller
+will ever remove.
+
+```bash
+kubectl delete sandboxes --all --all-namespaces
+kubectl delete sandboxpools --all --all-namespaces
+kubectl get sandboxes --all-namespaces   # wait until empty
+helm uninstall mitos -n mitos
+```
+
+What intentionally survives `helm uninstall`:
+
+- **The CRDs and any remaining CRs** (Workspaces, WorkspaceRevisions, Orgs, and
+  anything you chose not to delete above). Helm never deletes `crds/` content,
+  by design.
+- **The install namespace**, when you created it yourself per the documented
+  install path (`namespace.create=false`). Out-of-band Secrets in it (the
+  database DSN, OIDC, expose, billing Secrets, and the controller-minted PKI)
+  go away only with the namespace.
+- **Node-local data** under `forkd.dataDir` (default `/var/lib/mitos`) on each
+  KVM node: it is a hostPath, so nothing in the cluster deletes it.
+- **The Postgres database**, which is external by design.
+- PVCs: the chart creates none, so there are none to clean up.
+
+Full cleanup, after the uninstall:
+
+```bash
+# WARNING: deleting a CRD deletes EVERY object of that kind cluster-wide,
+# including workspace revision history. There is no undo.
+kubectl delete crd sandboxes.mitos.run sandboxpools.mitos.run \
+  workspaces.mitos.run workspacerevisions.mitos.run orgs.mitos.run
+
+kubectl delete namespace mitos
+```
+
+Then remove the data dir on each KVM node out of band (for example
+`rm -rf /var/lib/mitos` over SSH, or the equivalent on Talos), and drop or
+retire the Postgres database per your data-retention policy.
+
+If a Sandbox is already wedged in Terminating because the controller was
+uninstalled first, remove the finalizer by hand and let the GC-less delete
+finish, accepting that the backing VM (if any survives) is reaped only by the
+node teardown:
+
+```bash
+kubectl patch sandbox <name> -n <namespace> --type=merge \
+  -p '{"metadata":{"finalizers":[]}}'
+```

--- a/docs/platforms/prerequisites.md
+++ b/docs/platforms/prerequisites.md
@@ -127,3 +127,6 @@ actionable remediation per failing check (`/dev/kvm`, the `nf_tables` /
 the image pull secret, and the privileged PSA label). Run it on a KVM node or as
 an in-cluster Job; it exits non-zero if any check fails. See
 `host-prerequisites.md` for the host/kernel checklist it enforces.
+
+Once the install is healthy, `lifecycle.md` is the day-2 guide: upgrading, CRD
+schema changes, rolling back, backing up state, and uninstalling.

--- a/docs/runbooks/WarmPoolStarved.md
+++ b/docs/runbooks/WarmPoolStarved.md
@@ -22,6 +22,8 @@ count or a low-water mark.
   See `docs/husk-pods.md` (Self-healing template rebuild, #584).
 - Husk pods are not at the desired replica count (the `HuskPodsReady` condition).
 - Claims are draining the warm pool faster than it refills (demand spike).
+- A pool with `spec.warm.min` below 2 has no headroom during a rebuild: a
+  single claim can starve the pool until the next husk activates.
 - No KVM-labeled node is available to hold the pool's snapshot.
 
 ## Diagnosis


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; self-host is a first-class Apache-2.0 surface.
> - The install path is strong (chart, prerequisites docs, mitos doctor preflight), but a 2026-07-02 audit found day-2 lifecycle undocumented: no upgrade or rollback guidance, the CRD upgrade step exists only as a "manage out of band" note, no backup story for the Postgres that holds accounts and the credit ledger, and the chart README values table was stale at v0.13.0.
> - Best-in-class self-hostable products (GitLab upgrade paths, cert-manager CRD docs) treat lifecycle docs as part of the product; users rank terrifying upgrades and dirty uninstalls among their top self-host complaints.
> - This pull request adds a verified day-2 guide and refreshes the chart README so every documented value actually exists.
> - The benefit is that a platform engineer can upgrade, roll back, back up, and cleanly uninstall mitos without reading templates or Go source.

## Linked Issues or Issue Description

Related: #620 (chart hardening follow-ups; the version-skew policy and crds.enabled work remain there), #590 (the WarmPoolStarved caveat rider).

## What Changed

- New `docs/platforms/lifecycle.md` (263 lines): upgrading (HTTP repo, OCI, and checkout paths; CRDs before upgrade; per-component roll behavior), CRD upgrades (`kubectl apply --server-side` against the shipped CRD manifests plus one honest paragraph on Helm's install-only crds/ behavior), rolling back (what helm rollback does and does not touch; forward-only DB migrations mean restore-from-dump is the DB rollback), backing up state (a what-lives-where table; pg_dump/pg_restore recipe; managed-Postgres PITR named the production path), uninstalling (delete sandboxes before helm uninstall so finalizers still have a controller; what survives; wedged-finalizer remediation).
- `deploy/charts/mitos/README.md`: stale tag rows replaced with the verified empty-tag-resolves-to-appVersion behavior; CRD count corrected to five; values tables extended to console, gateway, database, telemetry, canary; new Upgrading section linking lifecycle.md.
- `docs/runbooks/WarmPoolStarved.md`: warm.min below 2 has no rebuild headroom caveat.
- Pointers from prerequisites.md and k3s-quickstart.md.

## Verification

- [x] `helm lint deploy/charts/mitos` passes
- [x] Every resource name, Secret name and key, CRD name, and Postgres table named in the guide was checked against the chart templates, `deploy/charts/mitos/crds/`, and `internal/saas/pgstore`
- [x] Zero em or en dashes in the diff
- [x] Behaviors that could not be verified are stated as undefined (raw-forkd sandbox survival across a forkd image roll; old binary against newer schema) rather than claimed

## Risks

Low risk; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.
