### PR TITLE
fix(sdk): fork POST waits longer than the server ready deadline

### DIFF
--- a/sdk/python/mitos/direct.py
+++ b/sdk/python/mitos/direct.py
@@ -163,8 +163,24 @@ def _resolve_auth(
     return key, url.rstrip("/")
 
 
+# The control plane polls a fork to Ready for up to its ready deadline (the
+# gateway --ready-timeout, 120s by default) before returning. A hosted LIVE fork
+# (snapshot the running source VM, schedule the child pod, restore, wait for the
+# guest agent) can take much longer than a warm pool claim, especially cold. The
+# per-request fork deadline must therefore EXCEED the server's own deadline, so a
+# slow-but-succeeding fork surfaces the server's real answer rather than a
+# premature client-side fork_unavailable. The default DirectSandbox client
+# timeout (30s) is far too short for this and would spuriously fail a fork the
+# server completes in, say, 45s.
+FORK_CLIENT_TIMEOUT_SECONDS = 130.0
+
+
 def _fork_post(
-    http: httpx.Client, url: str, json_body: dict, headers: dict
+    http: httpx.Client,
+    url: str,
+    json_body: dict,
+    headers: dict,
+    timeout: float = FORK_CLIENT_TIMEOUT_SECONDS,
 ) -> httpx.Response:
     """POST to the fork endpoint, mapping a transport timeout to a structured,
     LLM-legible AgentRunError instead of a raw ``httpx.ReadTimeout``.
@@ -174,9 +190,13 @@ def _fork_post(
     Surfacing that as a typed ``fork_unavailable`` error with retry guidance (not
     an opaque transport exception) is the boring-failure-behavior contract: the
     caller can branch on the type and back off rather than parse a stack trace.
+
+    timeout overrides the client's default deadline for THIS request only, so a
+    live fork gets room to complete without lengthening the other lifecycle
+    calls (see FORK_CLIENT_TIMEOUT_SECONDS).
     """
     try:
-        return http.post(url, json=json_body, headers=headers)
+        return http.post(url, json=json_body, headers=headers, timeout=timeout)
     except httpx.TimeoutException as exc:
         raise AgentRunError(
             "fork did not complete before the client deadline",

--- a/sdk/python/tests/test_fork_timeout.py
+++ b/sdk/python/tests/test_fork_timeout.py
@@ -1,0 +1,52 @@
+"""The fork POST must give the server room to finish.
+
+A hosted live fork is polled to Ready by the control plane for up to its ready
+deadline (120s by default). The DirectSandbox http client defaults to a 30s
+timeout, which would raise fork_unavailable client-side on a slow-but-succeeding
+fork. _fork_post therefore overrides the per-request timeout to exceed the
+server's own deadline.
+"""
+
+import httpx
+import pytest
+
+from mitos.direct import _fork_post, FORK_CLIENT_TIMEOUT_SECONDS
+from mitos.errors import AgentRunError
+
+
+class _RecordingClient:
+    """Stands in for httpx.Client, recording the timeout the fork POST used."""
+
+    def __init__(self):
+        self.last_timeout = None
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.last_timeout = timeout
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+
+def test_fork_post_default_timeout_exceeds_server_ready_deadline():
+    # The gateway ready deadline is 120s; the client must wait longer so the
+    # server's real answer surfaces instead of a premature client timeout.
+    assert FORK_CLIENT_TIMEOUT_SECONDS > 120.0
+    client = _RecordingClient()
+    _fork_post(client, "http://x/v1/sandboxes/a/fork", {"id": "a"}, {})
+    assert client.last_timeout == FORK_CLIENT_TIMEOUT_SECONDS
+
+
+def test_fork_post_timeout_is_overridable():
+    client = _RecordingClient()
+    _fork_post(client, "http://x/v1/fork", {"id": "a"}, {}, timeout=5.0)
+    assert client.last_timeout == 5.0
+
+
+class _TimingOutClient:
+    def post(self, url, json=None, headers=None, timeout=None):
+        raise httpx.ReadTimeout("read timed out")
+
+
+def test_fork_post_maps_timeout_to_structured_error():
+    with pytest.raises(AgentRunError) as excinfo:
+        _fork_post(_TimingOutClient(), "http://x/v1/fork", {"id": "a"}, {})
+    assert excinfo.value.code == "fork_unavailable"


### PR DESCRIPTION
## Thinking Path

While verifying the hosted live fork on prod, `sb.fork()` raised `fork_unavailable` (an httpx `ReadTimeout`) at exactly 30s while `create` on the same node succeeded. `create` uses a 60s client and fork uses the DirectSandbox default 30s client (direct.py). The control plane polls a fork to Ready for up to its ready deadline (the gateway `--ready-timeout`, 120s by default). A cold live fork (snapshot the running VM, schedule the child pod, restore, wait for the guest agent) can take far longer than a warm pool claim, so a 30s client deadline turns a slow-but-succeeding fork into a spurious client-side failure. The client should not give up before the server does.

## Linked Issues or Issue Description

The SDK fork path used a client timeout (30s) shorter than the server's own fork ready deadline (120s), so a fork the server would complete raised `fork_unavailable` client-side. Found while verifying the hosted live fork end to end on prod.

## What Changed

- `_fork_post` takes a `timeout` argument (default `FORK_CLIENT_TIMEOUT_SECONDS = 130.0`, just over the 120s server deadline) and passes it as the per-request timeout, so a live fork gets room to complete without lengthening the other lifecycle calls (terminate, set_timeout, pause, resume, preview).
- Both fork call sites (the live `_fork_one` and the module `fork`) inherit the longer deadline through the default.
- New unit tests: the default exceeds the 120s server deadline, the timeout is overridable, and a transport timeout still maps to the structured `fork_unavailable` error.

## Verification

- `python3 -m pytest tests/test_fork_timeout.py tests/test_live_fork.py` : 6 passed.
- `python3 -m pytest tests/test_direct.py tests/test_flat_create.py tests/test_from_name.py tests/test_errors.py` : 57 passed (no regression).

## Risks

Very low. The change only lengthens how long the client waits for a fork response; it does not change request shape, retries, or the error surface. A fork that genuinely hangs still fails as `fork_unavailable`, just after a deadline that matches the server's rather than one shorter than it.

## Model Used

Claude Opus 4.8

## Checklist

- [x] Tests added and passing
- [x] No em or en dashes in added lines
- [x] No security surface change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fork request reliability by using a longer timeout, helping prevent premature failures during slower responses.
  * Timeouts are now consistently surfaced as a clear “fork unavailable” error instead of an unstructured transport failure.

* **Tests**
  * Added coverage for fork request timeout behavior, including the default timeout, per-request overrides, and timeout-to-error mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->