### PR TITLE
fix(saas): create fails fast and legibly on an unknown pool

### DIFF
--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -52,6 +52,15 @@ func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
 		Build()
 }
 
+// poolIn builds a SandboxPool named name in the org namespace. create() now
+// pre-checks that the referenced pool exists before building the Sandbox, so
+// create tests that expect the object to be built must seed its pool.
+func poolIn(org, name string) *v1.SandboxPool {
+	return &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: tenant.NamespaceForOrg(org)},
+	}
+}
+
 // readySandbox builds a Ready sandbox in the org namespace with the org label,
 // plus its token Secret.
 func readySandbox(org, name, endpoint, token string) (*v1.Sandbox, *corev1.Secret) {
@@ -90,7 +99,7 @@ func decodeBody(t *testing.T, b []byte) map[string]any {
 // Sandbox in mitos-org-<org> with the org label and the right pool, polls to
 // Ready, and returns id+endpoint+token (the token comes from the Secret).
 func TestCreateBuildsSandboxAndReturnsTokenOnReady(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "default"))
 	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
 
 	// Flip the created sandbox to Ready and seed its token Secret in the
@@ -144,7 +153,7 @@ func TestCreateBuildsSandboxAndReturnsTokenOnReady(t *testing.T) {
 // TestCreateUsesDefaultPoolWhenUnset asserts a create with no pool/image uses the
 // configured default pool.
 func TestCreateUsesDefaultPoolWhenUnset(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "base"))
 	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second), WithDefaultPool("base"))
 	stop := flipToReadyWhenCreated(t, c, orgA, "1.2.3.4:9091", "tok")
 	defer stop()
@@ -180,10 +189,45 @@ func TestCreateNoPoolNoDefaultRejected(t *testing.T) {
 	}
 }
 
+// TestCreateUnknownPoolFailsFast asserts a create naming a pool that does not
+// exist in the tenant namespace returns an instant, LLM-legible 404 that names
+// the pool, and creates no Sandbox object. Without the pre-check the create
+// would build a Sandbox that only pends until the controller's bounded grace
+// expires while the caller blocks for the full ready timeout (issue #630).
+func TestCreateUnknownPoolFailsFast(t *testing.T) {
+	c := newFakeClient(t) // no pools seeded
+	// A long ready timeout would make a regression (create then poll) hang; the
+	// pre-check must return before any poll, so this stays fast regardless.
+	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
+
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"typo-not-a-pool"}`),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", resp.Status, resp.Body)
+	}
+	body := string(resp.Body)
+	if !strings.Contains(body, "typo-not-a-pool") {
+		t.Errorf("error does not name the pool: %s", body)
+	}
+	if !strings.Contains(body, "not_found") {
+		t.Errorf("error is not shaped as not_found: %s", body)
+	}
+	// No Sandbox was built for a rejected create.
+	var list v1.SandboxList
+	_ = c.List(context.Background(), &list)
+	if len(list.Items) != 0 {
+		t.Errorf("created %d sandboxes for an unknown-pool request", len(list.Items))
+	}
+}
+
 // TestCreateFailedReturnsRejectionMessage asserts a Failed phase yields an
 // LLM-legible error carrying the rejection condition message.
 func TestCreateFailedReturnsRejectionMessage(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "default"))
 	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
 	stop := flipWhenCreated(t, c, orgA, func(sb *v1.Sandbox) {
 		sb.Status.Phase = v1.SandboxFailed
@@ -206,7 +250,7 @@ func TestCreateFailedReturnsRejectionMessage(t *testing.T) {
 // TestCreateTimeoutReturnsClearError asserts a sandbox that never becomes Ready
 // times out with a 504-style error.
 func TestCreateTimeoutReturnsClearError(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "default"))
 	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(40*time.Millisecond))
 	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.create", Body: []byte(`{"pool":"default"}`)})
 	if resp.Status != http.StatusGatewayTimeout {
@@ -753,7 +797,7 @@ func TestForwardUnknownOpReturnsNotFound(t *testing.T) {
 // after opFromPath maps it to sandbox.create: the SDK sends template, not pool
 // or image, so the create handler must check all three fields.
 func TestForkBodyTemplateFieldResolvesPool(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "python"))
 	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
 
 	stop := flipToReadyWhenCreated(t, c, orgA, "10.1.2.3:9091", "tok-fork")
@@ -784,7 +828,7 @@ func TestForkBodyTemplateFieldResolvesPool(t *testing.T) {
 // DirectSandbox constructor reads. Without them the SDK raises a KeyError even if
 // the gateway correctly routes the request.
 func TestCreateResponseIncludesTemplateIDAndForkTimeMs(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "python"))
 	cp := New(c, WithPollInterval(5*time.Millisecond), WithReadyTimeout(2*time.Second))
 
 	stop := flipToReadyWhenCreated(t, c, orgA, "10.1.2.3:9091", "tok-shape")
@@ -820,7 +864,7 @@ func TestCreateResponseIncludesTemplateIDAndForkTimeMs(t *testing.T) {
 // namespaces are not provisioned.
 func TestSingleTenantNamespaceAllOpsUseMitosNS(t *testing.T) {
 	const ns = "mitos"
-	c := newFakeClient(t)
+	c := newFakeClient(t, &v1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "python", Namespace: ns}})
 	cp := New(c,
 		WithPollInterval(5*time.Millisecond),
 		WithReadyTimeout(2*time.Second),
@@ -929,7 +973,7 @@ func TestSingleTenantNamespaceCrossOrgAuthzPreserved(t *testing.T) {
 // is a no-op: the per-org namespace is still used, preserving the
 // mitos-org-alpha default-mode behavior.
 func TestSingleTenantNamespaceEmptyIsNoOp(t *testing.T) {
-	c := newFakeClient(t)
+	c := newFakeClient(t, poolIn(orgA, "default"))
 	cp := New(c,
 		WithPollInterval(5*time.Millisecond),
 		WithReadyTimeout(2*time.Second),
@@ -1062,6 +1106,7 @@ func TestCreateApiServerInvalidSurfacesValidationCause(t *testing.T) {
 	base := fakeclient.NewClientBuilder().
 		WithScheme(newScheme(t)).
 		WithStatusSubresource(&v1.Sandbox{}).
+		WithObjects(poolIn(orgA, "default")).
 		Build()
 	c := interceptor.NewClient(base, interceptor.Funcs{
 		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -121,6 +121,26 @@ func (k *K8sControlPlane) create(ctx context.Context, req saas.ForwardRequest) (
 	}
 
 	ns := k.namespaceForOrg(req.OrgID)
+
+	// Fast-fail on an unknown pool. In the hosted control plane pools are
+	// pre-provisioned and stable, so a create naming a pool that does not exist
+	// in the tenant namespace is a typo, not a manifest-ordering race: return an
+	// instant, LLM-legible 404 instead of creating a Sandbox that can only pend
+	// until the controller's bounded grace expires (issue #630) while the caller
+	// blocks for the full ready timeout and then sees a misleading "did not
+	// become ready" 504. k.c is an uncached reader, so this Get is authoritative
+	// for the exact namespace the sandbox would be created in and the controller
+	// would resolve the poolRef in. A transient (non-NotFound) read error is NOT
+	// treated as absent: the create proceeds and the controller's bounded grace
+	// still governs the direct and GitOps-race paths.
+	var poolObj v1.SandboxPool
+	if err := k.c.Get(ctx, client.ObjectKey{Namespace: ns, Name: pool}, &poolObj); err != nil && apierrors.IsNotFound(err) {
+		return errResp(apierr.Get(apierr.CodeNotFound).
+			WithMessage(fmt.Sprintf("no such pool %q", pool)).
+			WithCause(fmt.Sprintf("no SandboxPool named %q exists in namespace %q", pool, ns)).
+			WithRemediation("Check the pool name for a typo and use a pool listed by GET /v1/templates, or create the SandboxPool before launching a sandbox from it.")), nil
+	}
+
 	name := generateName()
 
 	sb := &v1.Sandbox{


### PR DESCRIPTION
## Summary

The hosted control plane created a Sandbox for any named pool and then polled it to Ready/Failed. A typo in the pool name produced a Sandbox that can only pend until the controller's bounded grace expires (#630, default 5m), while the caller blocked for the full gateway ready timeout (120s) and then got a misleading "did not become ready ... still Pending" 504.

`create()` now pre-checks that the referenced pool exists in the tenant namespace before building the Sandbox, returning an instant `not_found` 404 that names the pool and points at `GET /v1/templates`.

This complements #637: #637 makes a nonexistent-pool Sandbox fail terminally and GC-reap at the controller (covering the direct/GitOps-race paths); this closes the hosted user-experience gap #637 leaves, where pools are pre-provisioned and stable so a missing pool is a typo, not a race.

## Thinking Path

Rolling #637 to prod v1.15.0 and verifying revealed the hosted gap: a typo'd pool still hangs the create for 120s and returns a misleading timeout. The controller grace (5m, reuses `--max-pending-duration`) is deliberately longer than the gateway timeout (120s) to tolerate manifest-ordering races, so the controller-side fix alone cannot make the hosted call fast. The right place for an instant, accurate error is the control plane, which uses an uncached reader in the exact namespace the poolRef resolves in. Only a definitive `NotFound` fast-fails; a transient read error falls through to create so the controller's grace still governs.

## Verification

- `go test ./internal/saas/controlplane/` green (new `TestCreateUnknownPoolFailsFast` plus 6 existing create tests updated to seed their pool).
- `go build ./internal/... ./cmd/...` on darwin and `GOOS=linux`.
- `golangci-lint run` and `GOOS=linux golangci-lint run` on the package: clean.
- Live on prod v1.15.0 the pre-fix behavior reproduced: a create with a nonexistent pool hung the full 120s and returned `did not become ready ... still Pending`; the controller logs confirmed the Sandbox then failed terminally at `waited 5m2s, maxWait 5m0s` (the #637 path). This PR turns that into an instant `no such pool` 404.

## Model Used

Claude Opus 4.8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Create requests now fail fast with a clear not-found error when a selected pool does not exist.
  * The error message now includes the missing pool name and guidance to pick an existing pool.
  * Sandbox creation now behaves more consistently across template-based, fork-based, and single-tenant namespace flows.
  * Validation paths now proceed as expected by ensuring required pool data is present during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->