### PR TITLE
fix(console): bound live log stream memory by bytes; heartbeat empty streams (#726)

### DIFF
--- a/cmd/console/sandboxcontrol.go
+++ b/cmd/console/sandboxcontrol.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 
 	"k8s.io/client-go/kubernetes"
@@ -44,11 +45,11 @@ func buildSandboxControl(logger *slog.Logger) console.SandboxControl {
 func buildPodLogStreamer() (clustersandbox.PodLogStreamer, error) {
 	cfg, err := ctrlconfig.GetConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load kube config for pod log streamer: %w", err)
 	}
 	cs, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build clientset for pod log streamer: %w", err)
 	}
 	return clustersandbox.NewClientsetPodLogStreamer(cs), nil
 }

--- a/internal/saas/console/clustersandbox/logs.go
+++ b/internal/saas/console/clustersandbox/logs.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -55,13 +56,19 @@ func (p clientsetPodLogStreamer) StreamPodLogs(ctx context.Context, ns, pod stri
 	return p.cs.CoreV1().Pods(ns).GetLogs(pod, &opts).Stream(ctx)
 }
 
-// logLineBufferCap bounds how many pod-log lines StreamLogs holds between the
-// upstream follow read and the sink write. A slow sink (a laggy client, or
-// one that stopped reading) must never make this accumulate unbounded memory:
-// once the buffer is full, the OLDEST queued line is dropped to make room for
-// the newest, so a lagging client sees a gap in the tail rather than the
-// console process growing without bound.
-const logLineBufferCap = 512
+// maxLogBufferBytes bounds the total BYTES StreamLogs holds queued between
+// the upstream follow read and the sink write. A prior line-COUNT cap (512
+// lines) let a slow sink accumulate up to 512 x maxLogLineBytes (~512 MiB)
+// per stream, since each line can independently be as large as
+// maxLogLineBytes; several concurrent slow viewers could exhaust the
+// multi-tenant console's memory. A slow sink (a laggy client, or one that
+// stopped reading) must never make this accumulate unbounded memory: once
+// the queued bytes exceed this cap, the OLDEST queued lines are dropped, by
+// bytes, to make room for the newest, so a lagging client sees a gap in the
+// tail rather than the console process growing without bound. A single line
+// is always <= maxLogLineBytes (1 MiB, enforced upstream by
+// discardOversizedLine), so it always fits within this cap on its own.
+const maxLogBufferBytes = 4 * 1024 * 1024
 
 // maxLogLineBytes bounds a single line's buffered length: a pod writing one
 // absurdly long line with no newline must not grow memory without bound
@@ -101,30 +108,28 @@ func (s *Control) StreamLogs(ctx context.Context, orgID, sandboxID string, sink 
 }
 
 // streamPodLines pumps newline-delimited lines from r into sink through a
-// bounded, drop-oldest buffer (logLineBufferCap) so a slow sink cannot make
-// this hold unbounded memory. It returns when ctx is done (r is closed, which
-// stops the upstream follow), r reaches a clean EOF (nil error), or
-// sink.Write errors (the client disconnected). A single line over
-// maxLogLineBytes does not end the follow: it is replaced by
+// byte-bounded, drop-oldest buffer (lineBuffer, capped at maxLogBufferBytes)
+// so a slow sink cannot make this hold unbounded memory. It returns when ctx
+// is done (r is closed, which stops the upstream follow), r reaches a clean
+// EOF (nil error), or sink.Write errors (the client disconnected). A single
+// line over maxLogLineBytes does not end the follow: it is replaced by
 // truncatedLineMarker and streaming continues with the next line.
 func streamPodLines(ctx context.Context, r io.ReadCloser, sink console.LogSink) error {
 	defer r.Close()
 
-	lines := make(chan []byte, logLineBufferCap)
-	scanDone := make(chan error, 1)
+	buf := newLineBuffer()
 	go func() {
-		defer close(lines)
 		br := bufio.NewReaderSize(r, maxLogLineBytes)
 		for {
 			line, err := readBoundedLine(br)
 			if len(line) > 0 {
-				pushDropOldest(lines, line)
+				buf.push(line)
 			}
 			if err != nil {
 				if err == io.EOF {
-					scanDone <- nil // a clean end, matching bufio.Scanner's nil Err() on EOF
+					buf.close(nil) // a clean end, matching bufio.Scanner's nil Err() on EOF
 				} else {
-					scanDone <- err
+					buf.close(err)
 				}
 				return
 			}
@@ -135,12 +140,15 @@ func streamPodLines(ctx context.Context, r io.ReadCloser, sink console.LogSink) 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case line, ok := <-lines:
-			if !ok {
-				return <-scanDone // nil on a clean EOF
+		case <-buf.notify:
+			lines, closed, err := buf.drain()
+			for _, line := range lines {
+				if writeErr := sink.Write(line); writeErr != nil {
+					return writeErr
+				}
 			}
-			if err := sink.Write(line); err != nil {
-				return err
+			if closed {
+				return err // nil on a clean EOF
 			}
 		}
 	}
@@ -205,20 +213,78 @@ func discardOversizedLine(br *bufio.Reader) ([]byte, error) {
 	}
 }
 
-// pushDropOldest sends line on ch, dropping the oldest queued line first if
-// ch is full. It never blocks: there is exactly one producer goroutine
-// (streamPodLines's scan loop above), so the drop-then-retry loop always
-// terminates in at most one drop.
-func pushDropOldest(ch chan []byte, line []byte) {
-	for {
-		select {
-		case ch <- line:
-			return
-		default:
-			select {
-			case <-ch:
-			default:
-			}
-		}
+// lineBuffer is a byte-bounded, drop-oldest queue of pending log lines
+// shared between streamPodLines's single producer goroutine (the upstream
+// scan loop) and its consumer (the ctx/notify select loop). It replaces a
+// plain buffered channel because a channel can only bound line COUNT, not
+// total bytes; lineBuffer instead tracks running byte size and drops from
+// the front until push's new line fits under maxLogBufferBytes.
+//
+// notify is a capacity-1 "something changed" signal, not a data channel: the
+// consumer wakes on it and then calls drain to actually read the queued
+// lines (and the closed/err state) under the lock. This is the standard
+// level-triggered wakeup idiom, so a signal coalesced by the capacity-1
+// buffer while the consumer is busy is never a lost wakeup: the consumer
+// always re-checks state after waking, and every state change (push, close)
+// posts to notify after releasing the lock.
+type lineBuffer struct {
+	mu     sync.Mutex
+	lines  [][]byte
+	bytes  int
+	notify chan struct{}
+	closed bool
+	err    error
+}
+
+func newLineBuffer() *lineBuffer {
+	return &lineBuffer{notify: make(chan struct{}, 1)}
+}
+
+// push appends line to the queue, then drops the OLDEST queued lines (by
+// bytes, never the just-appended newest one) until the total is back within
+// maxLogBufferBytes. A single line is always <= maxLogLineBytes (well under
+// maxLogBufferBytes, enforced upstream by discardOversizedLine), so the
+// newest line alone always fits and is never itself dropped.
+func (b *lineBuffer) push(line []byte) {
+	b.mu.Lock()
+	b.lines = append(b.lines, line)
+	b.bytes += len(line)
+	for b.bytes > maxLogBufferBytes && len(b.lines) > 1 {
+		b.bytes -= len(b.lines[0])
+		b.lines = b.lines[1:]
+	}
+	b.mu.Unlock()
+	b.wake()
+}
+
+// close records the scan loop's terminal outcome (nil for a clean EOF, the
+// read error otherwise) for drain to report once every already-queued line
+// has been drained.
+func (b *lineBuffer) close(err error) {
+	b.mu.Lock()
+	b.closed = true
+	b.err = err
+	b.mu.Unlock()
+	b.wake()
+}
+
+// drain atomically takes every currently queued line (resetting the queue to
+// empty) along with the closed/err state, so the consumer can forward the
+// lines to sink and then decide whether to keep looping.
+func (b *lineBuffer) drain() (lines [][]byte, closed bool, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	lines, b.lines = b.lines, nil
+	b.bytes = 0
+	return lines, b.closed, b.err
+}
+
+// wake posts a non-blocking signal to notify; a already-pending signal (the
+// consumer has not yet woken to consume it) makes this a no-op, since the
+// consumer will observe the latest state on its next drain regardless.
+func (b *lineBuffer) wake() {
+	select {
+	case b.notify <- struct{}{}:
+	default:
 	}
 }

--- a/internal/saas/console/clustersandbox/logs.go
+++ b/internal/saas/console/clustersandbox/logs.go
@@ -251,6 +251,7 @@ func (b *lineBuffer) push(line []byte) {
 	b.bytes += len(line)
 	for b.bytes > maxLogBufferBytes && len(b.lines) > 1 {
 		b.bytes -= len(b.lines[0])
+		b.lines[0] = nil
 		b.lines = b.lines[1:]
 	}
 	b.mu.Unlock()

--- a/internal/saas/console/clustersandbox/logs_test.go
+++ b/internal/saas/console/clustersandbox/logs_test.go
@@ -261,18 +261,64 @@ func TestReadBoundedLineEOFMidLineStripsTrailingCR(t *testing.T) {
 	}
 }
 
-// TestPushDropOldestDropsOldestWhenFull is the deterministic unit test for
-// the bounded, drop-oldest buffer streamPodLines relies on to bound memory
-// against a slow sink: once full, pushing one more line drops the OLDEST
-// queued line, not the newest.
-func TestPushDropOldestDropsOldestWhenFull(t *testing.T) {
-	ch := make(chan []byte, 2)
-	pushDropOldest(ch, []byte("a"))
-	pushDropOldest(ch, []byte("b"))
-	pushDropOldest(ch, []byte("c")) // "a" is the oldest; it must be dropped
+// TestLineBufferPushDropsOldestWhenOverByteCap is the deterministic unit
+// test for lineBuffer's drop-oldest behavior at small scale: once the total
+// queued bytes would exceed maxLogBufferBytes, push drops from the front
+// (oldest first) until the newest line fits, never dropping the newest line
+// itself.
+func TestLineBufferPushDropsOldestWhenOverByteCap(t *testing.T) {
+	buf := newLineBuffer()
+	// Three lines whose first two together already exceed a tiny custom
+	// budget would be awkward to express against the real (4 MiB)
+	// maxLogBufferBytes, so this test instead drives push directly with
+	// lines sized relative to the real cap: two lines just over half the
+	// cap each, so the second push's drop-oldest loop must evict the first.
+	half := maxLogBufferBytes/2 + 1
+	a := bytes.Repeat([]byte("a"), half)
+	b := bytes.Repeat([]byte("b"), half)
+	buf.push(a)
+	buf.push(b) // "a" no longer fits alongside "b"; it must be dropped
 
-	first, second := string(<-ch), string(<-ch)
-	if first != "b" || second != "c" {
-		t.Fatalf("drained = [%q %q], want [\"b\" \"c\"] (drop-oldest)", first, second)
+	lines, _, _ := buf.drain()
+	if len(lines) != 1 || string(lines[0]) != string(b) {
+		t.Fatalf("drained %d line(s), want exactly the newest (b) line; oldest (a) was not dropped", len(lines))
+	}
+}
+
+// TestLineBufferPushBoundsTotalBytesAndKeepsNewest is the TDD test for the
+// MAJOR fix in issue #726: pushing many near-1-MiB lines (each individually
+// under maxLogLineBytes, exactly as a chatty sandbox's real log lines would
+// be truncated to by discardOversizedLine) must NEVER let the buffer's total
+// queued bytes exceed maxLogBufferBytes, regardless of how many lines a slow
+// consumer lets accumulate. The prior line-COUNT cap (512 lines) allowed up
+// to ~512 MiB here; the byte-bounded queue must hold at most a handful of
+// near-1-MiB lines. The newest line must always survive (drop-oldest, never
+// drop-newest).
+func TestLineBufferPushBoundsTotalBytesAndKeepsNewest(t *testing.T) {
+	buf := newLineBuffer()
+	const lineSize = maxLogLineBytes - 10 // near 1 MiB, comfortably under maxLogBufferBytes on its own
+	const pushCount = 50                  // 50 * ~1 MiB > 48 MiB, far over the 4 MiB cap
+
+	var last []byte
+	for i := 0; i < pushCount; i++ {
+		line := bytes.Repeat([]byte{byte('a' + i%26)}, lineSize)
+		last = line
+		buf.push(line)
+		if buf.bytes > maxLogBufferBytes {
+			t.Fatalf("after push %d: buffered bytes = %d, want <= maxLogBufferBytes (%d)", i, buf.bytes, maxLogBufferBytes)
+		}
+	}
+
+	lines, _, _ := buf.drain()
+	if len(lines) == 0 {
+		t.Fatal("every line was dropped; the newest line must always be kept")
+	}
+	if newest := lines[len(lines)-1]; string(newest) != string(last) {
+		t.Fatal("the newest pushed line was not the newest line retained; drop-oldest was violated")
+	}
+	// Sanity: with lineSize near 1 MiB and a 4 MiB cap, at most a handful of
+	// lines can coexist, proving this is nowhere near the old ~512-line cap.
+	if len(lines) > 10 {
+		t.Fatalf("retained %d lines of ~1 MiB each, want a small handful under the 4 MiB cap", len(lines))
 	}
 }

--- a/internal/saas/console/sandbox_ops.go
+++ b/internal/saas/console/sandbox_ops.go
@@ -574,6 +574,16 @@ func (c *Console) handleSandboxLogsStream(w http.ResponseWriter, r *http.Request
 			}
 			if !sink.wrote {
 				writeSSEHeaders(w)
+				// Without this, an empty stream (StreamLogs completed
+				// cleanly with zero lines, e.g. no log output yet) would
+				// send its 200 SSE headers here but sink.wrote would stay
+				// false forever: heartbeat() no-ops on !wrote, so the
+				// ticker.C case below would never emit another byte for
+				// the rest of this connection's life, and an idle-timeout
+				// proxy between the console and the browser could drop it
+				// as dead despite the connection being intentionally held
+				// open.
+				sink.wrote = true
 			}
 			flusher.Flush()
 		case <-ticker.C:

--- a/internal/saas/console/sandbox_ops_test.go
+++ b/internal/saas/console/sandbox_ops_test.go
@@ -547,6 +547,74 @@ func TestSandboxLogsStreamHeartbeatsDuringBlockingFollowTransport(t *testing.T) 
 	}
 }
 
+// emptyLogStreamer models a LogStreamer that completes cleanly having
+// written zero lines (e.g. a sandbox with no log output yet). It is the
+// stand-in for the MINOR fix in issue #726: before that fix, this exact
+// shape left sink.wrote permanently false even after writeSSEHeaders had
+// already sent the 200 response, so the ticker.C heartbeat case no-op'd for
+// the rest of the connection's life.
+type emptyLogStreamer struct{}
+
+func (emptyLogStreamer) StreamLogs(_ context.Context, _, _ string, _ LogSink) error {
+	return nil
+}
+
+// TestSandboxLogsStreamEmptyStreamStillHeartbeats is the regression test for
+// the MINOR fix in issue #726: a stream that finishes with zero log lines
+// (StreamLogs returns nil having never called sink.Write) must still send
+// heartbeats for as long as the connection is held open, not go silent after
+// its initial 200 response. Before the fix, writeSSEHeaders was called but
+// sink.wrote was never latched true on this path, so heartbeat() kept
+// no-op'ing forever and an idle-timeout proxy could drop the connection
+// despite it being intentionally kept alive.
+func TestSandboxLogsStreamEmptyStreamStillHeartbeats(t *testing.T) {
+	origInterval := sseHeartbeatInterval
+	sseHeartbeatInterval = 5 * time.Millisecond
+	t.Cleanup(func() { sseHeartbeatInterval = origInterval })
+
+	sandboxes := NewMemSandboxControl()
+	sandboxes.Add(SandboxView{ID: "sb-1", OrgID: "org-alice"})
+	con := New(Deps{
+		Accounts:  newMemberAuthorizedAccounts(t, "acct-1", "org-alice"),
+		Sandboxes: sandboxes,
+		Logs:      emptyLogStreamer{},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest("GET", "/console/sandboxes/sb-1/logs/stream", nil)
+	r = r.WithContext(WithCaller(ctx, "acct-1", "org-alice"))
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		con.ServeHTTP(w, r)
+		close(done)
+	}()
+
+	// Give the heartbeat ticker time to fire more than once after StreamLogs
+	// already completed with zero lines, proving wrote latched true with no
+	// real content ever written.
+	time.Sleep(40 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after ctx cancel for an empty (zero-line) stream")
+	}
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "data:") {
+		t.Fatalf("expected no data events for an empty stream, got: %q", body)
+	}
+	if strings.Count(body, ": heartbeat") < 2 {
+		t.Fatalf("want at least 2 heartbeats for an empty (zero-line) stream, got: %q", body)
+	}
+}
+
 // recordingPeriodicLogStreamer models a real follow transport that keeps
 // writing lines on its own goroutine for as long as ctx is alive (a live
 // husk-pod follow with steady output), unlike blockingLogStreamer above which


### PR DESCRIPTION
Closes #726. Fast-follow hardening on the live log transport (#725) before it goes live under load.

- Live log-follow buffer was bounded by line count (512) with each line up to 1 MiB, so a slow SSE client plus a chatty sandbox could buffer up to ~512 MiB per stream and concurrent slow viewers could exhaust the multi-tenant console. Replaced with a mutex-guarded byte-bounded drop-oldest queue capped at 4 MiB (a single 1 MiB line always fits); per-line 1 MiB truncation unchanged.
- Empty SSE streams now mark the sink written after headers so they still heartbeat and survive idle proxies.
- Kube config-load vs clientset-construction errors wrapped with %w so logs identify the failing step.

## Thinking Path
CodeRabbit Major on PR #725; fixed as its own PR to land in the same release rather than defer live. TDD, independently reviewed (approved, no findings).

## Model Used
Claude Fable 5 orchestration + review, Claude Sonnet 5 implementation via Claude Code.

## Verification
go build clean; go test -race ./internal/saas/console/... green incl. new byte-cap and empty-stream-heartbeat regression tests (-count=5 no race); golangci-lint v1.64.8 clean; apierrlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented silent SSE log streams when no log lines are produced by continuing heartbeats until the request ends.
  * Improved log buffering to cap queued log data by total buffered bytes (dropping oldest as needed while keeping newest lines).
  * Added clearer, contextual error messages when log streaming setup fails.
* **Tests**
  * Added a regression test ensuring empty log streams still return `200 OK` and emit only heartbeat comments.
  * Replaced fixed-line drop tests with new byte-cap-focused buffering tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->