### PR TITLE
test(sandboxrpc): guest-nil bidi tests follow the connect-go raced-Send contract, fixing the RunCode flake

### DIFF
--- a/internal/sandboxrpc/portforward_test.go
+++ b/internal/sandboxrpc/portforward_test.go
@@ -186,7 +186,12 @@ func TestPortForwardGuestNilReturnsFollowup(t *testing.T) {
 	}); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("send open: %v", err)
 	}
-	_ = stream.CloseRequest()
+	// Same narrow tolerance as the Send above and the RunCode sibling test: a
+	// CloseRequest racing the termination may wrap io.EOF; anything else is a
+	// genuine failure this test must not mask.
+	if err := stream.CloseRequest(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("close request: %v", err)
+	}
 	_, err := stream.Receive()
 	if err == nil {
 		t.Fatal("expected error from nil Guest, got nil")

--- a/internal/sandboxrpc/portforward_test.go
+++ b/internal/sandboxrpc/portforward_test.go
@@ -177,9 +177,13 @@ func TestPortForwardGuestNilReturnsFollowup(t *testing.T) {
 
 	ctx := context.Background()
 	stream := client.PortForward(ctx)
+	// The guest-nil handler terminates the RPC without ever reading the request
+	// stream, so this open write races the termination. Per the connect-go
+	// contract, a Send that loses that race returns an error wrapping io.EOF
+	// and the real server error is surfaced by Receive below (issue #695).
 	if err := stream.Send(&sandboxv1.Frame{
 		Msg: &sandboxv1.Frame_Open{Open: &sandboxv1.PortForwardOpen{Port: 3000}},
-	}); err != nil {
+	}); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("send open: %v", err)
 	}
 	_ = stream.CloseRequest()

--- a/internal/sandboxrpc/runcode_test.go
+++ b/internal/sandboxrpc/runcode_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -218,12 +219,16 @@ func TestRunCodeGuestNilReturnsFollowup(t *testing.T) {
 	ctx := context.Background()
 
 	stream := client.RunCode(ctx)
+	// The guest-nil handler terminates the RPC without ever reading the request
+	// stream, so this open write races the termination. Per the connect-go
+	// contract, a Send that loses that race returns an error wrapping io.EOF
+	// and the real server error is surfaced by Receive below (issue #695).
 	if err := stream.Send(&sandboxv1.RunCodeRequest{
 		Msg: &sandboxv1.RunCodeRequest_Open{Open: &sandboxv1.RunCodeOpen{Code: "1+1"}},
-	}); err != nil {
+	}); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("send open: %v", err)
 	}
-	if err := stream.CloseRequest(); err != nil {
+	if err := stream.CloseRequest(); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("close request: %v", err)
 	}
 
@@ -238,6 +243,45 @@ func TestRunCodeGuestNilReturnsFollowup(t *testing.T) {
 	}
 	if connErr.Code() != connect.CodeUnimplemented {
 		t.Fatalf("code = %v, want CodeUnimplemented", connErr.Code())
+	}
+}
+
+// TestRunCodeGuestNilRacedSendStillSurfacesFollowup pins the issue #695 race
+// deterministically. The guest-nil handler terminates the RPC without reading
+// the request stream, so a client write can land after the termination and
+// fail with an error wrapping io.EOF ("write envelope: EOF"). The first Send
+// fires the HTTP request; the sleep lets the handler terminate the RPC; the
+// second Send then deterministically hits the closed stream, reproducing the
+// window that the first Send only hits under CI load. The connect-go contract
+// requires that such a raced Send wraps io.EOF and that Receive still surfaces
+// the real followup error, which is exactly what this test asserts.
+func TestRunCodeGuestNilRacedSendStillSurfacesFollowup(t *testing.T) {
+	svc := &Service{}
+	client, _ := newTestServer(t, svc)
+
+	stream := client.RunCode(context.Background())
+	if err := stream.Send(&sandboxv1.RunCodeRequest{
+		Msg: &sandboxv1.RunCodeRequest_Open{Open: &sandboxv1.RunCodeOpen{Code: "1+1"}},
+	}); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("send open: %v", err)
+	}
+	// Give the handler time to return the followup error and terminate the RPC.
+	time.Sleep(100 * time.Millisecond)
+	if err := stream.Send(&sandboxv1.RunCodeRequest{
+		Msg: &sandboxv1.RunCodeRequest_Stdin{Stdin: []byte("x")},
+	}); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("raced send must wrap io.EOF per the connect-go contract, got: %v", err)
+	}
+	if err := stream.CloseRequest(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("close request: %v", err)
+	}
+
+	_, err := stream.Receive()
+	if err == nil {
+		t.Fatal("expected error from nil Guest, got nil")
+	}
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Fatalf("code = %v, want CodeUnimplemented", connect.CodeOf(err))
 	}
 }
 

--- a/internal/sandboxrpc/runcode_test.go
+++ b/internal/sandboxrpc/runcode_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"testing"
-	"time"
 
 	"connectrpc.com/connect"
 
@@ -265,23 +264,32 @@ func TestRunCodeGuestNilRacedSendStillSurfacesFollowup(t *testing.T) {
 	}); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("send open: %v", err)
 	}
-	// Give the handler time to return the followup error and terminate the RPC.
-	time.Sleep(100 * time.Millisecond)
-	if err := stream.Send(&sandboxv1.RunCodeRequest{
-		Msg: &sandboxv1.RunCodeRequest_Stdin{Stdin: []byte("x")},
-	}); err != nil && !errors.Is(err, io.EOF) {
-		t.Fatalf("raced send must wrap io.EOF per the connect-go contract, got: %v", err)
-	}
-	if err := stream.CloseRequest(); err != nil && !errors.Is(err, io.EOF) {
-		t.Fatalf("close request: %v", err)
-	}
 
+	// Surface the followup FIRST: once Receive has returned the server error,
+	// the RPC is deterministically terminated client-side, no sleep needed.
 	_, err := stream.Receive()
 	if err == nil {
 		t.Fatal("expected error from nil Guest, got nil")
 	}
 	if connect.CodeOf(err) != connect.CodeUnimplemented {
 		t.Fatalf("code = %v, want CodeUnimplemented", connect.CodeOf(err))
+	}
+
+	// A Send against the terminated stream is exactly what a raced open write
+	// experiences (issue #695). It MUST fail, and per the connect-go contract
+	// the failure wraps io.EOF; a nil error here would mean the regression pin
+	// is not exercising the race at all.
+	sendErr := stream.Send(&sandboxv1.RunCodeRequest{
+		Msg: &sandboxv1.RunCodeRequest_Stdin{Stdin: []byte("x")},
+	})
+	if sendErr == nil {
+		t.Fatal("send after termination unexpectedly succeeded; the pin does not exercise the issue #695 race")
+	}
+	if !errors.Is(sendErr, io.EOF) {
+		t.Fatalf("raced send must wrap io.EOF per the connect-go contract, got: %v", sendErr)
+	}
+	if err := stream.CloseRequest(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("close request: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; internal/sandboxrpc is the Connect runtime service in front of the guest.
> - The go-test job on the v1.20.0 release PR (#694), a changelog-only diff, reddened on TestRunCodeGuestNilReturnsFollowup with "send open: unknown: write envelope: EOF" in 0.00s; any PR's required go-test can flake the same way.
> - Root cause: the guest-nil RunCode handler returns the honest followup error without ever reading the request stream, so the server can terminate the RPC while the client's first Send is still writing the open envelope.
> - connect-go documents exactly this case (client_stream.go, BidiStreamForClient.Send): "If the server returns an error, Send returns an error that wraps io.EOF. Clients should check for EOF using errors.Is and call Receive to retrieve the error." The test violated that contract by t.Fatal'ing on any Send error.
> - This is not a server-readiness gap to synchronize away: the handler is ready and terminates instantly by design, and the raced write is inherent protocol behavior, so the correct fix is to make the test follow the documented client contract, not to add sleeps or retries.
> - This pull request makes the two guest-nil bidi tests (RunCode, PortForward) tolerate an io.EOF-wrapped Send/CloseRequest error and assert the CodeUnimplemented followup from Receive, and adds a regression test that reproduces the raced write deterministically.
> - The benefit is a green required go-test that no longer flakes on scheduler timing, with the protocol contract pinned by a deterministic test instead of luck.

## Linked Issues or Issue Description

Closes #695

## What Changed

- `internal/sandboxrpc/runcode_test.go`: TestRunCodeGuestNilReturnsFollowup now treats a Send or CloseRequest error that wraps io.EOF as the documented raced-termination outcome and asserts the real CodeUnimplemented followup via Receive.
- `internal/sandboxrpc/runcode_test.go`: new TestRunCodeGuestNilRacedSendStillSurfacesFollowup reproduces the race deterministically: the first Send fires the HTTP request, a sleep lets the zero-read handler terminate the RPC, and the second Send then hits exactly "unknown: write envelope: EOF" (verified errors.Is(err, io.EOF) is true); Receive must still surface the followup error.
- `internal/sandboxrpc/portforward_test.go`: TestPortForwardGuestNilReturnsFollowup had the identical latent flake (same fatal-on-Send pattern against a handler that never reads); fixed the same way.

Production is unaffected and intentionally unchanged: the handler returning before reading is documented Connect/gRPC protocol behavior, any conforming client retrieves the real error via Receive, and the only production bidi RunCode Send site (internal/daemon/vsock_guestconn.go, daemon to guest agent) targets a server that reads the open before erroring.

## Verification

- [x] Root cause proven, not guessed: a temporary repro that writes an envelope after the guest-nil termination fails deterministically with the exact CI string ("send second: unknown: write envelope: EOF", 3/3 runs); the same mechanism hits the first Send only under CI load, which is why the flake was rare and 0.00s.
- [x] Before the fix, plain `go test -race -count=500` on the two tests did not reproduce locally (the window needs load); the deterministic repro above stands in as the failing test, and its fixed form is committed as TestRunCodeGuestNilRacedSendStillSurfacesFollowup.
- [x] `go test -race -count=500 -failfast -run 'TestRunCodeGuestNilReturnsFollowup|TestPortForwardGuestNilReturnsFollowup|TestRunCodeGuestNilRacedSendStillSurfacesFollowup' ./internal/sandboxrpc/` passes (61s).
- [x] `go test -race ./internal/sandboxrpc/` passes.
- [x] `golangci-lint run --timeout=5m` and `GOOS=linux golangci-lint run --timeout=5m`: no findings introduced; the darwin run's single finding (internal/fork/uffd.go unused func) is pre-existing on the base commit and darwin-only; the linux run is clean.

## Risks

- Low risk: test-only change. The io.EOF tolerance is scoped to the guest-nil tests whose handler never reads the request stream; the data-path tests (drainRunCode and friends) keep strict Send/CloseRequest assertions because their handlers read the open first, so no real transport failure is masked.

## Model Used

- Claude Fable 5 (claude-fable-5), via Claude Code subagent.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (none needed: test-only, no user-facing surface)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (it did not)
- [x] Benchmark run (bench/) included if the hot path was touched (it was not)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sandboxed code or port-forward sessions terminate before a request is fully read.
  * Follow-up errors are now surfaced more consistently, even when stream send and session shutdown race.
  * Added/updated automated coverage for nil-guest edge cases involving early RPC termination to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->