### PR TITLE
fix(cli): hosted fork and ls against the real gateway wire

### DIFF
--- a/internal/agentcli/hostedbackend.go
+++ b/internal/agentcli/hostedbackend.go
@@ -51,14 +51,14 @@ func inClusterBaseURL() string {
 //	ws (workspace verbs)     -> not supported; use the hosted dashboard or cluster mode
 //	template build/push      -> not supported; use cluster mode with a KVM node
 //
-// Fork semantics: Fork(sandboxID, n) issues n POST /v1/fork calls, each with
-// {"template": sandboxID, "id": newID}. The gateway resolves the sandbox to its
-// original template and re-forks from that snapshot -- exactly what
-// mcp.HTTPBackend.Fork does and what the Python SDK does (passing self.template
-// to /v1/fork). The source sandbox keeps running; each child is an independent
-// sibling cloned from the shared template snapshot, NOT a live memory fork of
-// the running sandbox. That live-fork capability requires the cluster backend
-// (source.fromSandbox on a KVM node).
+// Fork semantics: Fork(sandboxID, n) issues n POST /v1/sandboxes/{id}/fork
+// calls (one per child, each with a fresh Idempotency-Key), the TRUE live-fork
+// route the gateway serves since PR #710: the control plane checkpoints the
+// running source and boots each child from that checkpoint (source.fromSandbox),
+// so children inherit the source's live memory and disk. This is exactly what
+// mcp.HTTPBackend.Fork does and what the Python SDK's _fork_one does. Against
+// an older server without that route, Fork falls back once to the legacy flat
+// template route (POST /v1/fork).
 type HostedBackend struct {
 	baseURL string           // trailing slash stripped; set once at construction
 	apiKey  string           // bearer token; NEVER logged or placed in errors
@@ -179,12 +179,17 @@ func (b *HostedBackend) WriteFile(ctx context.Context, sandboxID, path, content 
 	return b.hb.WriteFile(ctx, sandboxID, path, content)
 }
 
-// Fork forks sandboxID into n independent siblings by issuing n POST /v1/fork
-// calls, each with {"template": sandboxID, "id": <random>}. The gateway
-// resolves the sandbox to its template and re-forks from that snapshot; the
-// source sandbox keeps running. This matches the mcp.HTTPBackend.Fork and
-// Python SDK fork behavior. A replicas value below 1 is treated as 1. On a
-// mid-loop failure the error names the already-created ids.
+// Fork live-forks sandboxID into n children by issuing n POST
+// /v1/sandboxes/{id}/fork calls (each with {"id": <child>, "pause_source":
+// true} and a fresh Idempotency-Key): the gateway checkpoints the RUNNING
+// source and boots each child from that checkpoint, so children inherit the
+// source's live memory and disk; the source keeps running. The old flat
+// POST /v1/fork {"template": sandboxID} route is only used as a one-shot
+// fallback against older servers (the hosted control plane resolves that
+// template field as a pool name and answers 404 `no such pool "sb-..."`).
+// This matches the mcp.HTTPBackend.Fork and Python SDK fork behavior. A
+// replicas value below 1 is treated as 1. On a mid-loop failure the error
+// names the already-created ids.
 func (b *HostedBackend) Fork(ctx context.Context, sandboxID string, n int) ([]string, error) {
 	return b.hb.Fork(ctx, sandboxID, n)
 }
@@ -194,35 +199,82 @@ func (b *HostedBackend) Terminate(ctx context.Context, sandboxID string) error {
 	return b.hb.Terminate(ctx, sandboxID)
 }
 
-// hostedSandboxEntry is one element of the GET /v1/sandboxes response.
+// hostedSandboxEntry is one element of the GET /v1/sandboxes response. It
+// covers BOTH wire shapes: the hosted gateway's entries carry id, phase,
+// endpoint, and a camelCase createdAt; the standalone sandbox-server's entries
+// carry id, template_id, endpoint, snake_case created_at, and fork_time_ms.
 type hostedSandboxEntry struct {
-	ID         string  `json:"id"`
-	TemplateID string  `json:"template_id"`
-	Endpoint   string  `json:"endpoint"`
-	CreatedAt  string  `json:"created_at"`
-	ForkTimeMs float64 `json:"fork_time_ms"`
+	ID         string `json:"id"`
+	TemplateID string `json:"template_id"`
+	Endpoint   string `json:"endpoint"`
+	Phase      string `json:"phase"`
+	CreatedAt  string `json:"created_at"`
+	// CreatedAtCamel is the hosted gateway's spelling of the creation
+	// timestamp; createdTime returns whichever key the server sent.
+	CreatedAtCamel string  `json:"createdAt"`
+	ForkTimeMs     float64 `json:"fork_time_ms"`
+}
+
+// createdTime returns the creation timestamp under whichever key the server
+// used (created_at on the standalone server, createdAt on the hosted gateway).
+func (s hostedSandboxEntry) createdTime() string {
+	if s.CreatedAt != "" {
+		return s.CreatedAt
+	}
+	return s.CreatedAtCamel
+}
+
+// decodeSandboxList decodes a GET /v1/sandboxes response body in EITHER wire
+// shape: the hosted gateway returns an object {"sandboxes": [...]}, while the
+// standalone sandbox-server returns a bare array.
+func decodeSandboxList(raw []byte) ([]hostedSandboxEntry, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var items []hostedSandboxEntry
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return nil, fmt.Errorf("decode sandbox list array: %w", err)
+		}
+		return items, nil
+	}
+	var wrapped struct {
+		Sandboxes []hostedSandboxEntry `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(trimmed, &wrapped); err != nil {
+		return nil, fmt.Errorf("decode sandbox list object: %w", err)
+	}
+	return wrapped.Sandboxes, nil
 }
 
 // List calls GET /v1/sandboxes and maps the results to SandboxInfo rows. The
 // namespace argument is ignored in hosted mode (the api key scopes visibility).
-// The Phase is always "Ready" because listed sandboxes are live by definition.
-// The Pool field carries the template id, the nearest analog to a pool name.
+// The Phase comes off the wire when the server reports one (the hosted gateway
+// does) and defaults to "Ready" otherwise (the standalone server lists only
+// live sandboxes). The Pool field carries the template id when the server
+// reports one, the nearest analog to a pool name.
 func (b *HostedBackend) List(ctx context.Context, _ string) ([]SandboxInfo, error) {
-	var items []hostedSandboxEntry
-	if err := b.do(ctx, http.MethodGet, "/v1/sandboxes", nil, &items); err != nil {
+	var raw json.RawMessage
+	if err := b.do(ctx, http.MethodGet, "/v1/sandboxes", nil, &raw); err != nil {
+		return nil, fmt.Errorf("list sandboxes: %w", err)
+	}
+	items, err := decodeSandboxList(raw)
+	if err != nil {
 		return nil, fmt.Errorf("list sandboxes: %w", err)
 	}
 	now := time.Now()
 	out := make([]SandboxInfo, 0, len(items))
 	for _, s := range items {
 		age := time.Duration(0)
-		if t, err := time.Parse(time.RFC3339, s.CreatedAt); err == nil {
+		if t, err := time.Parse(time.RFC3339, s.createdTime()); err == nil {
 			age = now.Sub(t)
+		}
+		phase := s.Phase
+		if phase == "" {
+			phase = "Ready"
 		}
 		out = append(out, SandboxInfo{
 			Name:     s.ID,
 			Pool:     s.TemplateID,
-			Phase:    "Ready",
+			Phase:    phase,
 			Node:     "",
 			Endpoint: s.Endpoint,
 			Age:      age,

--- a/internal/agentcli/hostedbackend_test.go
+++ b/internal/agentcli/hostedbackend_test.go
@@ -22,6 +22,7 @@ type hostedCaptured struct {
 	Method string
 	Path   string
 	Auth   string
+	Idem   string // Idempotency-Key header, empty when absent
 	Body   map[string]any
 }
 
@@ -83,8 +84,13 @@ type hostedGateway struct {
 	Requests []*hostedCaptured
 
 	// Canned REST responses.
-	forkID    string
-	listItems []hostedSandboxEntry
+	forkID string
+	// listJSON is the EXACT GET /v1/sandboxes response body. The production
+	// hosted gateway returns an OBJECT {"sandboxes":[...]} whose entries carry
+	// id, phase, endpoint, and a camelCase createdAt; the standalone
+	// sandbox-server returns a BARE ARRAY of {id, template_id, endpoint,
+	// created_at, fork_time_ms}. Tests set whichever wire shape they assert.
+	listJSON string
 
 	// connect handler for runtime RPCs.
 	connectFake *hostedFakeSandbox
@@ -102,6 +108,7 @@ func (g *hostedGateway) capture(r *http.Request) *hostedCaptured {
 		Method: r.Method,
 		Path:   r.URL.Path,
 		Auth:   r.Header.Get("Authorization"),
+		Idem:   r.Header.Get("Idempotency-Key"),
 	}
 	if r.Body != nil {
 		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
@@ -143,11 +150,34 @@ func (g *hostedGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"fork_time_ms": 12.5,
 		})
 
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/sandboxes/") && strings.HasSuffix(r.URL.Path, "/fork"):
+		// Live fork (PR #710): create-shaped response {id, endpoint, token,
+		// phase, template_id, fork_time_ms}.
+		id := g.forkID
+		if raw, ok := c.Body["id"].(string); ok && raw != "" {
+			id = raw
+		}
+		writeJSON(http.StatusOK, map[string]any{
+			"id":           id,
+			"endpoint":     "sandbox-endpoint:9091",
+			"token":        "child-token-never-used-by-fork",
+			"phase":        "Ready",
+			"template_id":  "python",
+			"fork_time_ms": 42.5,
+		})
+
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes":
-		writeJSON(http.StatusOK, g.listItems)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		body := g.listJSON
+		if body == "" {
+			body = `{"sandboxes":[]}`
+		}
+		_, _ = w.Write([]byte(body))
 
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/v1/sandboxes/"):
-		writeJSON(http.StatusOK, nil)
+		// The hosted gateway answers a terminate with 204 No Content.
+		w.WriteHeader(http.StatusNoContent)
 
 	default:
 		// Fall through to the Connect RPC handler (served from the mux).
@@ -252,33 +282,19 @@ func TestHostedBackendExec(t *testing.T) {
 	}
 }
 
-// TestHostedBackendForkN asserts Fork(id, n) issues n POST /v1/fork requests,
-// each with {"template": sandboxID, "id": <unique>}, all carrying the Bearer
-// token, and returns n distinct ids.
+// TestHostedBackendForkN asserts Fork(id, n) issues n POST
+// /v1/sandboxes/{id}/fork live-fork requests (one per child, NEVER the flat
+// /v1/fork template route, which the hosted control plane resolves as a pool
+// name and 404s with `no such pool "sb-..."`), each carrying the Bearer token,
+// a unique child id with pause_source, and a unique Idempotency-Key, and
+// returns n distinct ids.
 func TestHostedBackendForkN(t *testing.T) {
 	const apiKey = "sk-test-fork"
 	const srcID = "sbx-src"
 	const n = 3
 
 	gw := newHostedGateway(apiKey)
-	// Override to echo the id from the request body.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c := gw.capture(r)
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/fork":
-			id, _ := c.Body["id"].(string)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id":          id,
-				"template_id": c.Body["template"],
-				"endpoint":    "ep:9091",
-				"fork_time_ms": 5.0,
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(srv.Close)
+	srv := hostedTestServer(t, gw)
 
 	b := NewHostedBackend(srv.URL, apiKey, srv.Client())
 	ids, err := b.Fork(context.Background(), srcID, n)
@@ -293,34 +309,94 @@ func TestHostedBackendForkN(t *testing.T) {
 		t.Fatalf("Fork made %d requests, want %d", len(gw.Requests), n)
 	}
 	seen := map[string]bool{}
+	seenKeys := map[string]bool{}
 	for i, req := range gw.Requests {
-		if req.Method != http.MethodPost || req.Path != "/v1/fork" {
-			t.Fatalf("Fork req[%d] = %s %s, want POST /v1/fork", i, req.Method, req.Path)
+		if req.Method != http.MethodPost || req.Path != "/v1/sandboxes/"+srcID+"/fork" {
+			t.Fatalf("Fork req[%d] = %s %s, want POST /v1/sandboxes/%s/fork", i, req.Method, req.Path, srcID)
 		}
 		if bearerOf(req.Auth) != apiKey {
 			t.Fatalf("Fork req[%d] auth = %q, want Bearer %s", i, req.Auth, apiKey)
-		}
-		if req.Body["template"] != srcID {
-			t.Fatalf("Fork req[%d] template = %v, want %s", i, req.Body["template"], srcID)
 		}
 		id, _ := req.Body["id"].(string)
 		if id == "" || seen[id] {
 			t.Fatalf("Fork req[%d] had empty or duplicate id %q", i, id)
 		}
 		seen[id] = true
+		if pause, ok := req.Body["pause_source"].(bool); !ok || !pause {
+			t.Fatalf("Fork req[%d] pause_source = %v, want true", i, req.Body["pause_source"])
+		}
+		if req.Idem == "" || seenKeys[req.Idem] {
+			t.Fatalf("Fork req[%d] had empty or duplicate Idempotency-Key %q", i, req.Idem)
+		}
+		seenKeys[req.Idem] = true
+	}
+}
+
+// TestHostedBackendForkFallsBackOnOlderGateway asserts that a server which
+// answers the live-fork route with a route-level 404 (an older deployment
+// without the sandbox.fork op) makes Fork fall back ONCE to the legacy flat
+// /v1/fork template route for every child.
+func TestHostedBackendForkFallsBackOnOlderGateway(t *testing.T) {
+	const apiKey = "sk-test-fork-fallback"
+	const srcID = "sbx-src"
+
+	gw := newHostedGateway(apiKey)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c := gw.capture(r)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/sandboxes/") && strings.HasSuffix(r.URL.Path, "/fork"):
+			// The older gateway's exact route-level not_found envelope.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"no such route or operation","cause":"the request did not map to a known gateway operation (resolved op \"sandbox.post\")","remediation":"Use a documented route."}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fork":
+			id, _ := c.Body["id"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           id,
+				"template_id":  c.Body["template"],
+				"endpoint":     "ep:9091",
+				"fork_time_ms": 5.0,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	b := NewHostedBackend(srv.URL, apiKey, srv.Client())
+	ids, err := b.Fork(context.Background(), srcID, 2)
+	if err != nil {
+		t.Fatalf("Fork with fallback: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("Fork returned %d ids, want 2", len(ids))
+	}
+	// Exactly one live-route probe, then 2 flat-route forks.
+	if len(gw.Requests) != 3 {
+		t.Fatalf("Fork made %d requests, want 3 (1 probe + 2 flat)", len(gw.Requests))
+	}
+	if gw.Requests[0].Path != "/v1/sandboxes/"+srcID+"/fork" {
+		t.Fatalf("first request = %q, want the live-fork probe", gw.Requests[0].Path)
+	}
+	for i, req := range gw.Requests[1:] {
+		if req.Path != "/v1/fork" || req.Body["template"] != srcID {
+			t.Fatalf("fallback req[%d] = %s body %v, want POST /v1/fork with template %s", i, req.Path, req.Body, srcID)
+		}
 	}
 }
 
 // TestHostedBackendList asserts List calls GET /v1/sandboxes with the Bearer
-// token and maps the response to SandboxInfo rows. The namespace argument is
-// ignored in hosted mode.
+// token and decodes the PRODUCTION hosted gateway shape: an OBJECT
+// {"sandboxes":[...]} (not a bare array) whose entries carry id, phase,
+// endpoint, and a camelCase createdAt. Phase and age must come from the wire.
 func TestHostedBackendList(t *testing.T) {
 	const apiKey = "sk-test-list"
 	gw := newHostedGateway(apiKey)
-	gw.listItems = []hostedSandboxEntry{
-		{ID: "sbx-1", TemplateID: "python", Endpoint: "ep1:9091", CreatedAt: time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)},
-		{ID: "sbx-2", TemplateID: "node", Endpoint: "ep2:9091", CreatedAt: time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)},
-	}
+	created1 := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	created2 := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	gw.listJSON = `{"sandboxes":[` +
+		`{"id":"sbx-1","phase":"Ready","endpoint":"ep1:9091","createdAt":"` + created1 + `"},` +
+		`{"id":"sbx-2","phase":"Pending","endpoint":"ep2:9091","createdAt":"` + created2 + `"}]}`
 	srv := hostedTestServer(t, gw)
 
 	b := NewHostedBackend(srv.URL, apiKey, srv.Client())
@@ -347,17 +423,53 @@ func TestHostedBackendList(t *testing.T) {
 		t.Fatalf("List auth = %q, want Bearer %s", listReq.Auth, apiKey)
 	}
 
-	// Assert row mapping.
+	// Assert row mapping: phase and age come off the wire, not hardcoded.
+	wantPhase := map[string]string{"sbx-1": "Ready", "sbx-2": "Pending"}
 	for _, info := range infos {
-		if info.Phase != "Ready" {
-			t.Errorf("List row %s phase = %q, want Ready", info.Name, info.Phase)
-		}
-		if info.Name != "sbx-1" && info.Name != "sbx-2" {
+		want, ok := wantPhase[info.Name]
+		if !ok {
 			t.Errorf("List row name = %q, want sbx-1 or sbx-2", info.Name)
+			continue
+		}
+		if info.Phase != want {
+			t.Errorf("List row %s phase = %q, want %q", info.Name, info.Phase, want)
 		}
 		if info.Age <= 0 {
-			t.Errorf("List row %s age = %v, want > 0", info.Name, info.Age)
+			t.Errorf("List row %s age = %v, want > 0 (createdAt must be parsed)", info.Name, info.Age)
 		}
+	}
+}
+
+// TestHostedBackendListBareArray asserts List also decodes the STANDALONE
+// sandbox-server shape: a bare JSON array of {id, template_id, endpoint,
+// created_at, fork_time_ms} entries. Entries without a phase default to Ready.
+func TestHostedBackendListBareArray(t *testing.T) {
+	const apiKey = "sk-test-list-array"
+	gw := newHostedGateway(apiKey)
+	created := time.Now().Add(-90 * time.Second).UTC().Format(time.RFC3339)
+	gw.listJSON = `[{"id":"sbx-a","template_id":"python","endpoint":"ep:9091","created_at":"` + created + `","fork_time_ms":12.5}]`
+	srv := hostedTestServer(t, gw)
+
+	b := NewHostedBackend(srv.URL, apiKey, srv.Client())
+	infos, err := b.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("List (bare array): %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("List returned %d rows, want 1", len(infos))
+	}
+	info := infos[0]
+	if info.Name != "sbx-a" {
+		t.Errorf("row name = %q, want sbx-a", info.Name)
+	}
+	if info.Pool != "python" {
+		t.Errorf("row pool = %q, want python (template_id)", info.Pool)
+	}
+	if info.Phase != "Ready" {
+		t.Errorf("row phase = %q, want Ready default when the wire has no phase", info.Phase)
+	}
+	if info.Age <= 0 {
+		t.Errorf("row age = %v, want > 0 (created_at must be parsed)", info.Age)
 	}
 }
 
@@ -552,9 +664,8 @@ func TestHostedBackendCLIRoutesOnAPIKey(t *testing.T) {
 	// This exercises the agentcli.Run dispatch with a HostedBackend.
 	const apiKey = "sk-cli-route-test"
 	gw := newHostedGateway(apiKey)
-	gw.listItems = []hostedSandboxEntry{
-		{ID: "sbx-1", TemplateID: "python", Endpoint: "ep:9091", CreatedAt: time.Now().UTC().Format(time.RFC3339)},
-	}
+	gw.listJSON = `{"sandboxes":[{"id":"sbx-1","phase":"Ready","endpoint":"ep:9091","createdAt":"` +
+		time.Now().UTC().Format(time.RFC3339) + `"}]}`
 	srv := hostedTestServer(t, gw)
 
 	b := NewHostedBackend(srv.URL, apiKey, srv.Client())

--- a/internal/mcp/httpbackend.go
+++ b/internal/mcp/httpbackend.go
@@ -41,7 +41,7 @@ func validSandboxID(id string) bool {
 // Transport split (issue #358): the runtime calls (exec, file read, file write)
 // ride the Connect sandbox.v1.Sandbox protocol via the in-module generated
 // connect-go client (ExecStream, ReadFile, WriteFile RPCs); the lifecycle calls
-// (fork, terminate) stay on the legacy /v1 JSON routes via do. Both reach the
+// (create, fork, terminate) stay on the /v1 JSON routes via do. Both reach the
 // same baseURL with the same bearer token; the sandbox id rides the
 // X-Sandbox-Id header on the runtime RPCs.
 //
@@ -87,11 +87,33 @@ func newSandboxID() string {
 	return "sbx-" + hex.EncodeToString(b[:])
 }
 
+// httpStatusError is a non-2xx /v1 response. The status and (already redacted)
+// body stay structured so a caller can branch on the exact failure, e.g. Fork's
+// live-route fallback, without parsing the error string. Its Error string is
+// byte-for-byte the message do has always produced.
+type httpStatusError struct {
+	Method string
+	Path   string
+	Status int
+	Body   string // redacted before construction; never carries the token
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("%s %s: status %d: %s", e.Method, e.Path, e.Status, e.Body)
+}
+
 // do issues an HTTP request to path with an optional JSON body and decodes a
 // 2xx JSON response into out (when out is non-nil). A non-2xx status becomes an
 // error carrying the response body as context, with any echo of the bearer
 // token redacted first so the secret never reaches a caller, a log, or an LLM.
 func (b *HTTPBackend) do(ctx context.Context, method, path string, body any, out any) error {
+	return b.doWithHeader(ctx, method, path, nil, body, out)
+}
+
+// doWithHeader is do with extra request headers (e.g. Idempotency-Key on a
+// fork). A nil header sends none beyond the standard Content-Type and
+// Authorization pair. A non-2xx status returns an *httpStatusError.
+func (b *HTTPBackend) doWithHeader(ctx context.Context, method, path string, header http.Header, body any, out any) error {
 	var reader io.Reader
 	if body != nil {
 		raw, err := json.Marshal(body)
@@ -104,6 +126,11 @@ func (b *HTTPBackend) do(ctx context.Context, method, path string, body any, out
 	req, err := http.NewRequestWithContext(ctx, method, b.baseURL+path, reader)
 	if err != nil {
 		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -121,7 +148,12 @@ func (b *HTTPBackend) do(ctx context.Context, method, path string, body any, out
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, b.redact(string(respBody)))
+		return &httpStatusError{
+			Method: method,
+			Path:   path,
+			Status: resp.StatusCode,
+			Body:   b.redact(string(respBody)),
+		}
 	}
 
 	if out != nil {
@@ -356,16 +388,75 @@ func (b *HTTPBackend) WriteFile(ctx context.Context, sandboxID, path, content st
 	return nil
 }
 
-// Fork forks the sandbox replicas times. The sandbox-server fork endpoint has
-// no replicas parameter, so this issues one POST /v1/fork per replica. Caveat:
-// the sandbox-server /v1/fork "template" field is a template lookup, so this
-// passes the source sandbox id as the template key; on the standalone server a
-// fork-of-a-fork therefore requires that key to resolve to a known template.
-// The richer k8s SandboxFork path (true fork-of-a-running-sandbox) belongs to
-// the future k8s backend. A replicas value below 1 is treated as 1.
+// idempotencyHeader is the header carrying the fork idempotency key, matching
+// the Python and Go SDKs, so a transparently retried fork never double-creates
+// a child (issue #22).
+const idempotencyHeader = "Idempotency-Key"
+
+// newIdempotencyKey returns a random hex Idempotency-Key. An empty string (the
+// never-in-practice crypto/rand failure) means the header is simply omitted.
+func newIdempotencyKey() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// isLiveForkRouteMissing reports whether err is a ROUTE-LEVEL 404 for the
+// per-sandbox live-fork route: the server does not serve the route at all
+// (an older gateway without the sandbox.fork op, or an older standalone
+// sandbox-server whose mux answers a plain "404 page not found"). A 404 whose
+// error envelope names a missing SANDBOX or POOL is a real answer about the
+// fork source and must never be mistaken for a missing route.
+func isLiveForkRouteMissing(err error) bool {
+	var se *httpStatusError
+	if !errors.As(err, &se) || se.Status != http.StatusNotFound {
+		return false
+	}
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal([]byte(se.Body), &env); jsonErr == nil && env.Error.Code != "" {
+		if env.Error.Code != "not_found" {
+			return false
+		}
+		// The older gateway's route-level 404 says "no such route or operation";
+		// a missing source says "no such sandbox" and a pool lookup says "no such
+		// pool", neither of which mentions a route or operation.
+		msg := strings.ToLower(env.Error.Message)
+		return strings.Contains(msg, "route") || strings.Contains(msg, "operation")
+	}
+	// Not the /v1 error envelope: an older standalone sandbox-server without
+	// the route answers with net/http's default "404 page not found".
+	return strings.Contains(strings.ToLower(se.Body), "page not found")
+}
+
+// Fork forks the RUNNING sandbox replicas times via the per-sandbox live-fork
+// route: one POST /v1/sandboxes/{id}/fork per child with {"id": <child>,
+// "pause_source": true} and a fresh Idempotency-Key, exactly like the Python
+// SDK's _fork_one. The server checkpoints the running source (memory plus
+// on-disk filesystem, captured while the source is paused so the two are
+// consistent) and boots each child from that checkpoint; the response is
+// create-shaped (id, endpoint, token, phase, template_id, fork_time_ms).
 //
-// On a mid-loop failure, the error wraps the already-created ids so callers can
-// terminate them: "fork created [id1 id2] before failing: <cause>".
+// The previous behavior (POST /v1/fork with the SOURCE SANDBOX ID in the
+// template field) only worked when that id happened to name a template; the
+// hosted control plane resolves the template field as a pool name, so it
+// failed with 404 `no such pool "sb-..."`.
+//
+// Compatibility: a server that does not serve the live-fork route answers the
+// FIRST call with a route-level 404 (see isLiveForkRouteMissing); Fork then
+// falls back ONCE to the legacy flat template route (POST /v1/fork
+// {template: sandboxID, id}) for every child. A 404 naming a missing sandbox
+// or pool is a real failure and is returned, never treated as a missing route.
+//
+// A replicas value below 1 is treated as 1. On a mid-loop failure, the error
+// wraps the already-created ids so callers can terminate them:
+// "fork created [id1 id2] before failing: <cause>".
 func (b *HTTPBackend) Fork(ctx context.Context, sandboxID string, replicas int) ([]string, error) {
 	if !validSandboxID(sandboxID) {
 		return nil, fmt.Errorf("fork: invalid sandbox id %q", sandboxID)
@@ -373,14 +464,36 @@ func (b *HTTPBackend) Fork(ctx context.Context, sandboxID string, replicas int) 
 	if replicas < 1 {
 		replicas = 1
 	}
+	livePath := "/v1/sandboxes/" + url.PathEscape(sandboxID) + "/fork"
+	useFlat := false
 	ids := make([]string, 0, replicas)
 	for i := 0; i < replicas; i++ {
 		id := newSandboxID()
 		var resp forkResponse
-		if err := b.do(ctx, http.MethodPost, "/v1/fork", map[string]any{
-			"template": sandboxID,
-			"id":       id,
-		}, &resp); err != nil {
+		var err error
+		if !useFlat {
+			header := http.Header{}
+			if key := newIdempotencyKey(); key != "" {
+				header.Set(idempotencyHeader, key)
+			}
+			err = b.doWithHeader(ctx, http.MethodPost, livePath, header, map[string]any{
+				"id":           id,
+				"pause_source": true,
+			}, &resp)
+			if err != nil && i == 0 && isLiveForkRouteMissing(err) {
+				// Older server without the live-fork route: fall back once to
+				// the legacy flat template route for this and every later child.
+				useFlat = true
+			}
+		}
+		if useFlat {
+			resp = forkResponse{}
+			err = b.do(ctx, http.MethodPost, "/v1/fork", map[string]any{
+				"template": sandboxID,
+				"id":       id,
+			}, &resp)
+		}
+		if err != nil {
 			return ids, fmt.Errorf("fork created %v before failing: %w", ids, err)
 		}
 		if resp.ID != "" {

--- a/internal/mcp/httpbackend_test.go
+++ b/internal/mcp/httpbackend_test.go
@@ -141,6 +141,7 @@ type capturedRequest struct {
 	Method string
 	Path   string
 	Auth   string
+	Idem   string // Idempotency-Key header, empty when absent
 	Body   map[string]any
 }
 
@@ -155,6 +156,7 @@ func recordingServer(t *testing.T, got *[]capturedRequest, handler func(cr captu
 			Method: r.Method,
 			Path:   r.URL.Path,
 			Auth:   r.Header.Get("Authorization"),
+			Idem:   r.Header.Get("Idempotency-Key"),
 		}
 		if len(raw) > 0 {
 			_ = json.Unmarshal(raw, &cr.Body)
@@ -344,10 +346,28 @@ func TestHTTPBackendWriteFile(t *testing.T) {
 	}
 }
 
+// TestHTTPBackendFork asserts Fork rides the per-sandbox LIVE fork route: n
+// POST /v1/sandboxes/{id}/fork calls (one per child), each carrying the bearer
+// token, a unique client-generated child id, pause_source, and a unique
+// Idempotency-Key, and that the create-shaped live-fork response (PR #710:
+// id, endpoint, token, phase, template_id, fork_time_ms) is decoded for the
+// returned ids. The legacy flat /v1/fork template route must NOT be called
+// when the live route works.
 func TestHTTPBackendFork(t *testing.T) {
 	var got []capturedRequest
 	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
-		return http.StatusOK, map[string]any{"id": cr.Body["id"], "template_id": cr.Body["template"]}
+		if cr.Path == "/v1/fork" {
+			return http.StatusNotFound, json.RawMessage(`{"error":{"code":"not_found","message":"no such pool \"sbx-1\"","remediation":"Create the pool first."}}`)
+		}
+		// Exact production live-fork response contract (PR #710).
+		return http.StatusOK, map[string]any{
+			"id":           cr.Body["id"],
+			"endpoint":     "sandbox-ep:9091",
+			"token":        "child-token-never-used-by-fork",
+			"phase":        "Ready",
+			"template_id":  "python",
+			"fork_time_ms": 42.5,
+		}
 	})
 	defer srv.Close()
 
@@ -362,19 +382,27 @@ func TestHTTPBackendFork(t *testing.T) {
 	if len(got) != 3 {
 		t.Fatalf("Fork made %d requests, want 3", len(got))
 	}
-	seen := map[string]bool{}
+	seenIDs := map[string]bool{}
+	seenKeys := map[string]bool{}
 	for i, req := range got {
-		if req.Method != http.MethodPost || req.Path != "/v1/fork" {
-			t.Fatalf("Fork req %d = %s %s", i, req.Method, req.Path)
+		if req.Method != http.MethodPost || req.Path != "/v1/sandboxes/sbx-1/fork" {
+			t.Fatalf("Fork req %d = %s %s, want POST /v1/sandboxes/sbx-1/fork", i, req.Method, req.Path)
 		}
 		if req.Auth != "Bearer tok-123" {
 			t.Fatalf("Fork req %d auth = %q", i, req.Auth)
 		}
 		id, _ := req.Body["id"].(string)
-		if id == "" || seen[id] {
+		if id == "" || seenIDs[id] {
 			t.Fatalf("Fork req %d had empty or duplicate id %q", i, id)
 		}
-		seen[id] = true
+		seenIDs[id] = true
+		if pause, ok := req.Body["pause_source"].(bool); !ok || !pause {
+			t.Fatalf("Fork req %d pause_source = %v, want true", i, req.Body["pause_source"])
+		}
+		if req.Idem == "" || seenKeys[req.Idem] {
+			t.Fatalf("Fork req %d had empty or duplicate Idempotency-Key %q", i, req.Idem)
+		}
+		seenKeys[req.Idem] = true
 	}
 }
 
@@ -392,6 +420,136 @@ func TestHTTPBackendForkDefaultsToOne(t *testing.T) {
 	}
 	if len(ids) != 1 || len(got) != 1 {
 		t.Fatalf("Fork with 0 replicas made %d reqs / %d ids, want 1/1", len(got), len(ids))
+	}
+	if got[0].Path != "/v1/sandboxes/sbx-1/fork" {
+		t.Fatalf("Fork path = %q, want /v1/sandboxes/sbx-1/fork", got[0].Path)
+	}
+}
+
+// gatewayUnknownRouteBody is the EXACT envelope an older hosted gateway (before
+// the sandbox.fork op existed) returns for POST /v1/sandboxes/{id}/fork: the
+// path falls through opFromPath to "sandbox.post" and the control plane answers
+// 404 not_found "no such route or operation".
+const gatewayUnknownRouteBody = `{"error":{"code":"not_found","message":"no such route or operation","cause":"the request did not map to a known gateway operation (resolved op \"sandbox.post\")","remediation":"Use a documented route."}}`
+
+// TestHTTPBackendForkFallsBackOnUnknownRoute asserts that when the server 404s
+// the live-fork route with the gateway's route-level not_found envelope, Fork
+// probes the live route exactly ONCE and then serves every child through the
+// legacy flat template route (POST /v1/fork {template: sandboxID, id}).
+func TestHTTPBackendForkFallsBackOnUnknownRoute(t *testing.T) {
+	var got []capturedRequest
+	srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+		if strings.HasSuffix(cr.Path, "/fork") && strings.HasPrefix(cr.Path, "/v1/sandboxes/") {
+			return http.StatusNotFound, json.RawMessage(gatewayUnknownRouteBody)
+		}
+		return http.StatusOK, map[string]any{"id": cr.Body["id"], "template_id": cr.Body["template"]}
+	})
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	ids, err := b.Fork(context.Background(), "sbx-1", 2)
+	if err != nil {
+		t.Fatalf("Fork with fallback: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("Fork returned %d ids, want 2", len(ids))
+	}
+	// One live-route probe, then 2 flat-route forks.
+	if len(got) != 3 {
+		t.Fatalf("Fork made %d requests, want 3 (1 probe + 2 flat)", len(got))
+	}
+	if got[0].Path != "/v1/sandboxes/sbx-1/fork" {
+		t.Fatalf("first request path = %q, want the live-fork probe", got[0].Path)
+	}
+	for i, req := range got[1:] {
+		if req.Method != http.MethodPost || req.Path != "/v1/fork" {
+			t.Fatalf("fallback req %d = %s %s, want POST /v1/fork", i, req.Method, req.Path)
+		}
+		if req.Body["template"] != "sbx-1" {
+			t.Fatalf("fallback req %d template = %v, want sbx-1", i, req.Body["template"])
+		}
+	}
+}
+
+// TestHTTPBackendForkFallsBackOnPlainMux404 asserts an older standalone
+// sandbox-server without the live-fork route (whose net/http mux answers a
+// plain-text "404 page not found") also triggers the flat-route fallback.
+func TestHTTPBackendForkFallsBackOnPlainMux404(t *testing.T) {
+	var got []capturedRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/fork", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		cr := capturedRequest{Method: r.Method, Path: r.URL.Path}
+		_ = json.Unmarshal(raw, &cr.Body)
+		got = append(got, cr)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": cr.Body["id"], "template_id": cr.Body["template"]})
+	})
+	// No live-fork route registered: /v1/sandboxes/{id}/fork gets the mux
+	// default "404 page not found".
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+	ids, err := b.Fork(context.Background(), "sbx-1", 1)
+	if err != nil {
+		t.Fatalf("Fork with mux-404 fallback: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("Fork returned %d ids, want 1", len(ids))
+	}
+	if len(got) != 1 || got[0].Body["template"] != "sbx-1" {
+		t.Fatalf("fallback flat fork not issued correctly: %+v", got)
+	}
+}
+
+// TestHTTPBackendForkMissingSourceIsNotFallback asserts a 404 that names a
+// missing SANDBOX or POOL (the source does not exist, or the caller is probing
+// another org's id) surfaces as an error and NEVER falls back to the flat
+// template route: only a route-level 404 means "older server".
+func TestHTTPBackendForkMissingSourceIsNotFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "hosted missing or cross-org sandbox",
+			body: `{"error":{"code":"not_found","message":"no such sandbox","cause":"no sandbox \"sbx-ghost\" exists for this organization","remediation":"Confirm the sandbox id exists and is Ready before calling."}}`,
+		},
+		{
+			name: "standalone missing sandbox",
+			body: `{"error":{"code":"not_found","message":"no such sandbox","cause":"sandbox \"sbx-ghost\" not found","remediation":"Confirm the sandbox id exists and is Ready before calling."}}`,
+		},
+		{
+			name: "pool-shaped not_found",
+			body: `{"error":{"code":"not_found","message":"no such pool \"sbx-ghost\"","remediation":"Create the pool first."}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []capturedRequest
+			srv := recordingServer(t, &got, func(cr capturedRequest) (int, any) {
+				return http.StatusNotFound, json.RawMessage(tc.body)
+			})
+			defer srv.Close()
+
+			b := NewHTTPBackend(srv.URL, "tok-123", srv.Client())
+			_, err := b.Fork(context.Background(), "sbx-ghost", 2)
+			if err == nil {
+				t.Fatal("expected error for a missing fork source")
+			}
+			if !strings.Contains(err.Error(), "404") {
+				t.Fatalf("error should carry the 404 status, got %q", err.Error())
+			}
+			for _, req := range got {
+				if req.Path == "/v1/fork" {
+					t.Fatalf("Fork fell back to the flat template route on a missing source: %+v", got)
+				}
+			}
+			if len(got) != 1 {
+				t.Fatalf("Fork made %d requests, want exactly the 1 failed live call", len(got))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Two hosted CLI bugs verified on production today: `mitos fork <id>` fails 404 `no such pool "sb-..."` (the shared mcp.HTTPBackend.Fork POSTs the flat /v1/fork route with the sandbox id as template, a resolution the server never implemented; cmd/mitos-mcp sandbox_fork shares the path), and `mitos sandbox ls` fails to unmarshal because the gateway returns {"sandboxes":[...]} while the CLI decoded a bare array.

## Thinking Path

Traced HostedBackend.Fork to its delegation into mcp.HTTPBackend.Fork and fixed the shared backend once: use the PR #710 per-sandbox live-fork route (one POST per child, Idempotency-Key like the Python SDK), with a single explicit fallback to the legacy flat route only on a route-level 404 (gateway unknown-route envelope or plain mux 404), never on a missing-sandbox or missing-pool 404. For ls, decoded via json.RawMessage into both wire shapes (hosted object, standalone bare array) after confirming each server's handler; the same route audit surfaced two latent mismatches (camelCase createdAt never parsed, phase hardcoded Ready) fixed with tests. Audited terminate and exec paths for shape mismatches: none (204 empty body; Connect RPCs).

## Change

- internal/mcp/httpbackend.go: Fork issues POST /v1/sandboxes/{id}/fork per child with {"id", "pause_source": true} and fresh Idempotency-Key; typed *httpStatusError from do/doWithHeader for precise fallback gating; single fallback to flat /v1/fork for old standalone servers.
- internal/agentcli/hostedbackend.go: decodeSandboxList accepts both shapes; hosted entries parse createdAt and real phase.

## Verification

- go build ./... clean; go test internal/agentcli 0.628s ok, internal/mcp 0.248s ok.
- golangci-lint GOOS=linux clean; darwin shows only the pre-existing internal/fork/uffd.go unused finding (reproduces on origin/main).
- TDD: table-driven httptest servers speaking the exact production wire bodies; every case red first (live-route contract, both fallback triggers, 3-case no-fallback table, both list shapes, CLI ls e2e via Run).
- No em or en dashes in the diff.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosted sandboxes now support the newer live-fork flow, with improved compatibility for servers that use either the new or legacy fork route.
  * Sandbox listings now work across multiple response shapes, including hosted and bare-array formats.

* **Bug Fixes**
  * Improved handling of missing creation timestamps and phase values so sandbox age and status display more reliably.
  * Added better fallback behavior when a live-fork route is unavailable, while avoiding fallback for real “not found” sandbox errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->