### PR TITLE
fix(controller): lifetime terminate actually stops the husk VM

### DIFF
--- a/docs/failure-gc.md
+++ b/docs/failure-gc.md
@@ -52,11 +52,23 @@ A Ready claim with `spec.timeout` set reaches the terminal `Terminated` phase
 once `StartedAt + timeout` passes. The reaper terminates the VM, stamps
 `FinishedAt`, and sets a `Terminated` condition with reason `MaxLifetimeExceeded`
 (`terminateLifetime(..., "MaxLifetimeExceeded", ...)`,
-`sandboxclaim_controller.go:1183`). maxLifetime does not depend on a reachable
+`sandboxclaim_controller.go`). maxLifetime does not depend on a reachable
 forkd for the decision.
 
-- Bound: terminal within a reconcile after the deadline.
-- Proving test: `TestClaimMaxLifetimeReaped`.
+In HUSK mode the backing VM lives in the claim's husk pod, which forkd never
+tracks, so the raw-mode `terminateOnNode` reap is a no-op for it. The lifetime
+reaper therefore DELETES the claimed husk pod right after the terminal phase is
+stamped, exactly as object deletion does: the VM stops, the warm slot refills
+via the pool reconcile, and the usage scrape lister drops the pod so billing
+ends at the terminate instant (issue #688). `Terminated` always means the VM
+stopped. If the pod delete fails or the controller crashes between the stamp
+and the delete, the reconcile of the Terminated claim retries the reap until
+the pod is gone; the reap after the stamp records no second usage event.
+
+- Bound: terminal within a reconcile after the deadline; the husk pod delete is
+  in the same reconcile, retried on the Terminated claim until it lands.
+- Proving tests: `TestClaimMaxLifetimeReaped`,
+  `TestHuskClaimLifetimeTerminateDeletesPod`.
 
 ### idleTimeout: an inactive Ready claim is reaped
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -129,6 +129,12 @@ and the Daytona interaction-only idle timer (background jobs killed mid-run).
 When a sandbox crosses its bound it is TERMINATED, not paused: the backing VM is
 reaped and the claim reaches the terminal `Terminated` phase with a condition
 carrying the reason (`MaxLifetimeExceeded`, `IdleTimeout`, or `TimeoutExpired`).
+`Terminated` means the VM actually stopped, in both run modes: raw-forkd mode
+terminates the VM on its node, and husk mode deletes the claimed husk pod (the
+VM lives inside it), which releases the memory, refills the warm-pool slot, and
+ends usage metering at the terminate instant. The sandbox object itself is NOT
+deleted on expiry; it stays readable in the terminal phase until its owner
+deletes it.
 A subsequent call against a reaped sandbox returns the typed `idle_timeout` error
 (`docs/api/errors.md`), whose remediation points at creating a fresh sandbox or
 calling `set_timeout` earlier to keep it alive. Pause is the explicit way to hold

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -199,6 +199,15 @@ in-memory and best-effort: a controller restart or a node-loss drain loses the
 tail sample, which under-bills that tail and nothing else; recording never
 blocks or fails a terminate.
 
+The terminate instant is also the **billing boundary** (issue #688): every
+terminate path, including lifetime and idle expiry, DELETES the claim's husk
+pod right after recording the event and stamping the terminal phase, so the
+scrape lister (which selects claimed, org-labeled, Running pods, never claim
+phase) stops returning the sandbox on the next cycle. A Terminated sandbox
+therefore never accrues live samples past its recorded terminate event; the
+tail between the last scrape and that instant is carried by the single
+termination event above, and nothing after it is billed.
+
 The **org tag** comes from the sandbox -> owning-org mapping, and it is a billing
 trust boundary: the org is derived solely from control-plane identity, never from
 client input. There are two attribution paths:

--- a/docs/saas/usage-pipeline.md
+++ b/docs/saas/usage-pipeline.md
@@ -199,11 +199,13 @@ in-memory and best-effort: a controller restart or a node-loss drain loses the
 tail sample, which under-bills that tail and nothing else; recording never
 blocks or fails a terminate.
 
-The terminate instant is also the **billing boundary** (issue #688): every
-terminate path, including lifetime and idle expiry, DELETES the claim's husk
-pod right after recording the event and stamping the terminal phase, so the
-scrape lister (which selects claimed, org-labeled, Running pods, never claim
-phase) stops returning the sandbox on the next cycle. A Terminated sandbox
+The terminate instant is also the **billing boundary** (issue #688): for a
+husk-backed sandbox, every terminate path, including lifetime and idle expiry,
+DELETES the claim's husk pod right after recording the event and stamping the
+terminal phase, so the scrape lister (which selects claimed, org-labeled,
+Running pods, never claim phase) stops returning the sandbox on the next
+cycle. A raw-forkd claim has no husk pod; its VM is reaped via terminateOnNode
+and was never scraped by the husk lister. A Terminated sandbox
 therefore never accrues live samples past its recorded terminate event; the
 tail between the last scrape and that instant is carried by the single
 termination event above, and nothing after it is billed.

--- a/internal/controller/husk_lifetime_reap_test.go
+++ b/internal/controller/husk_lifetime_reap_test.go
@@ -1,0 +1,122 @@
+package controller_test
+
+// Envtest coverage for issue #688: a husk-backed claim that hits its lifetime
+// bound must actually STOP the in-pod VM. terminateOnNode is a no-op for husk
+// pods (forkd never tracks them), so terminateLifetime must delete the claimed
+// husk pod, exactly as reconcileDelete does on object deletion. Without that
+// the pod keeps Running with its claim+org labels, the usage scrape lister
+// (labels plus Running, never claim phase) keeps returning it, and the sandbox
+// keeps being billed as live after the platform said Terminated.
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/controller"
+	"mitos.run/mitos/internal/husk"
+	"mitos.run/mitos/internal/tenant"
+)
+
+// scrapeListerHasPod reports whether the usage HuskPodScrapeLister currently
+// returns a husk pod with the given vm-id (pod name): the exact billable-set
+// membership the collector uses each cycle.
+func scrapeListerHasPod(t *testing.T, name string) bool {
+	t.Helper()
+	lister := &controller.HuskPodScrapeLister{Client: k8sClient}
+	pods, err := lister.ListHuskPods(ctx)
+	if err != nil {
+		t.Fatalf("ListHuskPods: %v", err)
+	}
+	for _, p := range pods {
+		if p.VMID == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHuskClaimLifetimeTerminateDeletesPod(t *testing.T) {
+	pod := makeDormantHuskPod(t, "husk-life-pool", "10.1.2.77")
+
+	act := &fakeActivator{result: husk.ActivateResult{OK: true, VsockPath: "/run/husk/vm/vsock", LatencyMs: 1.0}}
+	setHuskTestActivator(act.activate)
+	t.Cleanup(func() { setHuskTestActivator(nil) })
+
+	pool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "husk-life-pool", Namespace: "default"},
+		Spec: v1.SandboxPoolSpec{
+			Template: &v1.PoolTemplateSpec{Image: "python:3.12-slim"},
+			Warm:     &v1.PoolWarm{Min: 1},
+		},
+	}
+	if err := k8sClient.Create(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, pool) })
+
+	// The claim carries the org label the hosted gateway stamps (copied onto the
+	// pod at claim time), so the pod is in the scrape lister's billable set, and
+	// a short maxLifetime so the lifetime reaper fires.
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "husk-life-claim",
+			Namespace: "default",
+			Labels: map[string]string{
+				controller.HuskTestClaimLabel: "true",
+				tenant.OrgLabelKey:            "org-life",
+			},
+		},
+		Spec: v1.SandboxSpec{
+			Source:   v1.SandboxSource{PoolRef: &v1.LocalObjectReference{Name: "husk-life-pool"}},
+			Lifetime: &v1.SandboxLifetime{TTL: &metav1.Duration{Duration: 2 * time.Second}},
+		},
+	}
+	if err := k8sClient.Create(ctx, claim); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, claim) })
+
+	waitClaimPhase(t, claim.Name, func(c *v1.Sandbox) bool {
+		return c.Status.Phase == v1.SandboxReady
+	})
+
+	// Before the lifetime bound, the claimed org-labeled Running pod is in the
+	// billable set.
+	if !scrapeListerHasPod(t, pod.Name) {
+		t.Fatalf("claimed husk pod %s not in the scrape lister's billable set while Ready", pod.Name)
+	}
+
+	got := waitClaimTerminated(t, claim.Name)
+	if r := terminatedReason(got); r != "MaxLifetimeExceeded" {
+		t.Fatalf("terminated reason = %q, want MaxLifetimeExceeded", r)
+	}
+
+	// The fix: the claimed husk pod must be DELETED at the lifetime terminate,
+	// not just the claim stamped Terminated. Poll for it to vanish.
+	gone := false
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var p corev1.Pod
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: "default"}, &p)
+		if apierrors.IsNotFound(err) {
+			gone = true
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	if !gone {
+		t.Fatal("husk pod still exists after lifetime terminate; the in-pod VM keeps running, holding a warm slot, and BILLING (issue #688)")
+	}
+
+	// The scrape lister must no longer return the pod: billing stops at the
+	// terminate instant (the tail is carried by the single termination event).
+	if scrapeListerHasPod(t, pod.Name) {
+		t.Fatal("scrape lister still returns the terminated sandbox's pod")
+	}
+}

--- a/internal/controller/husk_reap_test.go
+++ b/internal/controller/husk_reap_test.go
@@ -1,0 +1,174 @@
+package controller
+
+// Unit coverage for reapClaimHuskPods, the shared claim-release reaper (issue
+// #688): a husk-backed claim's terminate paths must actually STOP the in-pod
+// VM by deleting the claimed husk pods, and must record the usage termination
+// tail BEFORE the delete (order matters: the collector needs the event to bill
+// the [last scrape, terminate] window, and recordHuskTerminations reads the
+// pod labels that the delete removes).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/usage"
+)
+
+// TestReapClaimHuskPodsRecordsTailThenDeletes asserts the reaper records ONE
+// termination for the claim's org-labeled pod and then deletes that pod, while
+// another claim's pod is left alone. This is the issue #688 fix shape: the
+// scrape lister selects on labels plus Running, so only deleting the pod stops
+// the sandbox from being scraped and billed as live.
+func TestReapClaimHuskPodsRecordsTailThenDeletes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	started := metav1.NewTime(time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC))
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-reap", Namespace: "mitos-org-acme"},
+		Status:     v1.SandboxStatus{Phase: v1.SandboxReady, StartedAt: &started},
+	}
+
+	claimed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-reap",
+			Namespace: "mitos-org-acme",
+			Labels: map[string]string{
+				huskLabel:       "true",
+				huskClaimLabel:  "sb-reap",
+				"mitos.run/org": "acme",
+			},
+		},
+	}
+	other := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-other",
+			Namespace: "mitos-org-acme",
+			Labels: map[string]string{
+				huskLabel:       "true",
+				huskClaimLabel:  "sb-other",
+				"mitos.run/org": "acme",
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(claimed, other).Build()
+	frozen := time.Date(2026, 7, 4, 10, 2, 0, 0, time.UTC)
+	r := &SandboxReconciler{
+		Client:            cl,
+		UsageTerminations: usage.NewTerminationLog(),
+		Now:               func() time.Time { return frozen },
+	}
+
+	if err := r.reapClaimHuskPods(context.Background(), claim); err != nil {
+		t.Fatalf("reapClaimHuskPods: %v", err)
+	}
+
+	terms := r.UsageTerminations.Drain()
+	if len(terms) != 1 {
+		t.Fatalf("want exactly 1 termination event, got %d: %+v", len(terms), terms)
+	}
+	if terms[0].VMID != "python-husk-reap" {
+		t.Errorf("VMID = %q, want python-husk-reap", terms[0].VMID)
+	}
+	if !terms[0].At.Equal(frozen) {
+		t.Errorf("At = %v, want the frozen reconciler clock %v", terms[0].At, frozen)
+	}
+
+	var gone corev1.Pod
+	err := cl.Get(context.Background(), types.NamespacedName{Name: "python-husk-reap", Namespace: "mitos-org-acme"}, &gone)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("claimed husk pod still exists after reap (err=%v); the in-pod VM keeps running and billing (issue #688)", err)
+	}
+	var kept corev1.Pod
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "python-husk-other", Namespace: "mitos-org-acme"}, &kept); err != nil {
+		t.Errorf("another claim's pod was deleted by this claim's reap: %v", err)
+	}
+}
+
+// TestReapClaimHuskPodsTerminatedClaimDeletesWithoutSecondEvent pins the
+// one-event-per-claim contract through the reaper: a claim already Terminated
+// recorded its event at the lifetime terminate, so a later reap (the object
+// delete, or a retry after a failed pod delete) must still delete the pod but
+// record NOTHING.
+func TestReapClaimHuskPodsTerminatedClaimDeletesWithoutSecondEvent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-done", Namespace: "mitos-org-acme"},
+		Status:     v1.SandboxStatus{Phase: v1.SandboxTerminated},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-done",
+			Namespace: "mitos-org-acme",
+			Labels: map[string]string{
+				huskLabel:       "true",
+				huskClaimLabel:  "sb-done",
+				"mitos.run/org": "acme",
+			},
+		},
+	}
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := &SandboxReconciler{Client: cl, UsageTerminations: usage.NewTerminationLog()}
+
+	if err := r.reapClaimHuskPods(context.Background(), claim); err != nil {
+		t.Fatalf("reapClaimHuskPods: %v", err)
+	}
+
+	if terms := r.UsageTerminations.Drain(); len(terms) != 0 {
+		t.Fatalf("a Terminated claim's reap recorded %d events, want 0 (one claim, one event): %+v", len(terms), terms)
+	}
+	var gone corev1.Pod
+	err := cl.Get(context.Background(), types.NamespacedName{Name: "python-husk-done", Namespace: "mitos-org-acme"}, &gone)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("husk pod still exists after reap of a Terminated claim (err=%v)", err)
+	}
+}
+
+// TestReapClaimHuskPodsNilUsageLogStillDeletes asserts the reap is lifecycle,
+// not billing: a reconciler without usage wiring (self-host, collector off)
+// must still delete the claimed pod, and never panic.
+func TestReapClaimHuskPodsNilUsageLogStillDeletes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	claim := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb-selfhost", Namespace: "default"},
+		Status:     v1.SandboxStatus{Phase: v1.SandboxReady},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "python-husk-selfhost",
+			Namespace: "default",
+			Labels:    map[string]string{huskLabel: "true", huskClaimLabel: "sb-selfhost"},
+		},
+	}
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := &SandboxReconciler{Client: cl}
+
+	if err := r.reapClaimHuskPods(context.Background(), claim); err != nil {
+		t.Fatalf("reapClaimHuskPods: %v", err)
+	}
+	var gone corev1.Pod
+	err := cl.Get(context.Background(), types.NamespacedName{Name: "python-husk-selfhost", Namespace: "default"}, &gone)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("husk pod still exists after reap without usage wiring (err=%v); stopping the VM must not depend on billing", err)
+	}
+}

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -394,8 +394,18 @@ func (r *SandboxReconciler) reconcilePoolRef(ctx context.Context, claim *v1.Sand
 		return res, err
 	}
 
-	// Terminal phases: don't retry.
+	// Terminal phases: don't retry. A Terminated claim must never leave its
+	// backing husk pod running (issue #688): terminateLifetime deletes the pod
+	// after stamping the phase, and this reap is the self-heal for a crash or a
+	// failed delete between the stamp and the reap. Idempotent and usually a
+	// NotFound no-op; it records no usage event (the claim is Terminated, its
+	// one event was recorded at the terminate instant).
 	if claim.Status.Phase == v1.SandboxFailed || claim.Status.Phase == v1.SandboxTerminated {
+		if claim.Status.Phase == v1.SandboxTerminated {
+			if err := r.reapClaimHuskPods(ctx, claim); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -1223,31 +1233,13 @@ func (r *SandboxReconciler) reconcileDelete(ctx context.Context, claim *v1.Sandb
 		return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
 	}
 
-	// Husk path: the claim's backing VM lives in the husk pod this claim activated,
-	// labeled with the claim name. Delete it to reap the VM and FREE THE WARM-POOL
-	// SLOT: a husk pod is single-use (once a tenant ran in it, it cannot be
-	// re-dormanted safely), so releasing the claim deletes the pod and the pool
-	// reconcile refills a fresh dormant pod. Without this the pod lingers
-	// claimed-but-idle and the pool never recovers the slot. No-op in raw-forkd
-	// mode (no pod carries the label); terminateOnNode below covers that path.
-	var claimedHusk corev1.PodList
-	if err := r.List(ctx, &claimedHusk, client.InNamespace(claim.Namespace), client.MatchingLabels{huskClaimLabel: claim.Name}); err != nil {
-		logger.Error(err, "list claimed husk pods on delete; will retry", "claim", claim.Name)
-		return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
-	}
-	// Record the usage termination BEFORE deleting the pods, so the collector
-	// can bill the half-open [last scrape, terminate] window (issue #682). A
-	// claim already Terminated (lifetime expiry) recorded its event at the TRUE
-	// terminate instant and the hook skips it here: one claim, one event.
-	// Best-effort and idempotent downstream: a retried delete records again and
-	// the collector's finalized guard keeps a vm-id from ever billing twice. The
-	// instant comes from the reconciler clock (r.now()) so tests can freeze it.
-	r.recordHuskTerminations(claim, claimedHusk.Items, r.now())
-	for i := range claimedHusk.Items {
-		if err := r.Delete(ctx, &claimedHusk.Items[i], client.GracePeriodSeconds(0)); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "delete claimed husk pod on release", "pod", claimedHusk.Items[i].Name)
-			return ctrl.Result{}, err
-		}
+	// Husk path: the claim's backing VM lives in the husk pod this claim
+	// activated; reap it (record the usage tail, then delete the pod). No-op in
+	// raw-forkd mode (no pod carries the label); terminateOnNode below covers
+	// that path.
+	if err := r.reapClaimHuskPods(ctx, claim); err != nil {
+		logger.Error(err, "reap claimed husk pods on delete; will retry", "claim", claim.Name)
+		return ctrl.Result{}, err
 	}
 
 	if claim.Status.Node != "" && claim.Status.SandboxID != "" {
@@ -1262,6 +1254,38 @@ func (r *SandboxReconciler) reconcileDelete(ctx context.Context, claim *v1.Sandb
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+// reapClaimHuskPods reaps the husk pods this claim activated (labeled
+// mitos.run/claim=<name>): it records the usage termination tail for each
+// org-labeled pod FIRST, then deletes the pods. The order matters: the
+// collector needs the event to bill the half-open [last scrape, terminate]
+// window (issue #682), and the event fields come from the pod labels the
+// delete removes. Deleting the pod is what actually STOPS the in-pod VM
+// (forkd never tracks husk pods, so terminateOnNode is a no-op for them,
+// issue #688), drops the pod from the usage scrape lister's billable set, and
+// FREES THE WARM-POOL SLOT: a husk pod is single-use (once a tenant ran in
+// it, it cannot be re-dormanted safely), so the pool reconcile refills a
+// fresh dormant pod.
+//
+// One claim, one event: a claim already Terminated recorded its event at the
+// TRUE terminate instant and recordHuskTerminations skips it here, so the
+// object-delete reap and any retried reap delete pods without recording
+// again. Idempotent: pods already gone are NotFound no-ops, and in raw-forkd
+// mode no pod carries the label. The instant comes from the reconciler clock
+// (r.now()) so tests can freeze it.
+func (r *SandboxReconciler) reapClaimHuskPods(ctx context.Context, claim *v1.Sandbox) error {
+	var claimedHusk corev1.PodList
+	if err := r.List(ctx, &claimedHusk, client.InNamespace(claim.Namespace), client.MatchingLabels{huskClaimLabel: claim.Name}); err != nil {
+		return fmt.Errorf("list claimed husk pods: %w", err)
+	}
+	r.recordHuskTerminations(claim, claimedHusk.Items, r.now())
+	for i := range claimedHusk.Items {
+		if err := r.Delete(ctx, &claimedHusk.Items[i], client.GracePeriodSeconds(0)); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete claimed husk pod %s: %w", claimedHusk.Items[i].Name, err)
+		}
+	}
+	return nil
 }
 
 // reconcileLifetime drives a Ready claim to the terminal Terminated phase when
@@ -1372,9 +1396,11 @@ func (r *SandboxReconciler) terminateLifetime(ctx context.Context, claim *v1.San
 		}
 	}
 
-	// The backing VM is gone: close the usage tail window at this instant
-	// (issue #682). Best-effort; a duplicate record from the later object
-	// delete is deduplicated by the collector's finalized guard.
+	// Close the usage tail window at this instant, BEFORE the phase is stamped
+	// (issue #682): recordHuskTerminations records only for a not-yet-Terminated
+	// claim, so this is the claim's ONE event, at the true terminate instant.
+	// Best-effort; a duplicate record from a requeued terminate (the stamp below
+	// failing) is deduplicated by the collector's finalized guard.
 	r.recordClaimHuskTerminations(ctx, claim)
 
 	now := metav1.Now()
@@ -1388,6 +1414,21 @@ func (r *SandboxReconciler) terminateLifetime(ctx context.Context, claim *v1.San
 		Message:            message,
 	})
 	if err := r.Status().Update(ctx, claim); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// A husk-backed claim's VM lives in its claimed husk pod, which forkd never
+	// tracks, so terminateOnNode above did NOT stop it. Delete the pod so
+	// Terminated actually means the VM stopped: the memory and warm slot are
+	// released and the usage scrape lister drops the pod, so billing ends at
+	// the terminate instant recorded above (issue #688). This runs AFTER the
+	// terminal phase is durable so a retry can never observe Ready with a
+	// vanished pod and re-pend the claim into a fresh VM; the event record
+	// above is skipped on any later reap (the claim is Terminated). A delete
+	// error requeues, and the Terminated branch of reconcilePoolRef retries
+	// the reap until the pod is gone.
+	if err := r.reapClaimHuskPods(ctx, claim); err != nil {
+		logger.Error(err, "reap claimed husk pods on lifetime expiry; will retry", "claim", claim.Name)
 		return ctrl.Result{}, err
 	}
 	logger.Info("claim terminated by lifetime policy", "claim", claim.Name, "reason", reason)

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -403,6 +403,10 @@ func (r *SandboxReconciler) reconcilePoolRef(ctx context.Context, claim *v1.Sand
 	if claim.Status.Phase == v1.SandboxFailed || claim.Status.Phase == v1.SandboxTerminated {
 		if claim.Status.Phase == v1.SandboxTerminated {
 			if err := r.reapClaimHuskPods(ctx, claim); err != nil {
+				// This is the self-heal for a crash or failed delete between
+				// the Terminated stamp and the reap (issue #688); operators
+				// need the failure visible to diagnose a repeating loop here.
+				log.FromContext(ctx).Error(err, "self-heal reap of a Terminated claim's husk pods failed; will retry", "claim", claim.Name)
 				return ctrl.Result{}, err
 			}
 		}

--- a/internal/saas/controlplane/proxy.go
+++ b/internal/saas/controlplane/proxy.go
@@ -38,6 +38,13 @@ func (k *K8sControlPlane) proxy(ctx context.Context, req saas.ForwardRequest) (s
 	if !ok {
 		return notFound(id), nil
 	}
+	// Terminal phases answer with the typed error BEFORE any dial: the claim
+	// keeps its stale endpoint after the VM stopped (issue #688), and dialing
+	// it would surface a generic 502 where docs/lifecycle.md promises the typed
+	// idle_timeout error for a reaped sandbox.
+	if aerr := terminalRuntimeError(sb); aerr != nil {
+		return errResp(*aerr), nil
+	}
 	if sb.Status.Endpoint == "" {
 		return errResp(apierr.Get(apierr.CodeNotFound).
 			WithCause(fmt.Sprintf("sandbox %q has no runtime endpoint yet; it is not Ready", id))), nil

--- a/internal/saas/controlplane/runtime_resolve.go
+++ b/internal/saas/controlplane/runtime_resolve.go
@@ -29,6 +29,13 @@ func (k *K8sControlPlane) ResolveRuntime(ctx context.Context, orgID, id string) 
 			WithCause(fmt.Sprintf("no sandbox %q exists for this organization", id))
 		return saas.RuntimeTarget{}, &e
 	}
+	// Terminal phases answer with the typed error BEFORE any dial, mirroring
+	// proxy(): a Terminated claim keeps its stale endpoint after the VM stopped
+	// (issue #688), so the PTY must get the documented idle_timeout error, not
+	// a WebSocket dial failure against a dead pod IP.
+	if aerr := terminalRuntimeError(sb); aerr != nil {
+		return saas.RuntimeTarget{}, aerr
+	}
 	if sb.Status.Endpoint == "" {
 		e := apierr.Get(apierr.CodeNotFound).
 			WithCause(fmt.Sprintf("sandbox %q has no runtime endpoint yet; it is not Ready", id))

--- a/internal/saas/controlplane/terminal_runtime.go
+++ b/internal/saas/controlplane/terminal_runtime.go
@@ -1,0 +1,65 @@
+package controlplane
+
+import (
+	"fmt"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/apierr"
+)
+
+// terminalRuntimeError returns the typed, LLM-legible error a runtime call
+// (exec, files, run_code, and the PTY WebSocket) must receive when the target
+// sandbox is in a terminal phase, or nil when the sandbox is live. Both
+// runtime paths (proxy and ResolveRuntime) consult it BEFORE dialing: a
+// terminal claim keeps its stale Status.Endpoint in both run modes (the
+// raw-forkd VM is reaped on its node; the husk pod is deleted at lifetime
+// expiry, issue #688), so dialing it can only produce a generic 502 where
+// docs/lifecycle.md promises the typed idle_timeout error for a reaped
+// sandbox. The gate reads the claim PHASE, upstream of any mode-specific
+// endpoint, so raw-forkd and husk-backed sandboxes answer identically.
+//
+// A Terminated sandbox returns the documented idle_timeout catalogue entry
+// (410 Gone), with the message and remediation tailored to the reap reason
+// terminateLifetime recorded (IdleTimeout, MaxLifetimeExceeded, or
+// TimeoutExpired). A Failed sandbox never ran out a lifetime, so it returns
+// not_found with the failure detail from its Ready condition as the cause:
+// actionable, and honest that nothing is running to call. Condition messages
+// are controller-authored and never carry secret values.
+func terminalRuntimeError(sb *v1.Sandbox) *apierr.Error {
+	switch sb.Status.Phase {
+	case v1.SandboxTerminated:
+		reason := terminatedConditionReason(sb)
+		e := apierr.Get(apierr.CodeIdleTimeout)
+		switch reason {
+		case "MaxLifetimeExceeded":
+			e = e.WithMessage("the sandbox was reaped after exceeding its max lifetime").
+				WithRemediation("The sandbox hit its max lifetime and was reaped; create a fresh sandbox (or fork from a checkpoint) and retry. Set a longer lifetime on the sandbox at create time if the work needs more wall-clock time.")
+		case "TimeoutExpired":
+			e = e.WithMessage("the sandbox was reaped after its live set_timeout deadline expired").
+				WithRemediation("The set_timeout deadline expired and the sandbox was reaped; create a fresh sandbox and retry, or call set_timeout with a later deadline before it passes.")
+		}
+		if reason == "" {
+			reason = "Terminated"
+		}
+		e = e.WithCause(fmt.Sprintf("sandbox %q reached the terminal Terminated phase (%s); its VM is stopped and the object remains readable until deleted", sb.Name, reason))
+		return &e
+	case v1.SandboxFailed:
+		e := apierr.Get(apierr.CodeNotFound).
+			WithMessage("the sandbox failed and is not running").
+			WithCause(fmt.Sprintf("sandbox %q reached the terminal Failed phase: %s", sb.Name, failureReason(sb))).
+			WithRemediation("The sandbox failed terminally and will never serve runtime calls; inspect the failure cause, then create a new sandbox and retry.")
+		return &e
+	}
+	return nil
+}
+
+// terminatedConditionReason returns the reason from the sandbox's Terminated
+// condition (stamped by the controller's lifetime reaper), or "".
+func terminatedConditionReason(sb *v1.Sandbox) string {
+	for i := range sb.Status.Conditions {
+		if sb.Status.Conditions[i].Type == "Terminated" {
+			return sb.Status.Conditions[i].Reason
+		}
+	}
+	return ""
+}

--- a/internal/saas/controlplane/terminal_runtime_test.go
+++ b/internal/saas/controlplane/terminal_runtime_test.go
@@ -1,0 +1,170 @@
+package controlplane
+
+// Tests for the terminal-phase gate on the runtime proxy paths (issue #688
+// follow-up): a sandbox whose claim is Terminated keeps its stale
+// Status.Endpoint (both run modes do; the VM is stopped and, in husk mode, the
+// pod deleted), so exec/files/run_code/PTY calls between lifetime expiry and
+// object deletion used to dial a dead endpoint and surface a generic 502
+// internal error. docs/lifecycle.md promises the typed idle_timeout error for
+// a reaped sandbox (the API v2 LLM-legible error rule), and the gate reads the
+// claim PHASE, upstream of any mode-specific endpoint, so raw-forkd and
+// husk-backed sandboxes get the same typed answer.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/apierr"
+	"mitos.run/mitos/internal/saas"
+)
+
+// lifetimeTerminatedSandbox builds a sandbox exactly as the controller's
+// terminateLifetime stamps it: phase Terminated, FinishedAt, and a Terminated
+// condition carrying the reap reason, with the stale runtime endpoint still in
+// status.
+func lifetimeTerminatedSandbox(org, name, endpoint, token, reason string) (*v1.Sandbox, *metav1.Time) {
+	sb, secret := readySandbox(org, name, endpoint, token)
+	_ = secret
+	now := metav1.Now()
+	sb.Status.Phase = v1.SandboxTerminated
+	sb.Status.FinishedAt = &now
+	sb.Status.Conditions = []metav1.Condition{{
+		Type:               "Terminated",
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: now,
+		Reason:             reason,
+		Message:            "lifetime bound exceeded",
+	}}
+	return sb, &now
+}
+
+// TestProxyTerminatedSandboxTypedIdleTimeoutNeverDialed asserts a runtime call
+// against a lifetime-expired sandbox returns the documented typed idle_timeout
+// error (410 Gone) and NEVER dials the stale endpoint, for each reap reason
+// terminateLifetime records.
+func TestProxyTerminatedSandboxTypedIdleTimeoutNeverDialed(t *testing.T) {
+	for _, reason := range []string{"IdleTimeout", "MaxLifetimeExceeded", "TimeoutExpired"} {
+		t.Run(reason, func(t *testing.T) {
+			var reached bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+			endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+			sb, _ := lifetimeTerminatedSandbox(orgA, "sb-gone", endpoint, "tok", reason)
+			_, secret := readySandbox(orgA, "sb-gone", endpoint, "tok")
+			cp := New(newFakeClient(t, sb, secret), WithHTTPClient(srv.Client()))
+
+			hdr := http.Header{}
+			hdr.Set("X-Sandbox-Id", "sb-gone")
+			resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+				OrgID: orgA, Op: "sandbox.runtime", Path: "/sandbox.v1.Sandbox/Exec",
+				Method: http.MethodPost, Header: hdr, BodyStream: strings.NewReader("{}"),
+			})
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+			if reached {
+				t.Fatal("runtime call against a Terminated sandbox DIALED the stale endpoint")
+			}
+			if resp.Status != http.StatusGone {
+				t.Fatalf("status = %d, want 410 Gone (the typed reaped-sandbox error), body %s", resp.Status, resp.Body)
+			}
+			body := decodeBody(t, resp.Body)
+			errObj, ok := body["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("no error envelope in %s", resp.Body)
+			}
+			if errObj["code"] != string(apierr.CodeIdleTimeout) {
+				t.Errorf("code = %v, want idle_timeout (docs/lifecycle.md: a reaped sandbox returns the typed idle_timeout error, not a generic 502)", errObj["code"])
+			}
+			if rem, _ := errObj["remediation"].(string); rem == "" {
+				t.Error("remediation is empty; the error must be actionable (API v2 LLM-legible rule)")
+			}
+			if cause, _ := errObj["cause"].(string); !strings.Contains(cause, reason) {
+				t.Errorf("cause %q does not carry the termination reason %q", cause, reason)
+			}
+		})
+	}
+}
+
+// TestProxyFailedSandboxTypedNeverDialed asserts a runtime call against a
+// terminally Failed sandbox (raw-forkd node loss stamps Failed and keeps the
+// stale endpoint) gets a typed, actionable answer and never dials the dead
+// endpoint.
+func TestProxyFailedSandboxTypedNeverDialed(t *testing.T) {
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+
+	sb, secret := readySandbox(orgA, "sb-dead", endpoint, "tok")
+	now := metav1.Now()
+	sb.Status.Phase = v1.SandboxFailed
+	sb.Status.Conditions = []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: now,
+		Reason:             "NodeLost",
+		Message:            "the node running this sandbox left the cluster",
+	}}
+	cp := New(newFakeClient(t, sb, secret), WithHTTPClient(srv.Client()))
+
+	hdr := http.Header{}
+	hdr.Set("X-Sandbox-Id", "sb-dead")
+	resp, err := cp.Forward(context.Background(), saas.ForwardRequest{
+		OrgID: orgA, Op: "sandbox.runtime", Path: "/sandbox.v1.Sandbox/Exec",
+		Method: http.MethodPost, Header: hdr, BodyStream: strings.NewReader("{}"),
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if reached {
+		t.Fatal("runtime call against a Failed sandbox DIALED the stale endpoint")
+	}
+	if resp.Status == http.StatusBadGateway || resp.Status == http.StatusInternalServerError {
+		t.Fatalf("status = %d; a Failed sandbox must get a typed answer, not a generic internal error", resp.Status)
+	}
+	body := decodeBody(t, resp.Body)
+	errObj, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("no error envelope in %s", resp.Body)
+	}
+	if errObj["code"] != string(apierr.CodeNotFound) {
+		t.Errorf("code = %v, want not_found (the sandbox is not running and never will be)", errObj["code"])
+	}
+	if cause, _ := errObj["cause"].(string); !strings.Contains(cause, "node running this sandbox left") {
+		t.Errorf("cause %q does not carry the failure detail from the Ready condition", cause)
+	}
+}
+
+// TestResolveRuntimeTerminatedIsTypedIdleTimeout asserts the PTY WebSocket
+// resolve path refuses a Terminated sandbox with the same typed error as the
+// Forward proxy, instead of resolving the stale endpoint.
+func TestResolveRuntimeTerminatedIsTypedIdleTimeout(t *testing.T) {
+	sb, _ := lifetimeTerminatedSandbox(orgA, "sb-pty-gone", "10.1.2.3:9091", "tok", "IdleTimeout")
+	_, secret := readySandbox(orgA, "sb-pty-gone", "10.1.2.3:9091", "tok")
+	cp := New(newFakeClient(t, sb, secret))
+
+	_, aerr := cp.ResolveRuntime(context.Background(), orgA, "sb-pty-gone")
+	if aerr == nil {
+		t.Fatal("ResolveRuntime resolved a Terminated sandbox; the PTY would dial a dead endpoint")
+	}
+	if aerr.Code != string(apierr.CodeIdleTimeout) {
+		t.Fatalf("code = %q, want idle_timeout", aerr.Code)
+	}
+	if aerr.Status != http.StatusGone {
+		t.Errorf("status = %d, want 410", aerr.Status)
+	}
+}

--- a/internal/saas/controlplane/terminal_runtime_test.go
+++ b/internal/saas/controlplane/terminal_runtime_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "mitos.run/mitos/api/v1"
@@ -27,10 +28,10 @@ import (
 // lifetimeTerminatedSandbox builds a sandbox exactly as the controller's
 // terminateLifetime stamps it: phase Terminated, FinishedAt, and a Terminated
 // condition carrying the reap reason, with the stale runtime endpoint still in
-// status.
-func lifetimeTerminatedSandbox(org, name, endpoint, token, reason string) (*v1.Sandbox, *metav1.Time) {
+// status. Returns the sandbox-token Secret alongside so callers seed the fake
+// client without a second readySandbox call.
+func lifetimeTerminatedSandbox(org, name, endpoint, token, reason string) (*v1.Sandbox, *corev1.Secret) {
 	sb, secret := readySandbox(org, name, endpoint, token)
-	_ = secret
 	now := metav1.Now()
 	sb.Status.Phase = v1.SandboxTerminated
 	sb.Status.FinishedAt = &now
@@ -41,7 +42,7 @@ func lifetimeTerminatedSandbox(org, name, endpoint, token, reason string) (*v1.S
 		Reason:             reason,
 		Message:            "lifetime bound exceeded",
 	}}
-	return sb, &now
+	return sb, secret
 }
 
 // TestProxyTerminatedSandboxTypedIdleTimeoutNeverDialed asserts a runtime call
@@ -59,8 +60,7 @@ func TestProxyTerminatedSandboxTypedIdleTimeoutNeverDialed(t *testing.T) {
 			defer srv.Close()
 			endpoint := strings.TrimPrefix(srv.URL, "http://")
 
-			sb, _ := lifetimeTerminatedSandbox(orgA, "sb-gone", endpoint, "tok", reason)
-			_, secret := readySandbox(orgA, "sb-gone", endpoint, "tok")
+			sb, secret := lifetimeTerminatedSandbox(orgA, "sb-gone", endpoint, "tok", reason)
 			cp := New(newFakeClient(t, sb, secret), WithHTTPClient(srv.Client()))
 
 			hdr := http.Header{}
@@ -153,8 +153,7 @@ func TestProxyFailedSandboxTypedNeverDialed(t *testing.T) {
 // resolve path refuses a Terminated sandbox with the same typed error as the
 // Forward proxy, instead of resolving the stale endpoint.
 func TestResolveRuntimeTerminatedIsTypedIdleTimeout(t *testing.T) {
-	sb, _ := lifetimeTerminatedSandbox(orgA, "sb-pty-gone", "10.1.2.3:9091", "tok", "IdleTimeout")
-	_, secret := readySandbox(orgA, "sb-pty-gone", "10.1.2.3:9091", "tok")
+	sb, secret := lifetimeTerminatedSandbox(orgA, "sb-pty-gone", "10.1.2.3:9091", "tok", "IdleTimeout")
 	cp := New(newFakeClient(t, sb, secret))
 
 	_, aerr := cp.ResolveRuntime(context.Background(), orgA, "sb-pty-gone")


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; hosted tenants run every sandbox VM inside a claimed husk pod.
> - The controller's lifetime reaper (terminateLifetime) reaps expired sandboxes, and the usage collector bills claimed, org-labeled, Running husk pods each scrape cycle.
> - For a husk-backed claim, terminateOnNode is a no-op (forkd never tracks husk pods), so a lifetime or idle expiry stamped the claim Terminated but never stopped the in-pod VM: the pod kept Running with its claim and org labels, kept being scraped and BILLED as live, and kept holding memory and a warm slot until the object was deleted.
> - This is both an over-billing bug and a boring-failure honesty gap: Terminated must mean the VM stopped. The single-termination-event prerequisite already merged, so fixing this now does not open the phantom-rebill path.
> - This pull request makes terminateLifetime reap the claim's husk pods with the same record-then-delete shape reconcileDelete uses, extracted into one shared helper, deleting the pods only after the terminal phase is durable and self-healing from the Terminated branch.
> - The benefit is honest terminate semantics: billing ends at the recorded terminate instant, the VM's memory is released, and the warm-pool slot refills.

## Linked Issues or Issue Description

Closes #688. Related: #682, #687.

## What Changed

- Extracted reconcileDelete's list-record-delete block into `reapClaimHuskPods`: list the claim's `mitos.run/claim`-labeled pods, record the usage termination tail FIRST (the event fields come from labels the delete removes), then delete the pods with grace 0.
- `terminateLifetime` now calls the reaper AFTER stamping the Terminated phase, so a retry can never observe Ready with a vanished pod and re-pend the claim into a fresh VM; the record hook still fires before the stamp, at the true terminate instant, so one claim records exactly one event.
- The Terminated branch of `reconcilePoolRef` retries the reap (idempotent, records nothing for a Terminated claim) as the self-heal for a crash or failed delete between the stamp and the reap.
- Raw-forkd claims are unchanged: no pod carries the claim label, so the reap is a no-op and `terminateOnNode` still reaps the VM.
- Docs: `docs/lifecycle.md` (Terminated means the VM stopped in both run modes; the object stays readable), `docs/failure-gc.md` (husk maxLifetime bound and self-heal), `docs/saas/usage-pipeline.md` (the terminate instant is the billing boundary; nothing after it is billed).

## Verification

- [x] `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/` (full suite, 156s, ok; includes the new envtest `TestHuskClaimLifetimeTerminateDeletesPod`, which FAILED before the fix with the pod still Running after Terminated, and the existing raw-mode `TestClaimMaxLifetimeReaped` / `TestClaimIdleTimeoutReaped` unchanged)
- [x] New unit tests `TestReapClaimHuskPodsRecordsTailThenDeletes`, `TestReapClaimHuskPodsTerminatedClaimDeletesWithoutSecondEvent` (one claim, one event), `TestReapClaimHuskPodsNilUsageLogStillDeletes` (self-host: stopping the VM does not depend on billing wiring)
- [x] `go test ./internal/usage/...`
- [x] `make test-unit`
- [x] `golangci-lint run --timeout=5m` (only pre-existing `internal/fork/uffd.go` unused finding, present on main with this change stashed) and `GOOS=linux golangci-lint run --timeout=5m` (clean)

## Risks

- Low risk. The delete path is the exact code reconcileDelete has always run on object deletion; the pool reconciler already refills the freed slot. Ordering was chosen so a status-update conflict cannot resurrect an expired claim (pods are deleted only after Terminated is durable), and a failed delete self-heals on the next reconcile of the Terminated claim.
- The Terminated claim keeps its stale endpoint in status, same as raw-forkd mode after its VM is reaped; callers see the terminal phase.

## Model Used

- Claude Fable 5 (Anthropic), model id `claude-fable-5`, via Claude Code subagent.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (surface unmoved: the controller already deletes these pods on object delete; no new API or trust boundary)
- [ ] Benchmark run (bench/) included if the hot path was touched (not touched)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expiry/lifetime handling so billing stops at the exact terminate instant and claimed husk pods are reaped/deleted reliably across both runtime modes, including recovery after crashes or failed deletions.
  * Runtime entry requests for terminal sandboxes now return typed, user-friendly errors immediately (410) instead of dialing stale runtime endpoints.
* **Documentation**
  * Updated lifecycle, lifetime/expiry guarantees, and usage pipeline docs to reflect termination semantics and billing boundaries.
* **Tests**
  * Added coverage for husk reaping and typed terminal runtime responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->