### PR TITLE
fix(console): dark theme label token clears AA small-text contrast

### DIFF
--- a/web/packages/brand/src/tokens.css
+++ b/web/packages/brand/src/tokens.css
@@ -28,7 +28,7 @@
   /* ---- Ink: white at opacity, never gray hex ---- */
   --ink: rgba(236, 240, 250, 0.94);
   --ink-2: rgba(236, 240, 250, 0.62);
-  --ink-3: rgba(236, 240, 250, 0.40);
+  --ink-3: rgba(236, 240, 250, 0.49); /* 4.6:1 on --field, 4.7:1 on --field-1/-2 (AA small text; was 0.40 = 3.4:1) */
 
   /* ---- Signal channels: color = meaning only ---- */
   --magenta: #FF45C8;          /* PRIMARY signature: division / spindle / fork */


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the console must meet WCAG 2.2 AA in both themes (the EU Accessibility Act is enforced law).
> - Measuring contrast for the light theme (#634) exposed a pre-existing dark-theme gap: the `--ink-3` label token at 0.40 alpha composites to about 3.4:1 against the field surfaces, below the 4.5:1 floor for small text; it is used by table headers, legends, hints, and the roles matrix marker.
> - The light theme's equivalent was tuned to 5.0:1, so only the dark value needed lifting, staying below `--ink-2` so the dim-label hierarchy holds.
> - This pull request raises the dark `--ink-3` alpha to 0.49, measuring 4.62 to 4.66:1 on field, field-1, and field-2, with the ratios recorded in a token comment.
> - Every usage was audited: all are text labels except one decorative faux-window dot, which is acceptable slightly brighter.
> - The benefit is AA-clean small text across both themes.

## Linked Issues or Issue Description

Closes #635.

## What Changed

- `web/packages/brand/src/tokens.css`, dark `:root` only: `--ink-3` 0.40 to 0.49 alpha with the measured ratios in the comment. Light theme untouched.

## Verification

- [x] Computed alpha-composited ratios: field 4.62:1, field-1 4.66:1, field-2 4.65:1 (was 3.39 to 3.50:1)
- [x] web/app suite: 61 files, 293 tests passed including the axe a11y tests; `tsc --noEmit` clean
- [x] Zero em or en dashes

## Risks

Purely visual: dim labels get slightly brighter in dark mode; hierarchy against `--ink-2` (0.62) is preserved.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the dark theme’s secondary ink color to be slightly more opaque, improving text contrast and readability in low-light mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->