### PR TITLE
fix(daemon): exec ws accepts origin-bearing clients; bearer token is the gate

### DIFF
--- a/internal/daemon/exec_ws.go
+++ b/internal/daemon/exec_ws.go
@@ -142,6 +142,15 @@ func (api *SandboxAPI) handleExecWS(w http.ResponseWriter, r *http.Request) {
 
 	c, wsErr := websocket.Accept(w, r, &websocket.AcceptOptions{
 		Subprotocols: []string{execWSSubprotocol},
+		// The library's default same-origin check is deliberately disabled
+		// (issue #678): auth on this endpoint is the per-sandbox bearer token
+		// (ptyAuth above) and no cookies exist, so an origin check adds no
+		// CSRF protection. It only 403s legitimate origin-bearing clients: the
+		// backend Host is the pod IP and port, which no client Origin (the
+		// gateway-forwarded api host, a browser app, the Python SDK's default
+		// header) can ever match. The bearer token is the sole and sufficient
+		// gate; without it the request never reaches this Accept.
+		InsecureSkipVerify: true,
 	})
 	if wsErr != nil {
 		// websocket.Accept already wrote the failure status.

--- a/internal/daemon/exec_ws_test.go
+++ b/internal/daemon/exec_ws_test.go
@@ -152,3 +152,42 @@ func TestExecWSRejectsBadToken(t *testing.T) {
 
 // ensure fmt is used (kept for parity with sibling test files that format ids).
 var _ = fmt.Sprintf
+
+// TestExecWSAcceptsCrossOriginClients asserts an origin-bearing handshake is
+// accepted (issue #678). The Python SDK and any browser client send an Origin
+// header the backend Host (pod IP:port) can never match, and the library's
+// default same-origin check 403ed every such client at upgrade in production.
+// Auth here is the bearer token, not cookies, so origin adds no CSRF value.
+func TestExecWSAcceptsCrossOriginClients(t *testing.T) {
+	_, srv := newPtyAPI(t, "sekret")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c, _, err := websocket.Dial(ctx, wsExecURL(srv.URL, "sb1"), &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": {"Bearer sekret"},
+			// A public API origin, deliberately mismatching the test server host.
+			"Origin": {"https://api.mitos.run"},
+		},
+		Subprotocols: []string{execWSSubprotocol},
+	})
+	if err != nil {
+		t.Fatalf("dial with cross-origin header: %v (the exec ws must not enforce same-origin; auth is the bearer token)", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	// Prove the session is usable, not merely accepted: open a PTY and see the
+	// echo round-trip.
+	writeFrame(ctx, t, c, false, &sandboxv1.ExecRequest{
+		Msg: &sandboxv1.ExecRequest_Open{Open: &sandboxv1.ExecOpen{
+			Pty: &sandboxv1.PtyOptions{Size: &sandboxv1.WindowSize{Cols: 80, Rows: 24}},
+		}},
+	})
+	writeFrame(ctx, t, c, false, &sandboxv1.ExecRequest{
+		Msg: &sandboxv1.ExecRequest_Stdin{Stdin: []byte("origin-ok\n")},
+	})
+	_, resp := readResponse(ctx, t, c)
+	if string(resp.GetStdout()) != "origin-ok\n" {
+		t.Fatalf("stdout = %q, want %q", resp.GetStdout(), "origin-ok\n")
+	}
+}


### PR DESCRIPTION
## HOLD FOR REVIEW: touches internal/daemon (security-sensitive path rule). One-line behavior change plus tests; needs a named human reviewer. This is the last gate before #535 closes and the Orca integration resumes.

## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the in-pod exec WebSocket serves streaming exec and interactive PTY, authed by the per-sandbox bearer token.
> - The live #535 acceptance on v1.19.2 proved the #670 guest PTY fix works end to end, but the SHIPPED Python SDK still failed at the handshake: 403, request Origin api.mitos.run not authorized for Host <podIP>:9091.
> - Root cause: websocket.Accept's default same-origin check. Origin-bearing clients (the SDK sends Origin by default; every browser does) can never match the backend pod-IP Host, so all of them 403 at upgrade; with Origin suppressed the identical session passes fully (echo round-trip 0.15s, resize, clean exit 0).
> - The origin check protects cookie-authenticated endpoints from CSRF; this endpoint has no cookies, and the bearer gate (ptyAuth) runs BEFORE the upgrade, so the check added no security and only broke legitimate clients.
> - This pull request sets InsecureSkipVerify with the rationale documented at the call site, and pins both properties with tests: a cross-origin handshake is accepted and usable, and a bad token still 401s on the handshake.
> - The benefit is that the stock SDK PtyHandle (and future browser clients) can open PTYs against the hosted stack.

## Linked Issues or Issue Description

Closes #678. Part of #535 (final gate; live evidence for everything else is on the issue).

## What Changed

- `internal/daemon/exec_ws.go`: `AcceptOptions.InsecureSkipVerify: true` with the bearer-token rationale in a comment. Nothing else changes; the token gate still precedes the upgrade.
- `internal/daemon/exec_ws_test.go`: `TestExecWSAcceptsCrossOriginClients` (cross-origin handshake accepted AND the PTY echo round-trips), proven red before the fix; `TestExecWSRejectsBadToken` still green proves the auth gate is untouched.

## Verification

- [x] Red-green proof: the new test fails on origin/main's exec_ws.go and passes with the fix; full `go test ./internal/daemon/` ok
- [x] `GOOS=linux golangci-lint run ./internal/daemon/...` clean; zero em or en dashes
- [x] Live failure signature and with-origin-suppressed PASS transcript recorded on #678/#535 from prod

## Risks

The only behavior change is accepting WebSocket upgrades regardless of Origin on an endpoint whose sole auth is a bearer token; browsers cannot attach that token cross-site, so no ambient-credential attack surface opens. Threat model: the exec ws rows key on the bearer token, which is unchanged; no delta needed beyond the in-code rationale.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket exec connections now work from cross-origin clients when authenticated with a valid sandbox token.
  * Improved reliability for browser-based and remote exec sessions by removing an unnecessary origin check on this endpoint.
* **Tests**
  * Added coverage to verify cross-origin WebSocket access still supports interactive PTY input and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->