### PR TITLE
fix(saas): drawdown skips settled windows before pricing; markers leave the ledger

### DIFF
--- a/cmd/console/drawdown.go
+++ b/cmd/console/drawdown.go
@@ -17,14 +17,17 @@ import (
 // draw it down against the org's prepaid credit, but nothing called Drawdown,
 // so hosted credits never moved. This driver periodically replays each org's
 // recent FINALIZED usage records through billing.Service.Drawdown. Idempotency
-// is the service's contract (the ledger entry is keyed on the record's
-// (org, sandbox, window)), so replaying the same lookback window every tick
-// settles each record exactly once and never double-debits.
+// is the service's contract (the processed-window marker and the ledger entry
+// are keyed on the record's (org, sandbox, window)), so replaying the same
+// lookback window every tick settles each record exactly once and never
+// double-debits. The driver additionally SKIPS already-settled windows before
+// pricing them (issue #672): the lookback re-lists them every tick by design,
+// and pre-#672 each replay was re-priced and re-counted into settledCents.
 //
-// SECRET HYGIENE: the driver logs org/record/error COUNTS plus the cycle's
-// AGGREGATE settled cents and carried milli-cents (issues #662/#665: without
-// the settled amount a zero-settling system looks healthy); never a per-org
-// balance, a per-org cost, or any secret.
+// SECRET HYGIENE: the driver logs org/record/replay/error COUNTS plus the
+// cycle's AGGREGATE settled cents and carried milli-cents (issues #662/#665:
+// without the settled amount a zero-settling system looks healthy); never a
+// per-org balance, a per-org cost, or any secret.
 
 // defaultDrawdownInterval is how often the driver settles usage against credit
 // when MITOS_CONSOLE_DRAWDOWN_INTERVAL is unset and a live usage store is
@@ -48,8 +51,13 @@ type drawdownRecordLister interface {
 }
 
 // drawdowner is the narrow settlement seam (billing.Service satisfies it).
+// SettledWindowKeys and PruneProcessedWindows carry the issue #672 fix: the
+// driver skips already-settled windows BEFORE pricing them and prunes markers
+// that fell out of the lookback, so a tick prices only genuinely new usage.
 type drawdowner interface {
 	Drawdown(ctx context.Context, rec usage.UsageRecord) (billing.DrawdownResult, error)
+	SettledWindowKeys(ctx context.Context, orgID string, since time.Time) (map[string]bool, error)
+	PruneProcessedWindows(ctx context.Context, olderThan time.Time) (int64, error)
 }
 
 // drawdownInterval resolves the driver cadence from the raw
@@ -85,13 +93,24 @@ type drawdownStats struct {
 	records int
 	drawn   int
 	failed  int
-	// settledCents is the cycle's total credit debited across all orgs (the sum
-	// of every record's FromCredit). A steadily zero value under nonzero records
-	// is the issue #662 signature: usage is metered but no money moves.
+	// replayed counts listed records whose window was ALREADY settled by an
+	// earlier cycle: skipped before pricing via the processed-window skip set,
+	// or (if the skip set missed one) deduplicated by the ledger at settle time.
+	// The 2h lookback re-lists them every tick by design; before issue #672 each
+	// one was re-priced and its prior credit re-counted into settledCents.
+	replayed int
+	// settledCents is the cycle's total credit debited across all orgs: the sum
+	// of FromCredit over appends that actually LANDED this cycle, never over
+	// replays (issue #672). A steadily zero value under nonzero records is the
+	// issue #662 signature: usage is metered but no money moves.
 	settledCents int64
 	// carriedMilli is the sum over orgs of the sub-cent remainder carried into
-	// the next cycle (each org's remainder after its last settled record).
+	// the next cycle (each org's remainder after its last NEWLY settled record;
+	// an org whose records were all replays contributes nothing this cycle).
 	carriedMilli int64
+	// pruned is how many processed-window markers aged out of the lookback and
+	// were removed this cycle.
+	pruned int64
 }
 
 // runDrawdownOnce settles one cycle: list every org, fetch each org's usage
@@ -119,25 +138,67 @@ func runDrawdownOnce(ctx context.Context, logger *slog.Logger, orgs drawdownOrgL
 			stats.failed++
 			continue
 		}
+		if len(recs) == 0 {
+			continue
+		}
+		// The lookback re-lists every settled window each tick by design (late
+		// or out-of-order settles must still land), so skip the already-settled
+		// ones BEFORE pricing: one indexed read per org instead of one priced
+		// replay per record (issue #672). Without the skip set the ledger's
+		// dedup would still protect the money, but settledCents would count the
+		// replays, so an org whose skip set cannot be read is deferred whole to
+		// the next tick rather than settled blind.
+		settled, err := svc.SettledWindowKeys(ctx, org.ID, from)
+		if err != nil {
+			logger.Warn("usage drawdown: read settled windows failed", "org", org.ID, "err", err.Error())
+			stats.failed++
+			continue
+		}
 		var orgCarried int64
+		var orgSettled bool
 		for _, rec := range recs {
 			stats.records++
+			if settled[billing.DrawdownKey(rec.OrgID, rec.SandboxID, rec.Window)] {
+				stats.replayed++
+				continue
+			}
 			res, err := svc.Drawdown(ctx, rec)
 			if err != nil {
 				stats.failed++
 				continue
 			}
+			if res.Replayed {
+				// The skip set missed it (settled between the read and now, or by
+				// a concurrent writer); the ledger deduplicated it and nothing
+				// moved, so it counts as a replay, never into settledCents.
+				stats.replayed++
+				continue
+			}
 			stats.drawn++
 			stats.settledCents += int64(res.FromCredit)
-			// The org's current remainder is the one after its LAST settled record
-			// (a replayed record reports the untouched current remainder).
+			// The org's current remainder is the one after its LAST settled record.
 			orgCarried = res.CarriedMilliCents
+			orgSettled = true
 		}
-		stats.carriedMilli += orgCarried
+		if orgSettled {
+			stats.carriedMilli += orgCarried
+		}
+	}
+	// Markers whose window predates the lookback can never be listed again;
+	// drop them so the marker set stays bounded. A prune failure only delays
+	// the cleanup to the next tick.
+	pruned, err := svc.PruneProcessedWindows(ctx, from)
+	if err != nil {
+		logger.Warn("usage drawdown: prune processed windows failed", "err", err.Error())
+		stats.failed++
+	} else {
+		stats.pruned = pruned
 	}
 	logger.Info("usage drawdown cycle",
-		"orgs", stats.orgs, "records", stats.records, "drawnDown", stats.drawn, "errors", stats.failed,
-		"settledCents", stats.settledCents, "carriedMilliCents", stats.carriedMilli)
+		"orgs", stats.orgs, "records", stats.records, "drawnDown", stats.drawn,
+		"replayedRecords", stats.replayed, "errors", stats.failed,
+		"settledCents", stats.settledCents, "carriedMilliCents", stats.carriedMilli,
+		"prunedMarkers", stats.pruned)
 	return stats
 }
 

--- a/cmd/console/drawdown_test.go
+++ b/cmd/console/drawdown_test.go
@@ -48,12 +48,41 @@ type fakeDrawdowner struct {
 	// returns for it, so a test can simulate per-record settled cents and
 	// carried remainders. A record with no mapped result returns the zero result.
 	results map[string]billing.DrawdownResult
+	// settled maps orgID to the already-settled drawdown keys (DrawdownKey form)
+	// SettledWindowKeys returns; settledErr fails that read.
+	settled    map[string]map[string]bool
+	settledErr error
+	// settledSince records the since bound of each SettledWindowKeys call;
+	// pruneOlderThan records each PruneProcessedWindows horizon.
+	settledSince   map[string]time.Time
+	pruneOlderThan []time.Time
+	pruneErr       error
+	pruned         int64
 }
 
 func (f *fakeDrawdowner) Drawdown(_ context.Context, rec usage.UsageRecord) (billing.DrawdownResult, error) {
 	key := rec.OrgID + "|" + rec.SandboxID + "|" + rec.Window.UTC().Format(time.RFC3339)
 	f.keys = append(f.keys, key)
 	return f.results[key], f.err
+}
+
+func (f *fakeDrawdowner) SettledWindowKeys(_ context.Context, orgID string, since time.Time) (map[string]bool, error) {
+	if f.settledSince == nil {
+		f.settledSince = map[string]time.Time{}
+	}
+	f.settledSince[orgID] = since
+	if f.settledErr != nil {
+		return nil, f.settledErr
+	}
+	return f.settled[orgID], nil
+}
+
+func (f *fakeDrawdowner) PruneProcessedWindows(_ context.Context, olderThan time.Time) (int64, error) {
+	f.pruneOlderThan = append(f.pruneOlderThan, olderThan)
+	if f.pruneErr != nil {
+		return 0, f.pruneErr
+	}
+	return f.pruned, nil
 }
 
 func testLogger() *slog.Logger {
@@ -195,5 +224,277 @@ func TestRunDrawdownOnceReportsSettledCents(t *testing.T) {
 	// remainder; the stat is the sum across orgs: 177 + (-300).
 	if stats.carriedMilli != -123 {
 		t.Errorf("carriedMilli = %d, want -123 (org-a 177 + org-b -300)", stats.carriedMilli)
+	}
+}
+
+// TestRunDrawdownOnceSkipsSettledWindowsBeforePricing is the issue #672 core:
+// a window in the org's settled skip set is never handed to Drawdown at all
+// (no wasted pricing), counts as replayed, and contributes nothing to
+// settledCents. The skip set is read once per org with the lookback start as
+// the since bound.
+func TestRunDrawdownOnceSkipsSettledWindowsBeforePricing(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	w1 := now.Add(-10 * time.Minute)
+	w2 := now.Add(-9 * time.Minute)
+	orgs := &fakeOrgLister{orgs: []saas.Organization{{ID: "org-a"}}}
+	store := &fakeRecordLister{records: map[string][]usage.UsageRecord{
+		"org-a": {
+			{OrgID: "org-a", SandboxID: "sb-1", Window: w1},
+			{OrgID: "org-a", SandboxID: "sb-1", Window: w2},
+		},
+	}}
+	svc := &fakeDrawdowner{
+		settled: map[string]map[string]bool{
+			"org-a": {billing.DrawdownKey("org-a", "sb-1", w1): true},
+		},
+		results: map[string]billing.DrawdownResult{
+			"org-a|sb-1|" + w2.UTC().Format(time.RFC3339): {Cost: 2, FromCredit: 2, CarriedMilliCents: 40},
+		},
+	}
+
+	stats := runDrawdownOnce(context.Background(), testLogger(), orgs, store, svc, 2*time.Hour, now)
+
+	if len(svc.keys) != 1 {
+		t.Fatalf("Drawdown called %d times, want 1 (the settled window must be skipped before pricing): %v", len(svc.keys), svc.keys)
+	}
+	if stats.records != 2 || stats.drawn != 1 || stats.replayed != 1 || stats.failed != 0 {
+		t.Errorf("stats = %+v, want records=2 drawn=1 replayed=1 failed=0", stats)
+	}
+	if stats.settledCents != 2 {
+		t.Errorf("settledCents = %d, want 2 (only the new window)", stats.settledCents)
+	}
+	wantSince := now.Add(-2 * time.Hour)
+	if !svc.settledSince["org-a"].Equal(wantSince) {
+		t.Errorf("SettledWindowKeys since = %v, want the lookback start %v", svc.settledSince["org-a"], wantSince)
+	}
+}
+
+// TestRunDrawdownOnceCountsSettleTimeReplays: if the skip set misses a settled
+// window (settled between the read and the settle), the ledger dedup still
+// fires and Drawdown reports Replayed; the driver counts it as replayed and
+// keeps its prior credit OUT of settledCents (the pre-#672 over-report bug).
+func TestRunDrawdownOnceCountsSettleTimeReplays(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	w1 := now.Add(-10 * time.Minute)
+	orgs := &fakeOrgLister{orgs: []saas.Organization{{ID: "org-a"}}}
+	store := &fakeRecordLister{records: map[string][]usage.UsageRecord{
+		"org-a": {{OrgID: "org-a", SandboxID: "sb-1", Window: w1}},
+	}}
+	svc := &fakeDrawdowner{results: map[string]billing.DrawdownResult{
+		"org-a|sb-1|" + w1.UTC().Format(time.RFC3339): {Cost: 5, FromCredit: 5, CarriedMilliCents: 100, Replayed: true},
+	}}
+
+	stats := runDrawdownOnce(context.Background(), testLogger(), orgs, store, svc, 2*time.Hour, now)
+
+	if stats.replayed != 1 || stats.drawn != 0 {
+		t.Errorf("stats = %+v, want replayed=1 drawn=0", stats)
+	}
+	if stats.settledCents != 0 {
+		t.Errorf("settledCents = %d, want 0 (a replay's prior credit must not be re-counted)", stats.settledCents)
+	}
+	if stats.carriedMilli != 0 {
+		t.Errorf("carriedMilli = %d, want 0 (no NEW settle happened for the org)", stats.carriedMilli)
+	}
+}
+
+// TestRunDrawdownOnceSkipSetErrorDefersOrg: an org whose settled skip set
+// cannot be read is deferred whole (counted as a failure, no records priced);
+// settling blind would re-count every replay into settledCents.
+func TestRunDrawdownOnceSkipSetErrorDefersOrg(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	orgs := &fakeOrgLister{orgs: []saas.Organization{{ID: "org-a"}}}
+	store := &fakeRecordLister{records: map[string][]usage.UsageRecord{
+		"org-a": {{OrgID: "org-a", SandboxID: "sb-1", Window: now.Add(-5 * time.Minute)}},
+	}}
+	svc := &fakeDrawdowner{settledErr: errors.New("ledger down")}
+
+	stats := runDrawdownOnce(context.Background(), testLogger(), orgs, store, svc, time.Hour, now)
+
+	if len(svc.keys) != 0 {
+		t.Fatalf("Drawdown called %d times, want 0 (org must be deferred when the skip set is unreadable)", len(svc.keys))
+	}
+	if stats.failed != 1 || stats.drawn != 0 {
+		t.Errorf("stats = %+v, want failed=1 drawn=0", stats)
+	}
+}
+
+// TestRunDrawdownOncePrunesAgedMarkers: each cycle prunes processed-window
+// markers older than the lookback start (they can never be listed again) and
+// reports the count; a prune failure is counted, never fatal.
+func TestRunDrawdownOncePrunesAgedMarkers(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	orgs := &fakeOrgLister{}
+	store := &fakeRecordLister{}
+	svc := &fakeDrawdowner{pruned: 7}
+
+	stats := runDrawdownOnce(context.Background(), testLogger(), orgs, store, svc, 2*time.Hour, now)
+
+	if len(svc.pruneOlderThan) != 1 || !svc.pruneOlderThan[0].Equal(now.Add(-2*time.Hour)) {
+		t.Fatalf("prune calls = %v, want exactly one at the lookback start %v", svc.pruneOlderThan, now.Add(-2*time.Hour))
+	}
+	if stats.pruned != 7 {
+		t.Errorf("pruned = %d, want 7", stats.pruned)
+	}
+
+	failing := &fakeDrawdowner{pruneErr: errors.New("db down")}
+	stats = runDrawdownOnce(context.Background(), testLogger(), orgs, store, failing, 2*time.Hour, now)
+	if stats.failed != 1 {
+		t.Errorf("stats after prune failure = %+v, want failed=1", stats)
+	}
+}
+
+// realBillingHarness wires the REAL billing.Service over the in-memory ledger
+// so the driver tests below prove the end-to-end tick behavior: money moves
+// exactly once per window regardless of how often the lookback replays it.
+func realBillingHarness(t *testing.T, orgID string) (*billing.Service, *billing.MemCreditLedger) {
+	t.Helper()
+	l := billing.NewMemCreditLedger()
+	if err := billing.GrantSignupCredit(context.Background(), l, orgID, billing.USD(100), time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	return billing.NewService(billing.Config{Stripe: billing.NewFakeStripe(), Ledger: l, Rates: billing.DefaultRates()}), l
+}
+
+// centRecord is a usage record costing exactly 128 cents at DefaultRates
+// (100k vCPU-seconds), so settles are whole-cent and carry-free.
+func centRecord(org, sb string, w time.Time) usage.UsageRecord {
+	return usage.UsageRecord{OrgID: org, SandboxID: sb, Window: w, VCPUSeconds: 100_000}
+}
+
+// TestRunDrawdownReplayAcrossTicksBillsOnce is the issue #672 acceptance
+// against the real billing service: the lookback re-lists settled windows on
+// every tick, but each window debits credit exactly once, later ticks report
+// the replays as replayedRecords, and settledCents covers only the appends
+// that actually landed that tick.
+func TestRunDrawdownReplayAcrossTicksBillsOnce(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	w1 := now.Add(-10 * time.Minute)
+	w2 := now.Add(-9 * time.Minute)
+	w3 := now.Add(-8 * time.Minute)
+	svc, ledger := realBillingHarness(t, "org-a")
+	orgs := &fakeOrgLister{orgs: []saas.Organization{{ID: "org-a"}}}
+	store := &fakeRecordLister{records: map[string][]usage.UsageRecord{
+		"org-a": {centRecord("org-a", "sb-1", w1), centRecord("org-a", "sb-1", w2)},
+	}}
+
+	tick1 := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now)
+	if tick1.drawn != 2 || tick1.replayed != 0 || tick1.settledCents != 256 {
+		t.Fatalf("tick 1 = %+v, want drawn=2 replayed=0 settledCents=256", tick1)
+	}
+
+	// Tick 2 re-lists both settled windows (the lookback overlap) plus one new.
+	store.records["org-a"] = append(store.records["org-a"], centRecord("org-a", "sb-1", w3))
+	tick2 := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now.Add(5*time.Minute))
+	if tick2.drawn != 1 || tick2.replayed != 2 {
+		t.Fatalf("tick 2 = %+v, want drawn=1 replayed=2", tick2)
+	}
+	if tick2.settledCents != 128 {
+		t.Errorf("tick 2 settledCents = %d, want 128 (only the NEW window; pre-#672 this read 384)", tick2.settledCents)
+	}
+
+	// Tick 3 is a pure replay: nothing new, nothing settled, nothing debited.
+	tick3 := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now.Add(10*time.Minute))
+	if tick3.drawn != 0 || tick3.replayed != 3 || tick3.settledCents != 0 {
+		t.Fatalf("tick 3 = %+v, want drawn=0 replayed=3 settledCents=0", tick3)
+	}
+
+	bal, _ := ledger.Balance(ctx, "org-a")
+	if bal != billing.USD(100)-384 {
+		t.Errorf("balance = %d, want %d (three windows debited exactly once each)", int64(bal), int64(billing.USD(100)-384))
+	}
+	entries, _ := ledger.Entries(ctx, "org-a")
+	var drawdownRows int
+	for _, e := range entries {
+		if e.Kind == billing.KindUsageDrawdown {
+			drawdownRows++
+		}
+	}
+	if drawdownRows != 3 {
+		t.Errorf("usage_drawdown rows = %d, want 3 (one per window, no replay rows)", drawdownRows)
+	}
+}
+
+// TestRunDrawdownLateArrivingWindowSettlesOnce proves the reason the skip set
+// is keyed per window and NOT a per-org watermark: windows can settle out of
+// order (a transient per-record failure or a late-listed record leaves an
+// OLDER window unsettled while a newer one settles), and such a late window
+// must still settle exactly once when it appears inside the lookback.
+func TestRunDrawdownLateArrivingWindowSettlesOnce(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	wLate := now.Add(-30 * time.Minute) // older, arrives AFTER wNew settles.
+	wNew := now.Add(-9 * time.Minute)
+	svc, ledger := realBillingHarness(t, "org-a")
+	orgs := &fakeOrgLister{orgs: []saas.Organization{{ID: "org-a"}}}
+	store := &fakeRecordLister{records: map[string][]usage.UsageRecord{
+		"org-a": {centRecord("org-a", "sb-1", wNew)},
+	}}
+
+	tick1 := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now)
+	if tick1.drawn != 1 || tick1.settledCents != 128 {
+		t.Fatalf("tick 1 = %+v, want drawn=1 settledCents=128", tick1)
+	}
+
+	// The older window shows up late, still inside the lookback. A watermark at
+	// wNew would skip it forever; the per-window skip set settles it.
+	store.records["org-a"] = []usage.UsageRecord{
+		centRecord("org-a", "sb-1", wLate),
+		centRecord("org-a", "sb-1", wNew),
+	}
+	tick2 := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now.Add(5*time.Minute))
+	if tick2.drawn != 1 || tick2.replayed != 1 || tick2.settledCents != 128 {
+		t.Fatalf("tick 2 = %+v, want drawn=1 replayed=1 settledCents=128 (the late window settles once)", tick2)
+	}
+
+	// And only once: the next tick replays both.
+	tick3 := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now.Add(10*time.Minute))
+	if tick3.drawn != 0 || tick3.replayed != 2 || tick3.settledCents != 0 {
+		t.Fatalf("tick 3 = %+v, want drawn=0 replayed=2 settledCents=0", tick3)
+	}
+
+	bal, _ := ledger.Balance(ctx, "org-a")
+	if bal != billing.USD(100)-256 {
+		t.Errorf("balance = %d, want %d (both windows debited exactly once)", int64(bal), int64(billing.USD(100)-256))
+	}
+}
+
+// TestRunDrawdownSkipsWindowsSettledBeforeMarkerTable pins the deploy
+// transition: a window settled BEFORE the processed-window mechanism exists
+// only as a keyed credit_ledger row. The first post-deploy tick must treat it
+// as settled (the skip set consults both mechanisms), never re-price or
+// re-debit it. This dual consult is removable one lookback horizon after the
+// deploy.
+func TestRunDrawdownSkipsWindowsSettledBeforeMarkerTable(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	w1 := now.Add(-10 * time.Minute)
+	svc, ledger := realBillingHarness(t, "org-a")
+	// Simulate the pre-#672 settle: a keyed ledger row via plain Append (the
+	// old AppendWithRemainder wrote exactly this row), no marker.
+	if err := ledger.Append(ctx, billing.LedgerEntry{
+		OrgID:  "org-a",
+		Kind:   billing.KindUsageDrawdown,
+		Amount: -128,
+		Key:    billing.DrawdownKey("org-a", "sb-1", w1),
+		At:     now.Add(-9 * time.Minute),
+		Note:   "usage drawdown",
+	}); err != nil {
+		t.Fatalf("legacy append: %v", err)
+	}
+	balBefore, _ := ledger.Balance(ctx, "org-a")
+
+	orgs := &fakeOrgLister{orgs: []saas.Organization{{ID: "org-a"}}}
+	store := &fakeRecordLister{records: map[string][]usage.UsageRecord{
+		"org-a": {centRecord("org-a", "sb-1", w1)},
+	}}
+	stats := runDrawdownOnce(ctx, testLogger(), orgs, store, svc, 2*time.Hour, now)
+
+	if stats.drawn != 0 || stats.replayed != 1 || stats.settledCents != 0 {
+		t.Fatalf("stats = %+v, want drawn=0 replayed=1 settledCents=0 (legacy-settled window must be skipped)", stats)
+	}
+	balAfter, _ := ledger.Balance(ctx, "org-a")
+	if balAfter != balBefore {
+		t.Errorf("balance moved on a legacy-settled window: %d -> %d", int64(balBefore), int64(balAfter))
 	}
 }

--- a/internal/saas/billing/ledger.go
+++ b/internal/saas/billing/ledger.go
@@ -3,6 +3,7 @@ package billing
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -43,9 +44,38 @@ type LedgerEntry struct {
 }
 
 // ErrDuplicateEntry is returned when an entry with an existing idempotency key
-// is appended. It makes the drawdown idempotent: replaying the same usage record
-// is a no-op, never a second debit.
+// is appended, or when a settle's processed-window marker already exists. It
+// makes the drawdown idempotent: replaying the same usage record is a no-op,
+// never a second debit.
 var ErrDuplicateEntry = errors.New("billing: ledger entry with this key already exists")
+
+// ProcessedWindow identifies one settled usage window: the (org, sandbox,
+// window) key of a usage record the drawdown has already priced and settled.
+// Markers live NEXT TO the ledger (a table in the durable implementation, a
+// map in the in-memory one), never IN it, so a zero-cent settle no longer
+// writes a customer-visible zero-amount ledger row (issue #672). A marker is
+// prunable once its window falls out of the drawdown lookback horizon: the
+// driver never lists that window again, so the marker has nothing to guard.
+type ProcessedWindow struct {
+	OrgID     string
+	SandboxID string
+	Window    time.Time
+}
+
+// Key returns the marker's drawdown idempotency key, identical to the ledger
+// key the same window's debit carries, so the two dedup mechanisms compare
+// under one canonical form.
+func (w ProcessedWindow) Key() string {
+	return DrawdownKey(w.OrgID, w.SandboxID, w.Window)
+}
+
+// DrawdownKey is the canonical (org, sandbox, window) drawdown idempotency
+// key. It keys both the credit-ledger debit row and the processed-window
+// marker, and the drawdown driver computes it per listed record to skip
+// already-settled windows before pricing.
+func DrawdownKey(orgID, sandboxID string, window time.Time) string {
+	return fmt.Sprintf("drawdown:%s|%s|%s", orgID, sandboxID, window.UTC().Format(time.RFC3339Nano))
+}
 
 // CreditLedger is the per-org append-only credit ledger. The in-memory
 // implementation is the tested default; the durable implementation is
@@ -54,10 +84,11 @@ var ErrDuplicateEntry = errors.New("billing: ledger entry with this key already 
 //
 // The ledger also owns each org's carried DRAWDOWN REMAINDER (issue #662): the
 // signed sub-cent milli-cent balance left over after the accumulator settles
-// whole cents. It lives on the ledger, not in a separate store, so an
-// implementation can commit a debit and its remainder in ONE atomic step
-// (AppendWithRemainder); with two stores a crash between the writes would skew
-// the carry.
+// whole cents, and the PROCESSED-WINDOW markers (issue #672) recording which
+// usage windows have already settled. Both live on the ledger, not in separate
+// stores, so an implementation can commit a debit, its remainder, and its
+// marker in ONE atomic step (SettleWindow); with separate stores a crash
+// between the writes would skew the carry or drop the marker.
 type CreditLedger interface {
 	// Append adds an entry. If an entry with the same non-empty Key already exists
 	// for the org, it returns ErrDuplicateEntry and changes nothing (idempotency).
@@ -73,12 +104,34 @@ type CreditLedger interface {
 	// round-half-up settle in Service.Drawdown keeps it in (-500, 500); a
 	// negative value means the org prepaid a sub-cent that offsets future usage.
 	Remainder(ctx context.Context, orgID string) (int64, error)
-	// AppendWithRemainder appends e and sets the org's drawdown remainder in one
-	// ATOMIC step: on ErrDuplicateEntry (the replayed-window case) NEITHER the
-	// entries nor the remainder change, so a replayed drawdown cannot
-	// double-count the carry, and no crash can land the debit without its
-	// remainder (or vice versa).
-	AppendWithRemainder(ctx context.Context, e LedgerEntry, remainderMilliCents int64) error
+	// SettleWindow commits one drawdown settle in one ATOMIC step: the
+	// processed-window marker for w, the org's new drawdown remainder, and,
+	// ONLY when e.Amount is nonzero, the ledger entry e (a zero-cent settle
+	// marks the window and advances the carry without a customer-visible
+	// zero-amount ledger row, issue #672). If the marker for w already exists,
+	// or e.Amount is nonzero and e.Key already exists, it returns
+	// ErrDuplicateEntry and NOTHING changes, so a replayed drawdown can neither
+	// double-debit nor double-count the carry, and no crash can land any one of
+	// the three writes without the others. This is the issue #666
+	// AppendWithRemainder single-transaction path, extended with the marker.
+	SettleWindow(ctx context.Context, e LedgerEntry, remainderMilliCents int64, w ProcessedWindow) error
+	// SettledWindowKeys returns the set of drawdown idempotency keys
+	// (DrawdownKey form) already settled for the org since the given instant:
+	// the union of the processed-window markers (by window time) and the
+	// ledger's keyed usage_drawdown entries (by settle time). The ledger half
+	// exists for BACKWARD COMPATIBILITY with windows settled before the marker
+	// table existed (their only trace is the keyed ledger row) and is removable
+	// once one lookback horizon has passed since that deploy; every settle
+	// since writes a marker. A drawdown's settle time is always after its
+	// window closes, so filtering ledger entries on At >= since never hides a
+	// row whose window is inside [since, now).
+	SettledWindowKeys(ctx context.Context, orgID string, since time.Time) (map[string]bool, error)
+	// PruneProcessedWindows deletes processed-window markers whose window is
+	// before olderThan and returns how many were removed. The drawdown driver
+	// calls it with the start of its lookback: a window that old is never
+	// listed again, so its marker guards nothing and the marker set stays
+	// bounded.
+	PruneProcessedWindows(ctx context.Context, olderThan time.Time) (int64, error)
 }
 
 // MemCreditLedger is the in-memory CreditLedger. Safe for concurrent use.
@@ -87,11 +140,19 @@ type MemCreditLedger struct {
 	byOrg     map[string][]LedgerEntry
 	seenKey   map[string]bool  // org+"\x00"+key -> exists, the idempotency guard.
 	remainder map[string]int64 // org -> carried drawdown remainder, milli-cents.
+	// processed holds the processed-window markers: org -> drawdown key ->
+	// window time (kept for range filtering and pruning).
+	processed map[string]map[string]time.Time
 }
 
 // NewMemCreditLedger returns an empty ledger.
 func NewMemCreditLedger() *MemCreditLedger {
-	return &MemCreditLedger{byOrg: map[string][]LedgerEntry{}, seenKey: map[string]bool{}, remainder: map[string]int64{}}
+	return &MemCreditLedger{
+		byOrg:     map[string][]LedgerEntry{},
+		seenKey:   map[string]bool{},
+		remainder: map[string]int64{},
+		processed: map[string]map[string]time.Time{},
+	}
 }
 
 func (l *MemCreditLedger) Append(_ context.Context, e LedgerEntry) error {
@@ -120,17 +181,67 @@ func (l *MemCreditLedger) Remainder(_ context.Context, orgID string) (int64, err
 	return l.remainder[orgID], nil
 }
 
-// AppendWithRemainder appends e and sets the org's drawdown remainder under one
-// mutex hold: a duplicate key changes nothing, so a replayed drawdown can
-// neither double-debit nor double-count the carry.
-func (l *MemCreditLedger) AppendWithRemainder(_ context.Context, e LedgerEntry, remainderMilliCents int64) error {
+// SettleWindow writes the processed-window marker, the remainder, and (when
+// e.Amount is nonzero) the entry under one mutex hold: a duplicate marker or a
+// duplicate entry key changes nothing, so a replayed drawdown can neither
+// double-debit nor double-count the carry.
+func (l *MemCreditLedger) SettleWindow(_ context.Context, e LedgerEntry, remainderMilliCents int64, w ProcessedWindow) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if err := l.appendLocked(e); err != nil {
-		return err
+	key := w.Key()
+	if _, dup := l.processed[w.OrgID][key]; dup {
+		return ErrDuplicateEntry
 	}
+	if e.Amount != 0 {
+		if err := l.appendLocked(e); err != nil {
+			return err
+		}
+	}
+	if l.processed[w.OrgID] == nil {
+		l.processed[w.OrgID] = map[string]time.Time{}
+	}
+	l.processed[w.OrgID][key] = w.Window
 	l.remainder[e.OrgID] = remainderMilliCents
 	return nil
+}
+
+// SettledWindowKeys returns the org's settled drawdown keys since the given
+// instant: markers by window time, plus keyed usage_drawdown entries by settle
+// time (the backward-compatibility half for pre-marker settles).
+func (l *MemCreditLedger) SettledWindowKeys(_ context.Context, orgID string, since time.Time) (map[string]bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := map[string]bool{}
+	for key, window := range l.processed[orgID] {
+		if !window.Before(since) {
+			out[key] = true
+		}
+	}
+	for _, e := range l.byOrg[orgID] {
+		if e.Kind == KindUsageDrawdown && e.Key != "" && !e.At.Before(since) {
+			out[e.Key] = true
+		}
+	}
+	return out, nil
+}
+
+// PruneProcessedWindows removes markers whose window is before olderThan.
+func (l *MemCreditLedger) PruneProcessedWindows(_ context.Context, olderThan time.Time) (int64, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var n int64
+	for org, keys := range l.processed {
+		for key, window := range keys {
+			if window.Before(olderThan) {
+				delete(keys, key)
+				n++
+			}
+		}
+		if len(keys) == 0 {
+			delete(l.processed, org)
+		}
+	}
+	return n, nil
 }
 
 func (l *MemCreditLedger) Balance(_ context.Context, orgID string) (Money, error) {

--- a/internal/saas/billing/ledger_test.go
+++ b/internal/saas/billing/ledger_test.go
@@ -265,22 +265,23 @@ func TestDrawdownZeroUsageWritesNothing(t *testing.T) {
 	}
 }
 
-// TestMemLedgerAppendWithRemainderAtomicOnDuplicate asserts the combined
-// append-and-set-remainder is all-or-nothing: a duplicate idempotency key
-// returns ErrDuplicateEntry and leaves BOTH the entries and the remainder
+// TestMemLedgerSettleWindowAtomicOnDuplicate asserts the combined
+// marker-entry-remainder settle is all-or-nothing: a replayed window returns
+// ErrDuplicateEntry and leaves the entries, the remainder, and the marker set
 // exactly as they were. This is the invariant that makes a replayed drawdown
-// unable to double-count the carry.
-func TestMemLedgerAppendWithRemainderAtomicOnDuplicate(t *testing.T) {
+// unable to double-debit or double-count the carry.
+func TestMemLedgerSettleWindowAtomicOnDuplicate(t *testing.T) {
 	ctx := context.Background()
 	l := NewMemCreditLedger()
 	now := fixedNow()
 
-	e := LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: 0, Key: "w1", At: now, Note: "usage drawdown"}
-	if err := l.AppendWithRemainder(ctx, e, 100); err != nil {
-		t.Fatalf("first append: %v", err)
+	w := ProcessedWindow{OrgID: "org1", SandboxID: "sb1", Window: now}
+	e := LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: -1, Key: w.Key(), At: now, Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, e, 100, w); err != nil {
+		t.Fatalf("first settle: %v", err)
 	}
-	if err := l.AppendWithRemainder(ctx, e, 900); err != ErrDuplicateEntry {
-		t.Fatalf("duplicate append err = %v, want ErrDuplicateEntry", err)
+	if err := l.SettleWindow(ctx, e, 900, w); err != ErrDuplicateEntry {
+		t.Fatalf("duplicate settle err = %v, want ErrDuplicateEntry", err)
 	}
 	rem, err := l.Remainder(ctx, "org1")
 	if err != nil {
@@ -292,5 +293,240 @@ func TestMemLedgerAppendWithRemainderAtomicOnDuplicate(t *testing.T) {
 	entries, _ := l.Entries(ctx, "org1")
 	if len(entries) != 1 {
 		t.Errorf("entries after duplicate = %d, want 1", len(entries))
+	}
+	bal, _ := l.Balance(ctx, "org1")
+	if bal != -1 {
+		t.Errorf("balance after duplicate = %d, want -1 (the single debit)", int64(bal))
+	}
+}
+
+// TestMemLedgerSettleWindowDuplicateLedgerKeyLeavesMarkerUnset covers the
+// deploy transition: a window settled BEFORE the marker mechanism has only its
+// keyed ledger row. If a settle for that window slips past the skip set, the
+// keyed ledger insert must reject it and the marker must NOT land either (the
+// whole settle is one atomic step).
+func TestMemLedgerSettleWindowDuplicateLedgerKeyLeavesMarkerUnset(t *testing.T) {
+	ctx := context.Background()
+	l := NewMemCreditLedger()
+	now := fixedNow()
+
+	w := ProcessedWindow{OrgID: "org1", SandboxID: "sb1", Window: now}
+	// The pre-marker deploy wrote the keyed ledger row via plain Append.
+	old := LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: -2, Key: w.Key(), At: now, Note: "usage drawdown"}
+	if err := l.Append(ctx, old); err != nil {
+		t.Fatalf("legacy append: %v", err)
+	}
+
+	e := LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: -2, Key: w.Key(), At: now, Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, e, 250, w); err != ErrDuplicateEntry {
+		t.Fatalf("settle over legacy key err = %v, want ErrDuplicateEntry", err)
+	}
+	rem, _ := l.Remainder(ctx, "org1")
+	if rem != 0 {
+		t.Errorf("remainder after rejected settle = %d, want 0 (untouched)", rem)
+	}
+	keys, err := l.SettledWindowKeys(ctx, "org1", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("settled keys: %v", err)
+	}
+	// The window is still settled (the legacy ledger row says so), but only via
+	// the ledger half; the failed settle must not have half-written a marker
+	// alongside a rolled-back debit.
+	if !keys[w.Key()] {
+		t.Errorf("settled keys missing the legacy ledger key %q", w.Key())
+	}
+	entries, _ := l.Entries(ctx, "org1")
+	if len(entries) != 1 {
+		t.Errorf("entries = %d, want 1 (the legacy row only)", len(entries))
+	}
+}
+
+// TestMemLedgerZeroAmountSettleWritesMarkerNotEntry pins the issue #672 ledger
+// hygiene: a zero-cent settle (sub-cent usage folding into the carry) marks
+// the window processed and advances the remainder WITHOUT a customer-visible
+// zero-amount ledger row.
+func TestMemLedgerZeroAmountSettleWritesMarkerNotEntry(t *testing.T) {
+	ctx := context.Background()
+	l := NewMemCreditLedger()
+	now := fixedNow()
+
+	w := ProcessedWindow{OrgID: "org1", SandboxID: "sb1", Window: now}
+	e := LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: 0, Key: w.Key(), At: now, Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, e, 77, w); err != nil {
+		t.Fatalf("zero-amount settle: %v", err)
+	}
+	entries, _ := l.Entries(ctx, "org1")
+	if len(entries) != 0 {
+		t.Errorf("zero-amount settle wrote %d ledger entries, want 0", len(entries))
+	}
+	rem, _ := l.Remainder(ctx, "org1")
+	if rem != 77 {
+		t.Errorf("remainder = %d, want 77", rem)
+	}
+	// The marker still deduplicates a replay.
+	if err := l.SettleWindow(ctx, e, 154, w); err != ErrDuplicateEntry {
+		t.Fatalf("replayed zero-amount settle err = %v, want ErrDuplicateEntry", err)
+	}
+	keys, _ := l.SettledWindowKeys(ctx, "org1", now.Add(-time.Hour))
+	if !keys[w.Key()] {
+		t.Errorf("settled keys missing the marker key %q", w.Key())
+	}
+}
+
+// TestMemLedgerSettledWindowKeysUnionsMarkersAndLegacyRows asserts the skip
+// set consults BOTH dedup mechanisms during the transition horizon: windows
+// settled before the marker table (keyed ledger rows) AND windows settled
+// after (markers), each filtered to the since bound.
+func TestMemLedgerSettledWindowKeysUnionsMarkersAndLegacyRows(t *testing.T) {
+	ctx := context.Background()
+	l := NewMemCreditLedger()
+	now := fixedNow()
+
+	// A legacy pre-marker settle: keyed ledger row only.
+	legacyKey := DrawdownKey("org1", "sb1", now.Add(-10*time.Minute))
+	if err := l.Append(ctx, LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: 0, Key: legacyKey, At: now}); err != nil {
+		t.Fatalf("legacy append: %v", err)
+	}
+	// A post-deploy settle: marker (zero amount, so no ledger row).
+	w := ProcessedWindow{OrgID: "org1", SandboxID: "sb1", Window: now.Add(-5 * time.Minute)}
+	if err := l.SettleWindow(ctx, LedgerEntry{OrgID: "org1", Kind: KindUsageDrawdown, Amount: 0, Key: w.Key(), At: now}, 10, w); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	// A non-drawdown keyed entry must never enter the skip set.
+	if err := l.Append(ctx, LedgerEntry{OrgID: "org1", Kind: KindTopUp, Amount: 500, Key: "topup:pi_1", At: now}); err != nil {
+		t.Fatalf("topup append: %v", err)
+	}
+
+	keys, err := l.SettledWindowKeys(ctx, "org1", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("settled keys: %v", err)
+	}
+	if !keys[legacyKey] {
+		t.Errorf("missing legacy ledger key %q", legacyKey)
+	}
+	if !keys[w.Key()] {
+		t.Errorf("missing marker key %q", w.Key())
+	}
+	if keys["topup:pi_1"] {
+		t.Errorf("top-up key leaked into the settled-window skip set")
+	}
+	if len(keys) != 2 {
+		t.Errorf("settled keys = %d, want 2", len(keys))
+	}
+
+	// The since bound excludes older state: a since after everything yields none.
+	none, err := l.SettledWindowKeys(ctx, "org1", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("settled keys (future since): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("settled keys with future since = %d, want 0", len(none))
+	}
+}
+
+// TestMemLedgerPruneProcessedWindows asserts pruning removes only markers
+// whose window predates the horizon and reports the removed count.
+func TestMemLedgerPruneProcessedWindows(t *testing.T) {
+	ctx := context.Background()
+	l := NewMemCreditLedger()
+	now := fixedNow()
+
+	oldW := ProcessedWindow{OrgID: "org1", SandboxID: "sb1", Window: now.Add(-3 * time.Hour)}
+	newW := ProcessedWindow{OrgID: "org1", SandboxID: "sb1", Window: now.Add(-5 * time.Minute)}
+	for _, w := range []ProcessedWindow{oldW, newW} {
+		if err := l.SettleWindow(ctx, LedgerEntry{OrgID: w.OrgID, Kind: KindUsageDrawdown, Amount: 0, Key: w.Key(), At: now}, 0, w); err != nil {
+			t.Fatalf("settle %v: %v", w.Window, err)
+		}
+	}
+
+	n, err := l.PruneProcessedWindows(ctx, now.Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("pruned = %d, want 1", n)
+	}
+	keys, _ := l.SettledWindowKeys(ctx, "org1", time.Time{})
+	if keys[oldW.Key()] {
+		t.Errorf("pruned marker %q still present", oldW.Key())
+	}
+	if !keys[newW.Key()] {
+		t.Errorf("in-horizon marker %q was pruned", newW.Key())
+	}
+}
+
+// TestDrawdownReplayIsFlagged asserts a replayed Drawdown reports
+// Replayed=true (so the driver counts it out of settledCents) while a first
+// settle reports Replayed=false.
+func TestDrawdownReplayIsFlagged(t *testing.T) {
+	ctx := context.Background()
+	l := NewMemCreditLedger()
+	now := fixedNow()
+	if err := GrantSignupCredit(ctx, l, "org1", USD(100), now); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	svc := NewService(Config{Stripe: NewFakeStripe(), Ledger: l, Rates: DefaultRates(), Now: fixedNow})
+	rec := usage.UsageRecord{OrgID: "org1", SandboxID: "sb1", Window: now, VCPUSeconds: 100_000} // $1.28.
+
+	first, err := svc.Drawdown(ctx, rec)
+	if err != nil {
+		t.Fatalf("first drawdown: %v", err)
+	}
+	if first.Replayed {
+		t.Errorf("first drawdown reported Replayed=true, want false")
+	}
+	replay, err := svc.Drawdown(ctx, rec)
+	if err != nil {
+		t.Fatalf("replay drawdown: %v", err)
+	}
+	if !replay.Replayed {
+		t.Errorf("replayed drawdown reported Replayed=false, want true")
+	}
+	if replay.FromCredit != first.FromCredit || replay.Remaining != 0 {
+		t.Errorf("replay = %+v, want prior FromCredit %d and Remaining 0", replay, int64(first.FromCredit))
+	}
+}
+
+// TestDrawdownZeroCentSettleKeepsLedgerClean is the issue #672 acceptance at
+// the service level: sub-cent windows that settle 0 cents no longer write
+// zero-amount usage_drawdown ledger rows; only the windows that actually move
+// money appear in the customer-visible ledger.
+func TestDrawdownZeroCentSettleKeepsLedgerClean(t *testing.T) {
+	ctx := context.Background()
+	l := NewMemCreditLedger()
+	now := fixedNow()
+	if err := GrantSignupCredit(ctx, l, "org1", USD(5), now); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	svc := NewService(Config{Stripe: NewFakeStripe(), Ledger: l, Rates: DefaultRates(), Now: fixedNow})
+
+	// 10 sub-cent minutes settle exactly 1 cent (see
+	// TestDrawdownAccumulatesSubCentUsage): exactly ONE drawdown row.
+	for m := 0; m < 10; m++ {
+		if _, err := svc.Drawdown(ctx, minuteRecord("org1", "sb1", m)); err != nil {
+			t.Fatalf("drawdown minute %d: %v", m, err)
+		}
+	}
+	entries, _ := l.Entries(ctx, "org1")
+	var drawdownRows, zeroRows int
+	for _, e := range entries {
+		if e.Kind != KindUsageDrawdown {
+			continue
+		}
+		drawdownRows++
+		if e.Amount == 0 {
+			zeroRows++
+		}
+	}
+	if drawdownRows != 1 {
+		t.Errorf("usage_drawdown rows = %d, want 1 (only the settled cent)", drawdownRows)
+	}
+	if zeroRows != 0 {
+		t.Errorf("zero-amount usage_drawdown rows = %d, want 0 (issue #672)", zeroRows)
+	}
+	// Every priced window is still marked processed.
+	keys, _ := l.SettledWindowKeys(ctx, "org1", time.Time{})
+	if len(keys) != 10 {
+		t.Errorf("settled window keys = %d, want 10", len(keys))
 	}
 }

--- a/internal/saas/billing/service.go
+++ b/internal/saas/billing/service.go
@@ -180,6 +180,11 @@ type DrawdownResult struct {
 	// round-half-up settled a cent slightly ahead of usage (the org prepaid up to
 	// half a cent that offsets what accrues next).
 	CarriedMilliCents int64
+	// Replayed reports that this window was ALREADY settled by an earlier call:
+	// nothing moved on this one. The drawdown driver counts a replayed result
+	// separately and never adds its FromCredit to the cycle's settled total
+	// (issue #672: settledCents must reflect only appends that actually landed).
+	Replayed bool
 }
 
 // Drawdown prices a usage record in MILLI-cents, folds it into the org's
@@ -195,16 +200,17 @@ type DrawdownResult struct {
 // within half a cent at every point in time.
 //
 // Idempotency and atomicity: EVERY record with a nonzero milli-cent cost
-// writes a ledger entry keyed by the (org, sandbox, window) usage key, even
-// when the settled amount is 0 cents; that entry is both the debit and the
-// processed-window marker. The entry and the new remainder commit in ONE
-// atomic ledger step (AppendWithRemainder), and a replay hits
-// ErrDuplicateEntry BEFORE any state moves, so a replayed window can neither
-// double-debit nor double-count into the carry. Concurrent drawdown drivers
-// settling the SAME org can still interleave the remainder read and write
-// (last write wins, skewing the carry by under a cent per race, never the
-// debits); the console runs one sequential driver, so this does not occur in
-// the shipped wiring.
+// writes a processed-window marker keyed by the (org, sandbox, window) usage
+// key, plus a ledger entry under the same key when the settled amount is
+// nonzero (a zero-cent settle marks the window without a customer-visible
+// zero-amount ledger row, issue #672). The marker, the entry, and the new
+// remainder commit in ONE atomic ledger step (SettleWindow, the issue #666
+// AppendWithRemainder path extended), and a replay hits ErrDuplicateEntry
+// BEFORE any state moves, so a replayed window can neither double-debit nor
+// double-count into the carry. Concurrent drawdown drivers settling the SAME
+// org can still interleave the remainder read and write (last write wins,
+// skewing the carry by under a cent per race, never the debits); the console
+// runs one sequential driver, so this does not occur in the shipped wiring.
 func (s *Service) Drawdown(ctx context.Context, rec usage.UsageRecord) (DrawdownResult, error) {
 	costMilli := s.rates.CostMilliCents(rec)
 	if costMilli == 0 {
@@ -232,14 +238,14 @@ func (s *Service) Drawdown(ctx context.Context, rec usage.UsageRecord) (Drawdown
 	if fromCredit < 0 {
 		fromCredit = 0
 	}
-	err = s.ledger.AppendWithRemainder(ctx, LedgerEntry{
+	err = s.ledger.SettleWindow(ctx, LedgerEntry{
 		OrgID:  rec.OrgID,
 		Kind:   KindUsageDrawdown,
 		Amount: -fromCredit,
 		Key:    usageKey(rec),
 		At:     s.now(),
 		Note:   "usage drawdown",
-	}, newCarry)
+	}, newCarry, ProcessedWindow{OrgID: rec.OrgID, SandboxID: rec.SandboxID, Window: rec.Window})
 	if err == ErrDuplicateEntry {
 		// Idempotent replay: this window was already settled and the remainder
 		// already advanced; nothing moved on this call. Report the credit the
@@ -250,7 +256,7 @@ func (s *Service) Drawdown(ctx context.Context, rec usage.UsageRecord) (Drawdown
 		if perr != nil {
 			return DrawdownResult{}, perr
 		}
-		return DrawdownResult{Cost: prior, FromCredit: prior, Remaining: 0, CarriedMilliCents: carried}, nil
+		return DrawdownResult{Cost: prior, FromCredit: prior, Remaining: 0, CarriedMilliCents: carried, Replayed: true}, nil
 	}
 	if err != nil {
 		return DrawdownResult{}, fmt.Errorf("append drawdown: %w", err)
@@ -278,14 +284,30 @@ func (s *Service) priorDrawdownCredit(ctx context.Context, rec usage.UsageRecord
 			return 0, nil
 		}
 	}
-	// No matching entry: the first call debited nothing (fromCredit was 0), so the
-	// duplicate guard cannot have fired on a drawdown entry; treat as zero credit.
+	// No matching entry: the first call debited nothing (a zero-cent settle
+	// writes only the processed-window marker, no ledger row), so the replayed
+	// window's prior credit is zero.
 	return 0, nil
 }
 
 // usageKey is the (org, sandbox, window) ledger idempotency key for a drawdown.
 func usageKey(rec usage.UsageRecord) string {
-	return fmt.Sprintf("drawdown:%s|%s|%s", rec.OrgID, rec.SandboxID, rec.Window.UTC().Format(time.RFC3339Nano))
+	return DrawdownKey(rec.OrgID, rec.SandboxID, rec.Window)
+}
+
+// SettledWindowKeys exposes the ledger's already-settled window keys (the
+// union of processed-window markers and legacy keyed usage_drawdown rows) so
+// the drawdown driver can skip settled windows BEFORE pricing them (issue
+// #672). since bounds the read to the driver's lookback.
+func (s *Service) SettledWindowKeys(ctx context.Context, orgID string, since time.Time) (map[string]bool, error) {
+	return s.ledger.SettledWindowKeys(ctx, orgID, since)
+}
+
+// PruneProcessedWindows drops processed-window markers whose window is before
+// olderThan; the drawdown driver calls it once per cycle with the start of its
+// lookback so the marker set stays bounded.
+func (s *Service) PruneProcessedWindows(ctx context.Context, olderThan time.Time) (int64, error) {
+	return s.ledger.PruneProcessedWindows(ctx, olderThan)
 }
 
 // EnforceSpendCap checks an org's period spend against its caps and fires the

--- a/internal/saas/billingprovider/billingprovider_test.go
+++ b/internal/saas/billingprovider/billingprovider_test.go
@@ -25,8 +25,14 @@ func (errLedger) Entries(context.Context, string) ([]billing.LedgerEntry, error)
 	return nil, nil
 }
 func (errLedger) Remainder(context.Context, string) (int64, error) { return 0, nil }
-func (errLedger) AppendWithRemainder(context.Context, billing.LedgerEntry, int64) error {
+func (errLedger) SettleWindow(context.Context, billing.LedgerEntry, int64, billing.ProcessedWindow) error {
 	return errors.New("ledger unavailable")
+}
+func (errLedger) SettledWindowKeys(context.Context, string, time.Time) (map[string]bool, error) {
+	return nil, errors.New("ledger unavailable")
+}
+func (errLedger) PruneProcessedWindows(context.Context, time.Time) (int64, error) {
+	return 0, errors.New("ledger unavailable")
 }
 
 // handleTopUp builds a WebhookHandler with the given provider and ledger, POSTs

--- a/internal/saas/pgstore/creditledger.go
+++ b/internal/saas/pgstore/creditledger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -54,27 +55,43 @@ func (l *PgCreditLedger) Remainder(ctx context.Context, orgID string) (int64, er
 	return m, nil
 }
 
-// AppendWithRemainder inserts the entry and upserts the org's drawdown
-// remainder in ONE transaction: either both land or neither does. A duplicate
-// non-empty Key rolls the whole transaction back and returns
-// billing.ErrDuplicateEntry with the remainder untouched, which is what makes a
+// SettleWindow commits one drawdown settle in ONE transaction (issue #672,
+// extending the issue #666 AppendWithRemainder path): the processed-window
+// marker, the org's drawdown remainder, and, only when the amount is nonzero,
+// the ledger entry. A duplicate marker (the replayed-window case) or a
+// duplicate non-empty entry key (a window settled before the marker table
+// existed) rolls the whole transaction back and returns
+// billing.ErrDuplicateEntry with everything untouched, which is what makes a
 // replayed drawdown window unable to double-debit or double-count the carry.
-func (l *PgCreditLedger) AppendWithRemainder(ctx context.Context, e billing.LedgerEntry, remainderMilliCents int64) error {
+func (l *PgCreditLedger) SettleWindow(ctx context.Context, e billing.LedgerEntry, remainderMilliCents int64, w billing.ProcessedWindow) error {
 	tx, err := l.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin drawdown settle: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	const insert = `
-        INSERT INTO credit_ledger (org_id, kind, amount, idem_key, at, note)
-        VALUES ($1, $2, $3, $4, $5, $6)`
-	_, err = tx.Exec(ctx, insert, e.OrgID, string(e.Kind), int64(e.Amount), e.Key, e.At, e.Note)
-	if e.Key != "" && isUniqueViolation(err) {
+	const mark = `
+        INSERT INTO processed_usage_windows (org_id, sandbox_id, window_at)
+        VALUES ($1, $2, $3)`
+	_, err = tx.Exec(ctx, mark, w.OrgID, w.SandboxID, w.Window)
+	if isUniqueViolation(err) {
 		return billing.ErrDuplicateEntry
 	}
 	if err != nil {
-		return fmt.Errorf("append ledger entry: %w", err)
+		return fmt.Errorf("mark processed window: %w", err)
+	}
+
+	if e.Amount != 0 {
+		const insert = `
+        INSERT INTO credit_ledger (org_id, kind, amount, idem_key, at, note)
+        VALUES ($1, $2, $3, $4, $5, $6)`
+		_, err = tx.Exec(ctx, insert, e.OrgID, string(e.Kind), int64(e.Amount), e.Key, e.At, e.Note)
+		if e.Key != "" && isUniqueViolation(err) {
+			return billing.ErrDuplicateEntry
+		}
+		if err != nil {
+			return fmt.Errorf("append ledger entry: %w", err)
+		}
 	}
 
 	const upsert = `
@@ -90,6 +107,67 @@ func (l *PgCreditLedger) AppendWithRemainder(ctx context.Context, e billing.Ledg
 		return fmt.Errorf("commit drawdown settle: %w", err)
 	}
 	return nil
+}
+
+// SettledWindowKeys returns the org's already-settled drawdown keys since the
+// given instant: the processed-window markers (by window time) unioned with
+// the keyed usage_drawdown ledger rows (by settle time). The ledger half keeps
+// windows settled BEFORE migration 0011 deduplicated across the deploy (their
+// only trace is the ledger row) and is removable once one drawdown lookback
+// horizon has passed since that deploy. A settle always happens after its
+// window closes, so at >= since never hides a row whose window is in scope.
+func (l *PgCreditLedger) SettledWindowKeys(ctx context.Context, orgID string, since time.Time) (map[string]bool, error) {
+	out := map[string]bool{}
+
+	const markers = `
+        SELECT sandbox_id, window_at FROM processed_usage_windows
+        WHERE org_id = $1 AND window_at >= $2`
+	rows, err := l.pool.Query(ctx, markers, orgID, since)
+	if err != nil {
+		return nil, fmt.Errorf("read processed windows: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sandboxID string
+		var window time.Time
+		if err := rows.Scan(&sandboxID, &window); err != nil {
+			return nil, fmt.Errorf("scan processed window: %w", err)
+		}
+		out[billing.DrawdownKey(orgID, sandboxID, window)] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate processed windows: %w", err)
+	}
+
+	const legacy = `
+        SELECT idem_key FROM credit_ledger
+        WHERE org_id = $1 AND kind = $2 AND idem_key <> '' AND at >= $3`
+	lrows, err := l.pool.Query(ctx, legacy, orgID, string(billing.KindUsageDrawdown), since)
+	if err != nil {
+		return nil, fmt.Errorf("read settled ledger keys: %w", err)
+	}
+	defer lrows.Close()
+	for lrows.Next() {
+		var key string
+		if err := lrows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("scan settled ledger key: %w", err)
+		}
+		out[key] = true
+	}
+	if err := lrows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate settled ledger keys: %w", err)
+	}
+	return out, nil
+}
+
+// PruneProcessedWindows deletes markers whose window is before olderThan and
+// returns how many were removed.
+func (l *PgCreditLedger) PruneProcessedWindows(ctx context.Context, olderThan time.Time) (int64, error) {
+	tag, err := l.pool.Exec(ctx, `DELETE FROM processed_usage_windows WHERE window_at < $1`, olderThan)
+	if err != nil {
+		return 0, fmt.Errorf("prune processed windows: %w", err)
+	}
+	return tag.RowsAffected(), nil
 }
 
 // Balance returns the signed sum of the org's ledger entries. An org with no

--- a/internal/saas/pgstore/creditledger_test.go
+++ b/internal/saas/pgstore/creditledger_test.go
@@ -59,11 +59,11 @@ func TestPgCreditLedger(t *testing.T) {
 }
 
 // TestPgCreditLedgerRemainder covers the durable drawdown remainder (issue
-// #662, migration 0010): the default remainder is zero, AppendWithRemainder
-// commits the ledger entry and the remainder atomically, a duplicate
-// idempotency key leaves BOTH untouched, a negative carry (the round-half-up
-// prepaid sub-cent) round-trips, and the remainder survives a restart (a
-// second pgstore.Open over the same database).
+// #662, migration 0010): the default remainder is zero, SettleWindow commits
+// the ledger entry and the remainder atomically, a replayed window leaves BOTH
+// untouched, a negative carry (the round-half-up prepaid sub-cent) round-trips,
+// and the remainder survives a restart (a second pgstore.Open over the same
+// database).
 func TestPgCreditLedgerRemainder(t *testing.T) {
 	dsn := testDSN(t)
 	pg, err := pgstore.Open(context.Background(), dsn)
@@ -71,7 +71,7 @@ func TestPgCreditLedgerRemainder(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	t.Cleanup(pg.Close)
-	truncateTables(t, dsn, "credit_ledger", "drawdown_remainders")
+	truncateTables(t, dsn, "credit_ledger", "drawdown_remainders", "processed_usage_windows")
 	l := pgstore.NewPgCreditLedger(pg.Pool())
 	ctx := context.Background()
 	now := time.Unix(1700000000, 0).UTC()
@@ -85,10 +85,11 @@ func TestPgCreditLedgerRemainder(t *testing.T) {
 		t.Fatalf("fresh remainder = %d, want 0", rem)
 	}
 
-	// The combined write lands both the entry and the remainder.
-	e := billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: -1, Key: "w1", At: now, Note: "usage drawdown"}
-	if err := l.AppendWithRemainder(ctx, e, 231); err != nil {
-		t.Fatalf("append with remainder: %v", err)
+	// The combined write lands the entry, the remainder, and the marker.
+	w1 := billing.ProcessedWindow{OrgID: "o1", SandboxID: "sb1", Window: now}
+	e := billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: -1, Key: w1.Key(), At: now, Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, e, 231, w1); err != nil {
+		t.Fatalf("settle window: %v", err)
 	}
 	rem, _ = l.Remainder(ctx, "o1")
 	if rem != 231 {
@@ -99,9 +100,9 @@ func TestPgCreditLedgerRemainder(t *testing.T) {
 		t.Fatalf("balance = %d, want -1 (the appended debit)", int64(bal))
 	}
 
-	// A duplicate key is atomic: ErrDuplicateEntry, and NEITHER the entries nor
-	// the remainder move (a replayed drawdown cannot double-count the carry).
-	if err := l.AppendWithRemainder(ctx, e, 999); !errors.Is(err, billing.ErrDuplicateEntry) {
+	// A replayed window is atomic: ErrDuplicateEntry, and NEITHER the entries
+	// nor the remainder move (a replayed drawdown cannot double-count the carry).
+	if err := l.SettleWindow(ctx, e, 999, w1); !errors.Is(err, billing.ErrDuplicateEntry) {
 		t.Fatalf("duplicate err = %v, want ErrDuplicateEntry", err)
 	}
 	rem, _ = l.Remainder(ctx, "o1")
@@ -114,9 +115,10 @@ func TestPgCreditLedgerRemainder(t *testing.T) {
 	}
 
 	// A negative carry (round-half-up prepaid the sub-cent) round-trips.
-	e2 := billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: -1, Key: "w2", At: now, Note: "usage drawdown"}
-	if err := l.AppendWithRemainder(ctx, e2, -461); err != nil {
-		t.Fatalf("append negative remainder: %v", err)
+	w2 := billing.ProcessedWindow{OrgID: "o1", SandboxID: "sb1", Window: now.Add(time.Minute)}
+	e2 := billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: -1, Key: w2.Key(), At: now, Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, e2, -461, w2); err != nil {
+		t.Fatalf("settle negative remainder: %v", err)
 	}
 	rem, _ = l.Remainder(ctx, "o1")
 	if rem != -461 {
@@ -137,5 +139,132 @@ func TestPgCreditLedgerRemainder(t *testing.T) {
 	}
 	if rem != -461 {
 		t.Fatalf("remainder after restart = %d, want -461 (must be durable)", rem)
+	}
+}
+
+// TestPgProcessedWindows covers migration 0011 end to end on a real Postgres:
+// a zero-amount settle writes the marker and the remainder but NO ledger row,
+// a replayed window rolls the whole transaction back, a window settled before
+// the marker table (a keyed ledger row from the pre-#672 deploy) both blocks
+// a direct re-settle AND appears in the skip set, and pruning removes only
+// markers older than the horizon.
+func TestPgProcessedWindows(t *testing.T) {
+	dsn := testDSN(t)
+	pg, err := pgstore.Open(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	truncateTables(t, dsn, "credit_ledger", "drawdown_remainders", "processed_usage_windows")
+	l := pgstore.NewPgCreditLedger(pg.Pool())
+	ctx := context.Background()
+	now := time.Unix(1700000000, 0).UTC()
+
+	// The migration chain through 0011 is recorded.
+	var applied bool
+	if err := pg.Pool().QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE version = '0011_processed_usage_windows.sql')`).Scan(&applied); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	if !applied {
+		t.Fatalf("migration 0011_processed_usage_windows.sql not recorded as applied")
+	}
+
+	// Zero-amount settle: marker + remainder land, the customer-visible ledger
+	// stays clean (issue #672: no more zero-amount usage_drawdown rows).
+	wZero := billing.ProcessedWindow{OrgID: "o1", SandboxID: "sb1", Window: now}
+	eZero := billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: 0, Key: wZero.Key(), At: now, Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, eZero, 77, wZero); err != nil {
+		t.Fatalf("zero-amount settle: %v", err)
+	}
+	entries, _ := l.Entries(ctx, "o1")
+	if len(entries) != 0 {
+		t.Fatalf("zero-amount settle wrote %d ledger rows, want 0", len(entries))
+	}
+	rem, _ := l.Remainder(ctx, "o1")
+	if rem != 77 {
+		t.Fatalf("remainder = %d, want 77", rem)
+	}
+	// The marker still deduplicates: a replay changes nothing.
+	if err := l.SettleWindow(ctx, eZero, 154, wZero); !errors.Is(err, billing.ErrDuplicateEntry) {
+		t.Fatalf("replayed zero-amount settle err = %v, want ErrDuplicateEntry", err)
+	}
+	rem, _ = l.Remainder(ctx, "o1")
+	if rem != 77 {
+		t.Fatalf("remainder after replay = %d, want 77 (untouched)", rem)
+	}
+
+	// Transition compatibility: a window settled pre-#672 exists only as a
+	// keyed ledger row. A re-settle must be rejected atomically (no marker
+	// half-landed) and the skip set must report it settled.
+	wLegacy := billing.ProcessedWindow{OrgID: "o1", SandboxID: "sb1", Window: now.Add(time.Minute)}
+	if err := l.Append(ctx, billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: -2, Key: wLegacy.Key(), At: now.Add(time.Minute), Note: "usage drawdown"}); err != nil {
+		t.Fatalf("legacy append: %v", err)
+	}
+	eLegacy := billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: -2, Key: wLegacy.Key(), At: now.Add(2 * time.Minute), Note: "usage drawdown"}
+	if err := l.SettleWindow(ctx, eLegacy, 300, wLegacy); !errors.Is(err, billing.ErrDuplicateEntry) {
+		t.Fatalf("settle over legacy key err = %v, want ErrDuplicateEntry", err)
+	}
+	rem, _ = l.Remainder(ctx, "o1")
+	if rem != 77 {
+		t.Fatalf("remainder after rejected legacy settle = %d, want 77 (untouched)", rem)
+	}
+	var markers int
+	if err := pg.Pool().QueryRow(ctx, `SELECT COUNT(*) FROM processed_usage_windows WHERE org_id = 'o1'`).Scan(&markers); err != nil {
+		t.Fatalf("count markers: %v", err)
+	}
+	if markers != 1 {
+		t.Fatalf("markers = %d, want 1 (the rejected settle must not half-land its marker)", markers)
+	}
+
+	// The skip set unions both mechanisms, scoped to the org and the since
+	// bound; another org's settles never leak in.
+	wOther := billing.ProcessedWindow{OrgID: "o2", SandboxID: "sb9", Window: now}
+	if err := l.SettleWindow(ctx, billing.LedgerEntry{OrgID: "o2", Kind: billing.KindUsageDrawdown, Amount: 0, Key: wOther.Key(), At: now}, 0, wOther); err != nil {
+		t.Fatalf("other-org settle: %v", err)
+	}
+	keys, err := l.SettledWindowKeys(ctx, "o1", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("settled keys: %v", err)
+	}
+	if !keys[wZero.Key()] {
+		t.Errorf("skip set missing the marker key %q", wZero.Key())
+	}
+	if !keys[wLegacy.Key()] {
+		t.Errorf("skip set missing the legacy ledger key %q", wLegacy.Key())
+	}
+	if keys[wOther.Key()] {
+		t.Errorf("skip set leaked another org's key %q", wOther.Key())
+	}
+	if len(keys) != 2 {
+		t.Errorf("skip set size = %d, want 2", len(keys))
+	}
+	// A since bound after everything yields an empty set.
+	none, err := l.SettledWindowKeys(ctx, "o1", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("settled keys (future since): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("skip set with future since = %d keys, want 0", len(none))
+	}
+
+	// Pruning removes only markers whose window predates the horizon.
+	wOld := billing.ProcessedWindow{OrgID: "o1", SandboxID: "sb1", Window: now.Add(-3 * time.Hour)}
+	if err := l.SettleWindow(ctx, billing.LedgerEntry{OrgID: "o1", Kind: billing.KindUsageDrawdown, Amount: 0, Key: wOld.Key(), At: now}, 77, wOld); err != nil {
+		t.Fatalf("old-window settle: %v", err)
+	}
+	pruned, err := l.PruneProcessedWindows(ctx, now.Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("pruned = %d, want 1 (only the aged marker)", pruned)
+	}
+	keys, _ = l.SettledWindowKeys(ctx, "o1", time.Time{})
+	if keys[wOld.Key()] {
+		t.Errorf("pruned marker %q still in the skip set", wOld.Key())
+	}
+	if !keys[wZero.Key()] {
+		t.Errorf("in-horizon marker %q was pruned", wZero.Key())
 	}
 }

--- a/internal/saas/pgstore/migrations/0011_processed_usage_windows.sql
+++ b/internal/saas/pgstore/migrations/0011_processed_usage_windows.sql
@@ -1,0 +1,28 @@
+-- Processed usage windows (issue #672): the drawdown's idempotency markers,
+-- moved OUT of the customer-visible credit ledger. Before this table every
+-- priced usage record wrote a keyed credit_ledger row even when the settled
+-- amount was 0 cents, so ~94 percent of usage_drawdown rows were zero-amount
+-- markers and every 5m tick re-priced the whole 2h lookback before the ledger
+-- key rejected the replay. One row here marks one settled (org, sandbox,
+-- window); the drawdown driver skips marked windows BEFORE pricing, and the
+-- credit ledger only carries rows that actually moved money.
+--
+-- The row is written ATOMICALLY with the ledger debit and the drawdown
+-- remainder (PgCreditLedger.SettleWindow, the extended #666 single-transaction
+-- path), so a crash can never land a debit without its marker or vice versa.
+--
+-- Rows are pruned once window_at falls out of the drawdown lookback horizon:
+-- the driver never lists a window that old again, so the marker has nothing
+-- left to guard and the table stays bounded (lookback / usage-window rows per
+-- active sandbox).
+CREATE TABLE processed_usage_windows (
+    org_id     TEXT        NOT NULL,
+    sandbox_id TEXT        NOT NULL,
+    window_at  TIMESTAMPTZ NOT NULL,
+    settled_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, sandbox_id, window_at)
+);
+
+-- The pruning delete filters on window_at alone; the primary key only helps
+-- org-prefixed lookups.
+CREATE INDEX processed_usage_windows_window_idx ON processed_usage_windows (window_at);


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the drawdown driver settles metered usage against prepaid credit every 5 minutes over a 2 hour lookback.
> - The v1.19.0 charging verification (issue #672) showed three costs of pricing before dedup: settledCents over-reported by the replayed amount every tick, roughly 94 percent of usage_drawdown ledger rows were zero-amount idempotency markers, and ~780 records were re-priced per tick for nothing.
> - A per-org watermark cannot replace exact dedup: the collector never backfills (samples are stamped at scrape time with a 180s buffer), but the DRIVER settles out of order inside the lookback (a transient DB failure on one window while its neighbor succeeds, or console downtime under 2 hours), so late windows must still settle exactly once.
> - This pull request adds a processed_usage_windows table (migration 0011): the driver reads one indexed skip-set per org per tick and skips settled windows before pricing; zero-cent settles write a marker instead of a ledger row; markers older than the lookback are pruned each cycle.
> - The #666 atomicity property is preserved by extension, not duplication: marker, remainder, and debit commit in one transaction, and a duplicate on either mechanism rolls back everything.
> - The first post-deploy tick consults BOTH the new table and the legacy keyed ledger rows during the horizon (documented removable after one horizon), so nothing double-settles across the migration.

## Linked Issues or Issue Description

Closes #672. Evidence from the verifications on #662 and #613; the #665 remainder (collector-side observability) stays open.

## What Changed

- `0011_processed_usage_windows.sql`: (org_id, sandbox_id, window_at) PK plus a prune index.
- `internal/saas/billing`: `SettleWindow` replaces `AppendWithRemainder` (marker + remainder + debit in one atomic step; debit row only when nonzero); `SettledWindowKeys` unions markers and legacy keyed rows; `PruneProcessedWindows`; `DrawdownResult.Replayed`.
- `internal/saas/pgstore/creditledger.go`: single-transaction settle with rollback on duplicate in either mechanism; bounded skip-set queries.
- `cmd/console/drawdown.go`: skip before pricing; settledCents counts only appends that landed; cycle log gains replayedRecords and prunedMarkers; a skip-set read failure defers the org rather than settling blind; one prune per cycle.

## Verification

- [x] Full suite against postgres:16 with the migration chain through 0011: all ok (TestPgProcessedWindows, TestPgCreditLedgerRemainder, migration idempotency)
- [x] Replay across ticks bills once and never enters settledCents; late window inside the lookback settles exactly once; both rollback directions exercised on mem and Postgres; pre-migration ledger markers honored on the first tick
- [x] `go build ./...`; `GOOS=linux golangci-lint run` clean; darwin shows only the known pre-existing internal/fork finding; zero em or en dashes

## Risks

Ledger history keeps its existing zero-amount rows (no rewrite); new growth stops. The dual-mechanism skip check is one extra bounded query per org for one lookback horizon after deploy, then removable.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage drawdown processing is now more idempotent, preventing duplicate billing across repeated or late-arriving windows.
  * Previously processed windows are now tracked and pruned automatically to keep replay handling bounded.

* **Bug Fixes**
  * Replayed windows are no longer counted as new settlements or billed twice.
  * Zero-amount settlements now avoid creating unnecessary ledger rows while still preserving replay protection.
  * Billing runs now skip already-settled windows before pricing, improving consistency across retries and restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->