### PR TITLE
fix(cli): windows build of mitos, statfs check split behind build tags

### DIFF
--- a/internal/agentcli/doctor_probe.go
+++ b/internal/agentcli/doctor_probe.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -131,13 +130,11 @@ func (p *realProbe) GuestKernelStaged(context.Context) (bool, string, error) {
 // bytes available to an unprivileged writer (Bavail, not Bfree). Off a KVM node
 // the dir usually does not exist, which statfs reports as an error; the check
 // folds that into a WARN so a workstation run is not falsely blocked.
-func (p *realProbe) DataDirFree(context.Context) (uint64, string, error) {
-	var st syscall.Statfs_t
-	if err := syscall.Statfs(p.dataDirPath, &st); err != nil {
-		return 0, p.dataDirPath, err
-	}
-	// Bsize and Bavail widths differ across platforms; convert explicitly.
-	return uint64(st.Bavail) * uint64(st.Bsize), p.dataDirPath, nil
+// The statfs syscall is unix-only, so the implementation lives in
+// doctor_probe_unix.go with a windows stub beside it; the goreleaser windows
+// target failed to compile on syscall.Statfs on every release before the split.
+func (p *realProbe) DataDirFree(ctx context.Context) (uint64, string, error) {
+	return p.dataDirFree(ctx)
 }
 
 func (p *realProbe) PKISecretPresent(ctx context.Context, name string) (bool, error) {

--- a/internal/agentcli/doctor_probe_unix.go
+++ b/internal/agentcli/doctor_probe_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package agentcli
+
+import (
+	"context"
+	"syscall"
+)
+
+// dataDirFree is the unix implementation behind realProbe.DataDirFree; see the
+// doc comment there. Bsize and Bavail widths differ across platforms, so both
+// are converted explicitly.
+func (p *realProbe) dataDirFree(context.Context) (uint64, string, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(p.dataDirPath, &st); err != nil {
+		return 0, p.dataDirPath, err
+	}
+	return uint64(st.Bavail) * uint64(st.Bsize), p.dataDirPath, nil
+}

--- a/internal/agentcli/doctor_probe_windows.go
+++ b/internal/agentcli/doctor_probe_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package agentcli
+
+import (
+	"context"
+	"fmt"
+)
+
+// dataDirFree has no statfs on windows. forkd never runs on windows, so the
+// data-dir free-space preflight cannot apply; the error folds into the same
+// WARN path as a missing data dir on a workstation, keeping doctor usable from
+// a windows client against a remote cluster.
+func (p *realProbe) dataDirFree(context.Context) (uint64, string, error) {
+	return 0, p.dataDirPath, fmt.Errorf("data-dir free-space check is not supported on windows; run mitos doctor on the KVM node or from a linux or darwin client")
+}


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the CLI is a first-class client for both the hosted surface and clusters.
> - The goreleaser Release workflow has failed on every release since at least 1.13.1, so no CLI binaries or install-script artifacts have ever shipped; the documented `go install` path was silently the only working one.
> - Root cause: internal/agentcli/doctor_probe.go used syscall.Statfs for the data-dir free-space preflight, and syscall.Statfs does not exist on windows, which the goreleaser matrix builds for amd64 and arm64.
> - forkd never runs on windows, so the check cannot apply there; the honest behavior is an actionable per-platform error that folds into the existing WARN path, keeping `mitos doctor` usable from a windows client against a remote cluster.
> - This pull request splits DataDirFree behind build tags: the unix file keeps the statfs implementation byte-identical; the windows stub returns the actionable error.
> - The benefit is that the next release finally publishes CLI binaries for all six targets, which also ships `mitos init` to real users.

## Linked Issues or Issue Description

No issue existed because the failure was silent: the Release workflow is not a required PR check, so six consecutive releases failed goreleaser unnoticed. Worth a follow-up to alert on release-workflow failures.

## What Changed

- `internal/agentcli/doctor_probe.go`: DataDirFree delegates to a per-platform `dataDirFree`; syscall import removed.
- `internal/agentcli/doctor_probe_unix.go` (new, `//go:build unix`): the unchanged statfs implementation.
- `internal/agentcli/doctor_probe_windows.go` (new, `//go:build windows`): actionable unsupported-on-windows error.

## Verification

- [x] `go build ./cmd/mitos/` for all six goreleaser targets: linux, darwin, windows x amd64, arm64 (windows failed before the change with the exact release error)
- [x] `go test ./internal/agentcli/` ok; golangci-lint clean on the package for darwin and GOOS=linux
- [x] Zero em or en dashes

## Risks

None on unix (implementation unchanged, moved verbatim). Windows doctor reports the data-dir check as unsupported instead of failing to build.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk space checks in the doctor flow with platform-specific handling.
  * On Unix-like systems, free space is now calculated reliably using the native filesystem report.
  * On Windows, the check now returns a clear message that free-space checks aren’t supported there and suggests running from a supported environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->