### PR TITLE
ci: grpc-exec-smoke gates firecracker-test; PTY regressions can no longer hide

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -559,15 +559,13 @@ jobs:
       # relative "vsock.sock" used for fork-correctness, which relies on Firecracker
       # cwd resolution): this phase boots a fresh single VM, not a forked restore.
       #
-      # NON-BLOCKING (continue-on-error) for now: the Rust agent is the
-      # production default (Phase D, #310) and test-agent gates the gRPC exec
-      # path above; grpc-exec-smoke additionally proves STREAMING and PTY
-      # semantics via a separate driver over the same vsock gRPC transport.
-      # Kept non-blocking until this phase has been green on KVM CI for one
-      # full run (tracked as a follow-up of issue #24). Remove continue-on-error
-      # once the transport is consistently proven end to end here.
+      # This phase GATES: no continue-on-error. It was non-blocking from its
+      # introduction, which masked an interactive-PTY failure on every recorded
+      # run for weeks (devpts was never mounted in the guest; issues #535 and
+      # #671): job conclusions read success while Phase 2 always failed. Both
+      # phases were proven green on KVM CI with the #670 guest fix, so a PTY
+      # regression must fail the required check, never hide.
       - name: gRPC runtime protocol proof, streaming Exec and interactive PTY over vsock gRPC
-        continue-on-error: true
         timeout-minutes: 8
         run: |
           set -e


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the kvm-test workflow proves the vsock gRPC transport including streaming exec and interactive PTY.
> - The grpc-exec-smoke step was continue-on-error since its introduction, pending one green run; that green run never came, and the masking hid a total interactive-PTY failure (no devpts in the guest, #535) on every recorded run while job conclusions read success.
> - The #670 guest fix just produced the first fully green run on KVM CI (streaming PASS, interactive PTY proven: echo, resize, clean exit).
> - This pull request removes continue-on-error so the phase gates the required firecracker-test check, per the original intent.
> - A correctness phase must fail loudly; retry-worthy nested-KVM steps keep their retry mechanism, which this step never needed.
> - The benefit is that a PTY regression can never again ship silently.

## Linked Issues or Issue Description

Closes #671. Context: #535, #670.

## What Changed

- `.github/workflows/kvm-test.yaml`: the grpc-exec-smoke step loses `continue-on-error: true`; the comment records why it gates and the history of the masking.

## Verification

- [x] Both phases green on KVM CI on the #670 head (streaming exec PASS with incremental-delivery proof; "gRPC interactive PTY proven: echo, resize, clean exit over vsock gRPC")
- [x] Zero em or en dashes; workflow lint runs in CI (actionlint)

## Risks

If the PTY phase regresses, firecracker-test fails; that is the point. The #535-signature flake concern is gone with the root cause fixed (the failure was deterministic, not flaky).

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * KVM integration tests now fail the workflow if the gRPC runtime protocol proof, streaming Exec, or interactive PTY phase encounters an error.
  * Interactive PTY failures are no longer masked, making test results more accurate and actionable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->