### PR TITLE
fix(saas): create error journey speaks accurately (missing field, unknown route)

### DIFF
--- a/internal/saas/controlplane/controlplane_test.go
+++ b/internal/saas/controlplane/controlplane_test.go
@@ -182,10 +182,38 @@ func TestCreateNoPoolNoDefaultRejected(t *testing.T) {
 	if resp.Status != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", resp.Status, resp.Body)
 	}
+	// The body is valid JSON, so the error must be invalid_input (a missing
+	// field), not invalid_json (a parse failure); issue #640B.
+	body := string(resp.Body)
+	if !strings.Contains(body, "invalid_input") {
+		t.Errorf("missing-pool error should be invalid_input, got: %s", body)
+	}
+	if strings.Contains(body, "invalid_json") {
+		t.Errorf("missing-pool error wrongly labeled invalid_json: %s", body)
+	}
 	var list v1.SandboxList
 	_ = c.List(context.Background(), &list)
 	if len(list.Items) != 0 {
 		t.Errorf("created %d sandboxes for a rejected request", len(list.Items))
+	}
+}
+
+// TestUnknownOperationSaysRouteNotSandbox asserts an unmatched route (which
+// opFromPath maps to a nonexistent "sandbox.<method>" op) does not tell the
+// caller "no such sandbox": it hit a route the gateway does not expose, not a
+// missing sandbox. Issue #640C.
+func TestUnknownOperationSaysRouteNotSandbox(t *testing.T) {
+	cp := New(newFakeClient(t))
+	resp, _ := cp.Forward(context.Background(), saas.ForwardRequest{OrgID: orgA, Op: "sandbox.get", Path: "/v1/nonsense"})
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", resp.Status, resp.Body)
+	}
+	body := string(resp.Body)
+	if strings.Contains(body, "no such sandbox") {
+		t.Errorf("unknown route wrongly says 'no such sandbox': %s", body)
+	}
+	if !strings.Contains(body, "route or operation") {
+		t.Errorf("unknown route error should name the route/operation: %s", body)
 	}
 }
 

--- a/internal/saas/controlplane/forward.go
+++ b/internal/saas/controlplane/forward.go
@@ -53,8 +53,14 @@ func (k *K8sControlPlane) Forward(ctx context.Context, req saas.ForwardRequest) 
 	case "template.list":
 		return k.listTemplates(ctx, req)
 	default:
+		// An unmatched path reaches here as "sandbox.<method>" (opFromPath's
+		// fallback), which is not a sandbox at all: override the not_found default
+		// message ("no such sandbox") so the caller is not told a sandbox is
+		// missing when they hit a route the gateway does not expose (issue #640C).
 		return errResp(apierr.Get(apierr.CodeNotFound).
-			WithCause(fmt.Sprintf("unknown operation %q", req.Op))), nil
+			WithMessage("no such route or operation").
+			WithCause(fmt.Sprintf("the request did not map to a known gateway operation (resolved op %q)", req.Op)).
+			WithRemediation("Use a documented route: POST or GET /v1/sandboxes, GET or DELETE /v1/sandboxes/<id>, POST or GET /v1/templates, POST /v1/fork, or the runtime paths under /v1/sandboxes/<id>/.")), nil
 	}
 }
 
@@ -116,8 +122,11 @@ func (k *K8sControlPlane) create(ctx context.Context, req saas.ForwardRequest) (
 		pool = k.defaultPool
 	}
 	if pool == "" {
-		return errResp(apierr.Get(apierr.CodeInvalidJSON).
-			WithCause("the create request names neither a pool nor an image and no default pool is configured")), nil
+		// The body decoded fine; it just names no origin. That is a semantic
+		// input error, not a JSON parse failure (issue #640B).
+		return errResp(apierr.Get(apierr.CodeInvalidInput).
+			WithCause("the create request sets none of pool, image, or template and the server has no default pool configured").
+			WithRemediation("Set \"pool\" (or \"image\"/\"template\") in the request body to an existing pool; list pools with GET /v1/templates.")), nil
 	}
 
 	ns := k.namespaceForOrg(req.OrgID)


### PR DESCRIPTION
## Summary

Closes the two remaining error-journey gaps in #640 (gap A, the nonexistent-pool 120s hang, was fixed by #646 and verified live on prod):

- **B**: a create body that decodes but names no pool/image/template (and no default is configured) returned `invalid_json` ("the request body is not valid JSON"). The JSON is valid; the origin field is just absent. It now returns `invalid_input` with a cause naming the missing field and a remediation pointing at `GET /v1/templates`.
- **C**: an unmatched route (`opFromPath` maps it to a nonexistent `sandbox.<method>` op) returned the `not_found` default message "no such sandbox". The caller hit a route the gateway does not expose, not a missing sandbox; the message is now "no such route or operation" and the remediation lists the documented routes.

## Thinking Path

Found by the same live prod sweep that produced #646. `CodeInvalidInput` already exists in the catalogue (fully doc-synced) but was unused, so B is a one-line swap. C is a message override on the control-plane `Forward` default, using the existing `WithMessage`/`WithRemediation` builders. Neither touches routing or control flow, so blast radius is limited to the two error strings.

## Verification

- `go test ./internal/saas/... ./internal/apierr/`: green, including the strengthened `TestCreateNoPoolNoDefaultRejected` (asserts `invalid_input`, not `invalid_json`) and the new `TestUnknownOperationSaysRouteNotSandbox`.
- `go build ./internal/... ./cmd/...` on darwin and `GOOS=linux`.
- `golangci-lint run` and `GOOS=linux golangci-lint run` on the changed packages: clean.

## Model Used

Claude Opus 4.8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unmatched routes or operations, with clearer “route or operation” messaging and a more helpful not-found response.
  * Updated missing-pool creation errors to be reported as invalid input, with guidance on which fields to provide.
  * Added regression coverage to confirm rejected requests do not create sandbox objects and return the expected error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->