### PR TITLE
fix(sandbox): create fails fast and legibly on an unknown pool

### DIFF
--- a/internal/controller/claim_pool_notfound_test.go
+++ b/internal/controller/claim_pool_notfound_test.go
@@ -1,0 +1,210 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// TestReconcilePoolRefFailsFastOnMissingPool proves that a poolRef Sandbox naming
+// a pool that does not exist fails fast to a terminal Failed phase with an
+// actionable PoolNotFound condition, in a SINGLE reconcile, instead of requeuing
+// forever and leaving the create to hang the full ready-timeout. A genuinely
+// missing pool is a caller typo, not a transient error (issue #28 LLM-legible
+// errors; the no-dead-ends journey rule).
+func TestReconcilePoolRefFailsFastOnMissingPool(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-typo", Namespace: "default"},
+		Spec: v1.SandboxSpec{
+			Source: v1.SandboxSource{
+				PoolRef: &v1.LocalObjectReference{Name: "does-not-exist"},
+			},
+		},
+		Status: v1.SandboxStatus{Phase: v1.SandboxPending},
+	}
+
+	c := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1.Sandbox{}).
+		WithObjects(claim).
+		Build()
+	r := &SandboxReconciler{Client: c}
+	ctx := context.Background()
+
+	res, err := r.reconcilePoolRef(ctx, claim)
+	if err != nil {
+		t.Fatalf("reconcilePoolRef returned an error (should fail the claim terminally, not requeue): %v", err)
+	}
+	// A NotFound pool is terminal: no requeue. A requeue here would re-hammer the
+	// missing pool forever and hang the create for the full ready-timeout.
+	if res.RequeueAfter != 0 {
+		t.Fatalf("reconcilePoolRef requeued on a missing pool (RequeueAfter=%v); want terminal no-requeue", res.RequeueAfter)
+	}
+
+	var got v1.Sandbox
+	if err := c.Get(ctx, client.ObjectKeyFromObject(claim), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Phase != v1.SandboxFailed {
+		t.Fatalf("phase = %q, want %q (the claim must not stay Pending / requeue forever)", got.Status.Phase, v1.SandboxFailed)
+	}
+	// FinishedAt must be stamped so the GC TTL pass reaps this terminal claim;
+	// without it a typo'd-pool Failed sandbox leaks in etcd forever (matching the
+	// other terminal-Failed paths in reconcilePoolRef).
+	if got.Status.FinishedAt == nil {
+		t.Errorf("FinishedAt not stamped on the terminal Failed claim; the GC TTL pass would never reap it")
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, "Ready")
+	if cond == nil {
+		t.Fatalf("no Ready condition set on the failed claim")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Ready condition status = %q, want False", cond.Status)
+	}
+	if cond.Reason != "PoolNotFound" {
+		t.Errorf("Ready condition reason = %q, want PoolNotFound", cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "does-not-exist") || !strings.Contains(cond.Message, "default") {
+		t.Errorf("condition message must name the pool and namespace, got: %q", cond.Message)
+	}
+}
+
+// TestReconcilePoolRefRequeuesOnCacheLag proves that a pool the CACHED client has
+// not seen yet (a just-created pool, informer-cache lag) is NOT mistaken for a
+// caller typo: the reconciler confirms against the uncached apiserver
+// (r.APIReader), finds the pool there, and requeues instead of failing the claim.
+// Without this, create-pool-then-create-sandbox would wrongly reject a valid
+// sandbox on the racy first reconcile (this is what broke TestClaimMaxLifetimeReaped).
+func TestReconcilePoolRefRequeuesOnCacheLag(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-lag", Namespace: "default"},
+		Spec: v1.SandboxSpec{
+			Source: v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "lagging-pool"}},
+		},
+		Status: v1.SandboxStatus{Phase: v1.SandboxPending},
+	}
+	pool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "lagging-pool", Namespace: "default"},
+	}
+
+	// Cached client: has the claim but NOT the pool (informer has not caught up).
+	cached := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1.Sandbox{}).
+		WithObjects(claim).
+		Build()
+	// Uncached apiserver reader: the pool IS present (it was created).
+	uncached := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool).
+		Build()
+	r := &SandboxReconciler{Client: cached, APIReader: uncached}
+	ctx := context.Background()
+
+	res, err := r.reconcilePoolRef(ctx, claim)
+	if err != nil {
+		t.Fatalf("reconcilePoolRef errored on a cache-lag pool: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected a requeue to let the cache catch up, got RequeueAfter=%v", res.RequeueAfter)
+	}
+	var got v1.Sandbox
+	if err := cached.Get(ctx, client.ObjectKeyFromObject(claim), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Phase == v1.SandboxFailed {
+		t.Fatalf("a cache-lag pool wrongly failed a valid sandbox with PoolNotFound")
+	}
+}
+
+// TestReconcilePoolRefRequeuesOnTransientPoolGetError proves a NON-NotFound
+// (transient apiserver) error on the pool Get keeps the current requeue behavior:
+// a flaky apiserver must NOT wrongly fail a valid sandbox. The reconcile returns
+// the error (controller-runtime requeues) and the claim is not marked Failed.
+func TestReconcilePoolRefRequeuesOnTransientPoolGetError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-flaky", Namespace: "default"},
+		Spec: v1.SandboxSpec{
+			Source: v1.SandboxSource{
+				PoolRef: &v1.LocalObjectReference{Name: "real-pool"},
+			},
+		},
+		Status: v1.SandboxStatus{Phase: v1.SandboxPending},
+	}
+
+	base := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1.Sandbox{}).
+		WithObjects(claim).
+		Build()
+	// Wrap the pool Get with a transient (non-NotFound) server error.
+	c := &transientPoolGetClient{Client: base}
+	r := &SandboxReconciler{Client: c}
+	ctx := context.Background()
+
+	_, err := r.reconcilePoolRef(ctx, claim)
+	if err == nil {
+		t.Fatalf("reconcilePoolRef swallowed a transient pool Get error; a flaky apiserver must requeue, not fail the claim")
+	}
+
+	var got v1.Sandbox
+	if err := base.Get(ctx, client.ObjectKeyFromObject(claim), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Phase == v1.SandboxFailed {
+		t.Fatalf("a transient pool Get error wrongly failed a valid sandbox")
+	}
+}
+
+// transientPoolGetClient returns a synthetic server error on a SandboxPool Get,
+// modeling a flaky apiserver (not a genuine NotFound).
+type transientPoolGetClient struct {
+	client.Client
+}
+
+func (t *transientPoolGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*v1.SandboxPool); ok {
+		return apierrors.NewInternalError(errTransientPoolGet)
+	}
+	return t.Client.Get(ctx, key, obj, opts...)
+}
+
+var errTransientPoolGet = &transientErr{}
+
+type transientErr struct{}
+
+func (*transientErr) Error() string { return "synthetic transient apiserver error" }

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -267,6 +267,29 @@ func (r *SandboxReconciler) now() time.Time {
 	return time.Now()
 }
 
+// poolConfirmRequeue is how long a claim waits to re-check a pool the cached
+// client reported missing but the uncached apiserver has not confirmed absent (an
+// informer-cache lag for a just-created pool). Short so a real typo still fails
+// within a moment, not the full create ready-timeout.
+const poolConfirmRequeue = 500 * time.Millisecond
+
+// poolAbsentUncached reports whether the pool is CONFIRMED absent by reading the
+// uncached apiserver directly (r.APIReader), so a transient informer-cache lag on
+// the cached client is not mistaken for a caller typo. It returns true ONLY on a
+// definitive NotFound from the uncached reader; a found pool, or a transient
+// (non-NotFound) uncached error, returns false so the caller requeues rather than
+// failing the claim. A nil APIReader (a bare unit-test reconciler with no manager)
+// trusts the cached NotFound and returns true, matching the APIReader fallback
+// documented on the struct field.
+func (r *SandboxReconciler) poolAbsentUncached(ctx context.Context, namespace, name string) bool {
+	if r.APIReader == nil {
+		return true
+	}
+	var pool v1.SandboxPool
+	err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &pool)
+	return apierrors.IsNotFound(err)
+}
+
 // recordHuskDemand stamps a claim arrival for the claim's pool into the shared
 // demand tracker, the autoscaler's signal that warm capacity is being consumed.
 // It is best-effort: a nil tracker is a no-op. It records only the pool key and a
@@ -388,7 +411,49 @@ func (r *SandboxReconciler) reconcilePoolRef(ctx context.Context, claim *v1.Sand
 		Namespace: claim.Namespace,
 		Name:      claim.Spec.Source.PoolRef.Name,
 	}, &pool); err != nil {
-		logger.Error(err, "pool not found", "pool", claim.Spec.Source.PoolRef.Name)
+		// A genuinely missing pool is a caller typo: fail the claim fast and
+		// terminally with an actionable condition rather than requeuing forever
+		// (which would leave the control-plane create hanging the full ready-timeout
+		// and surface a misleading generic timeout). But a NotFound from the CACHED
+		// client can also be a transient informer-cache lag for a pool that was JUST
+		// created (create-pool-then-create-sandbox); failing on that would wrongly
+		// reject a valid sandbox. So a cached NotFound is confirmed against the
+		// uncached apiserver: a true typo is NotFound there too (fail fast), while a
+		// cache-lag pool is found and we requeue to let the cache catch up. A
+		// NON-NotFound (transient apiserver) error keeps the requeue behavior.
+		// (#28 LLM-legible errors; the no-dead-ends journey rule.)
+		if apierrors.IsNotFound(err) {
+			if !r.poolAbsentUncached(ctx, claim.Namespace, claim.Spec.Source.PoolRef.Name) {
+				// Not confirmed absent (cache lag, or a transient uncached read
+				// error): requeue shortly rather than fail. The informer catches up
+				// within a cache sync; the create keeps waiting, it does not fail.
+				logger.V(1).Info("pool not in cache yet; requeuing to confirm before failing",
+					"pool", claim.Spec.Source.PoolRef.Name, "namespace", claim.Namespace)
+				return ctrl.Result{RequeueAfter: poolConfirmRequeue}, nil
+			}
+			logger.Info("pool not found, failing claim", "pool", claim.Spec.Source.PoolRef.Name, "namespace", claim.Namespace)
+			now := metav1.NewTime(r.now())
+			claim.Status.Phase = v1.SandboxFailed
+			// Stamp FinishedAt so the GC TTL pass can reap this terminal claim;
+			// without it ttlFinished skips the claim forever (etcd leak), the same
+			// as the other terminal-Failed paths below.
+			claim.Status.FinishedAt = &now
+			setCondition(&claim.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: now,
+				Reason:             "PoolNotFound",
+				Message: fmt.Sprintf(
+					"no such pool %q in namespace %q; create the SandboxPool or correct the poolRef name, then recreate the sandbox",
+					claim.Spec.Source.PoolRef.Name, claim.Namespace,
+				),
+			})
+			if err := r.Status().Update(ctx, claim); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "pool lookup failed", "pool", claim.Spec.Source.PoolRef.Name)
 		return ctrl.Result{}, err
 	}
 

--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -165,13 +165,26 @@ func TestCreateUsesDefaultPoolWhenUnset(t *testing.T) {
 }
 
 // TestCreateNoPoolNoDefaultRejected asserts a create with neither pool nor a
-// default is a 400-style LLM-legible error and creates nothing.
+// default is a 400-style LLM-legible error and creates nothing. The body decoded
+// fine (it is valid JSON), so the error must be invalid_input naming the missing
+// pool field, NOT invalid_json (which would misleadingly blame the JSON syntax,
+// the #28 LLM-legible error rule).
 func TestCreateNoPoolNoDefaultRejected(t *testing.T) {
 	c := newFakeClient(t)
 	cp := New(c, WithPollInterval(5*time.Millisecond))
 	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.create", Body: []byte(`{}`)})
 	if resp.Status != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", resp.Status, resp.Body)
+	}
+	body := string(resp.Body)
+	if !strings.Contains(body, "invalid_input") {
+		t.Errorf("error code must be invalid_input for a valid-JSON body missing the pool field, got: %s", body)
+	}
+	if strings.Contains(body, "invalid_json") || strings.Contains(body, "not valid JSON") {
+		t.Errorf("error must not blame the JSON syntax when the body decoded fine: %s", body)
+	}
+	if !strings.Contains(body, "pool") {
+		t.Errorf("error cause must name the missing pool field: %s", body)
 	}
 	var list v1.SandboxList
 	_ = c.List(context.Background(), &list)

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -116,8 +116,12 @@ func (k *K8sControlPlane) create(ctx context.Context, req saas.ForwardRequest) (
 		pool = k.defaultPool
 	}
 	if pool == "" {
-		return errResp(apierr.Get(apierr.CodeInvalidJSON).
-			WithCause("the create request names neither a pool nor an image and no default pool is configured")), nil
+		// The body decoded fine (it is valid JSON); the pool field is just absent.
+		// CodeInvalidJSON ("the request body is not valid JSON") would misleadingly
+		// blame the JSON syntax, so surface an invalid_input naming the missing field
+		// (#28 LLM-legible errors).
+		return errResp(apierr.Get(apierr.CodeInvalidInput).
+			WithCause("the create request must set \"pool\" (or \"image\"/\"template\"); none was provided and no default pool is configured")), nil
 	}
 
 	ns := k.namespaceForOrg(req.OrgID)


### PR DESCRIPTION
Fixes A and B of #640 (create error-journey gaps found by a live prod sweep).

## Thinking Path

A prod sweep against api.mitos.run showed `mitos.create("typo-pool")` HANGS: the control-plane create creates the Sandbox CR, the controller's `reconcilePoolRef` can't resolve the pool and returned the Get error (requeue forever) without marking the claim Failed, so the sandbox pended and `pollReady` waited the full 120s ready-timeout before a generic timeout. Separately, a body missing the pool field returned `invalid_json` ("not valid JSON") when the JSON was valid. Both violate the #28 LLM-legible-error rule and the no-dead-ends journey rule. Fixed at the source: the controller fast-fails a genuinely-missing pool to a terminal Failed with a `PoolNotFound` condition (surfaced instantly by `pollReady`); a transient (non-NotFound) apiserver error still requeues so a flake never fails a valid sandbox. On review I caught that the new terminal-Failed branch omitted `Status.FinishedAt`, which every sibling terminal-Failed path stamps so the GC TTL reaps the claim; added it (plus a test assertion) so a typo'd-pool Failed sandbox does not leak in etcd.

## What

- `internal/controller/sandboxclaim_controller.go`: on `IsNotFound` pool Get, set `Phase=Failed` + a `Ready=False/PoolNotFound` condition naming the pool and namespace, stamp `FinishedAt` (GC reap), and stop requeuing. Non-NotFound errors keep requeuing.
- `internal/saas/controlplane/forward.go`: the missing-pool create error is now `invalid_input` naming the missing field, not `invalid_json`.

## Verification

- New tests: `TestReconcilePoolRefFailsFastOnMissingPool` (terminal Failed + PoolNotFound + FinishedAt stamped + no requeue, one reconcile) and `TestReconcilePoolRefRequeuesOnTransientPoolGetError` (a flaky apiserver still requeues, claim not failed); extended the controlplane create test for the `invalid_input` relabel.
- `go test ./internal/controller/ -run TestReconcilePoolRef` and `./internal/saas/controlplane/`: pass (envtest for the package via setup-envtest).
- `go build ./...` + `GOOS=linux go build ./...`: clean.
- `golangci-lint run` AND `GOOS=linux golangci-lint run` on the changed packages: both exit 0.
- No em/en dashes. Non-security path; no threat-model change (no auth/isolation surface moved).

## Model Used

Claude Opus 4.8 (Claude Code); TDD via a sub-agent implementer, then the coordinator reviewed the diff, caught the missing `FinishedAt` GC-reap (would leak Failed sandboxes), fixed it, and re-ran the full gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox creation now returns a clearer `invalid_input` response when the required pool field is missing and no default pool is configured (with improved error semantics).
  * Missing pool references now terminally fail the sandbox with `PoolNotFound`, a `Ready=False` condition, and a user-actionable message identifying the missing pool and namespace.
  * If pool absence is only due to cache/informer lag, reconciliation now briefly requeues instead of failing; transient lookup errors continue to requeue safely.
* **Tests**
  * Added/strengthened reconciliation test coverage for missing, cache-lag, and transient pool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->