### PR TITLE
test(daemon): chanConnListener.Close is idempotent, fixing the close-of-closed-channel flake

### DIFF
--- a/internal/daemon/vsock_guestconn_test.go
+++ b/internal/daemon/vsock_guestconn_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -311,8 +312,9 @@ func startFakeControlUDS(t *testing.T, sockPath string, sandbox sandboxv1.Sandbo
 // chanConnListener is a net.Listener that yields conns sent on its channel, used
 // to feed preamble-stripped guest conns to one grpc.Server.Serve loop.
 type chanConnListener struct {
-	conns chan net.Conn
-	done  chan struct{}
+	conns     chan net.Conn
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 func (l *chanConnListener) Accept() (net.Conn, error) {
@@ -325,11 +327,12 @@ func (l *chanConnListener) Accept() (net.Conn, error) {
 }
 
 func (l *chanConnListener) Close() error {
-	select {
-	case <-l.done:
-	default:
-		close(l.done)
-	}
+	// Close is called concurrently by the test's teardown and by
+	// grpc.Server.Serve on its exit path. The previous select-then-close guard
+	// was racy: two goroutines could both observe done as open and both close
+	// it, panicking the whole package run with "close of closed channel"
+	// (issue #642). sync.Once makes it idempotent.
+	l.closeOnce.Do(func() { close(l.done) })
 	return nil
 }
 


### PR DESCRIPTION
## HOLD FOR REVIEW: touches internal/daemon (security-sensitive path rule), though the change is a test helper only. Needs a named human reviewer; do not auto-merge.

## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; internal/daemon hosts forkd's sandbox API and its test doubles.
> - go-test failed on two consecutive unrelated PR runs today (both times on the durable-audit-log PR #633) with panic: close of closed channel, attributed to whatever test happened to be running.
> - The stack pins it to the fake guest gRPC listener in vsock_guestconn_test.go: Close is called concurrently by the test teardown and by grpc.Server.Serve's exit path, and the select-then-close guard is racy; both goroutines can observe the channel open before either closes it.
> - A package-wide panic from a test double is a merge-queue reliability problem: it can fail any PR's required go-test check.
> - This pull request replaces the racy guard with sync.Once, making Close idempotent. Test helper only; no production code changes.
> - The benefit is a merge queue that does not randomly fail on an unrelated race.

## Linked Issues or Issue Description

Closes #642. Observed failing runs: 28630094637 and its predecessor on PR #633.

## What Changed

- `internal/daemon/vsock_guestconn_test.go`: `chanConnListener` gains a `sync.Once`; `Close` uses it instead of select-then-close. A comment documents the concurrent callers and the prior race.

## Verification

- [x] `go test ./internal/daemon/ -race -count=8` passes (3.1s); gofmt clean
- [x] Test-only diff: no production files touched (single test file)
- [x] Zero em or en dashes

## Risks

None to production: the change is confined to a test double. The only behavior change is that a second Close returns nil instead of panicking, which matches net.Listener semantics.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made shutdown handling more reliable by preventing a channel from being closed more than once during concurrent cleanup.
  * Improved stability in connection teardown paths to avoid rare panic scenarios during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->