### PR TITLE
fix(saas): usage records carry the API-visible sandbox id, not the husk pod name

### DIFF
--- a/internal/controller/usage_scrape.go
+++ b/internal/controller/usage_scrape.go
@@ -115,8 +115,10 @@ func (l *PodLabelLookup) LabelsForSandbox(sandboxID string) (map[string]string, 
 // It lists mitos.run/husk pods that are Running, carry a claim label
 // (mitos.run/claim, so they are actually claimed, not warm), have a PodIP, and
 // carry a NON-EMPTY trusted mitos.run/org label. It returns each pod's vm-id (the
-// pod name, which the pod reports as its single metering sample id), its org (the
-// trusted label), and its podIP:huskSandboxPort endpoint.
+// pod name, which the pod reports as its single metering sample id), its
+// API-visible sandbox id (the claim label value: the claiming Sandbox's name, the
+// id the customer saw; issue #663), its org (the trusted label), and its
+// podIP:huskSandboxPort endpoint.
 //
 // SECURITY: the org is the controller's OWN stamped label, derived from the
 // trusted per-org namespace (see buildHuskPod), NEVER client input; the pod is
@@ -150,7 +152,14 @@ func (l *HuskPodScrapeLister) ListHuskPods(ctx context.Context) ([]usage.HuskPod
 			continue
 		}
 		out = append(out, usage.HuskPod{
-			VMID:     p.Name,
+			VMID: p.Name,
+			// The API-visible sandbox id (issue #663): the mitos.run/claim label
+			// holds the claiming Sandbox's NAME, stamped by markHuskPodClaimed,
+			// which is exactly the id the API returned to the customer (the
+			// hosted gateway names the Sandbox sb-<hex> and returns that name as
+			// the id). It is the controller's OWN label, never pod input. The
+			// source falls back to VMID if this is somehow empty.
+			APIID:    p.Labels[huskClaimLabel],
 			OrgID:    org,
 			Endpoint: fmt.Sprintf("%s:%d", p.Status.PodIP, huskSandboxPort),
 		})

--- a/internal/controller/usage_scrape_test.go
+++ b/internal/controller/usage_scrape_test.go
@@ -118,14 +118,17 @@ func TestPodLabelLookupListsOncePerCycle(t *testing.T) {
 
 // scrapablePod builds a Running, claimed, org-labeled husk pod with a PodIP: the
 // exact shape HuskPodScrapeLister must return for the usage.HuskSource to scrape.
-func scrapablePod(name, org, podIP string) *corev1.Pod {
+// claim is the mitos.run/claim label value: the claiming Sandbox's NAME, which is
+// the API-visible sandbox id (the hosted gateway names the Sandbox sb-<hex> and
+// returns that name as the customer-facing id).
+func scrapablePod(name, claim, org, podIP string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "mitos-org-" + org,
 			Labels: map[string]string{
 				huskLabel:       "true",
-				huskClaimLabel:  name,
+				huskClaimLabel:  claim,
 				"mitos.run/org": org,
 			},
 		},
@@ -134,10 +137,12 @@ func scrapablePod(name, org, podIP string) *corev1.Pod {
 }
 
 // TestHuskPodScrapeListerSelectsClaimedOrgLabeledPods asserts the lister returns
-// each Running, claimed, org-labeled husk pod's vm-id (pod name), trusted org, and
-// podIP:huskSandboxPort endpoint, and OMITS pods that are unclaimed, unattributed
-// (no org label), not Running, or have no PodIP: only a billable claimed pod is
-// scraped, and org comes from the trusted label, never client input.
+// each Running, claimed, org-labeled husk pod's vm-id (pod name), API-visible
+// sandbox id (the mitos.run/claim label value, the claiming Sandbox's name; issue
+// #663), trusted org, and podIP:huskSandboxPort endpoint, and OMITS pods that are
+// unclaimed, unattributed (no org label), not Running, or have no PodIP: only a
+// billable claimed pod is scraped, and org comes from the trusted label, never
+// client input.
 func TestHuskPodScrapeListerSelectsClaimedOrgLabeledPods(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
@@ -145,24 +150,27 @@ func TestHuskPodScrapeListerSelectsClaimedOrgLabeledPods(t *testing.T) {
 	}
 
 	// Unclaimed warm pod (no claim label): must be omitted.
-	warm := huskPod("sb-warm", "acme", "mitos-org-acme")
+	warm := huskPod("python-husk-warm", "acme", "mitos-org-acme")
 	// Claimed but no org label (self-host single-tenant): must be omitted.
 	noOrg := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sb-selfhost",
+			Name:      "python-husk-selfhost",
 			Namespace: "default",
 			Labels:    map[string]string{huskLabel: "true", huskClaimLabel: "sb-selfhost"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.9"},
 	}
 	// Claimed + org labeled but no PodIP yet: must be omitted.
-	noIP := scrapablePod("sb-noip", "acme", "")
+	noIP := scrapablePod("python-husk-noip", "sb-noip", "acme", "")
 
 	cl := fakeclient.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(
-			scrapablePod("sb-acme", "acme", "10.0.0.1"),
-			scrapablePod("sb-globex", "globex", "10.0.0.2"),
+			// The hosted shape from issue #663: the pod NAME is the husk pod name
+			// (the vm-id), while the claim label carries the sb-... id the
+			// customer saw. Both must surface, in the right fields.
+			scrapablePod("python-husk-2blsp", "sb-82813f5c", "acme", "10.0.0.1"),
+			scrapablePod("python-husk-9w8k5", "sb-45eac994", "globex", "10.0.0.2"),
 			warm, noOrg, noIP,
 		).
 		Build()
@@ -180,13 +188,13 @@ func TestHuskPodScrapeListerSelectsClaimedOrgLabeledPods(t *testing.T) {
 	if len(byVM) != 2 {
 		t.Fatalf("want 2 scrapable pods, got %d: %+v", len(byVM), got)
 	}
-	if p := byVM["sb-acme"]; p.OrgID != "acme" || p.Endpoint != "10.0.0.1:9091" {
-		t.Errorf("sb-acme = %+v, want org acme endpoint 10.0.0.1:9091", p)
+	if p := byVM["python-husk-2blsp"]; p.APIID != "sb-82813f5c" || p.OrgID != "acme" || p.Endpoint != "10.0.0.1:9091" {
+		t.Errorf("python-husk-2blsp = %+v, want api id sb-82813f5c org acme endpoint 10.0.0.1:9091", p)
 	}
-	if p := byVM["sb-globex"]; p.OrgID != "globex" || p.Endpoint != "10.0.0.2:9091" {
-		t.Errorf("sb-globex = %+v, want org globex endpoint 10.0.0.2:9091", p)
+	if p := byVM["python-husk-9w8k5"]; p.APIID != "sb-45eac994" || p.OrgID != "globex" || p.Endpoint != "10.0.0.2:9091" {
+		t.Errorf("python-husk-9w8k5 = %+v, want api id sb-45eac994 org globex endpoint 10.0.0.2:9091", p)
 	}
-	for _, absent := range []string{"sb-warm", "sb-selfhost", "sb-noip"} {
+	for _, absent := range []string{"python-husk-warm", "python-husk-selfhost", "python-husk-noip"} {
 		if _, ok := byVM[absent]; ok {
 			t.Errorf("%s must be omitted (unclaimed / no org / no PodIP)", absent)
 		}

--- a/internal/usage/husksource.go
+++ b/internal/usage/husksource.go
@@ -12,12 +12,16 @@ import (
 )
 
 // HuskPod is one claimed, org-labeled husk pod the HuskSource scrapes. VMID is
-// the pod's vm-id (the id the pod reports as its single metering Sample AND the
-// id the controller maps to an org); OrgID is the owning org from the TRUSTED
+// the pod's vm-id (the pod NAME: the id the pod reports as its single metering
+// Sample AND the id the controller maps to an org); APIID is the API-VISIBLE
+// sandbox id from the TRUSTED controller-stamped mitos.run/claim label (the
+// claiming Sandbox's name, the id the customer saw; issue #663), NEVER from
+// anything the pod returns; OrgID is the owning org from the TRUSTED
 // mitos.run/org pod label, NEVER from anything the pod returns; Endpoint is the
 // pod's in-pod sandbox HTTP endpoint (podIP:port) serving GET /v1/metering.
 type HuskPod struct {
 	VMID     string
+	APIID    string
 	OrgID    string
 	Endpoint string
 }
@@ -131,6 +135,20 @@ func (s *HuskSource) Collect(ctx context.Context) ([]Sample, error) {
 			return "", false
 		}
 		samples, _ := SamplesFromReport(pod.VMID, at, report, orgOf, s.vcpus)
+		// Emit the sample keyed by the API-VISIBLE sandbox id from the TRUSTED
+		// claim label (issue #663), so usage_records reconcile to the sb-... id
+		// the customer saw, never the internal husk pod name. The trust check
+		// above stays keyed on the pod's vm-id: the pod cannot choose its billing
+		// id, only the controller's label does. Fallback: a pod whose lister
+		// carried no APIID (label absent; pre-#663 lister or a bespoke self-host
+		// lister) keeps the pod name, preserving the old behavior rather than
+		// dropping the sample. The Sample's Node field keeps the pod name (the
+		// vm-id), so support can still map a record back to the pod.
+		if pod.APIID != "" {
+			for i := range samples {
+				samples[i].SandboxID = pod.APIID
+			}
+		}
 		out = append(out, samples...)
 	}
 	return out, nil

--- a/internal/usage/husksource_test.go
+++ b/internal/usage/husksource_test.go
@@ -22,6 +22,8 @@ func singleVMReport(vmID string) metering.Report {
 // TestHuskSourceCollectsClaimedPod asserts the husk source scrapes a claimed
 // pod's /v1/metering, converts its single-VM report to an org-tagged Sample, and
 // that the org came from the TRUSTED pod label (the lister), not from the report.
+// The pod carries NO APIID, so this doubles as the fallback case for issue #663:
+// with no API-visible id, the sample keeps the pod name as its SandboxID.
 func TestHuskSourceCollectsClaimedPod(t *testing.T) {
 	srv := meteringServer(t, singleVMReport("husk-pod-acme"))
 	defer srv.Close()
@@ -54,6 +56,76 @@ func TestHuskSourceCollectsClaimedPod(t *testing.T) {
 	}
 	if src.SkippedPods() != 0 {
 		t.Errorf("SkippedPods = %d, want 0", src.SkippedPods())
+	}
+}
+
+// TestHuskSourceEmitsAPIVisibleSandboxID is the issue #663 fix proof: a husk
+// pod's report is trusted only for its OWN vm-id (the pod name), but the Sample
+// the source emits must carry the API-VISIBLE sandbox id from the controller's
+// trusted claim label (HuskPod.APIID), so usage_records reconcile to the sb-...
+// id the customer saw, not the husk pod name.
+func TestHuskSourceEmitsAPIVisibleSandboxID(t *testing.T) {
+	// The pod reports its own vm-id, which is the POD NAME (--vm-id = POD_NAME).
+	srv := meteringServer(t, singleVMReport("python-husk-2blsp"))
+	defer srv.Close()
+
+	src := NewHuskSource(
+		staticHuskPods{{
+			VMID:     "python-husk-2blsp",
+			APIID:    "sb-82813f5c",
+			OrgID:    "acme",
+			Endpoint: srv.Listener.Addr().String(),
+		}},
+		nil,
+		srv.Client(),
+		"http",
+		nil,
+	)
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("want 1 sample, got %d: %+v", len(samples), samples)
+	}
+	if samples[0].SandboxID != "sb-82813f5c" {
+		t.Errorf("SandboxID = %q, want sb-82813f5c (the API-visible id from the trusted claim label)", samples[0].SandboxID)
+	}
+	if samples[0].OrgID != "acme" {
+		t.Errorf("OrgID = %q, want acme", samples[0].OrgID)
+	}
+}
+
+// TestHuskSourceAPIIDDoesNotWeakenVMIDTrust asserts the report-id trust check
+// stays keyed on the pod name even when an APIID is present: a pod whose report
+// carries any id other than its OWN vm-id (here, the API id itself) bills
+// NOTHING. The pod is untrusted for identity; only the controller's claim label
+// selects the billing id.
+func TestHuskSourceAPIIDDoesNotWeakenVMIDTrust(t *testing.T) {
+	// The pod tries to report under the API-visible id instead of its vm-id.
+	srv := meteringServer(t, singleVMReport("sb-82813f5c"))
+	defer srv.Close()
+
+	src := NewHuskSource(
+		staticHuskPods{{
+			VMID:     "python-husk-2blsp",
+			APIID:    "sb-82813f5c",
+			OrgID:    "acme",
+			Endpoint: srv.Listener.Addr().String(),
+		}},
+		nil,
+		srv.Client(),
+		"http",
+		nil,
+	)
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(samples) != 0 {
+		t.Fatalf("a report id that is not the pod's own vm-id must be rejected even when it equals the APIID, got %+v", samples)
 	}
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; hosted usage metering scrapes each claimed husk pod and settles the records against prepaid credit.
> - The v1.19.0 charging verification confirmed records reconcile to the wrong id: usage_records carried the husk pod name (python-husk-2blsp) while the customer saw sb-82813f5c, so invoices, the console usage view, and support cannot connect a record to anything the customer knows (issue #663).
> - The controller already stamps the claiming Sandbox's name on the pod at claim time (the mitos.run/claim label), and that name IS the id the hosted gateway returned to the customer; it is the controller's own label, never pod input, so it is a trusted source.
> - The husk source's defense-in-depth must not weaken: a pod may only bill its own vm-id, so the trust check stays keyed on the pod name and only the emitted sample is re-keyed to the API id.
> - This pull request adds the API id to the scrape lister from the claim label and re-keys emitted samples, with a fallback to the pod name when the label is absent.
> - The benefit is that every new usage record names the sandbox the customer actually saw.

## Linked Issues or Issue Description

Closes #663. Found and confirmed by the charging verifications recorded on #613 and #662.

## What Changed

- `internal/controller/usage_scrape.go`: HuskPod gains APIID, filled from the trusted mitos.run/claim label (stamped with the claiming Sandbox's name, verified at huskpod.go markHuskPodClaimed).
- `internal/usage/husksource.go`: the report-id trust check stays keyed on the pod's vm-id; emitted samples are re-keyed to APIID; absent label falls back to the pod name (pre-#663 listers, bespoke self-host listers). The sample's node field keeps the pod name so support can map a record back to the pod.
- Tests: lister asserts APIID comes from the claim label; source asserts the emitted sample carries the API id while a foreign reported vm-id is still rejected; fallback case covered.

## Verification

- [x] `go build ./...`; `go test ./internal/usage/` ok; controller envtest (scrape-focused run) ok
- [x] `GOOS=linux golangci-lint run` on both packages clean; zero em or en dashes
- [x] Rollout continuity reasoned in the commit: no migration, at most one window per live sandbox recorded under each key across the deploy

## Risks

Records created before the deploy keep pod-name ids (accepted; no rewrite of billing history). The dedup key (org, sandbox, window) changes identity for in-flight windows once, bounded to one window per live sandbox.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage reporting now includes the API-visible sandbox identifier for husk pods when available.
  * Emitted usage samples will use that sandbox identifier while still keeping the pod’s VM identity.

* **Bug Fixes**
  * Improved handling of claimed pods so usage data is only reported for eligible pods.
  * Added safeguards to ensure the new identifier does not weaken VM identity validation.

* **Tests**
  * Expanded coverage for claimed, unclaimed, and missing-IP pod scenarios.
  * Added checks for sandbox ID selection and identity trust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->