### PR TITLE
fix(frontdoor): route marketing pages + /mitos vanity to marketing; noindex console shell; www 301

### DIFF
--- a/cmd/console/spa/dist/index.html
+++ b/cmd/console/spa/dist/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="robots" content="noindex" />
     <title>Mitos console</title>
   </head>
   <body>

--- a/deploy/charts/mitos/templates/edge-gateway.yaml
+++ b/deploy/charts/mitos/templates/edge-gateway.yaml
@@ -102,7 +102,32 @@ spec:
             scheme: https
             statusCode: 301
 ---
-# HTTPRoute: HTTPS traffic from mitos.run and www.mitos.run -> mitos-frontdoor.
+# HTTPRoute: HTTPS traffic on www.mitos.run -> 301 to the apex. The apex is the
+# canonical host everywhere (sitemap, canonicals, OG tags); serving content on
+# www would create a full duplicate of the site. Kept as its own route (not a
+# hostname on mitos-edge-tls) so external-dns still provisions the www record.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mitos-edge-www-redirect
+  namespace: {{ $ns }}
+  labels:
+    {{- include "mitos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: edge-gateway
+spec:
+  parentRefs:
+    - name: mitos-edge
+      sectionName: https
+  hostnames:
+    - {{ printf "www.%s" $hostname | quote }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: {{ $hostname | quote }}
+            statusCode: 301
+---
+# HTTPRoute: HTTPS traffic from mitos.run -> mitos-frontdoor.
 # Security response headers are injected via ResponseHeaderModifier:
 #   HSTS: max-age 1 year, subdomains included.
 #   Content-Security-Policy: frame-ancestors 'none' (no embedding).
@@ -122,7 +147,6 @@ spec:
       sectionName: https
   hostnames:
     - {{ $hostname | quote }}
-    - {{ printf "www.%s" $hostname | quote }}
   rules:
     - backendRefs:
         - name: mitos-frontdoor

--- a/internal/frontdoor/router.go
+++ b/internal/frontdoor/router.go
@@ -23,16 +23,26 @@ type Decision struct {
 // marketingSegments are the first-segment values that map to the marketing
 // upstream with no session requirement.
 var marketingSegments = map[string]bool{
-	"pricing":   true,
-	"docs":      true,
-	"use-cases": true,
-	"compare":   true,
-	"blog":      true,
-	"about":     true,
+	"pricing":       true,
+	"docs":          true,
+	"use-cases":     true,
+	"compare":       true,
+	"blog":          true,
+	"about":         true,
+	"contact":       true,
+	"alternatives":  true,
+	"benchmarks":    true,
+	"terms":         true,
+	"privacy":       true,
+	"cookie-policy": true,
 	// /waitlist is the public post-signup "you are on the list" marketing page.
 	// No session required: visitors land here after joining the waitlist and must
 	// be able to read it without being redirected to the console.
 	"waitlist": true,
+	// /mitos is the Go vanity import tree: `go get mitos.run/mitos/...` fetches
+	// the go-import meta page, which the marketing site serves with HTTP 200 at
+	// every import depth. Routing it anywhere else breaks `go get`.
+	"mitos": true,
 	// Astro emits its bundled CSS/JS under /_astro/ (the build.assets default).
 	// The console's Vite bundle lives under /assets/, so /assets is owned by the
 	// console (see authSegments), NOT marketing. Routing /assets to marketing

--- a/internal/frontdoor/router_test.go
+++ b/internal/frontdoor/router_test.go
@@ -27,9 +27,19 @@ func TestDecide(t *testing.T) {
 		{"/blog", "marketing", false, false},
 		{"/blog/post-1", "marketing", false, false},
 		{"/about", "marketing", false, false},
+		{"/contact", "marketing", false, false},
+		{"/alternatives", "marketing", false, false},
+		{"/benchmarks", "marketing", false, false},
+		{"/terms", "marketing", false, false},
+		{"/privacy", "marketing", false, false},
+		{"/cookie-policy", "marketing", false, false},
 		// /waitlist is the public post-signup "you are on the list" marketing
 		// page; no session required.
 		{"/waitlist", "marketing", false, false},
+		// /mitos is the Go vanity import tree; `go get mitos.run/mitos/...`
+		// must reach the marketing-served go-import meta at every depth.
+		{"/mitos", "marketing", false, false},
+		{"/mitos/internal/frontdoor", "marketing", false, false},
 		{"/assets/x.js", "console", false, false},
 		{"/_astro/x.css", "marketing", false, false},
 		{"/og-image.png", "marketing", false, false},

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- The console is a signed-in app. The SPA shell answers 200 for any
+         extension-less path (org slugs, /signup, /keys), so without noindex
+         search engines index empty "Mitos console" duplicates of those URLs. -->
+    <meta name="robots" content="noindex" />
     <title>Mitos console</title>
     <script>
       // Pin a stored explicit theme before first paint so a manual override


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs, with a hosted control plane at mitos.run.
> - The front-door reverse proxy (cmd/frontdoor) splits mitos.run traffic between the marketing site and the console SPA using a hardcoded first-segment allowlist.
> - The marketing site has since added top-level pages (/terms, /privacy, /cookie-policy, /contact, /alternatives, /benchmarks) that are missing from the allowlist, so those paths fall through the org-slug fallback and anonymous visitors get the empty console shell with HTTP 200. A site audit on 2026-07-04 flagged all of them as thin duplicate pages with no H1, description, or canonical.
> - /mitos falls through the same way, which breaks `go get mitos.run/mitos/...` in production: the go-import meta page is served by marketing and is currently unreachable.
> - The console shell also carries no robots directive, so search engines index empty "Mitos console" duplicates for /signup, /keys, and org-slug URLs; and www.mitos.run would serve duplicate content instead of redirecting to the canonical apex host.
> - This pull request adds the missing marketing segments (including the /mitos vanity import tree), puts a noindex meta on the console shell, and adds an HTTPS 301 from www to the apex in the edge gateway chart.
> - The benefit is that every public marketing page is reachable and indexable, `go get` works again, and the console shell and www host stop polluting search results.

## Linked Issues or Issue Description

No issue exists. Following the bug report form:

- **What happened:** `https://mitos.run/terms` (and privacy, cookie-policy, contact, alternatives, benchmarks) return the 951-byte console SPA shell with HTTP 200 instead of the marketing pages; `curl 'https://mitos.run/mitos?go-get=1'` returns the shell instead of the go-import meta, breaking `go get mitos.run/mitos/...`.
- **Expected:** those paths serve the marketing site; the console shell is never indexable; www.mitos.run redirects 301 to mitos.run.
- **Component:** frontdoor router, console SPA shell, edge gateway chart.

## What Changed

- `internal/frontdoor/router.go`: added `contact`, `alternatives`, `benchmarks`, `terms`, `privacy`, `cookie-policy`, and `mitos` to `marketingSegments`.
- `internal/frontdoor/router_test.go`: table cases for each new segment, including `/mitos` and a deep `/mitos/...` import path.
- `web/app/index.html` and `cmd/console/spa/dist/index.html`: `<meta name="robots" content="noindex" />` on the console shell, which answers 200 for any extension-less path.
- `deploy/charts/mitos/templates/edge-gateway.yaml`: new `mitos-edge-www-redirect` HTTPRoute (www 301 to apex on HTTPS); `mitos-edge-tls` now serves the apex hostname only. Kept as a separate route so external-dns still provisions the www record.

## Verification

- [x] `go test ./internal/frontdoor/` passes with the new table cases
- [x] `go build ./...` and `go test ./...` pass (except the pre-existing controller envtest suite, which requires a local kubebuilder etcd binary and fails identically on main)
- [x] `helm template deploy/charts/mitos --set edge.enabled=true --kube-version 1.31.0` renders the www redirect HTTPRoute and the apex-only TLS route as intended
- [x] Live repro of the bug before the fix: `curl -s https://mitos.run/terms` returns the 951-byte console shell; `curl -s 'https://mitos.run/mitos?go-get=1'` contains no go-import meta

## Risks

- Low risk. The router change only widens the marketing allowlist; auth and app segments are untouched. If a future org slug collides with a marketing segment name it is already reserved by the site anyway.
- The www redirect route takes effect only where the edge chart is deployed; DNS for www must point at the gateway for it to matter.

## Model Used

- Provider and model: Anthropic Claude Fable 5
- Model id: claude-fable-5
- Reasoning mode: extended thinking, agentic (Claude Code)

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (comments in router.go and the chart are the docs surface for routing)
- [x] Threat-model delta not needed: no security surface moved (public paths only, no auth changes)
- [x] Benchmark run not needed: no hot path touched
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an HTTPS redirect so `www` requests automatically forward to the main site hostname.
* **Bug Fixes**
  * Corrected routing for Go vanity import tree paths (including `/mitos` and related internal paths) to reliably serve the intended public content without requiring a session.
  * Updated the app shell’s metadata to prevent search engines from indexing duplicate/empty SPA pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->