### PR TITLE
fix(usage): cycle-failure counter, reconciler-clock termination stamps, honest error-path stats

### DIFF
--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -158,15 +158,20 @@ CLAIMED husk pod's own in-pod `GET /v1/metering` through a BOUNDED worker pool
 (8 concurrent scrapes; issue #682): fleet size is per-VM, so a sequential scrape
 serialized N unreachable pods into N x the per-request timeout during a partial
 outage. With the pool the cycle duration is set by the slowest pool lane, not
-the fleet size. All samples in one cycle still share a single scrape timestamp,
-and unreachable pods are still skip-and-counted. Every completed cycle exports
-its wall duration as the `mitos_usage_collect_cycle_duration_seconds` gauge and
-logs a one-line summary at default verbosity (samples, records, orgs, duration,
-cumulative skip counters), so a healthy pipeline is visibly healthy, a
-zero-collecting one is visibly broken, and a slowing scrape path is alertable
-(issue #617). The console-side drawdown line reports `settledCents` and
-`carriedMilliCents` per cycle (issue #672), the money half of the same
-visibility gap.
+the fleet size. All live samples in one cycle still share a single scrape
+timestamp, and unreachable pods are still skip-and-counted. Every completed
+cycle exports its wall duration as the
+`mitos_usage_collect_cycle_duration_seconds` gauge and logs a one-line summary
+at default verbosity (samples, records, orgs, duration, cumulative skip
+counters). Zero samples with no claimed pods is a normal quiet fleet; the
+summary makes an UNEXPECTEDLY zero-collecting pipeline (zero samples while
+sandboxes are running) visible in one line, and the gauge makes a slowing
+scrape path alertable (issue #617). The duration gauge is set only on success,
+so failed cycles additionally increment the
+`mitos_usage_collect_cycle_failures_total` counter: alert on its rate for a
+collector that is erroring rather than slowing. The console-side drawdown line
+reports `settledCents` and `carriedMilliCents` per cycle (issue #672), the
+money half of the same visibility gap.
 
 **Terminate-time final sample** (issue #682, was #664): scraping once per
 window leaves the presence between the LAST scrape and terminate unrecorded (a

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -1240,8 +1240,9 @@ func (r *SandboxReconciler) reconcileDelete(ctx context.Context, claim *v1.Sandb
 	// claim already Terminated (lifetime expiry) recorded its event at the TRUE
 	// terminate instant and the hook skips it here: one claim, one event.
 	// Best-effort and idempotent downstream: a retried delete records again and
-	// the collector's finalized guard keeps a vm-id from ever billing twice.
-	r.recordHuskTerminations(claim, claimedHusk.Items, time.Now())
+	// the collector's finalized guard keeps a vm-id from ever billing twice. The
+	// instant comes from the reconciler clock (r.now()) so tests can freeze it.
+	r.recordHuskTerminations(claim, claimedHusk.Items, r.now())
 	for i := range claimedHusk.Items {
 		if err := r.Delete(ctx, &claimedHusk.Items[i], client.GracePeriodSeconds(0)); err != nil && !apierrors.IsNotFound(err) {
 			logger.Error(err, "delete claimed husk pod on release", "pod", claimedHusk.Items[i].Name)

--- a/internal/controller/usage_collector.go
+++ b/internal/controller/usage_collector.go
@@ -135,6 +135,10 @@ func (u *UsageCollectorRunnable) Start(ctx context.Context) error {
 func (u *UsageCollectorRunnable) cycle(ctx context.Context, logger logr.Logger, collector *usage.Collector, nodeSource *usage.NodeRegistrySource, huskSource *usage.HuskSource) {
 	stats, err := collector.CollectOnce(ctx)
 	if err != nil {
+		// Count the failure BEFORE logging: the duration gauge is set only on
+		// success, so under a sustained failure it freezes at the last healthy
+		// value; this counter is what lets #617 alert from metrics alone.
+		usageMetrics.ObserveCycleFailure()
 		// The cycle error carries only ids/window text from the store path, never a
 		// secret; still log it sparingly.
 		logger.Error(err, "usage collection cycle failed",

--- a/internal/controller/usage_collector_test.go
+++ b/internal/controller/usage_collector_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"mitos.run/mitos/internal/usage"
 )
@@ -63,4 +64,52 @@ func TestUsageCycleLogsSummaryAtDefaultVerbosity(t *testing.T) {
 		}
 	}
 	t.Fatalf("no healthy-cycle summary at default verbosity; got lines: %v", lines)
+}
+
+// cycleFailuresTotal reads the current mitos_usage_collect_cycle_failures_total
+// value from the controller-runtime metrics registry (0 if the family has not
+// been emitted yet).
+func cycleFailuresTotal(t *testing.T) float64 {
+	t.Helper()
+	mfs, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == "mitos_usage_collect_cycle_failures_total" {
+			return mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+// TestUsageCycleFailureIncrementsFailureMetric asserts a FAILED collection
+// cycle increments mitos_usage_collect_cycle_failures_total. The duration
+// gauge is only set on success, so under a sustained failure it freezes at the
+// last healthy value; the failure counter is what lets #617 alert on a failing
+// collector from metrics alone.
+func TestUsageCycleFailureIncrementsFailureMetric(t *testing.T) {
+	logger := funcr.New(func(_, _ string) {}, funcr.Options{})
+
+	// A fake client whose scheme lacks corev1 makes the husk pod List fail,
+	// which fails the whole cycle loudly (the issue #613 contract).
+	cl := fakeclient.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	nodeSource := usage.NewNodeRegistrySource(
+		RegistryNodeLister{Registry: NewNodeRegistry()},
+		usage.StaticOrgs{}, nil, nil, "", nil,
+	)
+	huskSource := usage.NewHuskSource(&HuskPodScrapeLister{Client: cl}, nil, nil, "", nil)
+	collector := usage.NewCollector(
+		usage.NewMultiSource(nodeSource, huskSource),
+		usage.NewMemUsageStore(),
+		usage.DefaultConfig(),
+	)
+
+	before := cycleFailuresTotal(t)
+	u := &UsageCollectorRunnable{}
+	u.cycle(context.Background(), logger, collector, nodeSource, huskSource)
+
+	if got := cycleFailuresTotal(t); got != before+1 {
+		t.Fatalf("mitos_usage_collect_cycle_failures_total = %v after a failed cycle, want %v", got, before+1)
+	}
 }

--- a/internal/controller/usage_termination.go
+++ b/internal/controller/usage_termination.go
@@ -70,18 +70,21 @@ func (r *SandboxReconciler) recordHuskTerminations(claim *v1.Sandbox, pods []cor
 
 // recordClaimHuskTerminations lists the claim's claimed husk pods (by the
 // mitos.run/claim label the controller stamped) and records a termination for
-// each org-labeled one, stamped now. It is the hook for terminate paths that
+// each org-labeled one, stamped with the reconciler's clock (r.now(), so tests
+// can freeze the release instant). It is the hook for terminate paths that
 // have not already listed the pods (lifetime/idle expiry). A list failure is
 // logged at V(1) and skipped: best-effort, the terminate must proceed and the
-// cost is one under-billed tail.
+// cost is one under-billed tail. The logged error is apiserver text: it
+// carries no secret values.
 func (r *SandboxReconciler) recordClaimHuskTerminations(ctx context.Context, claim *v1.Sandbox) {
 	if r.UsageTerminations == nil {
 		return
 	}
 	var pods corev1.PodList
 	if err := r.List(ctx, &pods, client.InNamespace(claim.Namespace), client.MatchingLabels{huskClaimLabel: claim.Name}); err != nil {
-		log.FromContext(ctx).V(1).Info("list husk pods for usage termination; tail window not recorded", "claim", claim.Name)
+		log.FromContext(ctx).V(1).Info("list husk pods for usage termination; tail window not recorded",
+			"claim", claim.Name, "err", err.Error())
 		return
 	}
-	r.recordHuskTerminations(claim, pods.Items, time.Now())
+	r.recordHuskTerminations(claim, pods.Items, r.now())
 }

--- a/internal/controller/usage_termination_test.go
+++ b/internal/controller/usage_termination_test.go
@@ -66,7 +66,12 @@ func TestRecordClaimHuskTerminations(t *testing.T) {
 	}
 
 	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(billable, unattributed, other).Build()
-	r := &SandboxReconciler{Client: cl, UsageTerminations: usage.NewTerminationLog()}
+	frozen := time.Date(2026, 7, 4, 10, 1, 40, 0, time.UTC)
+	r := &SandboxReconciler{
+		Client:            cl,
+		UsageTerminations: usage.NewTerminationLog(),
+		Now:               func() time.Time { return frozen },
+	}
 
 	r.recordClaimHuskTerminations(context.Background(), claim)
 
@@ -87,8 +92,8 @@ func TestRecordClaimHuskTerminations(t *testing.T) {
 	if !got.StartedAt.Equal(started.Time) {
 		t.Errorf("StartedAt = %v, want the claim's %v", got.StartedAt, started.Time)
 	}
-	if got.At.IsZero() {
-		t.Error("At is zero, want the release instant")
+	if !got.At.Equal(frozen) {
+		t.Errorf("At = %v, want the reconciler clock's release instant %v (the r.now() seam, so tests can freeze it)", got.At, frozen)
 	}
 }
 

--- a/internal/usage/collector.go
+++ b/internal/usage/collector.go
@@ -189,10 +189,11 @@ type CycleStats struct {
 	// Samples is how many samples this cycle's scrape returned (before
 	// buffering), the liveness signal for the scrape path.
 	Samples int
-	// Records is how many per-(sandbox, window) records the cycle recomputed and
-	// upserted from the rolling buffer.
+	// Records is how many per-(sandbox, window) records were ACTUALLY upserted
+	// this cycle: on success every recomputed record, on an upsert failure only
+	// the records that landed before it.
 	Records int
-	// Orgs is how many distinct org ids those records span.
+	// Orgs is how many distinct org ids those upserted records span.
 	Orgs int
 }
 
@@ -201,32 +202,32 @@ type CycleStats struct {
 // the idempotency tests drive directly. It appends the scrape to the rolling
 // buffer, prunes samples past the retention horizon, and integrates the buffer
 // so the rate units accumulate across cycles while staying idempotent on
-// (sandbox, window). On error the returned stats cover only the work done up to
-// the failure.
+// (sandbox, window). On error the returned stats cover exactly the work DONE
+// before the failure (Duration is always the real wall time of the attempt;
+// Records and Orgs count only what was upserted).
 func (c *Collector) CollectOnce(ctx context.Context) (CycleStats, error) {
 	start := time.Now()
 	var stats CycleStats
 	samples, err := c.src.Collect(ctx)
 	if err != nil {
+		stats.Duration = time.Since(start)
 		return stats, fmt.Errorf("collect samples: %w", err)
 	}
 	stats.Samples = len(samples)
 	c.buf = append(c.buf, samples...)
 	c.pruneBuffer()
 	recs := Integrate(c.buf, c.cfg)
-	stats.Records = len(recs)
-	// One pass over the records: count distinct orgs for the cycle summary and
-	// upsert as we go. On an upsert error the org count covers the records
-	// walked so far, consistent with "stats cover the work done up to the
-	// failure".
+	// One pass over the records: upsert, then count the record and its org, so
+	// on an upsert error the stats hold only the work that actually landed.
 	orgs := map[string]bool{}
 	for _, r := range recs {
-		orgs[r.OrgID] = true
 		if err := c.store.UpsertRecord(ctx, r); err != nil {
 			stats.Orgs = len(orgs)
 			stats.Duration = time.Since(start)
 			return stats, fmt.Errorf("upsert usage record (sandbox %s window %s): %w", r.SandboxID, r.Window, err)
 		}
+		stats.Records++
+		orgs[r.OrgID] = true
 	}
 	stats.Orgs = len(orgs)
 	if c.OnTotals != nil {

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -240,6 +241,74 @@ func TestCollectOnceReturnsCycleStats(t *testing.T) {
 	}
 	if stats.Duration <= 0 {
 		t.Errorf("Duration = %v, want a positive wall duration", stats.Duration)
+	}
+}
+
+// failAtStore wraps a UsageStore and fails the Nth UpsertRecord call, so the
+// error-path stats contract can be pinned.
+type failAtStore struct {
+	inner  UsageStore
+	failAt int
+	calls  int
+}
+
+func (s *failAtStore) UpsertRecord(ctx context.Context, rec UsageRecord) error {
+	s.calls++
+	if s.calls == s.failAt {
+		return fmt.Errorf("store unavailable")
+	}
+	return s.inner.UpsertRecord(ctx, rec)
+}
+
+func (s *failAtStore) ListRecords(ctx context.Context, orgID string, from, to time.Time) ([]UsageRecord, error) {
+	return s.inner.ListRecords(ctx, orgID, from, to)
+}
+
+// TestCollectOnceErrorPathStats pins the documented contract that on error the
+// returned CycleStats cover exactly the work DONE before the failure: a failed
+// scrape still reports a wall duration, and a mid-cycle upsert failure reports
+// only the records and orgs actually upserted, never the full intended count.
+func TestCollectOnceErrorPathStats(t *testing.T) {
+	ctx := context.Background()
+
+	// Scrape failure: no samples, no records, but the duration is still real.
+	c := NewCollector(staticSampleSource{err: fmt.Errorf("source down")}, NewMemUsageStore(), DefaultConfig())
+	stats, err := c.CollectOnce(ctx)
+	if err == nil {
+		t.Fatal("want a collect error")
+	}
+	if stats.Duration <= 0 {
+		t.Errorf("Duration = %v on a scrape failure, want a positive wall duration", stats.Duration)
+	}
+	if stats.Samples != 0 || stats.Records != 0 || stats.Orgs != 0 {
+		t.Errorf("stats = %+v on a scrape failure, want zero work counts", stats)
+	}
+
+	// Upsert failure on the second of two records: exactly one record (and its
+	// org) was actually upserted.
+	samples := []Sample{
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 0), VCPUs: 1},
+		{OrgID: "orgA", SandboxID: "sbx1", Timestamp: at(baseTime, 30), VCPUs: 1},
+		{OrgID: "orgB", SandboxID: "sbx2", Timestamp: at(baseTime, 0), VCPUs: 1},
+		{OrgID: "orgB", SandboxID: "sbx2", Timestamp: at(baseTime, 30), VCPUs: 1},
+	}
+	store := &failAtStore{inner: NewMemUsageStore(), failAt: 2}
+	c = NewCollector(staticSampleSource{samples: samples}, store, DefaultConfig())
+	stats, err = c.CollectOnce(ctx)
+	if err == nil {
+		t.Fatal("want an upsert error")
+	}
+	if stats.Samples != 4 {
+		t.Errorf("Samples = %d, want 4 (the scrape succeeded)", stats.Samples)
+	}
+	if stats.Records != 1 {
+		t.Errorf("Records = %d, want 1 (only the record upserted BEFORE the failure)", stats.Records)
+	}
+	if stats.Orgs != 1 {
+		t.Errorf("Orgs = %d, want 1 (only the org whose record actually landed)", stats.Orgs)
+	}
+	if stats.Duration <= 0 {
+		t.Errorf("Duration = %v on an upsert failure, want a positive wall duration", stats.Duration)
 	}
 }
 

--- a/internal/usage/usagemetrics.go
+++ b/internal/usage/usagemetrics.go
@@ -33,6 +33,11 @@ type Metrics struct {
 	// signal for #617 is "the cycle is slowing down", which a last-value gauge
 	// answers directly at the 1-per-cadence sample rate.
 	cycleSeconds prometheus.Gauge
+	// cycleFailures counts FAILED collection cycles. The duration gauge is set
+	// only on success, so under a sustained failure it freezes at the last
+	// healthy value and looks fine; this counter is the metrics-only signal
+	// that lets #617 alert on a failing collector (a nonzero rate).
+	cycleFailures prometheus.Counter
 }
 
 // NewMetrics builds the per-org usage metric vectors. They are unregistered; the
@@ -68,6 +73,10 @@ func NewMetrics() *Metrics {
 			Name: "mitos_usage_gpu_seconds_total",
 			Help: "Cumulative GPU-seconds of billable sandbox usage by org, summed over every settled usage record. Monotonic within a controller process; reset only by a restart, where the durable store is the system of record.",
 		}, []string{"org"}),
+		cycleFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "mitos_usage_collect_cycle_failures_total",
+			Help: "Total failed usage collection cycles (scrape, integrate, or upsert error). The cycle-duration gauge is set only on success, so alert on this counter's rate for a failing collector.",
+		}),
 		cycleSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "mitos_usage_collect_cycle_duration_seconds",
 			Help: "Wall duration of the most recent usage collection cycle (scrape, integrate, upsert) in seconds. The husk scrape fans out over a bounded worker pool, so this is set by the slowest pool lane, not the fleet size; a sustained rise means unreachable pods or fleet growth.",
@@ -79,7 +88,7 @@ func NewMetrics() *Metrics {
 // metrics registry). It panics on a duplicate registration, the standard
 // fail-fast for a misconfigured wiring.
 func (m *Metrics) MustRegister(reg prometheus.Registerer) {
-	reg.MustRegister(m.vcpuSeconds, m.memGiBSecs, m.egressBytes, m.gpuSeconds, m.cycleSeconds)
+	reg.MustRegister(m.vcpuSeconds, m.memGiBSecs, m.egressBytes, m.gpuSeconds, m.cycleSeconds, m.cycleFailures)
 }
 
 // ObserveCycle records one completed collection cycle's stats: today only the
@@ -87,6 +96,13 @@ func (m *Metrics) MustRegister(reg prometheus.Registerer) {
 // The stats carry counts and a duration only, never an id or a secret.
 func (m *Metrics) ObserveCycle(stats CycleStats) {
 	m.cycleSeconds.Set(stats.Duration.Seconds())
+}
+
+// ObserveCycleFailure counts one failed collection cycle. It carries no cause,
+// identity, or secret: the paired error log has the (sanitized) detail; the
+// counter exists so metrics alone can drive the #617 alert.
+func (m *Metrics) ObserveCycleFailure() {
+	m.cycleFailures.Inc()
 }
 
 // Observe sets the per-org gauges from the store's CUMULATIVE per-org Totals. It

--- a/internal/usage/usagemetrics_test.go
+++ b/internal/usage/usagemetrics_test.go
@@ -254,6 +254,40 @@ func TestObserveCycleExportsCycleDuration(t *testing.T) {
 	}
 }
 
+// TestObserveCycleFailureIncrementsCounter asserts the cycle-failure counter
+// (issue #682 review follow-up) is exported and counts every failed cycle. The
+// duration gauge is set only on success, so under a sustained failure it
+// freezes at the last healthy value; this counter is the metrics-only signal
+// #617 alerting needs for a failing collector.
+func TestObserveCycleFailureIncrementsCounter(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMetrics()
+	m.MustRegister(reg)
+
+	read := func() float64 {
+		t.Helper()
+		mfs, err := reg.Gather()
+		if err != nil {
+			t.Fatalf("gather: %v", err)
+		}
+		for _, mf := range mfs {
+			if mf.GetName() == "mitos_usage_collect_cycle_failures_total" {
+				return mf.GetMetric()[0].GetCounter().GetValue()
+			}
+		}
+		return 0
+	}
+
+	m.ObserveCycleFailure()
+	if got := read(); got != 1 {
+		t.Fatalf("cycle failures after one failure = %v, want 1", got)
+	}
+	m.ObserveCycleFailure()
+	if got := read(); got != 2 {
+		t.Fatalf("cycle failures after two failures = %v, want 2", got)
+	}
+}
+
 // gaugeValue reads the value of mitos_usage_vcpu_seconds_total for the given org
 // from the registry, and whether a series for that org is present.
 func gaugeValue(t *testing.T, reg *prometheus.Registry, org string) (float64, bool) {


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the hosted SaaS bills tenants from the usage metering pipeline (controller usage collector -> usage records -> console drawdown).
> - PR #687 hardened the husk usage collector (bounded scrape pool, terminate-time final sample, cycle summary) for issue #682.
> - Five review threads on #687 landed after it merged: a metrics blind spot (the duration gauge freezes under sustained failure), raw time.Now() termination stamps that tests cannot freeze, error-path CycleStats that did not match their documented contract, a dropped List error in a best-effort log, and a doc line that called every zero-sample cycle broken.
> - The metrics gap matters now because the #617 alerting work consumes exactly these series, and the stats/clock issues erode the test seams the rest of the reconciler relies on.
> - This pull request adds a cycle-failure counter, stamps terminations from the reconciler's injectable clock, makes error-path stats cover only work actually done, logs the List error text, and qualifies the doc claim.
> - The benefit is that a failing collector is alertable from metrics alone, the termination instant is testable, and the CycleStats contract is honest on every return path.

## Linked Issues or Issue Description

Closes out the five CodeRabbit review threads from PR #687, which squash-merged (b7da3fa3) before these fixes could land on its branch.

Refs #682 (closed by #687; this PR is its review follow-up)
Refs #617 (the failure counter and duration gauge are the series the alerting work consumes)

## What Changed

- **Cycle-failure counter**: `mitos_usage_collect_cycle_failures_total` (new `Metrics.ObserveCycleFailure`), incremented on the collector cycle's error branch. The duration gauge is set only on success, so under a sustained failure it froze at the last healthy value; the counter is the metrics-only signal #617 can alert on. Tests: counter unit test in `internal/usage`, plus a controller test driving a failing cycle and asserting the registered counter increments.
- **Reconciler clock for termination stamps**: both the delete path and `recordClaimHuskTerminations` stamp the release instant from the existing `r.now()` seam instead of raw `time.Now()`, so tests can freeze it. The existing hook test now injects a frozen clock and asserts the exact instant.
- **Honest error-path CycleStats**: `CollectOnce` sets `Duration` on every return path (the scrape-error path previously returned zero) and counts `Records`/`Orgs` as records ACTUALLY upserted before a failure, never the full intended count; field docs updated to state exactly that. New `TestCollectOnceErrorPathStats` pins both halves with a fail-on-Nth-upsert store.
- **List error in the log**: the best-effort List failure in `recordClaimHuskTerminations` now carries `err` (apiserver text, no secret values) instead of a canned message alone.
- **Doc qualification**: `docs/saas/usage-pipeline.md` no longer implies every zero-collecting cycle is broken; zero samples with no claimed pods is a normal quiet fleet, and the summary line targets the UNEXPECTEDLY zero case (zero samples while sandboxes run). The failure counter is documented next to the duration gauge.

Note on provenance: these fixes were prepared for the #687 branch, but #687 squash-merged while they were in flight, so they land as this follow-up (single cherry-picked commit on top of main).

## Verification

- [x] `go test ./internal/usage/ -race -count=1`
- [x] `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/ -count=1` (full envtest suite green on the pre-cherry-pick tree; the new-test subset re-run green after the cherry-pick onto main)
- [x] `golangci-lint run --timeout=5m` and `GOOS=linux golangci-lint run --timeout=5m` (clean for the diff; darwin still shows only the pre-existing untouched `internal/fork/uffd.go` finding)
- [x] TDD with discrimination proof: the counter increment and the clock seam were toggled off and the new tests observed failing (counter stayed 0; `At` carried the wall clock instead of the frozen instant); the stats test failed to compile or asserted the old full-count behavior before the fix
- [x] No em or en dashes in the diff (codepoint grep)

## Risks

- Low risk: one new no-label counter, log-field additions, and stats accounting on error paths only; the success-path CycleStats values are unchanged (existing tests untouched and green).
- The error-path `Records`/`Orgs` semantics change is observational only (log line and metrics); no billing math is touched.
- No security-surface change; no threat-model delta; not a hot path, no benchmark run.

## Model Used

Claude Fable 5 (Anthropic), model id claude-fable-5, via Claude Code subagent

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (not moved)
- [ ] Benchmark run (bench/) included if the hot path was touched (not touched)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
