### PR TITLE
fix(usage): concurrent husk scrape, terminate-time final sample, cycle summary with settled cents

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -466,12 +466,21 @@ func main() {
 		} else {
 			logger.Info("usage store: in-memory (DEV ONLY, usage is lost on restart; set --usage-database-dsn for durable Postgres)")
 		}
+		// Claim-release usage terminations (issue #682): the sandbox reconciler
+		// records an event at claim release/lifetime terminate, and the
+		// collector's husk source drains it to bill the [last scrape, terminate]
+		// tail window. The log is created only when the collector runs (the
+		// reconciler's nil default records nothing, so self-host pays nothing),
+		// and this assignment happens before mgr.Start, so no reconcile races it.
+		usageTerminations := usage.NewTerminationLog()
+		sandboxReconciler.UsageTerminations = usageTerminations
 		if err := mgr.Add(&controller.UsageCollectorRunnable{
-			Registry:   nodeRegistry,
-			Client:     mgr.GetClient(),
-			Cadence:    usageCollectorInterval,
-			HTTPScheme: "http",
-			Store:      usageStore,
+			Registry:     nodeRegistry,
+			Client:       mgr.GetClient(),
+			Cadence:      usageCollectorInterval,
+			HTTPScheme:   "http",
+			Store:        usageStore,
+			Terminations: usageTerminations,
 		}); err != nil {
 			logger.Error(err, "unable to add usage collector")
 			os.Exit(1)

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -160,8 +160,13 @@ serialized N unreachable pods into N x the per-request timeout during a partial
 outage. With the pool the cycle duration is set by the slowest pool lane, not
 the fleet size. All samples in one cycle still share a single scrape timestamp,
 and unreachable pods are still skip-and-counted. Every completed cycle exports
-its wall duration as the `mitos_usage_collect_cycle_duration_seconds` gauge, so
-a slowing scrape path is alertable (issue #617).
+its wall duration as the `mitos_usage_collect_cycle_duration_seconds` gauge and
+logs a one-line summary at default verbosity (samples, records, orgs, duration,
+cumulative skip counters), so a healthy pipeline is visibly healthy, a
+zero-collecting one is visibly broken, and a slowing scrape path is alertable
+(issue #617). The console-side drawdown line reports `settledCents` and
+`carriedMilliCents` per cycle (issue #672), the money half of the same
+visibility gap.
 
 **Terminate-time final sample** (issue #682, was #664): scraping once per
 window leaves the presence between the LAST scrape and terminate unrecorded (a

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -153,6 +153,16 @@ counted, never failing the whole cycle. The collector runs behind the
 deployment that does not want metering is unaffected; it is turned on for hosted
 multi-tenant. See `docs/design/observability-and-billing-spine.md`.
 
+The husk-pod source (`HuskSource`, `internal/usage/husksource.go`) scrapes each
+CLAIMED husk pod's own in-pod `GET /v1/metering` through a BOUNDED worker pool
+(8 concurrent scrapes; issue #682): fleet size is per-VM, so a sequential scrape
+serialized N unreachable pods into N x the per-request timeout during a partial
+outage. With the pool the cycle duration is set by the slowest pool lane, not
+the fleet size. All samples in one cycle still share a single scrape timestamp,
+and unreachable pods are still skip-and-counted. Every completed cycle exports
+its wall duration as the `mitos_usage_collect_cycle_duration_seconds` gauge, so
+a slowing scrape path is alertable (issue #617).
+
 The **org tag** comes from the sandbox -> owning-org mapping, and it is a billing
 trust boundary: the org is derived solely from control-plane identity, never from
 client input. There are two attribution paths:

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -163,6 +163,29 @@ and unreachable pods are still skip-and-counted. Every completed cycle exports
 its wall duration as the `mitos_usage_collect_cycle_duration_seconds` gauge, so
 a slowing scrape path is alertable (issue #617).
 
+**Terminate-time final sample** (issue #682, was #664): scraping once per
+window leaves the presence between the LAST scrape and terminate unrecorded (a
+sandbox alive ~100s billed 60 vcpu-seconds; a sub-minute job billed nothing).
+The sandbox reconciler records a `usage.Termination` per claimed, org-labeled
+husk pod at claim release and lifetime terminate (it knows the exact instant),
+and the husk source drains those events each cycle to emit a FINAL sample:
+
+- a pod scraped before gets a clone of its last measured sample stamped at the
+  release instant, so `Integrate` bills the `[last scrape, terminate]` tail at
+  the last measured level (bounded by `MaxHold`, and the cloned cumulative
+  counters delta to zero: no invented egress);
+- a pod that terminated before its first scrape gets a synthesized start/end
+  pair over `[StartedAt, terminate]` carrying ONLY the known vCPU allocation;
+  memory and disk were never measured and stay zero (customer-favorable), and
+  the start is clamped to `terminate - MaxHold` so a stale StartedAt can never
+  rewrite long-settled windows.
+
+A vm-id is finalized at most once (a duplicate event, for example lifetime
+expiry followed by the object delete, is dropped), so the tail can only be
+billed once. The event log is in-memory and best-effort: a controller restart
+or a node-loss drain loses the tail sample, which under-bills that tail and
+nothing else; recording never blocks or fails a terminate.
+
 The **org tag** comes from the sandbox -> owning-org mapping, and it is a billing
 trust boundary: the org is derived solely from control-plane identity, never from
 client input. There are two attribution paths:

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -185,11 +185,14 @@ and the husk source drains those events each cycle to emit a FINAL sample:
   the start is clamped to `terminate - MaxHold` so a stale StartedAt can never
   rewrite long-settled windows.
 
-A vm-id is finalized at most once (a duplicate event, for example lifetime
-expiry followed by the object delete, is dropped), so the tail can only be
-billed once. The event log is in-memory and best-effort: a controller restart
-or a node-loss drain loses the tail sample, which under-bills that tail and
-nothing else; recording never blocks or fails a terminate.
+One claim records ONE event, at the true terminate instant: a claim already
+Terminated (lifetime expiry) recorded its event then, and the later object
+delete records nothing. Downstream, a vm-id is finalized at most once (the
+collector's guard, the second line of defense for a requeued terminate that
+records twice), so the tail can only be billed once. The event log is
+in-memory and best-effort: a controller restart or a node-loss drain loses the
+tail sample, which under-bills that tail and nothing else; recording never
+blocks or fails a terminate.
 
 The **org tag** comes from the sandbox -> owning-org mapping, and it is a billing
 trust boundary: the org is derived solely from control-plane identity, never from

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -1236,7 +1236,9 @@ func (r *SandboxReconciler) reconcileDelete(ctx context.Context, claim *v1.Sandb
 		return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
 	}
 	// Record the usage termination BEFORE deleting the pods, so the collector
-	// can bill the half-open [last scrape, terminate] window (issue #682).
+	// can bill the half-open [last scrape, terminate] window (issue #682). A
+	// claim already Terminated (lifetime expiry) recorded its event at the TRUE
+	// terminate instant and the hook skips it here: one claim, one event.
 	// Best-effort and idempotent downstream: a retried delete records again and
 	// the collector's finalized guard keeps a vm-id from ever billing twice.
 	r.recordHuskTerminations(claim, claimedHusk.Items, time.Now())

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -21,6 +21,7 @@ import (
 	"mitos.run/mitos/internal/husk"
 	"mitos.run/mitos/internal/kms"
 	"mitos.run/mitos/internal/observability"
+	"mitos.run/mitos/internal/usage"
 	"mitos.run/mitos/internal/vsock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -144,6 +145,14 @@ type SandboxReconciler struct {
 
 	// Now is the reconciler's clock, injectable for tests. Nil uses time.Now.
 	Now func() time.Time
+
+	// UsageTerminations, when set (hosted, usage collector on), receives one
+	// usage.Termination per claimed, org-labeled husk pod at claim release or
+	// lifetime terminate, so the usage collector can bill the half-open window
+	// between the last scrape and the terminate instant (issue #682, was #664).
+	// Nil (the self-host default) records nothing; every call is nil-safe and
+	// best-effort: usage recording never blocks or fails a terminate.
+	UsageTerminations *usage.TerminationLog
 
 	// Demand is the shared per-pool claim-arrival tracker the warm-pool
 	// autoscaler reads. The claim reconciler records an arrival whenever a claim
@@ -1226,6 +1235,11 @@ func (r *SandboxReconciler) reconcileDelete(ctx context.Context, claim *v1.Sandb
 		logger.Error(err, "list claimed husk pods on delete; will retry", "claim", claim.Name)
 		return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
 	}
+	// Record the usage termination BEFORE deleting the pods, so the collector
+	// can bill the half-open [last scrape, terminate] window (issue #682).
+	// Best-effort and idempotent downstream: a retried delete records again and
+	// the collector's finalized guard keeps a vm-id from ever billing twice.
+	r.recordHuskTerminations(claim, claimedHusk.Items, time.Now())
 	for i := range claimedHusk.Items {
 		if err := r.Delete(ctx, &claimedHusk.Items[i], client.GracePeriodSeconds(0)); err != nil && !apierrors.IsNotFound(err) {
 			logger.Error(err, "delete claimed husk pod on release", "pod", claimedHusk.Items[i].Name)
@@ -1354,6 +1368,11 @@ func (r *SandboxReconciler) terminateLifetime(ctx context.Context, claim *v1.San
 			return ctrl.Result{}, err
 		}
 	}
+
+	// The backing VM is gone: close the usage tail window at this instant
+	// (issue #682). Best-effort; a duplicate record from the later object
+	// delete is deduplicated by the collector's finalized guard.
+	r.recordClaimHuskTerminations(ctx, claim)
 
 	now := metav1.Now()
 	claim.Status.Phase = v1.SandboxTerminated

--- a/internal/controller/usage_collector.go
+++ b/internal/controller/usage_collector.go
@@ -116,7 +116,8 @@ func (u *UsageCollectorRunnable) Start(ctx context.Context) error {
 // transient cycle error. The two skip counters are the degradation signals an
 // operator alerts on.
 func (u *UsageCollectorRunnable) cycle(ctx context.Context, logger logr.Logger, collector *usage.Collector, nodeSource *usage.NodeRegistrySource, huskSource *usage.HuskSource) {
-	if err := collector.CollectOnce(ctx); err != nil {
+	stats, err := collector.CollectOnce(ctx)
+	if err != nil {
 		// The cycle error carries only ids/window text from the store path, never a
 		// secret; still log it sparingly.
 		logger.Error(err, "usage collection cycle failed",
@@ -124,6 +125,10 @@ func (u *UsageCollectorRunnable) cycle(ctx context.Context, logger logr.Logger, 
 			"skippedHuskPods", huskSource.SkippedPods())
 		return
 	}
+	// Export the cycle duration (issue #682, was #656): with the bounded husk
+	// scrape pool this is set by the slowest pool lane, and a sustained rise is
+	// the degradation signal #617 alerting watches.
+	usageMetrics.ObserveCycle(stats)
 	if skipped := nodeSource.SkippedNodes(); skipped > 0 {
 		logger.V(1).Info("usage collection skipped unreachable nodes", "skippedNodesCumulative", skipped)
 	}

--- a/internal/controller/usage_collector.go
+++ b/internal/controller/usage_collector.go
@@ -44,6 +44,14 @@ type UsageCollectorRunnable struct {
 	// (or a future durable store) can inspect or substitute it; defaults to an
 	// in-memory store.
 	Store usage.UsageStore
+
+	// Terminations, when set, is the claim-release event log shared with the
+	// SandboxReconciler (issue #682): the reconciler records a termination at
+	// claim release, and the husk source drains it each cycle to emit the final
+	// sample that closes the [last scrape, terminate] window. Nil disables the
+	// tail accounting (samples then end at the last scrape, the pre-#682
+	// behavior).
+	Terminations *usage.TerminationLog
 }
 
 // Start runs the collector loop until ctx is canceled. It builds the live
@@ -81,6 +89,10 @@ func (u *UsageCollectorRunnable) Start(ctx context.Context) error {
 		u.HTTPScheme,
 		nil,
 	)
+	// Claim-release final samples (issue #682): the SandboxReconciler records a
+	// termination per released husk pod into this shared log; the husk source
+	// drains it each cycle to close the [last scrape, terminate] tail window.
+	huskSource.SetTerminations(u.Terminations)
 	source := usage.NewMultiSource(nodeSource, huskSource)
 
 	store := u.Store
@@ -111,10 +123,13 @@ func (u *UsageCollectorRunnable) Start(ctx context.Context) error {
 	}
 }
 
-// cycle runs one scrape-integrate-upsert-publish cycle and logs a COUNT of skipped
-// nodes and skipped husk pods (never node/pod identity or error text) on a
-// transient cycle error. The two skip counters are the degradation signals an
-// operator alerts on.
+// cycle runs one scrape-integrate-upsert-publish cycle. A SUCCESSFUL cycle
+// emits a one-line summary at default verbosity (issue #682, was #665: a
+// healthy pipeline must be visibly healthy, and a zero-collecting one must not
+// look identical to it); a failed cycle logs the error. Both lines carry
+// COUNTS and a duration only, never node/pod identity, org ids, error values,
+// or secrets. The cumulative skip counters on the summary are the degradation
+// signals an operator alerts on.
 func (u *UsageCollectorRunnable) cycle(ctx context.Context, logger logr.Logger, collector *usage.Collector, nodeSource *usage.NodeRegistrySource, huskSource *usage.HuskSource) {
 	stats, err := collector.CollectOnce(ctx)
 	if err != nil {

--- a/internal/controller/usage_collector.go
+++ b/internal/controller/usage_collector.go
@@ -144,12 +144,13 @@ func (u *UsageCollectorRunnable) cycle(ctx context.Context, logger logr.Logger, 
 	// scrape pool this is set by the slowest pool lane, and a sustained rise is
 	// the degradation signal #617 alerting watches.
 	usageMetrics.ObserveCycle(stats)
-	if skipped := nodeSource.SkippedNodes(); skipped > 0 {
-		logger.V(1).Info("usage collection skipped unreachable nodes", "skippedNodesCumulative", skipped)
-	}
-	if skipped := huskSource.SkippedPods(); skipped > 0 {
-		logger.V(1).Info("usage collection skipped unreachable husk pods", "skippedHuskPodsCumulative", skipped)
-	}
+	logger.Info("usage collection cycle",
+		"samples", stats.Samples,
+		"records", stats.Records,
+		"orgs", stats.Orgs,
+		"durationMs", stats.Duration.Milliseconds(),
+		"skippedNodesCumulative", nodeSource.SkippedNodes(),
+		"skippedHuskPodsCumulative", huskSource.SkippedPods())
 }
 
 // usageMetrics is the per-org usage Prometheus view, registered ONCE on the

--- a/internal/controller/usage_collector.go
+++ b/internal/controller/usage_collector.go
@@ -92,7 +92,9 @@ func (u *UsageCollectorRunnable) Start(ctx context.Context) error {
 	// Claim-release final samples (issue #682): the SandboxReconciler records a
 	// termination per released husk pod into this shared log; the husk source
 	// drains it each cycle to close the [last scrape, terminate] tail window.
-	huskSource.SetTerminations(u.Terminations)
+	// The configured MaxHold rides along so the source's tail clamp always
+	// matches the hold bound Integrate applies.
+	huskSource.SetTerminations(u.Terminations, cfg.MaxHold)
 	source := usage.NewMultiSource(nodeSource, huskSource)
 
 	store := u.Store

--- a/internal/controller/usage_collector_test.go
+++ b/internal/controller/usage_collector_test.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"mitos.run/mitos/internal/usage"
+)
+
+// TestUsageCycleLogsSummaryAtDefaultVerbosity is the issue #682 (was #665)
+// observability fix proof: a SUCCESSFUL collection cycle must emit a one-line
+// summary (samples, records, orgs, duration, skip counters) at DEFAULT
+// verbosity. Before the fix a healthy cycle logged nothing at V(0), so a
+// zero-collecting pipeline looked identical to a healthy one. The summary
+// carries counts only: no sandbox ids, org ids, node identity, or secrets.
+func TestUsageCycleLogsSummaryAtDefaultVerbosity(t *testing.T) {
+	var mu sync.Mutex
+	var lines []string
+	// Verbosity 0 is the default production level: V(1) lines are dropped, so
+	// the summary must be a plain Info to be seen.
+	logger := funcr.New(func(_, args string) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, args)
+	}, funcr.Options{Verbosity: 0})
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+	nodeSource := usage.NewNodeRegistrySource(
+		RegistryNodeLister{Registry: NewNodeRegistry()},
+		usage.StaticOrgs{}, nil, nil, "", nil,
+	)
+	huskSource := usage.NewHuskSource(&HuskPodScrapeLister{Client: cl}, nil, nil, "", nil)
+	collector := usage.NewCollector(
+		usage.NewMultiSource(nodeSource, huskSource),
+		usage.NewMemUsageStore(),
+		usage.DefaultConfig(),
+	)
+
+	u := &UsageCollectorRunnable{}
+	u.cycle(context.Background(), logger, collector, nodeSource, huskSource)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, l := range lines {
+		if strings.Contains(l, "usage collection cycle") &&
+			strings.Contains(l, "samples") &&
+			strings.Contains(l, "records") &&
+			strings.Contains(l, "orgs") &&
+			strings.Contains(l, "duration") {
+			return
+		}
+	}
+	t.Fatalf("no healthy-cycle summary at default verbosity; got lines: %v", lines)
+}

--- a/internal/controller/usage_termination.go
+++ b/internal/controller/usage_termination.go
@@ -31,8 +31,21 @@ import (
 // (no trusted mitos.run/org label: the self-host path) was never billable and
 // records nothing. Callers that already listed the claim's pods (the delete
 // path) pass them directly.
+//
+// ONE EVENT PER CLAIM: a claim whose phase is already Terminated recorded its
+// event at the lifetime terminate (terminateLifetime calls the hook BEFORE
+// stamping the phase), which is the TRUE instant the VM was reaped, so the
+// later object delete records nothing here. A second event would be worse
+// than none: it either no-op-consumes the collector's finalized guard (so the
+// event actually carrying the tail is guard-dropped) or, past the source's
+// retention horizon, synthesizes a phantom pair. The collector's finalized
+// guard stays as the second line of defense for a requeued terminate path
+// that records twice before the phase persists.
 func (r *SandboxReconciler) recordHuskTerminations(claim *v1.Sandbox, pods []corev1.Pod, at time.Time) {
 	if r.UsageTerminations == nil {
+		return
+	}
+	if claim.Status.Phase == v1.SandboxTerminated {
 		return
 	}
 	var started time.Time

--- a/internal/controller/usage_termination.go
+++ b/internal/controller/usage_termination.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/tenant"
+	"mitos.run/mitos/internal/usage"
+)
+
+// This file is the controller half of the issue #682 (was #664) terminate-time
+// usage fix: the usage collector scrapes claimed husk pods once a minute, so
+// presence between the LAST scrape and terminate was never recorded. The
+// reconciler knows the exact release instant, so the terminate paths record a
+// usage.Termination per claimed husk pod; the collector's HuskSource turns it
+// into a final sample on its next cycle.
+//
+// Both hooks are BEST-EFFORT and nil-safe: usage recording never blocks, fails,
+// or delays a terminate (boring failure behavior; losing an event only
+// under-bills a tail, never double-bills, and never wedges deletion). Every
+// recorded field is control-plane data: the pod name, the controller's OWN
+// stamped labels, and the claim status; nothing the pod reported. No secrets.
+
+// recordHuskTerminations records one termination event per claimed, ORG-LABELED
+// husk pod in pods, stamped at the given release instant. An unattributed pod
+// (no trusted mitos.run/org label: the self-host path) was never billable and
+// records nothing. Callers that already listed the claim's pods (the delete
+// path) pass them directly.
+func (r *SandboxReconciler) recordHuskTerminations(claim *v1.Sandbox, pods []corev1.Pod, at time.Time) {
+	if r.UsageTerminations == nil {
+		return
+	}
+	var started time.Time
+	if claim.Status.StartedAt != nil {
+		started = claim.Status.StartedAt.Time
+	}
+	for i := range pods {
+		pod := &pods[i]
+		org := pod.Labels[tenant.OrgLabelKey]
+		if org == "" {
+			continue
+		}
+		r.UsageTerminations.Record(usage.Termination{
+			VMID:      pod.Name,
+			APIID:     pod.Labels[huskClaimLabel],
+			OrgID:     org,
+			StartedAt: started,
+			At:        at,
+		})
+	}
+}
+
+// recordClaimHuskTerminations lists the claim's claimed husk pods (by the
+// mitos.run/claim label the controller stamped) and records a termination for
+// each org-labeled one, stamped now. It is the hook for terminate paths that
+// have not already listed the pods (lifetime/idle expiry). A list failure is
+// logged at V(1) and skipped: best-effort, the terminate must proceed and the
+// cost is one under-billed tail.
+func (r *SandboxReconciler) recordClaimHuskTerminations(ctx context.Context, claim *v1.Sandbox) {
+	if r.UsageTerminations == nil {
+		return
+	}
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, client.InNamespace(claim.Namespace), client.MatchingLabels{huskClaimLabel: claim.Name}); err != nil {
+		log.FromContext(ctx).V(1).Info("list husk pods for usage termination; tail window not recorded", "claim", claim.Name)
+		return
+	}
+	r.recordHuskTerminations(claim, pods.Items, time.Now())
+}

--- a/internal/controller/usage_termination_test.go
+++ b/internal/controller/usage_termination_test.go
@@ -1,0 +1,109 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/usage"
+)
+
+// TestRecordClaimHuskTerminations asserts the claim-release usage hook (issue
+// #682, was #664) records one Termination per claimed, ORG-LABELED husk pod:
+// vm-id from the pod name, API-visible id from the claim, org from the trusted
+// controller-stamped label (never client input), StartedAt from the claim
+// status, and a non-zero release instant. An unattributed pod (no org label,
+// the self-host path) records nothing: it was never billable.
+func TestRecordClaimHuskTerminations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	started := metav1.NewTime(time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC))
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-82813f5c", Namespace: "mitos-org-acme"},
+		Status:     v1.SandboxStatus{StartedAt: &started},
+	}
+
+	billable := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-2blsp",
+			Namespace: "mitos-org-acme",
+			Labels: map[string]string{
+				huskLabel:       "true",
+				huskClaimLabel:  "sb-82813f5c",
+				"mitos.run/org": "acme",
+			},
+		},
+	}
+	// Claimed by the same claim but carries no org label (self-host
+	// single-tenant): never billable, so never recorded.
+	unattributed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-noorg",
+			Namespace: "mitos-org-acme",
+			Labels:    map[string]string{huskLabel: "true", huskClaimLabel: "sb-82813f5c"},
+		},
+	}
+	// A different claim's pod: out of scope for this release.
+	other := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-other",
+			Namespace: "mitos-org-acme",
+			Labels: map[string]string{
+				huskLabel:       "true",
+				huskClaimLabel:  "sb-other",
+				"mitos.run/org": "acme",
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(billable, unattributed, other).Build()
+	r := &SandboxReconciler{Client: cl, UsageTerminations: usage.NewTerminationLog()}
+
+	r.recordClaimHuskTerminations(context.Background(), claim)
+
+	terms := r.UsageTerminations.Drain()
+	if len(terms) != 1 {
+		t.Fatalf("want exactly 1 termination (the org-labeled pod of THIS claim), got %+v", terms)
+	}
+	got := terms[0]
+	if got.VMID != "python-husk-2blsp" {
+		t.Errorf("VMID = %q, want the husk pod name python-husk-2blsp", got.VMID)
+	}
+	if got.APIID != "sb-82813f5c" {
+		t.Errorf("APIID = %q, want the customer-visible claim name sb-82813f5c", got.APIID)
+	}
+	if got.OrgID != "acme" {
+		t.Errorf("OrgID = %q, want acme (from the trusted controller-stamped label)", got.OrgID)
+	}
+	if !got.StartedAt.Equal(started.Time) {
+		t.Errorf("StartedAt = %v, want the claim's %v", got.StartedAt, started.Time)
+	}
+	if got.At.IsZero() {
+		t.Error("At is zero, want the release instant")
+	}
+}
+
+// TestRecordClaimHuskTerminationsNilLogIsNoOp asserts a reconciler without the
+// usage wiring (self-host, collector off) records nothing and never panics:
+// the hook must be invisible when metering is disabled.
+func TestRecordClaimHuskTerminationsNilLogIsNoOp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	r := &SandboxReconciler{Client: cl}
+
+	claim := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "sb-x", Namespace: "default"}}
+	r.recordClaimHuskTerminations(context.Background(), claim)
+	r.recordHuskTerminations(claim, nil, time.Now())
+}

--- a/internal/controller/usage_termination_test.go
+++ b/internal/controller/usage_termination_test.go
@@ -92,6 +92,57 @@ func TestRecordClaimHuskTerminations(t *testing.T) {
 	}
 }
 
+// TestRecordHuskTerminationsOncePerClaim pins the one-event-per-claim contract:
+// a lifetime-expired claim records its termination at the lifetime terminate
+// (the TRUE instant the VM was reaped; the hook runs before the Terminated
+// phase is stamped), and the later object delete, which sees the claim already
+// Terminated, must record NOTHING. Two events for the same claim are worse
+// than one: the first no-op-consumes the collector's finalized guard and the
+// second (the one carrying the tail) is then guard-dropped, or, past the
+// retention horizon, the second synthesizes a phantom pair.
+func TestRecordHuskTerminationsOncePerClaim(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	started := metav1.NewTime(time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC))
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-once", Namespace: "mitos-org-acme"},
+		Status:     v1.SandboxStatus{Phase: v1.SandboxReady, StartedAt: &started},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-once",
+			Namespace: "mitos-org-acme",
+			Labels: map[string]string{
+				huskLabel:       "true",
+				huskClaimLabel:  "sb-once",
+				"mitos.run/org": "acme",
+			},
+		},
+	}
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := &SandboxReconciler{Client: cl, UsageTerminations: usage.NewTerminationLog()}
+
+	// Lifetime expiry: terminateLifetime records BEFORE stamping Terminated.
+	r.recordClaimHuskTerminations(context.Background(), claim)
+
+	// terminateLifetime then stamps the terminal phase; the later object delete
+	// reconciles the claim in this state and must not record a second event.
+	claim.Status.Phase = v1.SandboxTerminated
+	r.recordHuskTerminations(claim, []corev1.Pod{*pod}, time.Now())
+	r.recordClaimHuskTerminations(context.Background(), claim)
+
+	terms := r.UsageTerminations.Drain()
+	if len(terms) != 1 {
+		t.Fatalf("want exactly 1 termination for a lifetime-terminated then deleted claim, got %d: %+v", len(terms), terms)
+	}
+	if terms[0].VMID != "python-husk-once" {
+		t.Errorf("VMID = %q, want python-husk-once", terms[0].VMID)
+	}
+}
+
 // TestRecordClaimHuskTerminationsNilLogIsNoOp asserts a reconciler without the
 // usage wiring (self-host, collector off) records nothing and never panics:
 // the hook must be invisible when metering is disabled.

--- a/internal/usage/collector.go
+++ b/internal/usage/collector.go
@@ -215,17 +215,20 @@ func (c *Collector) CollectOnce(ctx context.Context) (CycleStats, error) {
 	c.pruneBuffer()
 	recs := Integrate(c.buf, c.cfg)
 	stats.Records = len(recs)
+	// One pass over the records: count distinct orgs for the cycle summary and
+	// upsert as we go. On an upsert error the org count covers the records
+	// walked so far, consistent with "stats cover the work done up to the
+	// failure".
 	orgs := map[string]bool{}
 	for _, r := range recs {
 		orgs[r.OrgID] = true
-	}
-	stats.Orgs = len(orgs)
-	for _, r := range recs {
 		if err := c.store.UpsertRecord(ctx, r); err != nil {
+			stats.Orgs = len(orgs)
 			stats.Duration = time.Since(start)
 			return stats, fmt.Errorf("upsert usage record (sandbox %s window %s): %w", r.SandboxID, r.Window, err)
 		}
 	}
+	stats.Orgs = len(orgs)
 	if c.OnTotals != nil {
 		if tp, ok := c.store.(TotalsProvider); ok {
 			c.OnTotals(tp.TotalsByOrg())

--- a/internal/usage/collector.go
+++ b/internal/usage/collector.go
@@ -176,22 +176,54 @@ func NewCollector(src SampleSource, store UsageStore, cfg Config) *Collector {
 // windows fall out of the buffer and are never re-walked.
 func (c *Collector) retention() time.Duration { return c.cfg.Window + c.cfg.MaxHold }
 
-// CollectOnce runs a single scrape-buffer-integrate-upsert cycle. It is the unit
-// the Run loop calls on each tick and the unit the idempotency tests drive
-// directly. It appends the scrape to the rolling buffer, prunes samples past the
-// retention horizon, and integrates the buffer so the rate units accumulate
-// across cycles while staying idempotent on (sandbox, window).
-func (c *Collector) CollectOnce(ctx context.Context) error {
+// CycleStats summarizes what one CollectOnce cycle did, so the wiring can log a
+// healthy-cycle summary at default verbosity and export a cycle-duration metric
+// (issue #682, was #665/#656; the series #617 alerting watches). It carries
+// COUNTS and a duration only: no sandbox ids, org ids, or secrets, so it is
+// safe to log verbatim.
+type CycleStats struct {
+	// Duration is the wall time of the whole cycle: scrape, integrate, upsert.
+	// With the bounded husk scrape pool it is set by the slowest pool lane, not
+	// the fleet size; a sustained rise means unreachable pods or fleet growth.
+	Duration time.Duration
+	// Samples is how many samples this cycle's scrape returned (before
+	// buffering), the liveness signal for the scrape path.
+	Samples int
+	// Records is how many per-(sandbox, window) records the cycle recomputed and
+	// upserted from the rolling buffer.
+	Records int
+	// Orgs is how many distinct org ids those records span.
+	Orgs int
+}
+
+// CollectOnce runs a single scrape-buffer-integrate-upsert cycle and reports
+// its CycleStats. It is the unit the Run loop calls on each tick and the unit
+// the idempotency tests drive directly. It appends the scrape to the rolling
+// buffer, prunes samples past the retention horizon, and integrates the buffer
+// so the rate units accumulate across cycles while staying idempotent on
+// (sandbox, window). On error the returned stats cover only the work done up to
+// the failure.
+func (c *Collector) CollectOnce(ctx context.Context) (CycleStats, error) {
+	start := time.Now()
+	var stats CycleStats
 	samples, err := c.src.Collect(ctx)
 	if err != nil {
-		return fmt.Errorf("collect samples: %w", err)
+		return stats, fmt.Errorf("collect samples: %w", err)
 	}
+	stats.Samples = len(samples)
 	c.buf = append(c.buf, samples...)
 	c.pruneBuffer()
 	recs := Integrate(c.buf, c.cfg)
+	stats.Records = len(recs)
+	orgs := map[string]bool{}
+	for _, r := range recs {
+		orgs[r.OrgID] = true
+	}
+	stats.Orgs = len(orgs)
 	for _, r := range recs {
 		if err := c.store.UpsertRecord(ctx, r); err != nil {
-			return fmt.Errorf("upsert usage record (sandbox %s window %s): %w", r.SandboxID, r.Window, err)
+			stats.Duration = time.Since(start)
+			return stats, fmt.Errorf("upsert usage record (sandbox %s window %s): %w", r.SandboxID, r.Window, err)
 		}
 	}
 	if c.OnTotals != nil {
@@ -199,7 +231,8 @@ func (c *Collector) CollectOnce(ctx context.Context) error {
 			c.OnTotals(tp.TotalsByOrg())
 		}
 	}
-	return nil
+	stats.Duration = time.Since(start)
+	return stats, nil
 }
 
 // pruneBuffer drops samples older than the retention horizon, measured from the
@@ -242,7 +275,7 @@ func (c *Collector) Run(ctx context.Context, cadence time.Duration, onError func
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := c.CollectOnce(ctx); err != nil && onError != nil {
+			if _, err := c.CollectOnce(ctx); err != nil && onError != nil {
 				onError(err)
 			}
 		}

--- a/internal/usage/husksource.go
+++ b/internal/usage/husksource.go
@@ -81,7 +81,25 @@ type HuskSource struct {
 	// source's lifetime. It is a process counter the wiring surfaces as a metric or
 	// logged count; it never carries pod identity or error text.
 	skipped atomic.Int64
+
+	// terminations, when set (SetTerminations), is drained each Collect to emit
+	// a FINAL sample per released claim, closing the half-open window between
+	// the last scrape and terminate (issue #682, was #664). last remembers each
+	// pod's newest emitted sample (keyed by vm-id) so the final sample carries
+	// the last MEASURED levels; finalized remembers vm-ids already given their
+	// final sample so a duplicate termination event (lifetime expiry followed
+	// by object delete) can never bill twice. Both maps are touched only from
+	// Collect (the single collector goroutine) and pruned on a bounded horizon.
+	terminations *TerminationLog
+	last         map[string]Sample
+	finalized    map[string]time.Time
 }
+
+// terminationStateRetention bounds how long the source remembers a pod's last
+// sample and a finalized vm-id after it stops being scraped. Termination
+// events arrive within a reconcile of the release (seconds), so minutes of
+// memory is plenty; the bound keeps both maps from growing with fleet churn.
+const terminationStateRetention = 15 * time.Minute
 
 // NewHuskSource builds the live husk-pod source. vcpus may be nil (every sandbox
 // treated as 1 vCPU, matching the collector default). client may be nil (a default
@@ -169,7 +187,98 @@ func (s *HuskSource) Collect(ctx context.Context) ([]Sample, error) {
 	for _, samples := range results {
 		out = append(out, samples...)
 	}
+	out = s.appendFinalSamples(out, billable, results, at)
 	return out, nil
+}
+
+// SetTerminations wires the claim-release event log (issue #682, was #664).
+// When set, each Collect drains the log and emits a final sample per released
+// claim; nil (the default) disables the tracking entirely, so a wiring that
+// never terminates through the controller (tests, bespoke listers) pays
+// nothing. Call before the first Collect; not safe to swap concurrently.
+func (s *HuskSource) SetTerminations(log *TerminationLog) { s.terminations = log }
+
+// appendFinalSamples remembers this cycle's newest sample per pod, then drains
+// the termination log and appends one FINAL sample per released claim:
+//
+//   - A pod scraped before (a last sample within the retention horizon) gets a
+//     CLONE of its last measured sample stamped at the release instant. The
+//     ordinary Integrate path then bills the [last scrape, terminate] tail at
+//     the last measured level, holds at most MaxHold across a scrape gap, and
+//     the cloned cumulative counters delta to zero: no invented egress.
+//   - A pod NEVER scraped (terminated before its first scrape: the sub-minute
+//     job) gets a synthesized start/end pair over [StartedAt, At] carrying only
+//     the KNOWN allocation (vCPUs); memory and disk were never measured and
+//     stay zero (customer-favorable). The start is clamped to At-MaxHold so a
+//     stale StartedAt (scrape history lost across a controller restart) can
+//     never rewrite long-settled windows.
+//
+// A vm-id is finalized at most once (the finalized guard): a duplicate
+// termination event can only under-bill, never double-bill. An unattributed
+// event (no org) is dropped: it was never billable. Runs on the single
+// collector goroutine; both maps are private to it.
+func (s *HuskSource) appendFinalSamples(out []Sample, billable []HuskPod, results [][]Sample, at time.Time) []Sample {
+	if s.terminations == nil {
+		return out
+	}
+	if s.last == nil {
+		s.last = map[string]Sample{}
+		s.finalized = map[string]time.Time{}
+	}
+	for i, pod := range billable {
+		if len(results[i]) > 0 {
+			s.last[pod.VMID] = results[i][len(results[i])-1]
+		}
+	}
+	maxHold := DefaultConfig().MaxHold
+	for _, t := range s.terminations.Drain() {
+		if t.VMID == "" || t.OrgID == "" || t.At.IsZero() {
+			continue
+		}
+		if _, done := s.finalized[t.VMID]; done {
+			continue
+		}
+		s.finalized[t.VMID] = at
+		if lastSample, ok := s.last[t.VMID]; ok {
+			delete(s.last, t.VMID)
+			if t.At.After(lastSample.Timestamp) {
+				final := lastSample
+				final.Timestamp = t.At
+				out = append(out, final)
+			}
+			continue
+		}
+		// Never scraped: synthesize the pair from control-plane facts only.
+		if t.StartedAt.IsZero() {
+			continue
+		}
+		start := t.StartedAt
+		if minStart := t.At.Add(-maxHold); start.Before(minStart) {
+			start = minStart
+		}
+		if !t.At.After(start) {
+			continue
+		}
+		id := t.APIID
+		if id == "" {
+			id = t.VMID
+		}
+		first := Sample{OrgID: t.OrgID, SandboxID: id, Node: t.VMID, Timestamp: start, VCPUs: s.vcpus(id)}
+		last := first
+		last.Timestamp = t.At
+		out = append(out, first, last)
+	}
+	for vm, sample := range s.last {
+		if at.Sub(sample.Timestamp) > terminationStateRetention {
+			delete(s.last, vm)
+		}
+	}
+	for vm, ts := range s.finalized {
+		if at.Sub(ts) > terminationStateRetention {
+			delete(s.finalized, vm)
+		}
+	}
+	return out
 }
 
 // podSamples scrapes one billable husk pod and converts its report to

--- a/internal/usage/husksource.go
+++ b/internal/usage/husksource.go
@@ -93,6 +93,10 @@ type HuskSource struct {
 	terminations *TerminationLog
 	last         map[string]Sample
 	finalized    map[string]time.Time
+	// maxHold is the collector's configured Config.MaxHold, set alongside the
+	// termination log, so the synthesized-pair clamp and Integrate's own hold
+	// bound (cfg.MaxHold) never diverge on a non-default Config.
+	maxHold time.Duration
 }
 
 // terminationStateRetention bounds how long the source remembers a pod's last
@@ -128,10 +132,14 @@ func NewHuskSource(
 }
 
 // Collect scrapes every claimed org-labeled husk pod once and returns the union
-// of org-tagged Samples tagged with a single scrape timestamp so all samples in
-// one cycle share an instant (the property Integrate's windowing relies on). A
-// pod that is unreachable, errors, or returns a non-200 is skipped and counted;
-// Collect itself never returns an error for an unreachable pod.
+// of org-tagged Samples. Every LIVE (scraped) sample in a cycle shares the
+// cycle's single scrape timestamp; the final and synthesized samples appended
+// for released claims (SetTerminations) carry their own instants: the release
+// time and, for a never-scraped sandbox, its clamped start. Integrate handles
+// the mix because it groups and orders samples per sandbox; no cross-sandbox
+// timestamp property is assumed. A pod that is unreachable, errors, or returns
+// a non-200 is skipped and counted; Collect itself never returns an error for
+// an unreachable pod.
 //
 // The scrapes fan out over a bounded worker pool (huskScrapeConcurrency; issue
 // #682) so the cycle duration is set by the slowest pool lane, never by the
@@ -191,12 +199,21 @@ func (s *HuskSource) Collect(ctx context.Context) ([]Sample, error) {
 	return out, nil
 }
 
-// SetTerminations wires the claim-release event log (issue #682, was #664).
-// When set, each Collect drains the log and emits a final sample per released
-// claim; nil (the default) disables the tracking entirely, so a wiring that
-// never terminates through the controller (tests, bespoke listers) pays
-// nothing. Call before the first Collect; not safe to swap concurrently.
-func (s *HuskSource) SetTerminations(log *TerminationLog) { s.terminations = log }
+// SetTerminations wires the claim-release event log (issue #682, was #664) and
+// the collector's configured Config.MaxHold, which bounds how far back a
+// synthesized pair may reach (zero or negative falls back to the
+// DefaultConfig hold). When set, each Collect drains the log and emits a final
+// sample per released claim; a nil log (the default) disables the tracking
+// entirely, so a wiring that never terminates through the controller (tests,
+// bespoke listers) pays nothing. Call before the first Collect; not safe to
+// swap concurrently.
+func (s *HuskSource) SetTerminations(log *TerminationLog, maxHold time.Duration) {
+	if maxHold <= 0 {
+		maxHold = DefaultConfig().MaxHold
+	}
+	s.terminations = log
+	s.maxHold = maxHold
+}
 
 // appendFinalSamples remembers this cycle's newest sample per pod, then drains
 // the termination log and appends one FINAL sample per released claim:
@@ -230,7 +247,12 @@ func (s *HuskSource) appendFinalSamples(out []Sample, billable []HuskPod, result
 			s.last[pod.VMID] = results[i][len(results[i])-1]
 		}
 	}
-	maxHold := DefaultConfig().MaxHold
+	maxHold := s.maxHold
+	if maxHold <= 0 {
+		// SetTerminations normalizes this; keep a defensive floor for a wiring
+		// that set the field directly.
+		maxHold = DefaultConfig().MaxHold
+	}
 	for _, t := range s.terminations.Drain() {
 		if t.VMID == "" || t.OrgID == "" || t.At.IsZero() {
 			continue

--- a/internal/usage/husksource.go
+++ b/internal/usage/husksource.go
@@ -5,11 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"mitos.run/mitos/internal/metering"
 )
+
+// huskScrapeConcurrency bounds the number of in-flight husk-pod scrapes per
+// cycle (issue #682, was #656). Fleet size is per-VM (one husk pod per
+// sandbox), so a sequential scrape serialized N unreachable pods into
+// N x scrapeTimeout during a partial outage, delaying metering for the healthy
+// fleet. With the bounded pool the cycle duration is set by the slowest pool
+// lane, not the fleet size, while the bound keeps the controller from opening
+// an unbounded number of connections into tenant pod networks at once.
+const huskScrapeConcurrency = 8
 
 // HuskPod is one claimed, org-labeled husk pod the HuskSource scrapes. VMID is
 // the pod's vm-id (the pod NAME: the id the pod reports as its single metering
@@ -104,6 +114,14 @@ func NewHuskSource(
 // one cycle share an instant (the property Integrate's windowing relies on). A
 // pod that is unreachable, errors, or returns a non-200 is skipped and counted;
 // Collect itself never returns an error for an unreachable pod.
+//
+// The scrapes fan out over a bounded worker pool (huskScrapeConcurrency; issue
+// #682) so the cycle duration is set by the slowest pool lane, never by the
+// fleet size: N unreachable pods no longer serialize into N x scrapeTimeout.
+// The single shared scrape timestamp and the skip-and-count semantics are
+// unchanged; results keep the lister's pod order. Collect itself is meant for
+// ONE caller (the collector loop): the injected vcpus func must be safe for
+// concurrent use (the nil default is).
 func (s *HuskSource) Collect(ctx context.Context) ([]Sample, error) {
 	at := s.now()
 	pods, err := s.pods.ListHuskPods(ctx)
@@ -113,45 +131,84 @@ func (s *HuskSource) Collect(ctx context.Context) ([]Sample, error) {
 		// bill for the whole fleet, the exact failure mode issue #613 closes.
 		return nil, fmt.Errorf("list husk pods: %w", err)
 	}
-	var out []Sample
+	billable := pods[:0:0]
 	for _, pod := range pods {
 		if pod.OrgID == "" || pod.VMID == "" {
 			// An unattributed pod (no trusted org label) or one with no vm-id is not
 			// billable. Skip it without counting it as a scrape failure.
 			continue
 		}
-		report, ok := s.scrape(ctx, pod)
-		if !ok {
-			s.skipped.Add(1)
-			continue
+		billable = append(billable, pod)
+	}
+
+	results := make([][]Sample, len(billable))
+	workers := huskScrapeConcurrency
+	if len(billable) < workers {
+		workers = len(billable)
+	}
+	if workers > 0 {
+		next := make(chan int)
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := range next {
+					results[i] = s.podSamples(ctx, billable[i], at)
+				}
+			}()
 		}
-		// Attribute ONLY this pod's own vm-id to its org, from the TRUSTED label.
-		// Any other sample id the (untrusted) pod returns resolves unattributed and
-		// is dropped, so a pod can bill only its own vm-id/org (defense in depth).
-		orgOf := func(sandboxID string) (string, bool) {
-			if sandboxID == pod.VMID {
-				return pod.OrgID, true
-			}
-			return "", false
+		for i := range billable {
+			next <- i
 		}
-		samples, _ := SamplesFromReport(pod.VMID, at, report, orgOf, s.vcpus)
-		// Emit the sample keyed by the API-VISIBLE sandbox id from the TRUSTED
-		// claim label (issue #663), so usage_records reconcile to the sb-... id
-		// the customer saw, never the internal husk pod name. The trust check
-		// above stays keyed on the pod's vm-id: the pod cannot choose its billing
-		// id, only the controller's label does. Fallback: a pod whose lister
-		// carried no APIID (label absent; pre-#663 lister or a bespoke self-host
-		// lister) keeps the pod name, preserving the old behavior rather than
-		// dropping the sample. The Sample's Node field keeps the pod name (the
-		// vm-id), so support can still map a record back to the pod.
-		if pod.APIID != "" {
-			for i := range samples {
-				samples[i].SandboxID = pod.APIID
-			}
-		}
+		close(next)
+		wg.Wait()
+	}
+
+	var out []Sample
+	for _, samples := range results {
 		out = append(out, samples...)
 	}
 	return out, nil
+}
+
+// podSamples scrapes one billable husk pod and converts its report to
+// org-tagged Samples stamped with the cycle's shared timestamp. A failed scrape
+// is skip-and-counted (nil samples), never an error: one bad pod must not zero
+// out the bill for the healthy fleet. It is called from the Collect worker
+// pool, so it touches only the pod, the atomic skip counter, and the injected
+// seams; it never writes shared source state.
+func (s *HuskSource) podSamples(ctx context.Context, pod HuskPod, at time.Time) []Sample {
+	report, ok := s.scrape(ctx, pod)
+	if !ok {
+		s.skipped.Add(1)
+		return nil
+	}
+	// Attribute ONLY this pod's own vm-id to its org, from the TRUSTED label.
+	// Any other sample id the (untrusted) pod returns resolves unattributed and
+	// is dropped, so a pod can bill only its own vm-id/org (defense in depth).
+	orgOf := func(sandboxID string) (string, bool) {
+		if sandboxID == pod.VMID {
+			return pod.OrgID, true
+		}
+		return "", false
+	}
+	samples, _ := SamplesFromReport(pod.VMID, at, report, orgOf, s.vcpus)
+	// Emit the sample keyed by the API-VISIBLE sandbox id from the TRUSTED
+	// claim label (issue #663), so usage_records reconcile to the sb-... id
+	// the customer saw, never the internal husk pod name. The trust check
+	// above stays keyed on the pod's vm-id: the pod cannot choose its billing
+	// id, only the controller's label does. Fallback: a pod whose lister
+	// carried no APIID (label absent; pre-#663 lister or a bespoke self-host
+	// lister) keeps the pod name, preserving the old behavior rather than
+	// dropping the sample. The Sample's Node field keeps the pod name (the
+	// vm-id), so support can still map a record back to the pod.
+	if pod.APIID != "" {
+		for i := range samples {
+			samples[i].SandboxID = pod.APIID
+		}
+	}
+	return samples
 }
 
 // scrape GETs GET /v1/metering from one husk pod and decodes the Report. It

--- a/internal/usage/husksource_test.go
+++ b/internal/usage/husksource_test.go
@@ -2,6 +2,11 @@ package usage
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -209,6 +214,97 @@ func TestHuskSourceSkipsUnattributedPod(t *testing.T) {
 	}
 	if src.SkippedPods() != 0 {
 		t.Errorf("SkippedPods = %d, want 0 (an unattributed pod is not a scrape failure)", src.SkippedPods())
+	}
+}
+
+// TestHuskSourceScrapesConcurrentlyBounded is the issue #682 (was #656) fix
+// proof: the husk source scrapes claimed pods through a BOUNDED worker pool, so
+// the cycle duration is set by the slowest pool lane, not by the fleet size.
+// Twelve pods whose handlers each hold the request briefly must overlap in
+// flight (peak concurrency at least 2; the sequential implementation pins the
+// peak at 1) while never exceeding the pool bound. The single shared scrape
+// timestamp per cycle and the zero-skip accounting must survive the fan-out.
+func TestHuskSourceScrapesConcurrentlyBounded(t *testing.T) {
+	const podCount = 12
+
+	var inflight, peak atomic.Int64
+	pods := make(staticHuskPods, 0, podCount)
+	for i := 0; i < podCount; i++ {
+		vmID := fmt.Sprintf("husk-conc-%d", i)
+		report := singleVMReport(vmID)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/v1/metering", func(w http.ResponseWriter, _ *http.Request) {
+			cur := inflight.Add(1)
+			for {
+				p := peak.Load()
+				if cur <= p || peak.CompareAndSwap(p, cur) {
+					break
+				}
+			}
+			// Hold the request long enough that a concurrent implementation
+			// overlaps requests; a sequential one never does.
+			time.Sleep(50 * time.Millisecond)
+			inflight.Add(-1)
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(report); err != nil {
+				t.Errorf("encode report: %v", err)
+			}
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		pods = append(pods, HuskPod{VMID: vmID, OrgID: "acme", Endpoint: srv.Listener.Addr().String()})
+	}
+
+	scrapedAt := time.Date(2026, 7, 4, 9, 0, 0, 0, time.UTC)
+	src := NewHuskSource(pods, nil, &http.Client{}, "http", func() time.Time { return scrapedAt })
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(samples) != podCount {
+		t.Fatalf("want %d samples, got %d", podCount, len(samples))
+	}
+	for _, s := range samples {
+		if !s.Timestamp.Equal(scrapedAt) {
+			t.Fatalf("sample %s timestamp = %v, want the single shared cycle instant %v", s.SandboxID, s.Timestamp, scrapedAt)
+		}
+	}
+	if src.SkippedPods() != 0 {
+		t.Errorf("SkippedPods = %d, want 0", src.SkippedPods())
+	}
+	if got := peak.Load(); got < 2 {
+		t.Errorf("peak in-flight scrapes = %d, want at least 2 (sequential scraping serializes the cycle; issue #682)", got)
+	}
+	if got := peak.Load(); got > huskScrapeConcurrency {
+		t.Errorf("peak in-flight scrapes = %d, want at most the pool bound %d", got, huskScrapeConcurrency)
+	}
+}
+
+// TestHuskSourceConcurrentScrapePreservesSkipAndCount asserts the worker-pool
+// fan-out keeps the skip-and-count semantics: unreachable pods are skipped and
+// counted while every healthy pod still bills, exactly as in the sequential
+// implementation.
+func TestHuskSourceConcurrentScrapePreservesSkipAndCount(t *testing.T) {
+	good := meteringServer(t, singleVMReport("husk-ok"))
+	defer good.Close()
+
+	pods := staticHuskPods{
+		{VMID: "husk-dead-1", OrgID: "acme", Endpoint: "127.0.0.1:1"},
+		{VMID: "husk-ok", OrgID: "acme", Endpoint: good.Listener.Addr().String()},
+		{VMID: "husk-dead-2", OrgID: "acme", Endpoint: "127.0.0.1:1"},
+	}
+	src := NewHuskSource(pods, nil, &http.Client{}, "http", nil)
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect must not fail on unreachable pods: %v", err)
+	}
+	if len(samples) != 1 || samples[0].SandboxID != "husk-ok" {
+		t.Fatalf("want exactly the healthy pod's sample, got %+v", samples)
+	}
+	if src.SkippedPods() != 2 {
+		t.Errorf("SkippedPods = %d, want 2", src.SkippedPods())
 	}
 }
 

--- a/internal/usage/termination.go
+++ b/internal/usage/termination.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"sync"
+	"time"
+)
+
+// This file carries the claim-release half of the issue #682 (was #664) fix:
+// presence between the LAST scrape and terminate was never recorded, so a
+// sandbox alive ~100s billed 60 vcpu-seconds and a sub-minute sandbox billed
+// nothing. The controller records a Termination at claim release (it knows the
+// exact instant); the HuskSource turns it into a FINAL sample on the next
+// cycle, closing the half-open window through the ordinary Integrate path so
+// every idempotency and hold-then-gap property keeps applying.
+
+// Termination is one claim-release event for a husk-pod sandbox, recorded by
+// the controller's terminate paths. All fields come from the CONTROL PLANE
+// (pod name, trusted controller-stamped labels, claim status), never from
+// anything the pod reported; it carries ids and instants only, no secrets.
+type Termination struct {
+	// VMID is the husk pod name, the id the pod's own metering report samples
+	// are keyed on (and the key the source's last-sample memory uses).
+	VMID string
+	// APIID is the customer-visible sandbox id (the claiming Sandbox's name,
+	// the mitos.run/claim label value; issue #663). Empty falls back to VMID.
+	APIID string
+	// OrgID is the owning org from the TRUSTED mitos.run/org pod label. Empty
+	// means unattributed (self-host single-tenant): never billable, ignored.
+	OrgID string
+	// StartedAt is the claim's start time (Status.StartedAt); zero if unknown.
+	// It only matters for a sandbox that terminated before its first scrape.
+	StartedAt time.Time
+	// At is the release/terminate instant.
+	At time.Time
+}
+
+// terminationLogCap bounds the pending buffer (boring failure behavior: a
+// stalled collector must not grow the controller heap without limit). On
+// overflow the OLDEST events are dropped first: the most recent terminations
+// are the ones the next cycle can still bill accurately, and losing a tail
+// sample only ever under-bills (customer-favorable), never double-bills.
+const terminationLogCap = 4096
+
+// TerminationLog is the small thread-safe queue between the controller's
+// terminate paths (producers, reconciler goroutines) and the HuskSource's
+// Collect (the single consumer). It is in-memory only: a controller restart
+// loses pending events, which under-bills the affected tails and nothing else.
+// All methods are nil-safe so the self-host path (collector off, no log wired)
+// costs nothing and needs no call-site checks.
+type TerminationLog struct {
+	mu      sync.Mutex
+	pending []Termination
+}
+
+// NewTerminationLog builds an empty termination log.
+func NewTerminationLog() *TerminationLog { return &TerminationLog{} }
+
+// Record appends one termination event. Nil-safe no-op. At the cap the oldest
+// pending event is dropped (see terminationLogCap).
+func (l *TerminationLog) Record(t Termination) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.pending) >= terminationLogCap {
+		copy(l.pending, l.pending[1:])
+		l.pending = l.pending[:len(l.pending)-1]
+	}
+	l.pending = append(l.pending, t)
+}
+
+// Drain returns and clears the pending events. Nil-safe (returns nil).
+func (l *TerminationLog) Drain() []Termination {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := l.pending
+	l.pending = nil
+	return out
+}

--- a/internal/usage/termination_test.go
+++ b/internal/usage/termination_test.go
@@ -1,0 +1,327 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The issue #682 (was #664) gap: presence between the last 1-minute scrape and
+// terminate was never recorded. A sandbox alive ~100s billed 60 vcpu-seconds,
+// and a sub-minute sandbox billed nothing. These tests pin the fix: the
+// controller records a Termination at claim release, and the husk source turns
+// it into a FINAL sample (closing the half-open window), or into a synthesized
+// start/end pair for a sandbox that terminated before its first scrape.
+
+// mutableHuskPods is a HuskPodLister whose pod set a test can change between
+// cycles (a pod disappears when its claim is released).
+type mutableHuskPods struct{ pods []HuskPod }
+
+func (m *mutableHuskPods) ListHuskPods(context.Context) ([]HuskPod, error) { return m.pods, nil }
+
+// termBase is window-aligned so the integration math stays obvious.
+var termBase = time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+
+// TestTerminationLogNilSafe asserts a nil log records and drains as a no-op:
+// the self-host path runs without the usage collector and must never wire (or
+// nil-check) anything.
+func TestTerminationLogNilSafe(t *testing.T) {
+	var log *TerminationLog
+	log.Record(Termination{VMID: "husk-x", OrgID: "acme", At: termBase})
+	if got := log.Drain(); got != nil {
+		t.Fatalf("nil log Drain = %v, want nil", got)
+	}
+}
+
+// TestTerminationLogBounded asserts the pending buffer is bounded (boring
+// failure behavior: a stalled collector must not grow the controller heap
+// without limit) and drops the OLDEST events first, keeping the most recent
+// terminations, the ones the next cycle can still bill accurately.
+func TestTerminationLogBounded(t *testing.T) {
+	log := NewTerminationLog()
+	for i := 0; i < terminationLogCap+10; i++ {
+		log.Record(Termination{VMID: fmt.Sprintf("husk-%d", i), OrgID: "acme", At: termBase})
+	}
+	got := log.Drain()
+	if len(got) != terminationLogCap {
+		t.Fatalf("pending after overflow = %d, want the cap %d", len(got), terminationLogCap)
+	}
+	if got[len(got)-1].VMID != fmt.Sprintf("husk-%d", terminationLogCap+9) {
+		t.Errorf("newest termination was dropped; last kept = %s", got[len(got)-1].VMID)
+	}
+	if got[0].VMID == "husk-0" {
+		t.Errorf("oldest termination survived overflow; want oldest-first eviction")
+	}
+	if again := log.Drain(); len(again) != 0 {
+		t.Errorf("second Drain = %d events, want 0 (Drain consumes)", len(again))
+	}
+}
+
+// TestHuskSourceFinalSampleAtTermination is the core #664 fix proof: a pod
+// scraped at t0 whose claim is released at t0+40s yields a FINAL sample at the
+// release instant carrying the pod's last known levels, so integrating the
+// cycle's samples bills the tail [t0, t0+40] instead of dropping it. The final
+// sample is emitted exactly once: the termination is consumed.
+func TestHuskSourceFinalSampleAtTermination(t *testing.T) {
+	srv := meteringServer(t, singleVMReport("husk-final"))
+	defer srv.Close()
+
+	clock := termBase
+	pods := &mutableHuskPods{pods: []HuskPod{{
+		VMID: "husk-final", APIID: "sb-final", OrgID: "acme",
+		Endpoint: srv.Listener.Addr().String(),
+	}}}
+	terms := NewTerminationLog()
+	src := NewHuskSource(pods, nil, srv.Client(), "http", func() time.Time { return clock })
+	src.SetTerminations(terms)
+
+	first, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 1 || first[0].SandboxID != "sb-final" {
+		t.Fatalf("precondition: want 1 scraped sample for sb-final, got %+v", first)
+	}
+
+	// The claim is released 40s after the scrape; the pod is gone next cycle.
+	releasedAt := termBase.Add(40 * time.Second)
+	terms.Record(Termination{
+		VMID: "husk-final", APIID: "sb-final", OrgID: "acme",
+		StartedAt: termBase.Add(-30 * time.Second), At: releasedAt,
+	})
+	pods.pods = nil
+	clock = termBase.Add(60 * time.Second)
+
+	second, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("want exactly 1 final sample, got %+v", second)
+	}
+	final := second[0]
+	if !final.Timestamp.Equal(releasedAt) {
+		t.Errorf("final sample timestamp = %v, want the release instant %v", final.Timestamp, releasedAt)
+	}
+	if final.SandboxID != "sb-final" || final.OrgID != "acme" {
+		t.Errorf("final sample identity = (%s, %s), want (sb-final, acme)", final.SandboxID, final.OrgID)
+	}
+	if final.VCPUs != first[0].VCPUs || final.MemUniqueBytes != first[0].MemUniqueBytes {
+		t.Errorf("final sample levels = %+v, want the last scraped levels %+v", final, first[0])
+	}
+	if final.EgressBytes != first[0].EgressBytes {
+		// Cloning the cumulative counter means a ZERO counter delta over the
+		// tail: the final sample closes the rate window without inventing
+		// egress the pod never reported.
+		t.Errorf("final sample egress = %d, want the last scraped cumulative %d (zero delta)", final.EgressBytes, first[0].EgressBytes)
+	}
+
+	// The tail is billed: t0 -> t0+40 at the held level.
+	recs := Integrate(append(append([]Sample{}, first...), second...), DefaultConfig())
+	var vcpu float64
+	for _, r := range recs {
+		vcpu += r.VCPUSeconds
+	}
+	if vcpu != 40 {
+		t.Errorf("integrated vcpu-seconds = %v, want 40 (the [last scrape, terminate] tail)", vcpu)
+	}
+
+	// The termination was consumed: nothing more is emitted.
+	clock = termBase.Add(120 * time.Second)
+	third, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(third) != 0 {
+		t.Fatalf("final sample must be emitted exactly once, got %+v on the next cycle", third)
+	}
+}
+
+// TestHuskSourceHundredSecondSandboxBillsHundredSeconds is the issue's headline
+// number: a sandbox alive ~100s (scraped at t0 and t0+60, terminated at
+// t0+100) must bill 100 vcpu-seconds, not 60.
+func TestHuskSourceHundredSecondSandboxBillsHundredSeconds(t *testing.T) {
+	srv := meteringServer(t, singleVMReport("husk-100s"))
+	defer srv.Close()
+
+	clock := termBase
+	pods := &mutableHuskPods{pods: []HuskPod{{
+		VMID: "husk-100s", APIID: "sb-100s", OrgID: "acme",
+		Endpoint: srv.Listener.Addr().String(),
+	}}}
+	terms := NewTerminationLog()
+	src := NewHuskSource(pods, nil, srv.Client(), "http", func() time.Time { return clock })
+	src.SetTerminations(terms)
+
+	var all []Sample
+	collect := func() {
+		t.Helper()
+		s, err := src.Collect(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, s...)
+	}
+
+	collect() // t0
+	clock = termBase.Add(60 * time.Second)
+	collect() // t0+60
+
+	terms.Record(Termination{
+		VMID: "husk-100s", APIID: "sb-100s", OrgID: "acme",
+		StartedAt: termBase, At: termBase.Add(100 * time.Second),
+	})
+	pods.pods = nil
+	clock = termBase.Add(120 * time.Second)
+	collect() // final sample at t0+100
+
+	recs := Integrate(all, DefaultConfig())
+	var vcpu float64
+	for _, r := range recs {
+		vcpu += r.VCPUSeconds
+	}
+	if vcpu != 100 {
+		t.Errorf("integrated vcpu-seconds = %v, want 100 (60 from the scrapes + 40 tail)", vcpu)
+	}
+}
+
+// TestHuskSourceSynthesizesNeverScrapedSandbox covers the sub-minute job that
+// terminated before its first scrape: the source synthesizes a start/end
+// sample pair over [StartedAt, At] carrying ONLY the known allocation (vCPUs);
+// memory and disk are unknown and stay zero (customer-favorable: the customer
+// is never billed for a level nobody measured).
+func TestHuskSourceSynthesizesNeverScrapedSandbox(t *testing.T) {
+	clock := termBase.Add(50 * time.Second)
+	terms := NewTerminationLog()
+	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
+	src.SetTerminations(terms)
+
+	terms.Record(Termination{
+		VMID: "husk-short", APIID: "sb-short", OrgID: "acme",
+		StartedAt: termBase, At: termBase.Add(45 * time.Second),
+	})
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("want a synthesized start/end pair, got %+v", samples)
+	}
+	for _, s := range samples {
+		if s.SandboxID != "sb-short" || s.OrgID != "acme" || s.VCPUs != 1 {
+			t.Errorf("synthesized sample = %+v, want sb-short/acme with the 1 vCPU default", s)
+		}
+		if s.MemUniqueBytes != 0 || s.MemSharedAmortizedBytes != 0 || s.DiskBytes != 0 || s.EgressBytes != 0 || s.GPUSeconds != 0 {
+			t.Errorf("synthesized sample carries unmeasured levels: %+v (must bill only the known vCPU allocation)", s)
+		}
+	}
+	recs := Integrate(samples, DefaultConfig())
+	var vcpu float64
+	for _, r := range recs {
+		vcpu += r.VCPUSeconds
+	}
+	if vcpu != 45 {
+		t.Errorf("integrated vcpu-seconds = %v, want 45 (the sandbox's whole sub-minute life)", vcpu)
+	}
+}
+
+// TestHuskSourceSynthesizedPairClampsOldStart asserts the never-scraped pair
+// never reaches back further than MaxHold before the terminate instant: a
+// stale StartedAt (a long-lived sandbox whose scrape history was lost, for
+// example across a controller restart) must not rewrite long-settled windows.
+// Billing at most the MaxHold tail is the customer-favorable floor.
+func TestHuskSourceSynthesizedPairClampsOldStart(t *testing.T) {
+	endAt := termBase.Add(2 * time.Hour)
+	clock := endAt.Add(10 * time.Second)
+	terms := NewTerminationLog()
+	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
+	src.SetTerminations(terms)
+
+	terms.Record(Termination{
+		VMID: "husk-old", APIID: "sb-old", OrgID: "acme",
+		StartedAt: termBase, At: endAt,
+	})
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("want a clamped start/end pair, got %+v", samples)
+	}
+	wantStart := endAt.Add(-DefaultConfig().MaxHold)
+	if !samples[0].Timestamp.Equal(wantStart) {
+		t.Errorf("pair start = %v, want clamped to At-MaxHold %v", samples[0].Timestamp, wantStart)
+	}
+}
+
+// TestHuskSourceTerminationRecordedOnceGuard asserts a vm-id already finalized
+// is never billed again, even when a second termination event arrives (a
+// lifetime-expiry terminate followed by the object delete records twice).
+// Without the guard the second event would synthesize a fresh start/end pair
+// and double-bill the sandbox.
+func TestHuskSourceTerminationRecordedOnceGuard(t *testing.T) {
+	srv := meteringServer(t, singleVMReport("husk-twice"))
+	defer srv.Close()
+
+	clock := termBase
+	pods := &mutableHuskPods{pods: []HuskPod{{
+		VMID: "husk-twice", APIID: "sb-twice", OrgID: "acme",
+		Endpoint: srv.Listener.Addr().String(),
+	}}}
+	terms := NewTerminationLog()
+	src := NewHuskSource(pods, nil, srv.Client(), "http", func() time.Time { return clock })
+	src.SetTerminations(terms)
+
+	if _, err := src.Collect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lifetime expiry records the terminate, then the delete records it again.
+	terms.Record(Termination{VMID: "husk-twice", APIID: "sb-twice", OrgID: "acme", StartedAt: termBase, At: termBase.Add(30 * time.Second)})
+	terms.Record(Termination{VMID: "husk-twice", APIID: "sb-twice", OrgID: "acme", StartedAt: termBase, At: termBase.Add(35 * time.Second)})
+	pods.pods = nil
+	clock = termBase.Add(60 * time.Second)
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("want exactly 1 final sample for a double-recorded termination, got %+v", samples)
+	}
+
+	// A third event on a later cycle must also stay silent (the finalized guard,
+	// not just same-cycle dedupe).
+	terms.Record(Termination{VMID: "husk-twice", APIID: "sb-twice", OrgID: "acme", StartedAt: termBase, At: termBase.Add(40 * time.Second)})
+	clock = termBase.Add(120 * time.Second)
+	again, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("a finalized vm-id must never bill again, got %+v", again)
+	}
+}
+
+// TestHuskSourceIgnoresUnattributedTermination asserts a termination without a
+// trusted org bills nothing: the self-host single-tenant path has no org and
+// must stay out of billable samples, exactly like the live scrape path.
+func TestHuskSourceIgnoresUnattributedTermination(t *testing.T) {
+	clock := termBase
+	terms := NewTerminationLog()
+	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
+	src.SetTerminations(terms)
+
+	terms.Record(Termination{VMID: "husk-selfhost", StartedAt: termBase.Add(-30 * time.Second), At: termBase})
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 0 {
+		t.Fatalf("an unattributed termination must not bill, got %+v", samples)
+	}
+}

--- a/internal/usage/termination_test.go
+++ b/internal/usage/termination_test.go
@@ -74,7 +74,7 @@ func TestHuskSourceFinalSampleAtTermination(t *testing.T) {
 	}}}
 	terms := NewTerminationLog()
 	src := NewHuskSource(pods, nil, srv.Client(), "http", func() time.Time { return clock })
-	src.SetTerminations(terms)
+	src.SetTerminations(terms, 0)
 
 	first, err := src.Collect(context.Background())
 	if err != nil {
@@ -152,7 +152,7 @@ func TestHuskSourceHundredSecondSandboxBillsHundredSeconds(t *testing.T) {
 	}}}
 	terms := NewTerminationLog()
 	src := NewHuskSource(pods, nil, srv.Client(), "http", func() time.Time { return clock })
-	src.SetTerminations(terms)
+	src.SetTerminations(terms, 0)
 
 	var all []Sample
 	collect := func() {
@@ -195,7 +195,7 @@ func TestHuskSourceSynthesizesNeverScrapedSandbox(t *testing.T) {
 	clock := termBase.Add(50 * time.Second)
 	terms := NewTerminationLog()
 	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
-	src.SetTerminations(terms)
+	src.SetTerminations(terms, 0)
 
 	terms.Record(Termination{
 		VMID: "husk-short", APIID: "sb-short", OrgID: "acme",
@@ -237,7 +237,7 @@ func TestHuskSourceSynthesizedPairClampsOldStart(t *testing.T) {
 	clock := endAt.Add(10 * time.Second)
 	terms := NewTerminationLog()
 	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
-	src.SetTerminations(terms)
+	src.SetTerminations(terms, 0)
 
 	terms.Record(Termination{
 		VMID: "husk-old", APIID: "sb-old", OrgID: "acme",
@@ -257,9 +257,41 @@ func TestHuskSourceSynthesizedPairClampsOldStart(t *testing.T) {
 	}
 }
 
+// TestHuskSourceSynthesizedPairClampFollowsConfiguredMaxHold asserts the tail
+// clamp uses the COLLECTOR'S configured MaxHold, not the package default: with
+// a non-default hold the synthesized start must sit exactly hold before the
+// terminate instant, so the clamp and Integrate's own hold bound (cfg.MaxHold)
+// never diverge on a non-default Config.
+func TestHuskSourceSynthesizedPairClampFollowsConfiguredMaxHold(t *testing.T) {
+	endAt := termBase.Add(2 * time.Hour)
+	clock := endAt.Add(10 * time.Second)
+	terms := NewTerminationLog()
+	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
+	hold := 30 * time.Second // deliberately not DefaultConfig().MaxHold
+	src.SetTerminations(terms, hold)
+
+	terms.Record(Termination{
+		VMID: "husk-hold", APIID: "sb-hold", OrgID: "acme",
+		StartedAt: termBase, At: endAt,
+	})
+
+	samples, err := src.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("want a clamped start/end pair, got %+v", samples)
+	}
+	wantStart := endAt.Add(-hold)
+	if !samples[0].Timestamp.Equal(wantStart) {
+		t.Errorf("pair start = %v, want clamped to At minus the CONFIGURED hold %v", samples[0].Timestamp, wantStart)
+	}
+}
+
 // TestHuskSourceTerminationRecordedOnceGuard asserts a vm-id already finalized
-// is never billed again, even when a second termination event arrives (a
-// lifetime-expiry terminate followed by the object delete records twice).
+// is never billed again, even when a second termination event arrives (the
+// controller records once per claim, but a requeued terminate path can still
+// record twice before the Terminated phase persists).
 // Without the guard the second event would synthesize a fresh start/end pair
 // and double-bill the sandbox.
 func TestHuskSourceTerminationRecordedOnceGuard(t *testing.T) {
@@ -273,7 +305,7 @@ func TestHuskSourceTerminationRecordedOnceGuard(t *testing.T) {
 	}}}
 	terms := NewTerminationLog()
 	src := NewHuskSource(pods, nil, srv.Client(), "http", func() time.Time { return clock })
-	src.SetTerminations(terms)
+	src.SetTerminations(terms, 0)
 
 	if _, err := src.Collect(context.Background()); err != nil {
 		t.Fatal(err)
@@ -313,7 +345,7 @@ func TestHuskSourceIgnoresUnattributedTermination(t *testing.T) {
 	clock := termBase
 	terms := NewTerminationLog()
 	src := NewHuskSource(&mutableHuskPods{}, nil, nil, "http", func() time.Time { return clock })
-	src.SetTerminations(terms)
+	src.SetTerminations(terms, 0)
 
 	terms.Record(Termination{VMID: "husk-selfhost", StartedAt: termBase.Add(-30 * time.Second), At: termBase})
 

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -210,6 +210,39 @@ func TestStoreUpsertIdempotent(t *testing.T) {
 	}
 }
 
+// TestCollectOnceReturnsCycleStats asserts CollectOnce reports what one cycle
+// did (samples scraped, records upserted, distinct orgs, wall duration) so the
+// controller wiring can emit a healthy-cycle summary at default verbosity and a
+// cycle-duration metric (issue #682, was #665/#656; feeds #617 alerting).
+func TestCollectOnceReturnsCycleStats(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemUsageStore()
+	samples := []Sample{
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 0), VCPUs: 1},
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 30), VCPUs: 1},
+		{OrgID: "orgB", SandboxID: "sbx2", Timestamp: at(baseTime, 0), VCPUs: 1},
+		{OrgID: "orgB", SandboxID: "sbx2", Timestamp: at(baseTime, 30), VCPUs: 1},
+	}
+	c := NewCollector(&staticSource{samples: samples}, store, DefaultConfig())
+
+	stats, err := c.CollectOnce(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Samples != 4 {
+		t.Errorf("Samples = %d, want 4", stats.Samples)
+	}
+	if stats.Records != 2 {
+		t.Errorf("Records = %d, want 2 (one window per sandbox)", stats.Records)
+	}
+	if stats.Orgs != 2 {
+		t.Errorf("Orgs = %d, want 2", stats.Orgs)
+	}
+	if stats.Duration <= 0 {
+		t.Errorf("Duration = %v, want a positive wall duration", stats.Duration)
+	}
+}
+
 // TestRunCollectorIdempotentReplay drives the collector twice over the same
 // overlapping samples and asserts the store holds the same records (no double
 // bill) after the second pass: the end-to-end idempotency on (sandbox, window).
@@ -224,14 +257,14 @@ func TestRunCollectorIdempotentReplay(t *testing.T) {
 	src := &staticSource{samples: samples}
 	c := NewCollector(src, store, DefaultConfig())
 
-	if err := c.CollectOnce(ctx); err != nil {
+	if _, err := c.CollectOnce(ctx); err != nil {
 		t.Fatal(err)
 	}
 	first, _ := store.ListRecords(ctx, "orgA", time.Time{}, time.Time{})
 
 	// Replay the exact same samples (duplicate scrape / restart): records must not
 	// change.
-	if err := c.CollectOnce(ctx); err != nil {
+	if _, err := c.CollectOnce(ctx); err != nil {
 		t.Fatal(err)
 	}
 	second, _ := store.ListRecords(ctx, "orgA", time.Time{}, time.Time{})

--- a/internal/usage/usagemetrics.go
+++ b/internal/usage/usagemetrics.go
@@ -28,6 +28,11 @@ type Metrics struct {
 	memGiBSecs  *prometheus.GaugeVec
 	egressBytes *prometheus.GaugeVec
 	gpuSeconds  *prometheus.GaugeVec
+	// cycleSeconds is the wall duration of the most recent collection cycle
+	// (issue #682, was #656). It is a plain gauge (no labels): the alerting
+	// signal for #617 is "the cycle is slowing down", which a last-value gauge
+	// answers directly at the 1-per-cadence sample rate.
+	cycleSeconds prometheus.Gauge
 }
 
 // NewMetrics builds the per-org usage metric vectors. They are unregistered; the
@@ -63,6 +68,10 @@ func NewMetrics() *Metrics {
 			Name: "mitos_usage_gpu_seconds_total",
 			Help: "Cumulative GPU-seconds of billable sandbox usage by org, summed over every settled usage record. Monotonic within a controller process; reset only by a restart, where the durable store is the system of record.",
 		}, []string{"org"}),
+		cycleSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "mitos_usage_collect_cycle_duration_seconds",
+			Help: "Wall duration of the most recent usage collection cycle (scrape, integrate, upsert) in seconds. The husk scrape fans out over a bounded worker pool, so this is set by the slowest pool lane, not the fleet size; a sustained rise means unreachable pods or fleet growth.",
+		}),
 	}
 }
 
@@ -70,7 +79,14 @@ func NewMetrics() *Metrics {
 // metrics registry). It panics on a duplicate registration, the standard
 // fail-fast for a misconfigured wiring.
 func (m *Metrics) MustRegister(reg prometheus.Registerer) {
-	reg.MustRegister(m.vcpuSeconds, m.memGiBSecs, m.egressBytes, m.gpuSeconds)
+	reg.MustRegister(m.vcpuSeconds, m.memGiBSecs, m.egressBytes, m.gpuSeconds, m.cycleSeconds)
+}
+
+// ObserveCycle records one completed collection cycle's stats: today only the
+// wall duration, the signal #617 alerting watches for a slowing scrape path.
+// The stats carry counts and a duration only, never an id or a secret.
+func (m *Metrics) ObserveCycle(stats CycleStats) {
+	m.cycleSeconds.Set(stats.Duration.Seconds())
 }
 
 // Observe sets the per-org gauges from the store's CUMULATIVE per-org Totals. It

--- a/internal/usage/usagemetrics_test.go
+++ b/internal/usage/usagemetrics_test.go
@@ -50,10 +50,10 @@ func TestCollectorEmitsPerOrgMetric(t *testing.T) {
 	// Two scrape cycles in the same window: the second is a re-scrape of the same
 	// report. Idempotency means the store and the gauge land on the same per-org
 	// totals, not double them.
-	if err := c.CollectOnce(context.Background()); err != nil {
+	if _, err := c.CollectOnce(context.Background()); err != nil {
 		t.Fatalf("first CollectOnce: %v", err)
 	}
-	if err := c.CollectOnce(context.Background()); err != nil {
+	if _, err := c.CollectOnce(context.Background()); err != nil {
 		t.Fatalf("second CollectOnce: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestMetricStoreFedCumulativeAcrossWindowsQuietOrgRetained(t *testing.T) {
 
 	var prevAcme, prevGlobex float64
 	for cyc := 0; cyc < 3; cyc++ {
-		if err := coll.CollectOnce(ctx); err != nil {
+		if _, err := coll.CollectOnce(ctx); err != nil {
 			t.Fatalf("cycle %d: %v", cyc, err)
 		}
 		totals := store.TotalsByOrg()
@@ -222,6 +222,36 @@ func TestMetricStoreFedCumulativeAcrossWindowsQuietOrgRetained(t *testing.T) {
 		t.Fatalf("globex cumulative dropped to %v after going quiet; the quiet org was lost", finalGlobex)
 	}
 	assertGaugeEquals(t, reg, "globex", finalGlobex)
+}
+
+// TestObserveCycleExportsCycleDuration asserts the cycle-duration gauge (issue
+// #682, was #656; the series #617 alerting watches) is exported and set to the
+// most recent cycle's wall duration in seconds.
+func TestObserveCycleExportsCycleDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMetrics()
+	m.MustRegister(reg)
+
+	m.ObserveCycle(CycleStats{Duration: 1500 * time.Millisecond})
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var got float64
+	var found bool
+	for _, mf := range mfs {
+		if mf.GetName() == "mitos_usage_collect_cycle_duration_seconds" {
+			found = true
+			got = mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	if !found {
+		t.Fatal("mitos_usage_collect_cycle_duration_seconds not exported")
+	}
+	if got != 1.5 {
+		t.Errorf("cycle duration gauge = %v, want 1.5", got)
+	}
 }
 
 // gaugeValue reads the value of mitos_usage_vcpu_seconds_total for the given org


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the hosted SaaS bills tenants from the usage metering pipeline (controller usage collector -> usage records -> console drawdown).
> - The husk usage collector (internal/usage HuskSource plus the controller UsageCollectorRunnable) is the component involved, together with the sandbox reconciler's terminate paths and the console drawdown driver.
> - Three findings from the live metering audit (#656, #664, #665, consolidated as #682): sequential scrapes serialize N unreachable pods into N x scrapeTimeout, the tail between the last scrape and terminate is never billed (a ~100s sandbox recorded 60 vcpu-seconds; sub-minute jobs recorded nothing), and a healthy cycle logs nothing at default verbosity so a zero-collecting pipeline looked healthy.
> - Metering is now live in production and the #617 alerting work needs the signals; a partial pod outage today delays metering for the whole healthy fleet, and short-job workloads are materially under-recorded.
> - This pull request fans the husk scrape out over a bounded worker pool with a cycle-duration gauge, records a terminate-time final sample at claim release so the half-open tail window bills, and makes every successful cycle log a summary at default verbosity.
> - The benefit is that scrape latency is bounded by the slowest pool lane instead of the fleet size, short-lived sandboxes bill their real presence, and both the collection and settlement halves of the pipeline are observable and alertable.

## Linked Issues or Issue Description

Closes #682

## What Changed

- **Concurrent scrape (was #656)**: `HuskSource.Collect` now scrapes claimed husk pods through a bounded worker pool (`huskScrapeConcurrency = 8`). The single shared scrape timestamp per cycle, the skip-and-count semantics, and the lister's pod order are preserved (both pinned by tests). `Collector.CollectOnce` returns `CycleStats` (duration, samples, records, orgs), and the controller exports the cycle wall duration as a new `mitos_usage_collect_cycle_duration_seconds` gauge for #617 alerting.
- **Terminate-time final sample (was #664)**: the sandbox reconciler records a `usage.Termination` per claimed, org-labeled husk pod at claim release (`reconcileDelete`) and lifetime/idle terminate (`terminateLifetime`), through a new bounded, nil-safe, in-memory `usage.TerminationLog` shared with the collector. The husk source drains it each cycle and emits a final sample: a clone of the pod's last measured sample stamped at the release instant (so `Integrate` bills the `[last scrape, terminate]` tail; a ~100s sandbox now bills 100 vcpu-seconds), or, for a sandbox that terminated before its first scrape, a synthesized start/end pair over `[StartedAt, terminate]` carrying only the known vCPU allocation.
- **Cycle summary and settled cents (was #665)**: every successful collector cycle now logs `usage collection cycle` at default verbosity with samples, records, orgs, durationMs, and the cumulative node/husk skip counters (counts only, no identities, no secrets). The drawdown half of #665 (settled cents on the console drawdown line) already shipped with the #672 fix in PR #675: `runDrawdownOnce` logs `settledCents` and `carriedMilliCents` per cycle, with tests pinning that replays are never re-counted; no further change was needed there, and the pipeline doc now cross-references it.
- Docs: `docs/saas/usage-pipeline.md` gains the bounded fan-out, the cycle-duration gauge, the summary line, and a full section on terminate-time final samples and their accounting rules.

### Design decision: which fix shape for the tail window (and why)

The issue offered two shapes: a final sample at claim release, or half-open window accounting at claim release. I chose the final-sample shape, implemented as a controller-recorded release EVENT that the collector converts into an ordinary `Sample`, because it composes with the existing `Integrate` machinery instead of adding a second accounting path: the tail is billed by the same left-rectangle integration, the same `MaxHold` hold-then-gap bound applies, the `(sandbox, window)` idempotency is untouched, and cloned cumulative counters delta to zero so no egress is invented. It also keeps the terminate path boring: recording is an in-memory append, never an HTTP scrape, never blocking or failing a delete.

Customer-favorable accounting on every ambiguity, documented in code comments:

- a vm-id is finalized at most once (`finalized` guard), so a duplicate termination event (lifetime expiry followed by object delete, or a requeued delete) can only under-bill, never double-bill;
- a never-scraped sandbox bills only its known vCPU allocation; unmeasured memory/disk/egress stay zero;
- the synthesized pair's start is clamped to `terminate - MaxHold`, so a stale `StartedAt` (scrape history lost across a controller restart) can never rewrite long-settled windows;
- the event log is bounded (4096, oldest dropped) and in-memory: a controller restart or a node-loss drain loses tail samples, which under-bills those tails and nothing else.

## Verification

- [x] `go test ./internal/usage/ -count=1` and `go test -race ./internal/usage/ -count=1` (new tests: bounded-concurrency proof with peak in-flight tracking, skip-and-count preservation, CycleStats, cycle-duration gauge, final-sample-at-termination, the 100s-bills-100 headline case, never-scraped pair synthesis, clamp, double-record guard, unattributed drop, TerminationLog nil-safety and bound)
- [x] `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -count=1` (full envtest suite, including the new claim-release recording tests and the default-verbosity summary-line test)
- [x] `make test-unit` (fork, workspace, vsock)
- [x] `go test ./cmd/console/... ./cmd/controller/... -count=1`
- [x] `golangci-lint run --timeout=5m` and `GOOS=linux golangci-lint run --timeout=5m` (the darwin run flags a pre-existing `internal/fork/uffd.go` unused-func on an untouched file; the linux run is fully clean)
- [x] Every new test was written first and observed failing before the implementation (TDD, per commit)

## Risks

- The worker pool opens up to 8 concurrent connections into tenant pod networks per cycle instead of 1; the bound is deliberate and small, and per-request deadlines are unchanged.
- The final-sample path adds in-memory state to `HuskSource` (`last`, `finalized` maps); both are pruned on a 15-minute horizon and touched only from the single collector goroutine, and the whole path is inert unless `SetTerminations` is wired (self-host: never).
- Billing-behavior change: short-lived and just-terminated sandboxes now bill their real tail, which INCREASES recorded usage relative to before (correctly); every ambiguity resolves to under-billing, never double-billing, and idempotency on `(sandbox, window)` is untouched.
- The summary line adds one Info log per cycle (default 60s cadence) on deployments running `--usage-collector`; self-host with the collector off logs nothing new.
- No security-surface change: no new endpoints, no new trust inputs (termination events carry only control-plane data: pod name, controller-stamped labels, claim status), so no threat-model delta. Not a hot path (control-plane, once per minute), so no benchmark run.

## Model Used

Claude Fable 5 (Anthropic), model id claude-fable-5, via Claude Code subagent

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (not moved; see Risks)
- [ ] Benchmark run (bench/) included if the hot path was touched (not touched)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added termination-tail usage accounting to emit final usage samples when claimed husk pods are released or expire.
  * Introduced termination-aware billing drain for “final sample at terminate time” plus detailed per-cycle wall-duration reporting.

* **Bug Fixes**
  * Fixed terminate-time under-scraping by recording and draining termination events safely and at most once per VM.
  * Preserved correct skip counts while using bounded concurrent husk scraping.

* **Tests**
  * Added/updated coverage for termination logging, final/synthesized samples, cycle stats, and the new cycle-duration metric export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->