### PR TITLE
fix(fork): resume the source after a live fork instead of leaving it paused

### DIFF
--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -40,7 +40,8 @@ each guest with the secret value absent from the host-side logs. See
 A husk live fork (`internal/controller/sandboxfork_controller.go` `reconcileHuskFork`)
 produces children by SNAPSHOTTING the source pod's running VM (the husk stub
 `ForkSnapshot` op: pause, Full snapshot to `<dataDir>/forks/<fork-id>/{mem,vmstate}`,
-resume unless `pauseSource`) and ACTIVATING each child husk pod from that fork
+freeze the source rootfs to `<dataDir>/forks/<fork-id>/rootfs.ext4`, then ALWAYS
+resume the source) and ACTIVATING each child husk pod from that fork
 snapshot. Each child activates through the SAME `Activate` path a warm pod uses,
 so it runs the identical RNG-reseed + clock-step `NotifyForked` fork-correctness
 handshake (`internal/husk` `productionNotifier` -> Rust agent `NotifyForkedHandler`):
@@ -56,23 +57,40 @@ Memory/disk consistency (the disk half of the fork). The fork snapshot's
 `vmstate` is baked against the SOURCE sandbox's rootfs (`path_on_host`), so a
 restored child's guest memory (page cache, ext4 superblock, in-flight metadata)
 reflects the SOURCE disk, not the pristine template disk. The child's
-per-activation rootfs CoW clone is therefore made from the SOURCE pod's live
-rootfs (`<dataDir>/husk-rootfs/<source-pod-name>/rootfs.ext4`, threaded as
-`HuskPodOptions.ForkSourceRootfsPath` and passed to the stub as
-`--template-rootfs`), NOT the template rootfs. Cloning from the template instead
-would rebind the child to a disk that does not match its restored memory: any
-data the source wrote since boot would be lost in children and the
-cached-vs-on-disk mismatch could corrupt the child fs. This mirrors the raw-forkd
-`ForkRunning` path (`internal/fork/engine.go`), which clones the child's rootfs
-from the SOURCE's OWN writable rootfs clone (`source.rootfsClone`,
-`<dataDir>/sandboxes/<source-id>/rootfs.ext4`), captured while the source is
-paused, so memory and disk stay consistent. Issue #596: before that fix the
-raw-forkd path threaded `source.rootfsPath` (the read-only TEMPLATE the source
-was cloned from), so raw-forkd children silently lost every on-disk write the
-source made; the husk path was already correct. The clone is still per-child
-(keyed by the child pod name), so children remain independent; only the clone
-SOURCE is the source rootfs. Verified by `internal/controller`
-`TestBuildHuskPodForkChildClonesFromSourceRootfs`, by `internal/fork`
+per-activation rootfs CoW clone is therefore made from a FROZEN copy of the
+source rootfs the source stub captures INSIDE the fork snapshot's paused window,
+written next to `mem`/`vmstate` at `<dataDir>/forks/<fork-id>/rootfs.ext4` and
+mounted read-only at the child's snapshot mount (threaded as
+`HuskPodOptions.ForkSourceRootfsPath` = `huskForkRootfsInPodPath()` and passed to
+the stub as `--template-rootfs`), NOT the source's LIVE rootfs and NOT the
+template rootfs. The freeze is a reflink CoW copy taken while the VM is paused, so
+it is a point-in-time PAIR with the memory checkpoint. This is what makes the
+always-resume safe: the source resumes immediately after the checkpoint (so a
+post-fork exec against the SOURCE, the fork-the-winner-and-continue loop, does not
+time out), and because children clone from the FROZEN copy rather than the live
+rootfs, the resumed source can keep writing its own disk without ever drifting a
+child's clone out of sync with the child's restored memory. Leaving the source
+paused so its live rootfs stayed frozen for the whole child fan-out was the
+implicit old mechanism and the v1.24.1 production bug: nothing resumed the source
+(`pauseSource` on the hosted path), so a post-fork exec against it hung for 30s.
+Cloning from the template instead would rebind the child to a disk that does not
+match its restored memory: any data the source wrote since boot would be lost in
+children and the cached-vs-on-disk mismatch could corrupt the child fs. This
+mirrors the raw-forkd `ForkRunning` path (`internal/fork/engine.go`), which clones
+the child's rootfs from the SOURCE's OWN writable rootfs clone
+(`source.rootfsClone`, `<dataDir>/sandboxes/<source-id>/rootfs.ext4`) captured
+while the source is paused, then resumes the source; the husk path now captures
+the same paused-window point-in-time disk explicitly as a frozen file. Issue #596:
+before that fix the raw-forkd path threaded `source.rootfsPath` (the read-only
+TEMPLATE the source was cloned from), so raw-forkd children silently lost every
+on-disk write the source made. The clone is still per-child (keyed by the child
+pod name), so children remain independent; only the clone SOURCE is the frozen
+source rootfs. Verified by `internal/husk`
+`TestForkSnapshotFreezesRootfsInsidePausedWindow` and
+`TestForkSnapshotResumesSourceOnHostedPath`, by `internal/controller`
+`TestHuskForkRootfsInPodPathIsFrozenSnapshotCopy`,
+`TestBuildHuskPodForkChildClonesFromSourceRootfs`, and
+`TestHuskForkChildPodHasFullHuskShape`, by `internal/fork`
 `TestLiveForkRootfsBaseIsSourceClone`, and end to end on KVM by
 `cmd/live-state-fork-smoke`.
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -365,9 +365,13 @@ the controller identity only: `internal/husk.ServeTLS` plus
 `AuthorizeControllerIdentity`; the op rides the same op-dispatched channel that
 delivers secrets on activate). The op carries NO secrets (a fork id and a
 node-local snapshot path). The stub pauses the running VM, writes a Full
-Firecracker snapshot to a node hostPath `<dataDir>/forks/<fork-id>` (read-write
-only to the source pod that owns the VM; read-only to the child pods on the SAME
-node), then resumes the source unless `pauseSource`. The fork snapshot is a LIVE,
+Firecracker snapshot plus a frozen point-in-time copy of the source rootfs to a
+node hostPath `<dataDir>/forks/<fork-id>` (read-write only to the source pod that
+owns the VM; read-only to the child pods on the SAME node), then ALWAYS resumes
+the source (the `pauseSource` field no longer leaves it paused: leaving it paused
+was the v1.24.1 bug that hung a post-fork exec against the source for 30s; the
+frozen rootfs is what keeps the children consistent once the source resumes and
+mutates its own disk). The fork snapshot is a LIVE,
 EPHEMERAL artifact created by a trusted node-local stub and consumed by child
 stubs on the same node within the same trust boundary; it is NOT content-addressed,
 so the children activate it with verify disabled (`--allow-unverified-snapshots`),
@@ -377,8 +381,9 @@ does not exist for a live fork. The child still runs the full fail-closed RNG/cl
 reseed handshake (see `docs/fork-correctness.md`, husk fork children). Per-child
 independence: each child is its own husk pod + dormant VMM + per-activation rootfs
 CoW clone, so guest writes never cross between children or back to the source; the
-children share only the read-only fork snapshot mem+vmstate as a restore image,
-exactly as warm pods share the template snapshot. Each child mints its OWN bearer
+children share only the read-only fork snapshot (mem+vmstate plus the frozen
+source rootfs) as a restore image, exactly as warm pods share the template
+snapshot. Each child mints its OWN bearer
 token (the source's token never opens a child). Lifecycle: the fork snapshot is
 owned by the forking `Sandbox` and removed by its finalizer (`RemoveForkSnapshot` op)
 on delete; the child pods are owner-ref'd to the fork and reaped by Kubernetes GC.

--- a/internal/controller/huskfork_envtest_test.go
+++ b/internal/controller/huskfork_envtest_test.go
@@ -507,13 +507,22 @@ func TestHuskForkChildPodHasFullHuskShape(t *testing.T) {
 	}
 
 	// Fork-specific bits remain: pinned to the source node, and --template-rootfs
-	// (the CoW clone source) is the SOURCE pod's live rootfs, not the template's.
+	// (the CoW clone source) is the FROZEN source rootfs the source stub captured
+	// inside the fork snapshot's paused window (SnapshotDir/rootfs.ext4 on the
+	// read-only snapshot mount), NOT the source pod's LIVE rootfs under the
+	// husk-rootfs CoW dir. Cloning from the live rootfs would let the resumed
+	// source drift the child's disk out of sync with its memory checkpoint.
 	if child.Spec.Affinity == nil || child.Spec.Affinity.NodeAffinity == nil {
 		t.Fatalf("fork child must be pinned to the source node via affinity")
 	}
 	args := strings.Join(stub.Args, " ")
-	if !strings.Contains(args, "--template-rootfs /var/lib/mitos/husk-rootfs/"+srcPod.Name+"/rootfs.ext4") {
-		t.Fatalf("fork child --template-rootfs must be the source pod rootfs; args=%v", stub.Args)
+	if !strings.Contains(args, "--template-rootfs /var/lib/mitos/snapshot/rootfs.ext4") {
+		t.Fatalf("fork child --template-rootfs must be the frozen snapshot rootfs; args=%v", stub.Args)
+	}
+	// It must NOT clone from the source's live rootfs (the resumed source keeps
+	// writing that file).
+	if strings.Contains(args, "--template-rootfs /var/lib/mitos/husk-rootfs/"+srcPod.Name+"/rootfs.ext4") {
+		t.Fatalf("fork child must not clone from the source's live rootfs; args=%v", stub.Args)
 	}
 }
 

--- a/internal/controller/huskfork_rootfs_test.go
+++ b/internal/controller/huskfork_rootfs_test.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHuskForkRootfsInPodPathIsFrozenSnapshotCopy locks the controller's choice
+// of clone source for a fork child: it must be the FROZEN source rootfs the
+// source stub captured inside the fork snapshot's paused window (rootfs.ext4 next
+// to mem+vmstate on the read-only snapshot mount), NOT the source's LIVE
+// per-activation rootfs under the husk-rootfs CoW dir. Cloning from the live
+// rootfs would let the resumed source drift the child's disk out of sync with the
+// child's restored memory checkpoint (silent fs corruption); the frozen copy is
+// the point-in-time pair.
+func TestHuskForkRootfsInPodPathIsFrozenSnapshotCopy(t *testing.T) {
+	got := huskForkRootfsInPodPath()
+
+	if want := huskSnapshotMountPath + "/rootfs.ext4"; got != want {
+		t.Fatalf("fork child clone source = %q, want the frozen snapshot rootfs %q", got, want)
+	}
+	// It must live on the snapshot mount (the mem+vmstate pair), so the frozen
+	// disk is captured at the same instant as the memory checkpoint.
+	if !strings.HasPrefix(got, huskSnapshotMountPath+"/") {
+		t.Fatalf("fork child clone source %q must ride the snapshot mount %q", got, huskSnapshotMountPath)
+	}
+	// It must NOT be the source's live rootfs under the husk-rootfs CoW dir: a
+	// resumed source keeps writing that file, which would corrupt the child clone.
+	if strings.HasPrefix(got, huskRootfsCoWMountPath+"/") {
+		t.Fatalf("fork child clone source %q must not be the source's live rootfs under %q", got, huskRootfsCoWMountPath)
+	}
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -147,15 +147,18 @@ const (
 // claim reconciler threads this into the activate request.
 const HuskSnapshotDir = huskSnapshotMountPath
 
-// huskSourceRootfsInPodPath returns the IN-POD path a fork child clones the
-// SOURCE sandbox's live rootfs from. The source pod wrote its own per-activation
-// rootfs clone at <huskRootfsCoWMountPath>/<source-pod-name>/rootfs.ext4 under
-// the shared husk-rootfs hostPath dir; the fork child mounts that SAME dir, so
-// the source pod's rootfs is visible to it at this path. This is the rootfs the
-// fork snapshot's vmstate was baked against, so the child's CoW clone source
-// must be it (not the pristine template rootfs).
-func huskSourceRootfsInPodPath(sourcePodName string) string {
-	return filepath.Join(huskRootfsCoWMountPath, sourcePodName, "rootfs.ext4")
+// huskForkRootfsInPodPath returns the IN-POD path a fork child clones its rootfs
+// from: the FROZEN source rootfs the source stub captured INSIDE the fork
+// snapshot's paused window, written next to mem+vmstate at
+// SnapshotDir/rootfs.ext4 and mounted read-only at huskSnapshotMountPath in the
+// child. It is a point-in-time copy paired with the memory checkpoint, so the
+// child's restored guest memory (page cache, ext4 superblock, in-flight metadata)
+// matches the disk exactly. Cloning from the source's LIVE rootfs instead would
+// let a resumed source drift the disk out of sync with the checkpoint; cloning
+// from the pristine template rootfs would lose every write the source made. The
+// frozen copy avoids both.
+func huskForkRootfsInPodPath() string {
+	return filepath.Join(huskSnapshotMountPath, "rootfs.ext4")
 }
 
 // HuskPodOptions configures the husk pod spec the controller emits.
@@ -206,20 +209,20 @@ type HuskPodOptions struct {
 	// source sandbox's node). Required when ForkSnapshotID is set, since the fork
 	// snapshot is a node-local hostPath that exists only on that node.
 	ForkSourceNode string
-	// ForkSourceRootfsPath, set on a FORK CHILD, is the IN-POD path of the SOURCE
-	// sandbox's live rootfs that the child's per-activation CoW clone is made from.
-	// It is the source pod's own per-activation rootfs clone, exposed to the child
-	// through the shared husk-rootfs hostPath dir at
-	// <huskRootfsCoWMountPath>/<source-pod-name>/rootfs.ext4. This is load-bearing
-	// for fork correctness: the fork snapshot's vmstate was baked against the
-	// SOURCE's rootfs (path_on_host), so the child's restored guest memory (page
-	// cache, ext4 superblock, in-flight metadata) reflects the SOURCE disk. Cloning
-	// from the PRISTINE TEMPLATE rootfs instead (the bug) rebinds the child to a
-	// disk that does not match its memory: any data the source wrote since boot is
-	// lost and the cached-vs-on-disk mismatch can corrupt the child fs. When set,
-	// it replaces the template rootfs as the clone SOURCE; each child still writes
-	// its OWN per-activation clone (independence), only the clone source changes.
-	// Empty (a warm pod, not a fork child) clones from the template rootfs.
+	// ForkSourceRootfsPath, set on a FORK CHILD, is the IN-POD path of the FROZEN
+	// source rootfs the child's per-activation CoW clone is made from. The source
+	// stub captured it inside the fork snapshot's paused window at
+	// SnapshotDir/rootfs.ext4, mounted read-only at huskSnapshotMountPath in the
+	// child (huskForkRootfsInPodPath). This is load-bearing for fork correctness:
+	// the fork snapshot's vmstate was baked against the source's rootfs, so the
+	// child's restored guest memory (page cache, ext4 superblock, in-flight
+	// metadata) must pair with a disk captured at the SAME instant. The frozen copy
+	// is that instant. Cloning from the source's LIVE rootfs would let the resumed
+	// source drift the disk out of sync with the checkpoint; cloning from the
+	// PRISTINE TEMPLATE rootfs would lose every write the source made. Each child
+	// still writes its OWN per-activation clone (independence); only the clone
+	// source changes. Empty (a warm pod, not a fork child) clones from the template
+	// rootfs.
 	ForkSourceRootfsPath string
 	// SnapshotNodes is the set of node hostnames the pool has materialized the
 	// template snapshot on (the registry's NodesWithTemplate). When non-empty the
@@ -658,12 +661,14 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 
 		// The clone SOURCE for this pod's per-activation rootfs CoW. A WARM pod
 		// clones from the template rootfs (a fresh boot-time disk). A FORK CHILD
-		// must clone from the SOURCE sandbox's LIVE rootfs instead: the fork
-		// snapshot's vmstate was baked against the source's rootfs, so the child's
-		// restored guest memory reflects the SOURCE disk; cloning from the template
-		// would rebind the child to a disk that does not match its memory (silent
-		// data divergence / fs corruption). ForkSourceRootfsPath is the in-pod path
-		// of the source pod's rootfs (exposed through the shared husk-rootfs dir).
+		// must clone from the FROZEN source rootfs the source stub captured inside
+		// the fork snapshot's paused window instead: the fork snapshot's vmstate was
+		// baked against the source's rootfs at that instant, so the child's restored
+		// guest memory pairs with that exact disk; cloning from the template would
+		// rebind the child to a disk that does not match its memory (silent data
+		// divergence / fs corruption). ForkSourceRootfsPath is the in-pod path of
+		// the frozen rootfs (SnapshotDir/rootfs.ext4, on the read-only snapshot
+		// mount the child also restores mem+vmstate from).
 		cloneSourceRootfs := filepath.Join(templateDir, "rootfs.ext4")
 		if opts.ForkSourceRootfsPath != "" {
 			cloneSourceRootfs = opts.ForkSourceRootfsPath

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -512,12 +512,16 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		// reading --tls-cert. They are the SAME Secrets the warm-pool path uses.
 		TLSSecretName: r.HuskTLSSecretName,
 		CASecretName:  r.HuskCASecretName,
-		// BUG 1 fix: the child's per-activation rootfs CoW clone must be sourced
-		// from the SOURCE sandbox's live rootfs (the disk the fork snapshot's
-		// vmstate was baked against), NOT the pristine template rootfs. The source
-		// pod name is its Status.SandboxID; its rootfs is visible to the child
-		// through the shared husk-rootfs hostPath dir.
-		ForkSourceRootfsPath: huskSourceRootfsInPodPath(source.Status.SandboxID),
+		// The child's per-activation rootfs CoW clone is sourced from the FROZEN
+		// source rootfs the source stub captured inside the fork snapshot's paused
+		// window (SnapshotDir/rootfs.ext4), NOT the source's LIVE rootfs and NOT the
+		// pristine template rootfs. The frozen copy is a point-in-time pair with the
+		// mem+vmstate checkpoint, so the child's restored memory matches its disk.
+		// Cloning from the source's live rootfs would let the resumed source drift
+		// the disk out of sync with the checkpoint; the template rootfs would lose
+		// every write the source made. The frozen copy rides the SAME read-only
+		// snapshot mount the child restores mem+vmstate from.
+		ForkSourceRootfsPath: huskForkRootfsInPodPath(),
 	}
 
 	// Fixed-slot, idempotent child set. The child pods are EXACTLY Replicas, with

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -243,10 +243,13 @@ type ForkSnapshotRequest struct {
 }
 
 // ForkSnapshotResult is the control reply for a ForkSnapshot op. OK is true only
-// when the VM paused, the snapshot was written, the source rootfs was frozen, and
-// the VM resumed. SnapshotDir echoes where the snapshot was written (it carries
-// no secret). Error carries actionable remediation text when OK is false; it
-// never carries secrets.
+// when the VM paused, the snapshot was written, the source rootfs was frozen IF a
+// per-activation rootfs clone exists, and the VM resumed. The freeze is
+// CONDITIONAL: ForkSnapshot skips it when the stub has no on-disk rootfs clone
+// (the mock/CI paths) and still returns OK=true, so OK=true means paused +
+// snapshot written + (rootfs frozen only when a clone path exists) + resumed.
+// SnapshotDir echoes where the snapshot was written (it carries no secret). Error
+// carries actionable remediation text when OK is false; it never carries secrets.
 type ForkSnapshotResult struct {
 	OK          bool    `json:"ok"`
 	SnapshotDir string  `json:"snapshot_dir,omitempty"`

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -222,15 +222,20 @@ func readLineReader(r *bufio.Reader, v interface{}) error {
 // ForkSnapshotRequest asks a husk stub holding a RUNNING (active) VM to snapshot
 // that VM in place: pause it, write a Full Firecracker snapshot to SnapshotDir
 // (mem + vmstate, the same layout the fork engine and the activate path use),
-// then resume it unless PauseSource is set. The result snapshot is the restore
-// image the controller activates N independent CHILD husk pods from, so a husk
-// sandbox can be live-forked even though forkd's engine does not own its VM.
+// freeze the source rootfs to SnapshotDir/rootfs.ext4, then resume it. The result
+// snapshot is the restore image the controller activates N independent CHILD husk
+// pods from, so a husk sandbox can be live-forked even though forkd's engine does
+// not own its VM.
 //
 // ForkID is the node-local fork identifier the controller mints (the SandboxFork
 // child group); it is a content/address-like value, never a secret, and is the
 // directory leaf under the node forks dir. SnapshotDir is the in-pod path the
-// node forks dir is mounted at for THIS fork; the stub writes SnapshotDir/mem
-// and SnapshotDir/vmstate.
+// node forks dir is mounted at for THIS fork; the stub writes SnapshotDir/mem,
+// SnapshotDir/vmstate, and SnapshotDir/rootfs.ext4.
+//
+// PauseSource is a compatibility field. The pause is always internal to the
+// checkpoint and the source is always resumed afterward, so PauseSource no longer
+// leaves the source stopped (leaving it paused was the v1.24.1 production bug).
 type ForkSnapshotRequest struct {
 	ForkID      string `json:"fork_id"`
 	SnapshotDir string `json:"snapshot_dir"`
@@ -238,10 +243,10 @@ type ForkSnapshotRequest struct {
 }
 
 // ForkSnapshotResult is the control reply for a ForkSnapshot op. OK is true only
-// when the VM paused, the snapshot was written, and (unless PauseSource) the VM
-// resumed. SnapshotDir echoes where the snapshot was written (it carries no
-// secret). Error carries actionable remediation text when OK is false; it never
-// carries secrets.
+// when the VM paused, the snapshot was written, the source rootfs was frozen, and
+// the VM resumed. SnapshotDir echoes where the snapshot was written (it carries
+// no secret). Error carries actionable remediation text when OK is false; it
+// never carries secrets.
 type ForkSnapshotResult struct {
 	OK          bool    `json:"ok"`
 	SnapshotDir string  `json:"snapshot_dir,omitempty"`

--- a/internal/husk/forksnapshot_test.go
+++ b/internal/husk/forksnapshot_test.go
@@ -2,6 +2,7 @@ package husk
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -43,7 +44,14 @@ func TestForkSnapshotPausesSnapshotsResumes(t *testing.T) {
 	}
 }
 
-func TestForkSnapshotHonorsPauseSource(t *testing.T) {
+// TestForkSnapshotResumesSourceOnHostedPath is the production-confirmed bug fix
+// (v1.24.1): the hosted SDK POSTs /v1/sandboxes/{id}/fork with pause_source=true
+// to capture a quiescent checkpoint, but the source must still be RUNNING when
+// the fork snapshot returns. Leaving it paused makes a post-fork exec against the
+// SOURCE (the fork-the-winner-and-continue loop) time out at 30s. The pause is
+// only the brief quiescence CreateSnapshot requires; it is always followed by a
+// resume, so pause_source no longer leaves the source stopped.
+func TestForkSnapshotResumesSourceOnHostedPath(t *testing.T) {
 	f := &fakeVMM{}
 	s := activeStubWithFake(f)
 	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
@@ -55,10 +63,89 @@ func TestForkSnapshotHonorsPauseSource(t *testing.T) {
 		t.Fatalf("ForkSnapshot: err=%v res=%+v", err, res)
 	}
 	if !f.paused {
-		t.Fatalf("source VM was not paused")
+		t.Fatalf("source VM was not paused for the checkpoint")
 	}
-	if f.resumed {
-		t.Fatalf("PauseSource=true must leave the source paused, but it was resumed")
+	if !f.resumed {
+		t.Fatalf("source VM must be RESUMED after the fork snapshot even with pause_source=true; leaving it paused breaks a post-fork exec against the source")
+	}
+}
+
+// TestForkSnapshotFreezesRootfsInsidePausedWindow proves the source resume is
+// safe: with a per-activation rootfs clone present (the real hosted path), the
+// source's rootfs is frozen as a point-in-time copy INSIDE the paused window,
+// paired with mem+vmstate, BEFORE the source resumes. Child husk pods clone from
+// THIS frozen copy, so a resumed source that keeps writing its live disk can
+// never drift a child's rootfs out of sync with the memory checkpoint.
+func TestForkSnapshotFreezesRootfsInsidePausedWindow(t *testing.T) {
+	f := &fakeVMM{}
+	dir := t.TempDir()
+	cloneDir := t.TempDir()
+	clonePath := filepath.Join(cloneDir, "rootfs.ext4")
+	if err := os.WriteFile(clonePath, []byte("live-source-disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var gotSrc, gotDst string
+	s := &Stub{state: StateActive, vm: f, rootfsClonePath: clonePath}
+	s.reflink = func(src, dst string) error {
+		gotSrc, gotDst = src, dst
+		f.mu.Lock()
+		f.callOrder = append(f.callOrder, "reflink")
+		f.mu.Unlock()
+		return nil
+	}
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: dir,
+		PauseSource: true,
+	})
+	if err != nil || !res.OK {
+		t.Fatalf("ForkSnapshot: err=%v res=%+v", err, res)
+	}
+	if gotSrc != clonePath {
+		t.Fatalf("froze wrong rootfs: got src %q want %q", gotSrc, clonePath)
+	}
+	if want := filepath.Join(dir, "rootfs.ext4"); gotDst != want {
+		t.Fatalf("froze rootfs to wrong path: got %q want %q", gotDst, want)
+	}
+	// The freeze MUST land inside the paused window: pause -> snapshot ->
+	// reflink(freeze) -> resume.
+	firstIdx := map[string]int{}
+	for i, c := range f.callOrder {
+		if _, seen := firstIdx[c]; !seen {
+			firstIdx[c] = i
+		}
+	}
+	if !(firstIdx["pause"] < firstIdx["snapshot"] &&
+		firstIdx["snapshot"] < firstIdx["reflink"] &&
+		firstIdx["reflink"] < firstIdx["resume"]) {
+		t.Fatalf("freeze must happen inside the paused window (pause<snapshot<reflink<resume); order=%v", f.callOrder)
+	}
+}
+
+// TestForkSnapshotNoRootfsCloneSkipsFreeze keeps the mock/CI paths (no on-disk
+// rootfs) unchanged: with no per-activation clone there is nothing to freeze, so
+// the reflink seam is never called, and the source still resumes.
+func TestForkSnapshotNoRootfsCloneSkipsFreeze(t *testing.T) {
+	f := &fakeVMM{}
+	reflinkCalled := false
+	s := &Stub{state: StateActive, vm: f}
+	s.reflink = func(src, dst string) error {
+		reflinkCalled = true
+		return nil
+	}
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: t.TempDir(),
+		PauseSource: true,
+	})
+	if err != nil || !res.OK {
+		t.Fatalf("ForkSnapshot: err=%v res=%+v", err, res)
+	}
+	if reflinkCalled {
+		t.Fatalf("no per-activation rootfs clone: freeze must be skipped")
+	}
+	if !f.resumed {
+		t.Fatalf("source must resume even when there is no rootfs to freeze")
 	}
 }
 

--- a/internal/husk/forksnapshot_test.go
+++ b/internal/husk/forksnapshot_test.go
@@ -2,9 +2,11 @@ package husk
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // activeStubWithFake returns a Stub already in StateActive holding the given fake
@@ -146,6 +148,85 @@ func TestForkSnapshotNoRootfsCloneSkipsFreeze(t *testing.T) {
 	}
 	if !f.resumed {
 		t.Fatalf("source must resume even when there is no rootfs to freeze")
+	}
+}
+
+// TestForkSnapshotResumesSourceOnReflinkFailure covers the reflink-failure branch
+// of the freeze: when freezing the source rootfs fails, the op must STILL resume
+// the source (never leave a tenant's live sandbox frozen) before failing closed.
+func TestForkSnapshotResumesSourceOnReflinkFailure(t *testing.T) {
+	f := &fakeVMM{}
+	cloneDir := t.TempDir()
+	clonePath := filepath.Join(cloneDir, "rootfs.ext4")
+	if err := os.WriteFile(clonePath, []byte("live-source-disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Stub{state: StateActive, vm: f, rootfsClonePath: clonePath}
+	s.reflink = func(src, dst string) error {
+		return errors.New("reflink boom")
+	}
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: t.TempDir(),
+		PauseSource: true,
+	})
+	if err == nil || res.OK {
+		t.Fatalf("reflink failure must fail closed: err=%v res=%+v", err, res)
+	}
+	if !f.resumed {
+		t.Fatalf("source MUST be resumed after a reflink failure; leaving it paused frozen breaks a post-fork exec against the source")
+	}
+}
+
+// TestForkSnapshotResumeRetrySucceedsOnTransientError proves a TRANSIENT resume
+// error does not recreate the v1.24.1 stuck-paused incident: the first Resume
+// fails, the bounded retry tries again, the source comes back, and the op returns
+// OK=true with the source resumed.
+func TestForkSnapshotResumeRetrySucceedsOnTransientError(t *testing.T) {
+	f := &fakeVMM{resumeErrSeq: []error{errors.New("resume blip")}}
+	s := &Stub{state: StateActive, vm: f}
+	s.sleep = func(time.Duration) {} // no real sleeps in the retry
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: t.TempDir(),
+		PauseSource: true,
+	})
+	if err != nil || !res.OK {
+		t.Fatalf("a transient resume error that clears on retry must yield OK: err=%v res=%+v", err, res)
+	}
+	if !f.resumed {
+		t.Fatalf("source must be resumed after the retry succeeds")
+	}
+	if f.resumeCalls != 2 {
+		t.Fatalf("expected exactly 2 resume attempts (one blip then success), got %d", f.resumeCalls)
+	}
+}
+
+// TestForkSnapshotPersistentResumeFailureFiresMarker proves a PERSISTENT resume
+// failure fails closed, leaves the source NOT resumed, exhausts the bounded retry,
+// and fires the observability marker so a source left paused is visible.
+func TestForkSnapshotPersistentResumeFailureFiresMarker(t *testing.T) {
+	f := &fakeVMM{resumeErr: errors.New("resume rejected")}
+	markerFired := 0
+	s := &Stub{state: StateActive, vm: f}
+	s.sleep = func(time.Duration) {}
+	s.onSourceLeftPaused = func() { markerFired++ }
+	res, err := s.ForkSnapshot(context.Background(), ForkSnapshotRequest{
+		ForkID:      "fork-1",
+		SnapshotDir: t.TempDir(),
+		PauseSource: true,
+	})
+	if err == nil || res.OK {
+		t.Fatalf("a persistent resume failure must fail closed: err=%v res=%+v", err, res)
+	}
+	if f.resumed {
+		t.Fatalf("source must NOT be marked resumed when every resume attempt failed")
+	}
+	if f.resumeCalls != resumeMaxAttempts {
+		t.Fatalf("expected %d resume attempts before giving up, got %d", resumeMaxAttempts, f.resumeCalls)
+	}
+	if markerFired != 1 {
+		t.Fatalf("the source-left-paused marker must fire exactly once, got %d", markerFired)
 	}
 }
 

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -515,6 +515,15 @@ type Stub struct {
 	memStat     func(pid int) (unique, shared int64)
 	egressBytes func(tap string) int64
 
+	// sleep is the backoff sleep the bounded resume-retry uses; nil falls back to
+	// time.Sleep. Tests inject a no-op so the retry runs without real sleeps.
+	sleep func(time.Duration)
+	// onSourceLeftPaused fires when every resume attempt after a fork snapshot
+	// failed and the source is left paused (the v1.24.1 stuck-paused incident). It
+	// is the observability marker/metrics seam; nil is a no-op. The stub also logs
+	// a distinct error-level line in that case so a source left paused is visible.
+	onSourceLeftPaused func()
+
 	mu              sync.Mutex
 	state           State
 	vm              vmm
@@ -593,6 +602,9 @@ func New(cfg firecracker.VMConfig, opts Options) *Stub {
 	}
 	if s.egressBytes == nil {
 		s.egressBytes = readEgressCounterBytes
+	}
+	if s.sleep == nil {
+		s.sleep = time.Sleep
 	}
 	if s.wsTransport == nil {
 		s.wsTransport = productionWorkspaceTransport
@@ -941,6 +953,50 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 // error. On a snapshot or freeze failure it still attempts to resume the source
 // so a transient error does not leave a live sandbox frozen. The fork id and
 // snapshot paths carry no secrets.
+// resumeMaxAttempts and resumeRetryBackoff bound the resume-retry the fork
+// snapshot uses to keep its "never leave the source paused" guarantee: a
+// transient Resume error is retried a few times a short interval apart before we
+// give up, so a blip does not recreate the v1.24.1 stuck-paused incident.
+const (
+	resumeMaxAttempts  = 3
+	resumeRetryBackoff = 20 * time.Millisecond
+)
+
+// backoffSleep sleeps for the resume-retry backoff using the injected sleep seam
+// when present, else time.Sleep. It keeps the retry testable without real sleeps.
+func (s *Stub) backoffSleep(d time.Duration) {
+	if s.sleep != nil {
+		s.sleep(d)
+		return
+	}
+	time.Sleep(d)
+}
+
+// resumeSourceAfterFork resumes the source VM after a fork snapshot with a
+// bounded retry: a TRANSIENT resume error must not leave a tenant's live source
+// frozen (the v1.24.1 stuck-paused incident, where a post-fork exec against the
+// source timed out at 30s). It retries resumeMaxAttempts times, resumeRetryBackoff
+// apart, and returns nil as soon as one resume succeeds. When every attempt fails
+// it emits a distinct error-level log and fires the onSourceLeftPaused marker so a
+// source left paused is observable, then returns the last error. The caller under
+// s.mu owns the VM.
+func (s *Stub) resumeSourceAfterFork() error {
+	var err error
+	for attempt := 0; attempt < resumeMaxAttempts; attempt++ {
+		if attempt > 0 {
+			s.backoffSleep(resumeRetryBackoff)
+		}
+		if err = s.vm.Resume(); err == nil {
+			return nil
+		}
+	}
+	fmt.Fprintf(os.Stderr, "husk: source left paused after fork snapshot: resume failed after %d attempts: %v\n", resumeMaxAttempts, err)
+	if s.onSourceLeftPaused != nil {
+		s.onSourceLeftPaused()
+	}
+	return err
+}
+
 func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkSnapshotResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -998,7 +1054,9 @@ func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkS
 	if s.rootfsClonePath != "" {
 		frozenRootfs := filepath.Join(req.SnapshotDir, "rootfs.ext4")
 		if err := s.reflink(s.rootfsClonePath, frozenRootfs); err != nil {
-			_ = s.vm.Resume()
+			// Invariant: the source must not be left paused. Resume it (bounded
+			// retry) before failing closed on the freeze error.
+			_ = s.resumeSourceAfterFork()
 			werr := fmt.Errorf("husk: freeze source rootfs for fork snapshot: %w", err)
 			return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 		}
@@ -1012,8 +1070,9 @@ func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkS
 	// leaves the source stopped: the hosted fork-the-winner-and-continue loop
 	// POSTs pause_source=true and then execs against the SOURCE, which MUST be
 	// running. Leaving the source paused was the production bug (v1.24.1): a
-	// post-fork exec against the source timed out at 30s.
-	if err := s.vm.Resume(); err != nil {
+	// post-fork exec against the source timed out at 30s. The resume is retried a
+	// few times so a transient blip does not recreate that stuck-paused incident.
+	if err := s.resumeSourceAfterFork(); err != nil {
 		werr := fmt.Errorf("husk: resume source VM after fork snapshot: %w", err)
 		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -924,15 +924,23 @@ func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResul
 // the owning stub to snapshot it.
 //
 // It pauses the VM (CreateSnapshot requires a paused VM), writes a Full snapshot
-// to req.SnapshotDir/{mem,vmstate} (the same layout Activate reads), then resumes
-// it UNLESS req.PauseSource is set, in which case it leaves the source paused.
-// The stub stays StateActive throughout: it still owns its one VM.
+// to req.SnapshotDir/{mem,vmstate} (the same layout Activate reads), freezes the
+// source rootfs to req.SnapshotDir/rootfs.ext4 (a point-in-time CoW copy paired
+// with the memory checkpoint, so a resumed source cannot drift a child's rootfs
+// clone), then ALWAYS resumes the source. The stub stays StateActive throughout:
+// it still owns its one VM.
+//
+// req.PauseSource is a compatibility field: the pause is always internal to the
+// checkpoint and the source is always resumed afterward. Leaving the source
+// paused (the old PauseSource behavior) was the production bug on v1.24.1: the
+// hosted fork-the-winner-and-continue loop POSTs pause_source=true and then execs
+// against the SOURCE, which timed out at 30s because nothing resumed it.
 //
 // FAIL CLOSED: it requires StateActive (else error, no snapshot); a pause,
-// snapshot-create, or resume failure returns OK=false plus an error. On a
-// snapshot failure it still attempts to resume the source so a transient
-// snapshot error does not leave a live sandbox frozen. The fork id and snapshot
-// paths carry no secrets.
+// snapshot-create, rootfs-freeze, or resume failure returns OK=false plus an
+// error. On a snapshot or freeze failure it still attempts to resume the source
+// so a transient error does not leave a live sandbox frozen. The fork id and
+// snapshot paths carry no secrets.
 func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkSnapshotResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -975,13 +983,39 @@ func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkS
 		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}
 
-	// Resume the source UNLESS the fork asked to keep it paused. PauseSource
-	// trades a brief source interruption for a colder, quiescent snapshot.
-	if !req.PauseSource {
-		if err := s.vm.Resume(); err != nil {
-			werr := fmt.Errorf("husk: resume source VM after fork snapshot: %w", err)
+	// Freeze the source rootfs INSIDE the paused window, as a point-in-time pair
+	// with the mem+vmstate checkpoint just written. Child husk pods clone from
+	// THIS frozen copy (the controller points their per-activation CoW clone at
+	// SnapshotDir/rootfs.ext4), never the source's live rootfs, so once the source
+	// resumes below and keeps writing its own disk it can NEVER drift a child's
+	// rootfs clone out of sync with that child's restored memory. reflink makes
+	// the freeze a copy-on-write clone (cheap on a reflink filesystem, a full copy
+	// otherwise), the same primitive the activate path uses for the per-activation
+	// clone. Skipped when this stub has no per-activation clone (the mock/CI paths
+	// with no on-disk rootfs), which leaves those paths unchanged. The path
+	// carries no secret. On failure the source is resumed (never leave a tenant's
+	// live sandbox frozen) before we fail closed.
+	if s.rootfsClonePath != "" {
+		frozenRootfs := filepath.Join(req.SnapshotDir, "rootfs.ext4")
+		if err := s.reflink(s.rootfsClonePath, frozenRootfs); err != nil {
+			_ = s.vm.Resume()
+			werr := fmt.Errorf("husk: freeze source rootfs for fork snapshot: %w", err)
 			return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 		}
+	}
+
+	// ALWAYS resume the source after the checkpoint. The pause above is only the
+	// brief quiescence CreateSnapshot requires; the memory checkpoint AND the
+	// frozen rootfs are a consistent point-in-time pair captured entirely inside
+	// that paused window, so the source is safe to run and mutate its live disk
+	// again. PauseSource stays a wire field for compatibility, but it no longer
+	// leaves the source stopped: the hosted fork-the-winner-and-continue loop
+	// POSTs pause_source=true and then execs against the SOURCE, which MUST be
+	// running. Leaving the source paused was the production bug (v1.24.1): a
+	// post-fork exec against the source timed out at 30s.
+	if err := s.vm.Resume(); err != nil {
+		werr := fmt.Errorf("husk: resume source VM after fork snapshot: %w", err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}
 
 	latency := time.Since(start)

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -39,7 +39,11 @@ type fakeVMM struct {
 
 	resumeCalls int
 	resumeErr   error
-	resumed     bool
+	// resumeErrSeq scripts per-call Resume results (consumed one per call, front
+	// first); once exhausted Resume falls back to resumeErr. It lets a test model a
+	// transient resume error that clears on retry.
+	resumeErrSeq []error
+	resumed      bool
 
 	// paused / pauseErr / snapMem / snapState / snapErr support the fork-snapshot
 	// op: ForkSnapshot pauses the source VM, writes a Full snapshot, then resumes.
@@ -106,9 +110,18 @@ func (f *fakeVMM) Resume() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.resumeCalls++
-	f.resumed = true
 	f.callOrder = append(f.callOrder, "resume")
-	return f.resumeErr
+	err := f.resumeErr
+	if len(f.resumeErrSeq) > 0 {
+		err = f.resumeErrSeq[0]
+		f.resumeErrSeq = f.resumeErrSeq[1:]
+	}
+	// resumed reflects an ACTUAL resume: it is set only when Resume succeeds, so a
+	// test can assert a source was left NOT resumed after a persistent failure.
+	if err == nil {
+		f.resumed = true
+	}
+	return err
 }
 
 func (f *fakeVMM) Close() error {


### PR DESCRIPTION
## Thinking Path

The hosted SDK POSTs `/v1/sandboxes/{id}/fork` with `pause_source: true`. On the husk live-fork path (`internal/husk/stub.go` `ForkSnapshot`) the source stub pauses the source VM to write a consistent checkpoint, then, when `pauseSource` was set, left the source paused with nothing to resume it. A post-fork exec against the SOURCE then timed out at 30s, breaking the fork-the-winner-and-continue loop. Production-confirmed on v1.24.1.

Why leave-paused existed, and why it was load-bearing. Its stated purpose was "a colder, quiescent snapshot", but it was ALSO the implicit mechanism keeping the child fan-out consistent. Each child husk pod reflink-clones the source rootfs at its OWN Prepare time, several reconcile passes after `ForkSnapshot` returns (`reconcileHuskFork` creates children after the snapshot; children take passes to reach Ready). With the source frozen, every child cloned a disk that paired with the shared `mem`/`vmstate` checkpoint. So a naive "just resume" would let the source keep writing its live `rootfs.ext4` and drift a later child's clone out of sync with that child's restored memory: silent fs corruption. This is the exact hazard flagged in the task: today the clone happens OUTSIDE the pause.

Why the resume is now safe (rootfs consistency). I took option (a): make `pause_source` an internal pause-during-checkpoint detail and ALWAYS resume, but first capture the disk half of the fork INSIDE the paused window. `ForkSnapshot` now reflink-freezes the source rootfs to `SnapshotDir/rootfs.ext4` right after `CreateSnapshot`, while the VM is still paused, so memory and disk are one point-in-time pair. The controller points fork children at that frozen copy (`ForkSourceRootfsPath = huskForkRootfsInPodPath()` = the read-only snapshot mount, `/var/lib/mitos/snapshot/rootfs.ext4`) instead of the source's live rootfs. A resumed source can now mutate its own disk without ever corrupting a child clone. Child boot, the per-activation CoW clone, and the fail-closed RNG/clock reseed (`NotifyForked`) are unchanged; only the clone SOURCE moves from the live rootfs to the frozen copy.

Correct for all callers. The only consumer of the husk leave-paused behavior is `reconcileHuskFork` via `ForkSnapshotOnHusk`; no caller ever wants the source dead. The raw-forkd `engine.ForkRunning` path is separate and already always resumes the source (deferred `Resume`) and already clones the child rootfs from `source.rootfsClone` captured while paused, so it needed no change. Mock/CI paths with no on-disk rootfs skip the freeze and still resume, so they are unchanged.

## Verification

Production evidence: v1.24.1, 2026-07-06. Hosted SDK fork with `pause_source: true` leaves the source paused; a post-fork exec against the SOURCE times out at 30s.

TDD: three stub tests written first and observed RED before the fix:

```
--- FAIL: TestForkSnapshotResumesSourceOnHostedPath (0.00s)
    forksnapshot_test.go:69: source VM must be RESUMED after the fork snapshot even with pause_source=true; leaving it paused breaks a post-fork exec against the source
--- FAIL: TestForkSnapshotFreezesRootfsInsidePausedWindow (0.00s)
    forksnapshot_test.go:105: froze wrong rootfs: got src "" want ".../rootfs.ext4"
--- FAIL: TestForkSnapshotNoRootfsCloneSkipsFreeze (0.00s)
    forksnapshot_test.go:148: source must resume even when there is no rootfs to freeze
```

`go build ./...`: exit 0.

`go test ./internal/controller/... ./internal/husk/... ./internal/fork/... ./internal/daemon/...` (controller via `setup-envtest use 1.31`):

```
ok  	mitos.run/mitos/internal/controller	164.561s
ok  	mitos.run/mitos/internal/husk	3.736s
ok  	mitos.run/mitos/internal/fork	32.190s
ok  	mitos.run/mitos/internal/daemon	1.196s
```

`golangci-lint run --timeout=5m` (darwin): the single pre-existing darwin-only finding, nothing else:

```
internal/fork/uffd.go:42:22: func `uffdMapping.pageSizeBytes` is unused (unused)
```

`GOOS=linux golangci-lint run --timeout=5m`: exit 0, clean.

Only the real-KVM `firecracker-test` suite can prove the end-to-end assertion: that a resumed real Firecracker source keeps running (a live exec against it succeeds) while a child restores a disk consistent with its memory checkpoint from the frozen `rootfs.ext4`. The stub/controller tests here prove the ordering (freeze inside the paused window: `pause < snapshot < reflink < resume`), the resume, and the child clone-source wiring, all with the mock VM (`KVMAvailable=false`) so they run in normal CI.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forked children now always clone from a frozen root filesystem stored inside the fork snapshot, improving disk/memory consistency and preventing live-rootfs drift.
  * The source VM is always resumed after fork snapshot creation, eliminating cases where it could remain paused.
  * If the root filesystem freeze fails, the operation now fails safely while ensuring the source is resumed.

* **Documentation**
  * Updated fork behavior and consistency explanations in the threat model and fork correctness docs.

* **Tests**
  * Expanded/adjusted fork snapshot and child restore assertions to verify the new freeze-and-resume invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->