### PR TITLE
fix(saas): quota denials carry a specific cause and actionable remediation

### DIFF
--- a/internal/saas/quota/gateway_adapter.go
+++ b/internal/saas/quota/gateway_adapter.go
@@ -95,11 +95,21 @@ func envelopeFor(err error) apierr.Error {
 	case errors.Is(err, ErrRateLimited):
 		return apierr.Get(apierr.CodeRateLimited).
 			WithCause("the organization or source IP exceeded its request rate")
-	case errors.Is(err, ErrConcurrencyExceeded),
-		errors.Is(err, ErrAggregateExceeded),
-		errors.Is(err, ErrSandboxTooLarge):
+	case errors.Is(err, ErrConcurrencyExceeded):
+		// The most common denial: a create or a fork(n) that would push the org
+		// past its plan's concurrent-sandbox cap (each fork child counts). Name a
+		// concrete way forward so the caller is not at a dead end.
 		return apierr.Get(apierr.CodeQuotaExceeded).
-			WithCause("the organization exceeded a hosted-plan quota")
+			WithCause("the organization is already running the maximum number of concurrent sandboxes its plan allows").
+			WithRemediation("Terminate a running sandbox to free a slot (GET /v1/sandboxes lists them; DELETE /v1/sandboxes/<id> frees one), or upgrade the organization's plan for a higher concurrency limit. A fork counts each child against this limit, so fork fewer children or raise the limit.")
+	case errors.Is(err, ErrAggregateExceeded):
+		return apierr.Get(apierr.CodeQuotaExceeded).
+			WithCause("the organization's running sandboxes would exceed its plan's aggregate resource limit").
+			WithRemediation("Terminate a running sandbox to free resources, or upgrade the organization's plan for a higher aggregate limit.")
+	case errors.Is(err, ErrSandboxTooLarge):
+		return apierr.Get(apierr.CodeQuotaExceeded).
+			WithCause("the requested sandbox size exceeds the largest the organization's plan permits").
+			WithRemediation("Request a smaller sandbox (fewer vCPUs or less memory), or upgrade the organization's plan for larger sandboxes.")
 	default:
 		return apierr.Get(apierr.CodeQuotaExceeded).
 			WithCause("the organization quota check denied the request")

--- a/internal/saas/quota/gateway_adapter_test.go
+++ b/internal/saas/quota/gateway_adapter_test.go
@@ -1,0 +1,82 @@
+package quota
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mitos.run/mitos/internal/apierr"
+)
+
+// A quota denial is the most likely failure a hosted user hits (for example a
+// fork(n) that would exceed the plan's concurrent-sandbox cap). Per the
+// LLM-legible-error rule (issue #28) and the no-dead-ends journey rule, each
+// distinct quota denial must carry its OWN cause and an actionable remediation,
+// not collapse into one opaque "exceeded a hosted-plan quota" with no way
+// forward.
+func TestQuotaDenialsCarrySpecificRemediation(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode string
+		// substrings the remediation must contain so the caller knows what to do.
+		wantRemediation []string
+	}{
+		{
+			name:            "concurrency",
+			err:             ErrConcurrencyExceeded,
+			wantCode:        string(apierr.CodeQuotaExceeded),
+			wantRemediation: []string{"terminate", "upgrade"},
+		},
+		{
+			name:            "aggregate",
+			err:             ErrAggregateExceeded,
+			wantCode:        string(apierr.CodeQuotaExceeded),
+			wantRemediation: []string{"upgrade"},
+		},
+		{
+			name:            "size",
+			err:             ErrSandboxTooLarge,
+			wantCode:        string(apierr.CodeQuotaExceeded),
+			wantRemediation: []string{"smaller"},
+		},
+	}
+
+	seenCauses := map[string]string{}
+	for _, tc := range cases {
+		env := envelopeFor(tc.err)
+		if env.Code != tc.wantCode {
+			t.Errorf("%s: code = %q, want %q", tc.name, env.Code, tc.wantCode)
+		}
+		if strings.TrimSpace(env.Remediation) == "" {
+			t.Errorf("%s: remediation is empty; a quota denial must tell the caller how to proceed", tc.name)
+		}
+		low := strings.ToLower(env.Remediation)
+		for _, want := range tc.wantRemediation {
+			if !strings.Contains(low, want) {
+				t.Errorf("%s: remediation %q does not mention %q", tc.name, env.Remediation, want)
+			}
+		}
+		if strings.TrimSpace(env.Cause) == "" {
+			t.Errorf("%s: cause is empty", tc.name)
+		}
+		if prev, ok := seenCauses[env.Cause]; ok {
+			t.Errorf("%s and %s share the same cause %q; each quota type must be distinguishable", tc.name, prev, env.Cause)
+		}
+		seenCauses[env.Cause] = tc.name
+	}
+}
+
+// Rate-limit and suspension denials keep their own envelopes and are not
+// mislabeled as quota_exceeded.
+func TestNonQuotaDenialsKeepTheirEnvelopes(t *testing.T) {
+	if env := envelopeFor(ErrRateLimited); env.Code != string(apierr.CodeRateLimited) {
+		t.Errorf("rate-limit code = %q, want %q", env.Code, apierr.CodeRateLimited)
+	}
+	if env := envelopeFor(ErrSuspended); env.Code != string(apierr.CodeForbidden) {
+		t.Errorf("suspended code = %q, want %q", env.Code, apierr.CodeForbidden)
+	}
+	if env := envelopeFor(errors.New("some other error")); env.Code != string(apierr.CodeQuotaExceeded) {
+		t.Errorf("default code = %q, want %q", env.Code, apierr.CodeQuotaExceeded)
+	}
+}


### PR DESCRIPTION
## Thinking Path

While verifying the fork(n) fleet fan-out live on prod, `sb.fork(3)` on a fresh free-tier org returned `quota_exceeded: "the organization exceeded a hosted-plan quota"` with no remediation. That is correct enforcement (TierFree allows 2 concurrent sandboxes, so parent + fork(2) is already over), but the error is a dead end: it does not say which limit, or how to proceed. The enforcer already distinguishes concurrency, aggregate, and per-sandbox-size denials, but `envelopeFor` collapsed all three into one opaque cause with no `WithRemediation`. That violates the LLM-legible-error rule (issue #28) and the no-dead-ends journey rule, and it is the most likely first failure a hosted user hits.

## Linked Issues or Issue Description

Hosted quota denials (concurrency, aggregate, per-sandbox size) returned a single opaque `quota_exceeded` envelope with no actionable remediation, so a caller (for example a fork that exceeds the concurrent-sandbox cap) had no way forward.

## What Changed

- `envelopeFor` now returns a distinct cause and an actionable remediation per quota denial:
  - concurrency: terminate a running sandbox (with the list and delete routes) or upgrade the plan; notes that a fork counts each child against the limit.
  - aggregate: free resources or upgrade.
  - per-sandbox size: request a smaller sandbox or upgrade.
- New unit tests assert each quota type carries a non-empty, distinct cause and a remediation with the right guidance, and that rate-limit and suspension denials keep their own envelopes.

## Verification

- `go test ./internal/saas/quota/` : all pass (new remediation tests + existing enforcer/fork-op suite).
- `go build ./internal/saas/... ./cmd/gateway/...` : clean.
- `gofmt -l` : clean.

## Risks

Very low. The change only enriches the error envelope text for denials that already occurred; it does not change WHEN a request is denied, the HTTP status, or the machine-readable `code`. No security surface moves (no new information beyond the org's own plan limits, which the org may see), so no threat-model delta.

## Model Used

Claude Opus 4.8

## Checklist

- [x] Tests added and passing
- [x] gofmt and build clean
- [x] No em or en dashes in added lines
- [x] No security surface change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quota-related errors now show more specific messages and guidance, making it clearer how to resolve concurrency, resource, and size limits.
  * Improved clarity for error handling so non-quota issues keep their own appropriate messages and status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->