### PR TITLE
fix(controller): fork child pod inherits source scheduling so it lands on the tainted KVM node

### DIFF
--- a/internal/controller/husk_activation_test.go
+++ b/internal/controller/husk_activation_test.go
@@ -75,8 +75,10 @@ func (f *fakeActivator) callCount() int {
 
 // makeDormantHuskPod creates a husk pod and forces it Running+Ready with a
 // PodIP, simulating a warm dormant slot (envtest has no kubelet, so the test
-// drives the status directly).
-func makeDormantHuskPod(t *testing.T, poolName, podIP string) *corev1.Pod {
+// drives the status directly). Optional mutators adjust the pod spec before
+// creation (e.g. to give a fork SOURCE pod the placement nodeSelector and
+// tolerations a real warm pod carries).
+func makeDormantHuskPod(t *testing.T, poolName, podIP string, mutate ...func(*corev1.Pod)) *corev1.Pod {
 	t.Helper()
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -94,6 +96,9 @@ func makeDormantHuskPod(t *testing.T, poolName, podIP string) *corev1.Pod {
 				Image: "mitos-husk-stub:test",
 			}},
 		},
+	}
+	for _, m := range mutate {
+		m(pod)
 	}
 	// reconcileHuskPods stamps a controller owner reference to the pool on every
 	// husk pod it creates, and selectDormantHuskPod now REQUIRES it before a pod

--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -565,3 +565,112 @@ func TestHuskForkAdoptsAlreadyActiveChild(t *testing.T) {
 		return got.Status.ReadyReplicas == 2
 	})
 }
+
+// TestHuskForkChildPodInheritsSourcePodScheduling is the regression for the
+// production fork 504: the fork child pod is pinned to the source node via
+// nodeAffinity, but the hosted KVM node carries the mitos.run/dedicated
+// NoSchedule taint that warm pods tolerate via the pool's spec.placement
+// tolerations. The fork path never carried those tolerations onto the child,
+// so the child sat Pending forever with FailedScheduling "1 node(s) had
+// untolerated taint {mitos.run/dedicated}". The child must inherit the SOURCE
+// pod's own scheduling constraints (tolerations and nodeSelector; the source
+// pod's spec is the authoritative record of what it took to land on that
+// node), while keeping the exact-node affinity pin. Like the full-shape test
+// this drives the real controller opts path, not a direct builder call.
+// envtest schedules nothing (no scheduler, untainted fake nodes), so only a
+// real-cluster e2e proves scheduling against actual taints; this test pins the
+// pod SPEC the controller emits.
+func TestHuskForkChildPodInheritsSourcePodScheduling(t *testing.T) {
+	poolName := uniqueName("pool-sched")
+	srcClaimName := uniqueName("src-claim-sched")
+	forkName := uniqueName("sched")
+
+	notReadySecs := int64(60)
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.5.5", func(p *corev1.Pod) {
+		// The scheduling constraints a real warm husk pod carries on a hosted
+		// dedicated KVM node: the KVM+placement nodeSelector and the
+		// fast-node-loss pair plus the placement toleration for the node taint.
+		p.Spec.NodeSelector = map[string]string{
+			"mitos.run/kvm":    "true",
+			"mitos.run/tenant": "acme",
+		}
+		p.Spec.Tolerations = []corev1.Toleration{
+			{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: &notReadySecs},
+			{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: &notReadySecs},
+			{Key: "mitos.run/dedicated", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+		}
+	})
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/x"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	var child corev1.Pod
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var pods corev1.PodList
+		_ = k8sClient.List(ctx, &pods, listForkChildren(forkName))
+		if len(pods.Items) == 0 {
+			return false
+		}
+		child = pods.Items[0]
+		return true
+	})
+
+	// The production failure: the child did not tolerate the source node's
+	// mitos.run/dedicated NoSchedule taint and could never schedule.
+	tolCount := map[string]int{}
+	for _, tol := range child.Spec.Tolerations {
+		tolCount[tol.Key]++
+	}
+	if tolCount["mitos.run/dedicated"] != 1 {
+		t.Errorf("fork child must carry the source pod's mitos.run/dedicated toleration exactly once, got %d; tolerations=%v", tolCount["mitos.run/dedicated"], child.Spec.Tolerations)
+	}
+	// Inheritance must not duplicate the fast node-loss pair huskTolerations
+	// adds to every husk pod.
+	for _, key := range []string{"node.kubernetes.io/not-ready", "node.kubernetes.io/unreachable"} {
+		if tolCount[key] != 1 {
+			t.Errorf("fork child toleration %s count = %d, want exactly 1 (no duplicates from source inheritance); tolerations=%v", key, tolCount[key], child.Spec.Tolerations)
+		}
+	}
+	// The source pod's merged nodeSelector (KVM + placement) rides along too.
+	if child.Spec.NodeSelector["mitos.run/tenant"] != "acme" || child.Spec.NodeSelector["mitos.run/kvm"] != "true" {
+		t.Errorf("fork child nodeSelector = %v, want the source pod's kvm=true + tenant=acme", child.Spec.NodeSelector)
+	}
+	// The exact-node pin stays: the fork snapshot is a node-local hostPath on
+	// the source node.
+	aff := child.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil || aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("fork child must keep the required nodeAffinity pin to the source node; affinity=%v", aff)
+	}
+	terms := aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	pinned := false
+	for _, term := range terms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == "kubernetes.io/hostname" && len(expr.Values) == 1 && expr.Values[0] == srcPod.Spec.NodeName {
+				pinned = true
+			}
+		}
+	}
+	if !pinned {
+		t.Errorf("fork child nodeAffinity must pin to the source node %q; terms=%v", srcPod.Spec.NodeName, terms)
+	}
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -235,7 +235,10 @@ type HuskPodOptions struct {
 	// husk pod's KVM nodeSelector (so the VM runs only on the tenant's dedicated
 	// nodes); the tolerations are appended so the pod schedules onto tainted
 	// dedicated nodes. Both empty/nil leave the pod unconstrained beyond KVM +
-	// snapshot-node affinity.
+	// snapshot-node affinity. For a FORK CHILD, buildForkChildPod fills both from
+	// the SOURCE husk pod's own spec (not the pool): the child must land on the
+	// source pod's exact node, so the source's scheduling constraints are the
+	// authoritative record of what it takes to get there.
 	PlacementNodeSelector map[string]string
 	PlacementTolerations  []corev1.Toleration
 }
@@ -987,7 +990,31 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 // then rewrites the ownership, labels, and name for the fork. The pod is pinned
 // to the source node (opts.ForkSourceNode) and activates from
 // <DataDir>/forks/<ForkSnapshotID> (opts.ForkSnapshotID), both set by the caller.
-func buildForkChildPod(fork *v1.Sandbox, childName string, opts HuskPodOptions, scheme *runtime.Scheme) *corev1.Pod {
+// srcPod is that source node's SOURCE husk pod; the child inherits its
+// scheduling constraints (nodeSelector and tolerations) so it can actually
+// land next to it (see the inheritance comment in the body).
+func buildForkChildPod(fork *v1.Sandbox, srcPod *corev1.Pod, childName string, opts HuskPodOptions, scheme *runtime.Scheme) *corev1.Pod {
+	// Inherit the SOURCE pod's scheduling constraints so the child can actually
+	// land on the source node. The child is pinned to that exact node by the
+	// ForkSourceNode nodeAffinity (the fork snapshot and the source rootfs are
+	// node-local hostPaths), but affinity does not clear taints: hosted KVM
+	// nodes carry mitos.run/dedicated:NoSchedule, which warm pods tolerate via
+	// the pool's spec.placement tolerations. The fork path has no pool in hand,
+	// and the pool's placement may have changed since the source scheduled, so
+	// the source pod's OWN spec is the authoritative record of what it took to
+	// land there; without this the child sits Pending forever (production
+	// FailedScheduling: "1 node(s) had untolerated taint {mitos.run/dedicated}")
+	// and the fork 504s. The pin deliberately stays scheduler-visible
+	// (nodeAffinity, NOT spec.nodeName): husk pods are scheduler-placed
+	// throughout this file, and the KVM extended-resource request must pass
+	// scheduler fit; spec.nodeName would bypass that and turn node capacity
+	// exhaustion into a terminal kubelet OutOf<kvm-resource> pod instead of a
+	// Pending pod that schedules when a slot frees.
+	if srcPod != nil {
+		opts.PlacementNodeSelector = srcPod.Spec.NodeSelector
+		opts.PlacementTolerations = forkChildInheritedTolerations(srcPod.Spec.Tolerations)
+	}
+
 	// buildHuskPod only reads r.Scheme() (for the owner ref we overwrite) and the
 	// opts, so a zero reconciler is sufficient to build the spec. A synthetic pool
 	// carrier supplies GenerateName/namespace; ownership and labels are overwritten
@@ -1334,6 +1361,25 @@ func huskTolerations(opts HuskPodOptions) []corev1.Toleration {
 		{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptrInt64(huskNodeLossTolerationSeconds)},
 	}
 	return append(tol, opts.PlacementTolerations...)
+}
+
+// forkChildInheritedTolerations returns the SOURCE husk pod's tolerations
+// minus the fast node-loss pair (node.kubernetes.io/not-ready and
+// node.kubernetes.io/unreachable) that huskTolerations re-adds to every husk
+// pod, so a fork child carries each toleration exactly once. Everything else
+// is copied verbatim: the pool placement tolerations the source scheduled with
+// (#172, e.g. the mitos.run/dedicated NoSchedule taint on hosted KVM nodes)
+// and anything admission injected for the source apply equally to the child,
+// which must land on the SAME node.
+func forkChildInheritedTolerations(src []corev1.Toleration) []corev1.Toleration {
+	var out []corev1.Toleration
+	for _, t := range src {
+		if t.Key == corev1.TaintNodeNotReady || t.Key == corev1.TaintNodeUnreachable {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 // huskPlacementNodeSelector / huskPlacementTolerations read the pool's

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -1045,7 +1045,8 @@ func TestBuildHuskPodForkChildClonesFromSourceRootfs(t *testing.T) {
 
 func TestBuildForkChildPodOwnedByFork(t *testing.T) {
 	fork := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "f1", Namespace: "default", UID: "uid-f1"}}
-	pod := controller.BuildForkChildPodForTest(fork, "child-0", controller.HuskPodOptions{
+	srcPod := &corev1.Pod{Spec: corev1.PodSpec{NodeName: "kvm-node-1"}}
+	pod := controller.BuildForkChildPodForTest(fork, srcPod, "child-0", controller.HuskPodOptions{
 		StubImage:      "img",
 		SnapshotID:     "tmpl-a",
 		DataDir:        "/data",
@@ -1090,7 +1091,8 @@ func TestBuildHuskPodDisablesSATokenAutomount(t *testing.T) {
 
 	// Fork-child pods share buildHuskPod, so they must inherit the opt-out too.
 	fork := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "sa-fork", Namespace: "default", UID: "uid-sa-fork"}}
-	child := controller.BuildForkChildPodForTest(fork, "sa-child-0", controller.HuskPodOptions{
+	srcPod := &corev1.Pod{Spec: corev1.PodSpec{NodeName: "kvm-node-1"}}
+	child := controller.BuildForkChildPodForTest(fork, srcPod, "sa-child-0", controller.HuskPodOptions{
 		StubImage:      "img",
 		SnapshotID:     "tmpl-a",
 		DataDir:        "/data",
@@ -1221,4 +1223,75 @@ func TestBuildHuskPodStampsOrgFromNamespace(t *testing.T) {
 			t.Errorf("org label = %q, want acme (client-set %q must be ignored)", got, "evil")
 		}
 	})
+}
+
+// TestBuildForkChildPodInheritsSourcePodScheduling is the builder-level
+// regression for the production fork 504 (FailedScheduling: "1 node(s) had
+// untolerated taint {mitos.run/dedicated}"). buildForkChildPod pins the child
+// to the source node via nodeAffinity, but affinity does not clear taints: the
+// child must also inherit the SOURCE pod's tolerations and nodeSelector (the
+// pod spec is the authoritative record of what it took to schedule onto that
+// node; the pool's spec.placement may have changed since). The fast node-loss
+// pair huskTolerations adds to every husk pod must not be duplicated by the
+// inheritance. Only a real-cluster e2e proves scheduling against actual taints
+// (kind/envtest nodes are untainted); this pins the emitted spec.
+func TestBuildForkChildPodInheritsSourcePodScheduling(t *testing.T) {
+	fork := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "f-sched", Namespace: "default", UID: "uid-f-sched"}}
+	notReadySecs := int64(60)
+	srcPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-a-husk-abcde", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "kvm-node-1",
+			NodeSelector: map[string]string{
+				"mitos.run/kvm":    "true",
+				"mitos.run/tenant": "acme",
+			},
+			Tolerations: []corev1.Toleration{
+				{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: &notReadySecs},
+				{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: &notReadySecs},
+				{Key: "mitos.run/dedicated", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+
+	child := controller.BuildForkChildPodForTest(fork, srcPod, "f-sched-fork-0", controller.HuskPodOptions{
+		StubImage:      "img",
+		SnapshotID:     "tmpl-a",
+		DataDir:        "/data",
+		ForkSnapshotID: "f-sched",
+		ForkSourceNode: srcPod.Spec.NodeName,
+	}, scheme)
+
+	tolCount := map[string]int{}
+	for _, tol := range child.Spec.Tolerations {
+		tolCount[tol.Key]++
+	}
+	if tolCount["mitos.run/dedicated"] != 1 {
+		t.Errorf("fork child must inherit the source pod's mitos.run/dedicated toleration exactly once, got %d; tolerations=%v", tolCount["mitos.run/dedicated"], child.Spec.Tolerations)
+	}
+	for _, key := range []string{"node.kubernetes.io/not-ready", "node.kubernetes.io/unreachable"} {
+		if tolCount[key] != 1 {
+			t.Errorf("fork child toleration %s count = %d, want exactly 1 (huskTolerations adds it; inheritance must not duplicate it)", key, tolCount[key])
+		}
+	}
+	if child.Spec.NodeSelector["mitos.run/tenant"] != "acme" || child.Spec.NodeSelector["mitos.run/kvm"] != "true" {
+		t.Errorf("fork child nodeSelector = %v, want the source pod's kvm=true + tenant=acme merged in", child.Spec.NodeSelector)
+	}
+	// The exact-node affinity pin must survive the inheritance: the fork
+	// snapshot and source rootfs are node-local hostPaths on kvm-node-1.
+	aff := child.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil || aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("fork child must keep the required nodeAffinity source-node pin; affinity=%v", aff)
+	}
+	pinned := false
+	for _, term := range aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == "kubernetes.io/hostname" && len(expr.Values) == 1 && expr.Values[0] == "kvm-node-1" {
+				pinned = true
+			}
+		}
+	}
+	if !pinned {
+		t.Errorf("fork child nodeAffinity must pin to the source node kvm-node-1; affinity=%v", aff.NodeAffinity)
+	}
 }

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -549,7 +549,7 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		childName := fmt.Sprintf("%s-fork-%d", fork.Name, i)
 
 		// Get-or-create the child pod for this slot (idempotent by the stable name).
-		child, err := r.ensureForkChildPod(ctx, fork, childName, opts)
+		child, err := r.ensureForkChildPod(ctx, fork, srcPod, childName, opts)
 		if err != nil {
 			logger.Error(err, "create fork child pod failed", "child", childName)
 			continue
@@ -656,8 +656,9 @@ func (r *SandboxReconciler) findHuskPod(ctx context.Context, ns, name string) (*
 
 // ensureForkChildPod creates the fork child pod if it does not exist and returns
 // the current pod object. Idempotent across requeues (a child already created is
-// fetched and returned).
-func (r *SandboxReconciler) ensureForkChildPod(ctx context.Context, fork *v1.Sandbox, name string, opts HuskPodOptions) (*corev1.Pod, error) {
+// fetched and returned). srcPod is the SOURCE husk pod whose scheduling
+// constraints the child inherits (buildForkChildPod).
+func (r *SandboxReconciler) ensureForkChildPod(ctx context.Context, fork *v1.Sandbox, srcPod *corev1.Pod, name string, opts HuskPodOptions) (*corev1.Pod, error) {
 	var existing corev1.Pod
 	err := r.Get(ctx, client.ObjectKey{Namespace: fork.Namespace, Name: name}, &existing)
 	if err == nil {
@@ -666,7 +667,7 @@ func (r *SandboxReconciler) ensureForkChildPod(ctx context.Context, fork *v1.San
 	if !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("get fork child pod %s: %w", name, err)
 	}
-	pod := buildForkChildPod(fork, name, opts, r.Scheme)
+	pod := buildForkChildPod(fork, srcPod, name, opts, r.Scheme)
 	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("create fork child pod %s: %w", name, err)
 	}

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -48,8 +48,8 @@ func (r *SandboxPoolReconciler) BuildHuskPodForTest(pool *v1.SandboxPool, templa
 
 // BuildForkChildPodForTest exposes buildForkChildPod to the external
 // controller_test package so the fork child pod spec can be unit-tested.
-func BuildForkChildPodForTest(fork *v1.Sandbox, childName string, opts HuskPodOptions, scheme *runtime.Scheme) *corev1.Pod {
-	return buildForkChildPod(fork, childName, opts, scheme)
+func BuildForkChildPodForTest(fork *v1.Sandbox, srcPod *corev1.Pod, childName string, opts HuskPodOptions, scheme *runtime.Scheme) *corev1.Pod {
+	return buildForkChildPod(fork, srcPod, childName, opts, scheme)
 }
 
 // SetForkSnapshotForTest installs the fork-snapshot seam (tests only).

--- a/internal/controller/usage_scrape_test.go
+++ b/internal/controller/usage_scrape_test.go
@@ -218,7 +218,8 @@ func TestBuildForkChildPodCarriesBillingLabels(t *testing.T) {
 		t.Fatal(err)
 	}
 	fork := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "sb-child-1", Namespace: "mitos-org-acme", UID: "uid-fork"}}
-	pod := buildForkChildPod(fork, "sb-child-1-0", HuskPodOptions{
+	srcPod := &corev1.Pod{Spec: corev1.PodSpec{NodeName: "kvm-node-1"}}
+	pod := buildForkChildPod(fork, srcPod, "sb-child-1-0", HuskPodOptions{
 		StubImage:      "img",
 		SnapshotID:     "tmpl-a",
 		DataDir:        "/data",


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The controller's husk live-fork path (POST /v1/sandboxes/{id}/fork, v1.24.0) creates fork child pods via buildForkChildPod, pinned to the source node by nodeAffinity because the fork snapshot and the source rootfs are node-local hostPaths.
> - On production the KVM node carries the mitos.run/dedicated:NoSchedule taint. Warm husk pods tolerate it via the pool's spec.placement tolerations, but the fork path never carried any placement tolerations or nodeSelector onto the child, so the child sat 0/1 Pending forever and the gateway 504ed every hosted fork.
> - This is a production-verified break of the flagship live-fork feature, so it needs fixing now; it serves the hosted launch hardening work.
> - I considered pinning via spec.nodeName (bypasses the scheduler and taints entirely) but rejected it: husk pods are scheduler-placed throughout huskpod.go, and the mitos.run/kvm extended-resource request must pass scheduler fit; spec.nodeName turns node capacity exhaustion into a terminal kubelet OutOf-resource pod instead of a Pending pod that schedules when a slot frees.
> - This pull request makes buildForkChildPod inherit the SOURCE husk pod's own spec.tolerations and spec.nodeSelector (the source pod's spec, not the pool, is the authoritative record of what it took to land on that node; the pool's placement may have changed since), while keeping the exact-node nodeAffinity pin.
> - The benefit is that hosted live forks schedule onto the tainted dedicated KVM node and complete instead of 504ing.

## Linked Issues or Issue Description

No public issue exists; observed directly on production (2026-07-06, v1.24.0):

- What happened: POST /v1/sandboxes/{id}/fork created the fork child pod, but it stayed 0/1 Pending forever and the gateway returned 504.
- Evidence (kubectl describe on the child pod):
  - `Node-Selectors: mitos.run/kvm=true`
  - `Tolerations: node.kubernetes.io/not-ready` (default only)
  - `Warning FailedScheduling ... 1 node(s) had untolerated taint {mitos.run/dedicated}`
- Expected: the fork child schedules onto the source pod's node (the fork snapshot is a node-local hostPath there) and the fork completes.

## What Changed

- `buildForkChildPod` (internal/controller/huskpod.go) now takes the SOURCE husk pod and fills `PlacementNodeSelector`/`PlacementTolerations` from the source pod's `spec.nodeSelector` and `spec.tolerations` before building the child spec; the exact-node `nodeAffinity` pin is unchanged and stays scheduler-visible.
- New `forkChildInheritedTolerations` filters out the fast node-loss pair (`node.kubernetes.io/not-ready`, `node.kubernetes.io/unreachable`) that `huskTolerations` re-adds to every husk pod, so the child carries each toleration exactly once.
- `ensureForkChildPod` / `reconcileHuskFork` (internal/controller/sandboxfork_controller.go) thread the already-resolved source pod into the builder.
- Audited the fork path for other pool-sourced scheduling fields warm pods get: the placement nodeSelector and tolerations were the only ones dropped; husk pods set no priorityClassName, runtimeClassName, or schedulerName anywhere, so there is nothing else to align.
- Tests (written first, watched fail): builder unit test `TestBuildForkChildPodInheritsSourcePodScheduling` (huskpod_test.go) and controller-path envtest `TestHuskForkChildPodInheritsSourcePodScheduling` (huskfork_envtest_test.go); `makeDormantHuskPod` gained optional spec mutators.

## Verification

TDD: both new tests were written first and failed with the exact production symptom before the fix:

```
huskfork_envtest_test.go:645: fork child must carry the source pod's mitos.run/dedicated toleration exactly once, got 0; tolerations=[{node.kubernetes.io/not-ready Exists  NoExecute ...} {node.kubernetes.io/unreachable Exists  NoExecute ...}]
huskfork_envtest_test.go:656: fork child nodeSelector = map[mitos.run/kvm:true], want the source pod's kvm=true + tenant=acme
```

After the fix:

- [x] `go build ./...` passes
- [x] `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/... -count=1` passes: `ok  mitos.run/mitos/internal/controller  165.002s`
- [x] `golangci-lint run --timeout=5m`: only the pre-existing darwin-only finding `internal/fork/uffd.go:42:22: func uffdMapping.pageSizeBytes is unused (unused)`; nothing new
- [x] `GOOS=linux golangci-lint run --timeout=5m`: clean (exit 0)

Note for reviewers: kind and envtest nodes are UNTAINTED, so no CI suite can prove scheduling against the real `mitos.run/dedicated` taint; these tests pin the pod spec the controller emits. Only the real-KVM-cluster e2e (cluster-e2e.yaml) exercises actual taint scheduling; production confirmation is a live fork against a tainted dedicated node.

## Risks

- Low risk: the change only widens the fork child's tolerations/nodeSelector to exactly what its source pod already carries; the exact-node affinity pin is unchanged, so the child cannot land anywhere new.
- Inheriting the source's nodeSelector could in theory block a child if the source node's labels were removed after the source scheduled, but the child was already hard-pinned to that node by hostname affinity, so such a node is unusable for the fork either way.

## Model Used

- Claude Fable 5 (claude-fable-5) via Claude Code, extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (behavior is documented in the affected code's doc comments; no user-facing docs describe fork child placement)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (not moved: scheduling only, no new privilege or surface)
- [x] Benchmark run (bench/) included if the hot path was touched (not touched: pod-spec construction in the controller)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fork-created child pods now inherit scheduling rules from the source pod more reliably, including node selection, tolerations, and node affinity.
  * Fixed duplicate tolerations so pods no longer carry repeated fast node-loss entries.
  * Child pods continue to keep the expected billing and ownership labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->