### PR TITLE
fix(guest): init skips kernel-premounted targets, ending the false /dev ERROR

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -528,6 +528,16 @@ jobs:
             exit 1
           }
 
+          # The guest kernel automounts devtmpfs on /dev (CONFIG_DEVTMPFS_MOUNT),
+          # so a correct init must skip that mount instead of logging an ERROR
+          # for the EBUSY (issue #668): that ERROR appeared in every boot and got
+          # real CI failures misattributed to the guest. Regression-gate it.
+          if grep -q "mount /dev: Resource busy" $WORKDIR/serial.log; then
+            echo "FAIL: guest init logged a false ERROR for the kernel-premounted /dev (issue #668)"
+            exit 1
+          fi
+          echo "OK: no false 'mount /dev' ERROR in the boot serial log (issue #668)"
+
           kill $FC_PID 2>/dev/null || true
 
       # gRPC runtime protocol proof (issue #24 stage 5, Task 5.4). This phase

--- a/guest/agent-rs/src/init/mod.rs
+++ b/guest/agent-rs/src/init/mod.rs
@@ -5,8 +5,35 @@
 // continues, because a PID-1 init failure must not halt the guest entirely.
 // This matches the Go agent's behavior (fmt.Fprintf(os.Stderr, ...) + continue).
 
-use crate::sys::mount::{mount, sethostname};
+use crate::sys::mount::{mount, mounted_fstype, sethostname};
 use tracing::error;
+
+/// What to do for a mount-table entry given what is already mounted at its
+/// target. The kernel automounts devtmpfs on /dev before init runs
+/// (CONFIG_DEVTMPFS_MOUNT), so a blind mount there always returns EBUSY;
+/// logging that as an ERROR is boot-log noise that gets real CI failures
+/// misattributed to the guest (issue #668).
+#[derive(Debug, PartialEq, Eq)]
+enum PremountAction {
+    /// Nothing mounted at the target: perform the mount.
+    Mount,
+    /// The target already carries the expected fstype: skip silently
+    /// (info-level), the work is done.
+    SkipAlreadyMounted,
+    /// The target is mounted with a DIFFERENT fstype: skip but log an error,
+    /// because the guest image is in a state init does not expect.
+    SkipUnexpectedFstype,
+}
+
+/// Decide the premount action from the fstype currently mounted at the
+/// target (None = not mounted) and the fstype the mount table wants.
+fn premount_action(existing: Option<&str>, want_fstype: &str) -> PremountAction {
+    match existing {
+        None => PremountAction::Mount,
+        Some(fs) if fs == want_fstype => PremountAction::SkipAlreadyMounted,
+        Some(_) => PremountAction::SkipUnexpectedFstype,
+    }
+}
 
 /// Describes a single filesystem mount.
 ///
@@ -50,8 +77,24 @@ pub fn init_system() {
         if let Err(e) = std::fs::create_dir_all(m.target) {
             error!("mkdir {}: {}", m.target, e);
         }
-        if let Err(e) = mount(m.source, m.target, m.fstype, 0) {
-            error!("mount {}: {}", m.target, e);
+        let existing = mounted_fstype(m.target);
+        match premount_action(existing.as_deref(), m.fstype) {
+            PremountAction::SkipAlreadyMounted => {
+                tracing::info!("{} already mounted ({}), skipping", m.target, m.fstype);
+            }
+            PremountAction::SkipUnexpectedFstype => {
+                error!(
+                    "{}: already mounted as {} (expected {}); leaving it in place",
+                    m.target,
+                    existing.as_deref().unwrap_or("?"),
+                    m.fstype
+                );
+            }
+            PremountAction::Mount => {
+                if let Err(e) = mount(m.source, m.target, m.fstype, 0) {
+                    error!("mount {}: {}", m.target, e);
+                }
+            }
         }
     }
     if let Err(e) = std::fs::create_dir_all("/workspace") {
@@ -131,5 +174,31 @@ mod tests {
     #[test]
     fn mount_table_has_six_entries() {
         assert_eq!(MOUNT_TABLE.len(), 6);
+    }
+
+    // Premount decision: the kernel automounts devtmpfs on /dev before init
+    // runs (CONFIG_DEVTMPFS_MOUNT), so init must skip an already-mounted
+    // target instead of logging a false ERROR on the EBUSY (issue #668).
+    use super::{PremountAction, premount_action};
+
+    #[test]
+    fn premount_skips_target_already_mounted_with_expected_fstype() {
+        assert_eq!(
+            premount_action(Some("devtmpfs"), "devtmpfs"),
+            PremountAction::SkipAlreadyMounted
+        );
+    }
+
+    #[test]
+    fn premount_flags_target_mounted_with_unexpected_fstype() {
+        assert_eq!(
+            premount_action(Some("tmpfs"), "devtmpfs"),
+            PremountAction::SkipUnexpectedFstype
+        );
+    }
+
+    #[test]
+    fn premount_mounts_when_target_not_mounted() {
+        assert_eq!(premount_action(None, "devtmpfs"), PremountAction::Mount);
     }
 }

--- a/guest/agent-rs/src/sys/mount.rs
+++ b/guest/agent-rs/src/sys/mount.rs
@@ -48,28 +48,51 @@ pub fn is_mounted(mount_path: &str) -> bool {
 
 #[cfg(target_os = "linux")]
 fn is_mounted_linux(mount_path: &str) -> bool {
-    use std::io::BufRead;
+    mounted_fstype(mount_path).is_some()
+}
 
-    let f = match std::fs::File::open("/proc/mounts") {
-        Ok(f) => f,
-        Err(_) => return false,
-    };
-    let reader = std::io::BufReader::new(f);
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => return false,
-        };
+/// Return the filesystem type mounted at `mount_path`, or None when nothing
+/// is mounted there (or /proc/mounts cannot be read, so the caller falls
+/// through to a mount attempt that fails loudly rather than silently skipping).
+///
+/// PID-1 init uses this to detect targets the kernel already mounted before
+/// the agent ran: with CONFIG_DEVTMPFS_MOUNT the kernel automounts devtmpfs
+/// on /dev, so init's own devtmpfs mount would return EBUSY (issue #668).
+///
+/// On non-Linux platforms always returns None (mount is a no-op there).
+pub fn mounted_fstype(mount_path: &str) -> Option<String> {
+    let content = read_proc_mounts()?;
+    fstype_from_mounts(&content, mount_path)
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_mounts() -> Option<String> {
+    std::fs::read_to_string("/proc/mounts").ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_proc_mounts() -> Option<String> {
+    None
+}
+
+/// Parse /proc/mounts content: return the fstype (field 3) of the line whose
+/// mount target (field 2) equals `mount_path` exactly. When several lines
+/// match (overmounts), the LAST one wins: /proc/mounts is ordered oldest
+/// first and the most recent mount is the visible one. Separated from the
+/// /proc/mounts read so it is unit-testable on any host.
+fn fstype_from_mounts(content: &str, mount_path: &str) -> Option<String> {
+    let mut found = None;
+    for line in content.lines() {
         let mut fields = line.split_ascii_whitespace();
-        // Field 0: device, field 1: mount target.
+        // Field 0: device, field 1: mount target, field 2: fstype.
         let _device = fields.next();
         if let Some(target) = fields.next()
             && target == mount_path
         {
-            return true;
+            found = fields.next().map(str::to_string);
         }
     }
-    false
+    found
 }
 
 /// Mount a filesystem.
@@ -156,6 +179,50 @@ fn sethostname_linux(name: &str) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const MOUNTS: &str = "\
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+devtmpfs /dev devtmpfs rw,nosuid,size=12448k,nr_inodes=31112,mode=755 0 0
+/dev/vda / ext4 rw,relatime 0 0
+tmpfs /tmp tmpfs rw,relatime 0 0
+";
+
+    #[test]
+    fn fstype_from_mounts_finds_dev_devtmpfs() {
+        assert_eq!(
+            fstype_from_mounts(MOUNTS, "/dev"),
+            Some("devtmpfs".to_string())
+        );
+    }
+
+    #[test]
+    fn fstype_from_mounts_none_for_unmounted_path() {
+        assert_eq!(fstype_from_mounts(MOUNTS, "/run"), None);
+    }
+
+    #[test]
+    fn fstype_from_mounts_matches_exact_target_only() {
+        // "/de" and "/dev/pts" must not match the "/dev" entry.
+        assert_eq!(fstype_from_mounts(MOUNTS, "/de"), None);
+        assert_eq!(fstype_from_mounts(MOUNTS, "/dev/pts"), None);
+    }
+
+    #[test]
+    fn fstype_from_mounts_ignores_malformed_lines() {
+        assert_eq!(fstype_from_mounts("devtmpfs /dev\n\n", "/dev"), None);
+    }
+
+    #[test]
+    fn fstype_from_mounts_last_overmount_wins() {
+        // /proc/mounts is ordered oldest first; the visible mount at a
+        // target is the most recent line.
+        let content = "devtmpfs /dev devtmpfs rw 0 0\ntmpfs /dev tmpfs rw 0 0\n";
+        assert_eq!(
+            fstype_from_mounts(content, "/dev"),
+            Some("tmpfs".to_string())
+        );
+    }
 
     #[test]
     fn mount_no_op_on_non_linux_or_bad_target() {


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the guest agent is PID 1 inside every VM.
> - Issue #668 reported a flaky guest-agent init: mount /dev intermittently fails EBUSY, blamed for failing the required firecracker-test job on unrelated PRs.
> - Investigation of the actual run logs shows the EBUSY is neither flaky nor a failure: the guest kernel automounts devtmpfs on /dev (CONFIG_DEVTMPFS_MOUNT) before init runs, so init's own devtmpfs mount ALWAYS returns EBUSY. The line appears 14 times in a fully green main run (28646803309); the runs cited by #668 actually failed on the PTY stdin race (fixed by #670, gated by #677), a live-fork egress socket collision (filed separately), and PR #612's own template-ownership bug.
> - The genuine defect is the false ERROR itself: boot-log noise at ERROR level in every VM boot is exactly how real failures get misattributed, which is what happened to #668.
> - This pull request makes init consult /proc/mounts before each mount-table entry: already-mounted-as-expected is skipped at info level, an unexpected fstype is left in place and logged at ERROR, and the firecracker-test boot smoke gains a regression gate asserting the false ERROR is gone from the serial log.
> - The benefit is a clean, truthful guest boot log: the next real firecracker-test failure will not have a red herring ERROR line pointing at the guest.

## Linked Issues or Issue Description

Closes #668.

## What Changed

- `guest/agent-rs/src/sys/mount.rs`: new `mounted_fstype()` returns the fstype mounted at a path from /proc/mounts; the parser (`fstype_from_mounts`) is a pure function, unit-tested on any host, and resolves overmounts to the LAST matching line (the visible mount). `is_mounted()` is refactored onto the same parser, semantics unchanged.
- `guest/agent-rs/src/init/mod.rs`: init decides per mount-table entry via `premount_action()`: `Mount` when nothing is mounted, `SkipAlreadyMounted` (info log) when the expected fstype is already there, `SkipUnexpectedFstype` (error log, mount left in place) when something else is. Decision logic is a pure function with unit tests.
- `.github/workflows/kvm-test.yaml`: the boot smoke now fails if the serial log contains the false `mount /dev: Resource busy` ERROR, so the fix cannot silently regress.

## Verification

- [x] `cargo test --lib` in `rust:1-bookworm` (privileged): 134 passed, and the SAME 10 environment-dependent failures (netlink dummy-link, in-container python kernel tests) as an origin/main baseline run in the identical container; zero regressions, 8 new tests pass.
- [x] The privileged run includes the `fork::volumes` mount-namespace tests, which exercise the refactored `is_mounted` against real mounts; they pass.
- [x] `rustfmt --check`: the only diff in touched files within this change's regions is resolved; pre-existing hand-aligned regions (MOUNT_TABLE) left untouched.
- [x] `cargo clippy --lib`: no new warnings introduced (checked for all new symbols).
- [x] The firecracker-test job on this PR is the end-to-end proof: the new serial-log gate passes only if the ERROR is gone on a real KVM boot.

## Risks

Low risk, but this is the PID-1 boot path of every guest (security-sensitive path, named human reviewer required). Behavior change: init no longer attempts to mount over an already-mounted target. For /dev this is strictly more correct (the EBUSY attempt was a no-op); for a hypothetical target premounted with a DIFFERENT fstype init now leaves it in place with an ERROR instead of stacking a mount over it, which is the more conservative and more visible behavior. No new interface, no secret handling, no threat-model surface move.

## Model Used

- Claude Fable 5 (Anthropic), model id `claude-fable-5`, extended thinking enabled, via Claude Code.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (none needed: no user-facing surface; boot-log behavior documented in code)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (surface did not move)
- [ ] Benchmark run (bench/) included if the hot path was touched (not touched: one /proc/mounts read per mount-table entry at boot, off the fork hot path)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup mounting behavior so existing mounts are handled safely and consistently, reducing noisy errors and avoiding unnecessary remount attempts.
  * Fixed mount detection to use exact mount targets, improving reliability when paths overlap or are overmounted.

* **New Features**
  * Added a regression check to catch a known false boot error during automated guest testing, helping prevent bad test results from slipping through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->