### PR TITLE
docs(plan): the winning fork primitive, cheap CoW forks per tenant on multi-node

### DIFF
--- a/docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md
+++ b/docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md
@@ -1,0 +1,161 @@
+# The winning fork primitive: cheap CoW forks per tenant, on multi-node k8s
+
+Status: design, needs sign-off before implementation. Owner: TBD.
+Relationship: supersedes the LATENCY approach in the warm-husk plan
+(2026-07-06-warm-husk-live-fork.md, #758). That plan's correctness milestones
+(#759 parent-resume, #760 child isolation) still stand and ship first. Its #761
+warm-husk-1:1 latency milestone is superseded by this document.
+
+## The one-sentence problem
+
+Mitos already ships a fork primitive that costs about 3 MiB per fork, and the
+hosted service does not run it. The husk-pod deployment model (one pod per VM,
+one honest 512Mi memory request each) discards a CoW memory-sharing primitive the
+raw-forkd engine already has, which is why hosted forks cost 512 MiB and about
+4.7s each while a competitor (deeplethe/forkd) does 100 forks in 101ms at 0.12 MiB
+per child.
+
+## What we already have (verified, origin/main)
+
+- Real CoW fan-out. Every fork of a template points Firecracker at the SAME
+  on-disk snapshot mem file; Firecracker `mmap(MAP_PRIVATE)`s it, so siblings
+  share clean pages through the kernel page cache and each fork's resident cost is
+  its private-dirty set. Measured about 3 MiB per fork, shared set counted once
+  (`internal/fork/engine.go:1209-1236`, `BENCHMARKS.md:72-77,169`).
+- A real, wired userfaultfd handler: fault to file-offset arithmetic, hot-page
+  capture, and preload (`internal/fork/uffd.go`, `uffd_linux.go`, `uffd_engine.go`).
+  It is a read-fault fill + prefetch handler today, wired for hugepage and
+  hot-set templates.
+- Many VMs per node already, in the raw-forkd engine: forkd is a DaemonSet, one
+  Firecracker PROCESS per VM (not one POD per VM). The 512Mi-per-VM cost is a
+  property of the husk-pod model layered on top for isolation, not of the engine.
+- Stock upstream Firecracker v1.15.0 (not vendored), giving two memory backends:
+  File (the `MAP_PRIVATE` CoW path) and Uffd (the read-fault handler).
+
+## What we lack vs deeplethe/forkd
+
+1. The cheap primitive is not on the hosted path. Hosted uses husk-pod
+   (one pod per VM), so a fork swarm is N pods x 512Mi, not N x 3 MiB in shared
+   memory. This is a deployment-model gap, not an engine gap.
+2. Cheap LIVE fork. A live fork (forking a running, mutated parent) writes a FULL
+   ~512Mi snapshot today (`SnapshotType: "Full"`, `internal/firecracker/client.go:461-464`),
+   then the child `MAP_PRIVATE`s that. Cheap for cold template fan-out, not for
+   live parents. Closing this needs a shared/memfd live-parent backing so the
+   child CoWs the running parent's pages directly.
+3. Async source resume. `ForkRunning` pauses the source across the full snapshot
+   write AND the child boot, resuming only in a deferred call after the child is
+   up. deeplethe uses UFFD write-protect so the source resumes in about 56ms while
+   dirty pages copy in the background. Mitos has no `UFFDIO_WRITEPROTECT` yet, but
+   the fault machinery to build it is about 90% present in the existing uffd code.
+4. Cross-node fork. Node-local today (checkpoint + rootfs are node-local
+   hostPaths, CAS is node-local). No competitor has cross-node fork either.
+
+## Target architecture
+
+### Layer 1: run the CoW engine per tenant, in one pod (the density win)
+
+The husk-pod model gives one pod per VM for isolation. But the pod is NOT the
+cross-tenant boundary today (nodes, `/dev/kvm`, snapshots, CAS are shared per node
+per ADR 0004; the microVM is the isolation boundary). And fork children are the
+SAME tenant as the source. So run a user's fork swarm as MANY same-tenant VMs in
+ONE pod, using the raw-forkd CoW engine scoped to that pod:
+
+- A session/fork-tree gets one pod (its own unprivileged, drop-ALL, seccomp,
+  netns, cgroup, NetworkPolicy envelope, exactly today's husk-pod posture).
+- Inside it, the CoW engine forks N sibling microVMs that `MAP_PRIVATE`-share the
+  parent memory image: about 3 MiB per fork, spawned as a control-op (Firecracker
+  process spawn + rootfs reflink + reseed handshake, tens of ms), NOT a pod op.
+- The N siblings keep microVM isolation (separate KVM + guest kernel), per-VM CoW
+  rootfs, and the per-VM fail-closed RNG/clock reseed (`NotifyForked`).
+- What is shared within the pod (acceptable because same-tenant): the pod memcg
+  (a sibling can OOM its siblings, the user's own workload), the pod netns + one
+  egress filter, and the husk-stub blast radius.
+
+This is the largest change: the single-VM husk stub becomes a multi-VM manager
+(`internal/husk/stub.go` single `state`/`vm` fields to a `map[vmID]*vmInstance`;
+`cmd/husk-stub/main.go` single socket/vmID/workdir to per-VM; controller
+`buildForkChildPod` from minting a pod to sending a spawn-VM control-op to the
+session pod). Roughly the scope of the original husk-pod work. Gate behind a flag;
+keep one-pod-per-VM as the conservative default until proven.
+
+### Layer 2: cheap live fork (memfd backing + UFFD_WP async resume)
+
+To make a live fork of a running parent as cheap as template fan-out:
+
+- Back the parent's guest RAM so a child can CoW the RUNNING parent's pages instead
+  of a full snapshot write. Two routes: (a) a shared/memfd Firecracker memory
+  backend, which likely needs a patched Firecracker (the one genuinely vendored
+  piece, matching what deeplethe did); (b) a UFFD-served live-memory scheme that
+  reuses the existing handler to serve the parent's pages to children without a
+  full snapshot. Prefer (b) first since it reuses shipped code and avoids vendoring;
+  fall back to (a) if (b) cannot hit the latency.
+- Add `UFFDIO_WRITEPROTECT` so the source resumes asynchronously while dirty pages
+  are captured in the background. Reuses about 90% of the existing uffd fault
+  machinery; the net-new is the WP ioctl wiring and the background drain lifecycle.
+
+### Layer 3: cross-node fork (the capability forkd cannot match)
+
+FEASIBLE-EXPENSIVE. Same-node cheapness comes from a resident shared page cache;
+across a node boundary every touched page must cross the network exactly once, so
+cross-node fork is latency-cheap (fast resume) but never bytes-cheap (about 0.12
+MiB is impossible off-node). Minimal v1, same-rack post-copy over UFFD:
+
+1. Source forkd keeps the paused snapshot mem file mmap'd (the uffd handler already
+   does) and exposes a gRPC `GetPage(offset, len)` over it: a memory-page server.
+2. Target forkd boots the child via the Uffd backend pointed at a local socket
+   whose handler, on each fault, computes the mem-file offset (`fileOffsetForAddr`,
+   already built) and fetches that page from the source over gRPC instead of a
+   local mmap, then `UFFDIO_COPY`s it.
+3. Preload the manifest hot-page set (`CaptureTemplateHotPages` to `Preload`,
+   already built) OVER THE WIRE before resume to shrink the fault tail.
+4. Keep same-rack to bound RTT; reset child network via the existing egress proxy
+   (#336). Source stays paused until the working set drains (or, with Layer 2's
+   UFFD_WP, resumes asynchronously during the drain).
+
+Reuses about 90% of `uffd.go`/`uffd_linux.go`/`uffd_engine.go`; net-new is the
+page-fetch RPC and the source pause/drain lifecycle.
+
+## Why this beats deeplethe/forkd
+
+- Same-node: we match their cheap CoW fork (about 3 MiB, tens of ms) with an engine
+  we already have, run per-tenant in one pod. Parity on the demo.
+- Cross-node: a swarm that outgrows one node spills to others via post-copy. They
+  are single-node only and defer multi-node; we already have the k8s platform and
+  the UFFD plumbing. This is a capability they cannot easily grow into.
+- Platform: multi-node scheduling, operator/CRDs/gitops, managed hosted service,
+  per-org tenancy, billing/metering, deny-all egress. They are single-node alpha
+  with manual netns setup and no egress policy.
+
+The winning claim is not "faster than forkd" (parity same-node); it is "the only
+one that gives you cheap live forks AND scales the swarm past one machine, managed,
+isolated, on your own k8s."
+
+## Milestones (each its own PR/issue; correctness first, then density, then reach)
+
+1. [#759] Parent-resume. Correctness; in flight (PR #763).
+2. [#760] Fork child inherits pool network/egress/resources. Correctness.
+3. NEW: benchmark the raw-forkd CoW density on the hosted node shape, to confirm
+   the about 3 MiB/fork holds on production hardware and set the honest target
+   (feeds #753).
+4. NEW: multi-same-tenant-VMs-per-pod (Layer 1). The density win. Flagged,
+   default off. Largest change; needs its own design review as a new execution
+   mode.
+5. NEW: cheap live fork (Layer 2): UFFD-served live-parent memory + UFFD_WP async
+   resume. Prefer the no-vendoring route first.
+6. NEW: cross-node post-copy fork (Layer 3): the memory-page server + network UFFD
+   handler, same-rack v1.
+
+## Risks and open questions
+
+- Layer 1 is a new execution mode, not a tweak; partial-failure semantics (one VM
+  dies, pod survives), per-VM billing within a shared pod, and the shared-memcg OOM
+  blast radius all need design.
+- Layer 2 route (b) may not hit the latency without vendoring Firecracker; route
+  (a) reintroduces a vendored-FC maintenance burden. Decide with a spike.
+- Cross-node cost is a working-set network stream; set expectations that off-node
+  forks are latency-cheap, not bytes-cheap. Do not claim cross-node swarms are as
+  cheap as same-node.
+- Marketing: per the standing decision, do NOT change copy; engineer toward the
+  numbers. But note internally that the about 3 MiB and about 27ms claims are real
+  ONLY in the raw-forkd/CoW engine, and the hosted path must actually run that
+  primitive before those claims are honest for hosted users.


### PR DESCRIPTION
## Problem

A competitor (deeplethe/forkd) forks 100 microVMs in 101ms at 0.12 MiB per child via CoW memory sharing + many-VMs-per-controller-pod + async UFFD write-protect live fork, while hosted Mitos forks at 512 MiB and ~4.7s each. An origin/main audit found the reason: Mitos ALREADY ships a CoW fork primitive (~3 MiB per fork, raw-forkd MAP_PRIVATE of a shared snapshot mem file, measured in BENCHMARKS.md) and the hosted husk-pod model (one pod per VM, one honest 512Mi request each) discards it. The problem is the deployment model, not the engine.

## Thinking Path

Two investigations plus the competitor's public repo established: (1) the raw-forkd engine's ~3 MiB/fork CoW is real and code-backed (engine.go:1209-1236); (2) Mitos has a real userfaultfd handler (fault-to-offset, hot-page capture, preload) ~90% of what a post-copy scheme needs, minus write-protect; (3) Firecracker is stock upstream, not vendored; (4) the live-fork gap vs deeplethe is ~1.5 pieces (a shared/memfd live-parent backing + UFFD_WP async resume), not a rewrite; (5) cross-node fork is FEASIBLE-EXPENSIVE via post-copy over UFFD (latency-cheap, never bytes-cheap) and no competitor has it. The design runs the existing CoW engine per-tenant in one pod (density parity, sound because forks are same-tenant and the pod is not the cross-tenant boundary today), adds cheap live fork, and adds cross-node post-copy as the differentiator forkd cannot match. Correctness milestones from the prior warm-husk plan (#759, #760) still ship first; that plan's warm-husk-1:1 latency milestone (#761) is superseded here.

## Verification

Docs-only; no em or en dashes (checked). Every architectural claim cites origin/main file:line or BENCHMARKS.md. Needs sign-off before the Layer 1 execution-mode work begins.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a design plan for multi-node fork support with staged architecture, milestones, and open risks.
  * Describes a path to cheaper copy-on-write forks, including live fork handling and cross-node page fetches.
  * Summarizes current capabilities versus remaining gaps and outlines next implementation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->