### PR TITLE
docs: self-host uses the same quickstart code; AgentRun is k8s-native depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Same engine, same API, more on-ramps. Depth is one click into [the docs](https:/
 
 The Go SDK ships in its own nested module (`github.com/mitos-run/mitos/sdk/go`), so importing it never pulls the controller into your build.
 
-**On a cluster you run.** The two-tier `AgentRun` path drives the CRDs directly:
+**Self-hosting? Same code.** The Helm chart deploys the same gateway the hosted service runs, so the quickstart above works unchanged against your own cluster: point `MITOS_BASE_URL` at your gateway and keep everything else. Hosted and self-hosted are one experience; only the URL and who operates it differ.
+
+**Kubernetes-native control, when you want it.** For platform teams that manage pools declaratively (GitOps, RBAC-scoped automation, operators), the two-tier `AgentRun` path skips the gateway and drives the `mitos.run/v1` CRDs through the Kubernetes API directly:
 
 ```python
 from mitos import AgentRun


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; hosted and self-host must be one experience (journey rules; capability document, never edition forks).
> - The user reading the README asked why cluster and hosted show different code; the quickstart correctly says the same code runs anywhere via MITOS_BASE_URL, but the later AgentRun block is headed "On a cluster you run", implying self-hosters must switch clients.
> - The chart deploys the same gateway the hosted service runs, so direct mode IS the self-host experience; AgentRun exists for a different persona: platform teams driving the CRDs declaratively (GitOps, RBAC-scoped automation).
> - This pull request reframes the section: one sentence stating self-host runs the identical quickstart against your own gateway URL, then AgentRun introduced as optional Kubernetes-native depth.
> - No code changes; the SDK surfaces are untouched.
> - The benefit is that the README stops manufacturing a two-experience impression the architecture does not have.

## Linked Issues or Issue Description

Raised directly by the user reading the README (why is there different code for in-cluster vs hosted). No tracker issue.

## What Changed

- README.md: the "On a cluster you run" lead-in becomes "Self-hosting? Same code." plus "Kubernetes-native control, when you want it." framing the AgentRun block.

## Verification

- [x] Docs only; zero em or en dashes; claims verified against the chart (gateway deployed for self-host) and the SDK quickstart text

## Risks

None.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Run it your way” section with clearer deployment options.
  * Added guidance for self-hosting using the quickstart with `MITOS_BASE_URL`.
  * Added Kubernetes-native usage notes for direct control through `mitos.run/v1` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->