### PR TITLE
chore(sdk): mitos-run 0.3.0, ship the hosted live-fork route

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@
 # scikit-learn -> sklearn.
 [project]
 name = "mitos-run"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for Mitos: snapshot-fork sandboxes for AI agents on Kubernetes."
 keywords = ["sandbox", "firecracker", "microvm", "ai-agents", "kubernetes", "code-interpreter", "mitos"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

PyPI mitos-run is stuck at 0.2.0, whose DirectSandbox._fork_one still POSTs the flat /v1/fork template route. No released Python client can reach the v1.24.0 hosted live fork; verified on production today (round-2 e2e forked via 0.2.0 and inherited no parent state). publish-sdks cannot re-upload an unchanged version, so the route fix that already sits on main never shipped.

## Thinking Path

The SDK code on main is already correct (per-sandbox route with pause_source and Idempotency-Key); the only missing piece is a version identity for PyPI. A version-only bump keeps the diff auditable and lets the existing publish-sdks path trigger on sdk/python/**. Minor bump because the fork behavior changes semantically (template re-fork to live fork).

## Verification

- grep confirms sdk/python/mitos/direct.py on this branch POSTs /v1/sandboxes/{id}/fork (line ~602).
- pyproject version 0.2.0 to 0.3.0 is the only change; python-test CI covers the SDK suite.
- After merge, publish-sdks should push 0.3.0; verify with pip index versions mitos-run.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python package version from 0.2.0 to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->