### PR TITLE
fix(controller): fork child inherits source pod placement so it can schedule

### DIFF
--- a/internal/controller/huskfork_placement_test.go
+++ b/internal/controller/huskfork_placement_test.go
@@ -1,0 +1,100 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimescheme "k8s.io/apimachinery/pkg/runtime"
+
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// A fork child is pinned to the SOURCE sandbox's node (ForkSourceNode). For a
+// dedicated pool that node is tainted (mitos.run/dedicated, workload=sandbox)
+// and selected by a nodeSelector (mitos.run/kvm). buildForkChildPod builds from
+// an EMPTY pool template, so without inheriting the source pod's placement the
+// child carries no tolerations and is unschedulable (Pending) until the create
+// ready deadline elapses. This is the root cause of the hosted live fork
+// timeout observed in prod: the child sandbox sits in Restoring while its husk
+// pod cannot schedule. The fix threads the source pod's tolerations and
+// nodeSelector through HuskPodOptions.
+func TestBuildForkChildPodInheritsSourcePlacement(t *testing.T) {
+	scheme := runtimescheme.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	sourceTolerations := []corev1.Toleration{
+		{Key: "workload", Operator: corev1.TolerationOpEqual, Value: "sandbox", Effect: corev1.TaintEffectNoSchedule},
+		{Key: "mitos.run/dedicated", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+	}
+	sourceNodeSelector := map[string]string{"mitos.run/kvm": "true", "pool": "dedicated"}
+
+	fork := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "sb-child-1", Namespace: "mitos", UID: "uid-fork"}}
+	pod := buildForkChildPod(fork, "sb-child-1-0", HuskPodOptions{
+		StubImage:              "img",
+		SnapshotID:             "tmpl-a",
+		DataDir:                "/data",
+		KVMResourceName:        "mitos.run/kvm",
+		ForkSnapshotID:         "sb-child-1",
+		ForkSourceNode:         "mitos-kvm-1",
+		ForkSourceTolerations:  sourceTolerations,
+		ForkSourceNodeSelector: sourceNodeSelector,
+	}, scheme)
+
+	// Every source toleration must be present on the child, else it cannot land
+	// on the tainted dedicated node it is pinned to.
+	for _, want := range sourceTolerations {
+		found := false
+		for _, got := range pod.Spec.Tolerations {
+			if got.Key == want.Key && got.Value == want.Value && got.Effect == want.Effect && got.Operator == want.Operator {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("fork child missing source toleration %+v; child would sit Pending on the tainted source node. tolerations=%+v", want, pod.Spec.Tolerations)
+		}
+	}
+
+	// The source nodeSelector labels must be present (merged with any kvm
+	// selector buildHuskPod set), so the child targets the same node class.
+	for k, v := range sourceNodeSelector {
+		if pod.Spec.NodeSelector[k] != v {
+			t.Fatalf("fork child nodeSelector[%q] = %q, want %q; selector=%v", k, pod.Spec.NodeSelector[k], v, pod.Spec.NodeSelector)
+		}
+	}
+}
+
+// Guard the regression directly: a fork child built WITHOUT source placement
+// (the pre-fix behavior) carries no tolerations, which is what left it Pending.
+// This documents that the inheritance, not buildHuskPod, supplies them.
+func TestBuildForkChildPodWithoutSourcePlacementHasNoTolerations(t *testing.T) {
+	scheme := runtimescheme.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	fork := &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "sb-child-2", Namespace: "mitos", UID: "uid-fork-2"}}
+	pod := buildForkChildPod(fork, "sb-child-2-0", HuskPodOptions{
+		StubImage:      "img",
+		SnapshotID:     "tmpl-a",
+		DataDir:        "/data",
+		ForkSnapshotID: "sb-child-2",
+		ForkSourceNode: "mitos-kvm-1",
+	}, scheme)
+	// The pod carries k8s's default not-ready/unreachable NoExecute tolerations,
+	// but NONE of the dedicated-node taints a pool pins its husks to. Without
+	// inheritance the child cannot land on the tainted source node.
+	for _, tol := range pod.Spec.Tolerations {
+		if tol.Key == "workload" || tol.Key == "mitos.run/dedicated" {
+			t.Fatalf("did not expect a dedicated-node toleration without source placement, got %+v", tol)
+		}
+	}
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -221,6 +221,17 @@ type HuskPodOptions struct {
 	// its OWN per-activation clone (independence), only the clone source changes.
 	// Empty (a warm pod, not a fork child) clones from the template rootfs.
 	ForkSourceRootfsPath string
+	// ForkSourceTolerations and ForkSourceNodeSelector, set on a FORK CHILD,
+	// carry the SOURCE husk pod's scheduling constraints so the child can land on
+	// the same node the source runs on. A fork child is pinned to the source node
+	// (ForkSourceNode) which, for a dedicated pool, is a tainted KVM node; without
+	// the source's tolerations the child is unschedulable (Pending) and the create
+	// ready deadline elapses (issue: hosted live fork times out). buildForkChildPod
+	// otherwise builds from an empty pool template with NO placement. The source
+	// pod already schedules on that node, so its tolerations and nodeSelector are
+	// exactly the constraints the child needs.
+	ForkSourceTolerations  []corev1.Toleration
+	ForkSourceNodeSelector map[string]string
 	// SnapshotNodes is the set of node hostnames the pool has materialized the
 	// template snapshot on (the registry's NodesWithTemplate). When non-empty the
 	// husk pod carries a nodeAffinity pinning it to exactly these nodes, so its
@@ -1014,6 +1025,27 @@ func buildForkChildPod(fork *v1.Sandbox, childName string, opts HuskPodOptions, 
 	// is silently unbilled, and the claim-label pod-deletion paths (release,
 	// lifetime terminate) reap by it.
 	pod.Labels[huskClaimLabel] = fork.Name
+
+	// Inherit the source husk pod's scheduling constraints. buildHuskPod above ran
+	// with an EMPTY pool template, so the child carries no pool Placement: on a
+	// dedicated (tainted) KVM node it would sit Pending until the create ready
+	// deadline. The child is pinned to the source NODE (opts.ForkSourceNode), and
+	// the source already schedules there, so the source's tolerations and
+	// nodeSelector are exactly what the child needs. Tolerations replace (the child
+	// has none of its own); nodeSelector is merged so the kvm selector buildHuskPod
+	// set is preserved alongside any pool placement labels.
+	if len(opts.ForkSourceTolerations) > 0 {
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, opts.ForkSourceTolerations...)
+	}
+	if len(opts.ForkSourceNodeSelector) > 0 {
+		if pod.Spec.NodeSelector == nil {
+			pod.Spec.NodeSelector = map[string]string{}
+		}
+		for k, v := range opts.ForkSourceNodeSelector {
+			pod.Spec.NodeSelector[k] = v
+		}
+	}
+
 	_ = controllerutil.SetControllerReference(fork, pod, scheme)
 	return pod
 }

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -518,6 +518,12 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		// pod name is its Status.SandboxID; its rootfs is visible to the child
 		// through the shared husk-rootfs hostPath dir.
 		ForkSourceRootfsPath: huskSourceRootfsInPodPath(source.Status.SandboxID),
+		// Inherit the source pod's scheduling constraints so the child can land on
+		// the same (for a dedicated pool, tainted) node the source runs on. Without
+		// these the fork child builds with no placement and sits Pending on a
+		// tainted KVM node until the create ready deadline elapses.
+		ForkSourceTolerations:  srcPod.Spec.Tolerations,
+		ForkSourceNodeSelector: srcPod.Spec.NodeSelector,
 	}
 
 	// Fixed-slot, idempotent child set. The child pods are EXACTLY Replicas, with


### PR DESCRIPTION
## Thinking Path

Verifying the hosted live fork end to end on prod (api.mitos.run, v1.24.0), `sb.fork()` on a running sandbox consistently failed. Isolating client from server: create and exec succeeded, but the fork POST hung for exactly 120.6s and returned an internal error. The SDK fork client uses a 30s deadline while create uses 60s, so I first raised the client budget to 240s; the fork still failed at 120.6s, which is the control plane `defaultReadyTimeout`. So the child sandbox was never becoming Ready and the gateway timed out into a `CodeInternal` 504.

A cluster diagnostic captured the child directly: the warm pool was healthy (8 husks Running), yet the fork child pod sat `Pending` for the full 120s with `FailedScheduling: untolerated taint {workload: sandbox}` and `NotTriggerScaleUp`. The child pins to the source sandbox's node (a dedicated, tainted KVM node) but had no tolerations. Reading `buildForkChildPod`, it builds the child from an empty `PoolTemplateSpec{}`, so the pod carries no `Placement` (tolerations, nodeSelector). Warm husk pods get placement from the real pool template; the fork child was silently missing it.

## Linked Issues or Issue Description

Hosted live fork (`POST /v1/sandboxes/{id}/fork`, shipped in v1.24.0 via #710) times out in production: the child `FromSandbox` sandbox never reaches Ready, so the caller gets a 504. Root cause is fork child pod placement, not the fork engine.

## What Changed

- `HuskPodOptions` gains `ForkSourceTolerations` and `ForkSourceNodeSelector`.
- `reconcileHuskFork` populates them from the source husk pod (`srcPod`), which already schedules on the target node.
- `buildForkChildPod` appends the source tolerations and merges the source nodeSelector onto the child pod, so a fork child can schedule on the same (for a dedicated pool, tainted) node its snapshot lives on.
- New unit tests assert the child inherits the source tolerations and merged nodeSelector, and that without inheritance the dedicated-node taints are absent.

## Verification

- `go test ./internal/controller/ -run TestBuildForkChildPod` : all pass (inherit, no-placement-negative, existing billing-labels and owned-by-fork).
- `go test ./internal/controller/ -run 'Fork|Husk'` : green (86s envtest).
- `go vet` and `gofmt -l` clean on the changed files.
- Field diagnosis on prod: the child pod's `FailedScheduling` event named the exact untolerated taint this change tolerates. A follow-up live fork acceptance (child inherits a post-boot marker) runs after this rolls.

## Risks

Low. The change only widens where a fork child may schedule, and only to the node its own source already runs on. It adds no new tolerations of its own; it copies the source pod's. No security surface moves (the child is more confined, landing on the dedicated node rather than nowhere), so no threat-model delta. Fork correctness is unaffected (placement only; the snapshot and rootfs paths are unchanged).

## Model Used

Claude Opus 4.8

## Checklist

- [x] Tests added and passing
- [x] gofmt and vet clean
- [x] No em or en dashes in added lines
- [x] No security surface change (no threat-model delta needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forked child pods now inherit the source pod’s placement settings, helping them land on the same node when needed.
  * Node selectors and tolerations are now carried over automatically during fork creation.

* **Bug Fixes**
  * Improved fork pod scheduling so workloads that depend on node-specific storage or constraints continue to run correctly after forking.

* **Tests**
  * Added coverage for inherited placement behavior and for cases where no source placement settings are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->