### PR TITLE
feat(husk): host two same-tenant VMs in one stub behind the multi-vm flag

### DIFF
--- a/cmd/husk-stub/main.go
+++ b/cmd/husk-stub/main.go
@@ -413,7 +413,12 @@ func run() error {
 		// from it. Empty disables the workspace ops (fail-closed).
 		CASDir: *casDir,
 		// EXPERIMENTAL multi-VM-per-pod mode (#764), default off: false keeps the
-		// single-VM behavior byte-for-byte. Increment 1 wires only the scaffold.
+		// single-VM behavior byte-for-byte. When on, the stub multiplexes the
+		// lifecycle over its per-VM instance map and derives each non-default VM's
+		// OWN workdir + Firecracker/vsock socket nested under this base --workdir
+		// (deriveVMConfig), so several Firecracker processes coexist in one pod
+		// without colliding on the single fixed socket the single-VM path uses. No
+		// production caller sets this yet; the controller is not wired to it.
 		MultiVM: *multiVM,
 	})
 	// Publish the constructed stub to the already-serving metering source.

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -81,6 +81,14 @@ type ActivateRequest struct {
 	// InboundCIDRs narrows an Inbound=allow to source CIDRs (Modal
 	// inbound_cidr_allowlist). Config.
 	InboundCIDRs []string `json:"inbound_cidrs,omitempty"`
+	// VMID names WHICH same-tenant VM in the pod this activate addresses, the
+	// explicit selector for the experimental multi-VM-per-pod mode (#764). It is
+	// honored ONLY when the stub runs with --multi-vm; on the default single-VM
+	// path it is ignored entirely, so the field changes no shipped behavior. Empty
+	// (every caller today, and omitempty keeps it off the wire) defaults to the
+	// pod's single implicit VM, so an existing activate stays byte-for-byte
+	// compatible. It is a node-local identifier, not a secret.
+	VMID string `json:"vm_id,omitempty"`
 }
 
 // ActivateResult is the control reply. OK is true only when the snapshot loaded

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -182,7 +182,7 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID) error {
 // not build. No production caller runs multi-VM yet, so nothing regresses.
 func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateRequest) (ActivateResult, error) {
 	if err := checkVMID(id); err != nil {
-		return ActivateResult{}, err
+		return ActivateResult{OK: false, Error: err.Error()}, err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -6,11 +6,31 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"mitos.run/mitos/internal/firecracker"
 	"mitos.run/mitos/internal/metering"
 )
+
+// validVMID is the allowlist a vmID must satisfy before it is ever used to
+// derive a Firecracker id, workdir, or socket path (deriveVMConfig). It is
+// intentionally identical to huskVMIDPattern in cmd/husk-stub (and firecracker's
+// internal vmIDPattern): a leading alphanumeric then up to 63 of
+// [alphanumeric _ -], which cannot contain "/", "..", or a NUL, so a vmID can
+// never traverse out of the pod workdir. defaultVMID satisfies it. Increment 2's
+// only live caller passes defaultVMID, but a later increment will thread a vmID
+// from the control plane, so the path-traversal gate is closed here now.
+var validVMID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`)
+
+// checkVMID rejects a vmID that is not on the validVMID allowlist, so it can
+// never be interpolated into a filesystem path unsafely.
+func checkVMID(id vmID) error {
+	if !validVMID.MatchString(string(id)) {
+		return fmt.Errorf("husk: invalid vm id %q: must match %s", string(id), validVMID.String())
+	}
+	return nil
+}
 
 // This file holds the EXPERIMENTAL multi-VM-per-pod execution mode (#764, Layer
 // 1 of docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md), gated
@@ -63,6 +83,9 @@ func (s *Stub) deriveVMConfig(id vmID) firecracker.VMConfig {
 // never touches the first. Fail closed: any error tears the dormant VMM down and
 // leaves the instance out of StateDormant.
 func (s *Stub) prepareInstance(ctx context.Context, id vmID) error {
+	if err := checkVMID(id); err != nil {
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -158,6 +181,9 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID) error {
 // the pod netns need a per-VM tap fan-out that this state-machine increment does
 // not build. No production caller runs multi-VM yet, so nothing regresses.
 func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateRequest) (ActivateResult, error) {
+	if err := checkVMID(id); err != nil {
+		return ActivateResult{}, err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -1,0 +1,417 @@
+package husk
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"mitos.run/mitos/internal/firecracker"
+	"mitos.run/mitos/internal/metering"
+)
+
+// This file holds the EXPERIMENTAL multi-VM-per-pod execution mode (#764, Layer
+// 1 of docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md), gated
+// behind Options.MultiVM (default OFF). It multiplexes the husk lifecycle over
+// the per-VM instances map so ONE husk pod can host MANY same-tenant VMs, each an
+// isolated Firecracker process with its OWN socket, workdir, and lifecycle state
+// machine. The single-VM code in stub.go is untouched and remains the only path
+// any production caller exercises today (no caller sets MultiVM; the controller
+// is not wired to it).
+//
+// Increment 2 scope (this file): the map-based state-machine multiplexing proven
+// with the mock VMM: two distinct vmIDs each Prepare -> Dormant -> Activate ->
+// Active independently, Close one without disturbing the other, Metering reports
+// every active VM. The per-VM egress tap / DNS proxy programming, the fork ops
+// (ForkSnapshot / workspace dehydrate-hydrate) keyed by vmID, and spawning a
+// second VM by CoW-restoring from a live parent are DEFERRED to a later increment
+// (they need the per-VM networking and real-Firecracker spawn wiring, provable
+// only on the KVM firecracker-test suite). This increment proves the state
+// machine and multiplexing, not the second real Firecracker process.
+
+// deriveVMConfig returns the firecracker.VMConfig for one VM in a multi-VM pod.
+// The default (primary) VM keeps the pod's base config unchanged, so a multi-VM
+// pod with a single default VM is configured exactly like a single-VM pod. Every
+// OTHER vmID gets its OWN Firecracker identity: a distinct process ID, a
+// per-VM workdir nested under the pod workdir, and the API + vsock sockets bound
+// inside that per-VM workdir. That per-VM socket/workdir isolation is what lets
+// several Firecracker processes coexist in one pod without colliding on the
+// single fixed firecracker.sock / vsock.sock the single-VM path uses.
+func (s *Stub) deriveVMConfig(id vmID) firecracker.VMConfig {
+	cfg := s.cfg
+	if id == defaultVMID {
+		return cfg
+	}
+	cfg.ID = s.cfg.ID + "-" + string(id)
+	// Nest each non-default VM's workdir under the pod workdir so its Firecracker
+	// API socket and the guest vsock UDS (bound relative to WorkDir) never collide
+	// with a sibling's. Empty base WorkDir (the unit path, which injects a fake
+	// starter that ignores the config) leaves the derived paths empty too.
+	if s.cfg.WorkDir != "" {
+		cfg.WorkDir = filepath.Join(s.cfg.WorkDir, string(id))
+		cfg.SocketPath = filepath.Join(cfg.WorkDir, "firecracker.sock")
+	}
+	return cfg
+}
+
+// prepareInstance brings up a DORMANT Firecracker VMM for one vmID and records it
+// on the per-VM instance, allocating the instance on first use. It mirrors the
+// single-VM Prepare (state gate, snapshot verify at prepare, per-activation rootfs
+// clone) but scoped to ONE entry in the instances map, so preparing a second VM
+// never touches the first. Fail closed: any error tears the dormant VMM down and
+// leaves the instance out of StateDormant.
+func (s *Stub) prepareInstance(ctx context.Context, id vmID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	inst := s.instances[id]
+	if inst == nil {
+		inst = newVMInstance()
+		s.instances[id] = inst
+	}
+	if inst.state != StateNew {
+		return fmt.Errorf("husk: prepare vm %q in state %s: already prepared", id, inst.state)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cfg := s.deriveVMConfig(id)
+	// Create the per-VM workdir before launching so the Firecracker API socket and
+	// vsock UDS have a home. The default VM reuses the pod workdir (already created
+	// by cmd/husk-stub), and the unit path has an empty workdir, so only a nested
+	// non-default VM needs the mkdir here.
+	if cfg.WorkDir != "" && id != defaultVMID {
+		if err := os.MkdirAll(cfg.WorkDir, 0o755); err != nil {
+			return fmt.Errorf("husk: create per-VM workdir for vm %q: %w", id, err)
+		}
+	}
+	vm, err := s.start(cfg)
+	if err != nil {
+		return fmt.Errorf("husk: prepare dormant VMM for vm %q: %w", id, err)
+	}
+	inst.vm = vm
+
+	// Snapshot verify at prepare time (pre-paid, dormant), the same fail-closed
+	// gate the single-VM Prepare runs, when the pod was started with the snapshot
+	// dir + expected digest. The snapshot is read-only and content-addressed, so
+	// verifying once here is equivalent to verifying at activate.
+	if s.prepareSnapshotDir != "" && s.prepareExpectedDigest != "" {
+		for _, name := range []string{"mem", "vmstate"} {
+			f := filepath.Join(s.prepareSnapshotDir, name)
+			if err := waitForFile(ctx, f, rootfsTemplateWait); err != nil {
+				_ = inst.vm.Close()
+				inst.vm = nil
+				return fmt.Errorf("husk: snapshot file %s not ready for vm %q: %w", f, id, err)
+			}
+		}
+		if err := s.verify(ActivateRequest{
+			SnapshotDir:    s.prepareSnapshotDir,
+			ExpectedDigest: s.prepareExpectedDigest,
+		}); err != nil {
+			_ = inst.vm.Close()
+			inst.vm = nil
+			return fmt.Errorf("husk: prepare-time snapshot verification failed for vm %q: %w", id, err)
+		}
+		inst.prepareVerified = true
+	}
+
+	// Per-activation rootfs CoW clone, scoped to this VM's derived id so two VMs in
+	// the pod never share or overwrite a rootfs clone. Same primitive and dormant
+	// pre-paid timing as the single-VM Prepare.
+	if s.rootfsTemplatePath != "" && s.rootfsCoWDir != "" {
+		clonePath := filepath.Join(s.rootfsCoWDir, cfg.ID, "rootfs.ext4")
+		if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
+			_ = inst.vm.Close()
+			inst.vm = nil
+			return fmt.Errorf("husk: create per-activation rootfs dir for vm %q: %w", id, err)
+		}
+		if err := waitForFile(ctx, s.rootfsTemplatePath, rootfsTemplateWait); err != nil {
+			_ = inst.vm.Close()
+			inst.vm = nil
+			return fmt.Errorf("husk: per-activation rootfs template %s not ready for vm %q: %w", s.rootfsTemplatePath, id, err)
+		}
+		if err := s.reflink(s.rootfsTemplatePath, clonePath); err != nil {
+			_ = inst.vm.Close()
+			inst.vm = nil
+			return fmt.Errorf("husk: clone per-activation rootfs for vm %q: %w", id, err)
+		}
+		inst.rootfsClonePath = clonePath
+	}
+
+	inst.state = StateDormant
+	return nil
+}
+
+// activateInstance loads the snapshot into one dormant per-VM instance and waits
+// for its guest to answer, scoped to ONE entry in the instances map. It mirrors
+// the single-VM Activate state machine (verify -> load paused -> rootfs rebind ->
+// resume -> guest ready -> fork-correctness handshake) but drives inst.vm and
+// advances inst.state, so activating a second VM neither reads nor mutates the
+// first VM's state. Fail closed: any step failing returns OK=false and leaves the
+// instance NOT active.
+//
+// The per-VM in-pod egress filter + DNS proxy (which the single-VM Activate
+// programs) are DEFERRED for multi-VM to a later increment: several VMs sharing
+// the pod netns need a per-VM tap fan-out that this state-machine increment does
+// not build. No production caller runs multi-VM yet, so nothing regresses.
+func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateRequest) (ActivateResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	inst := s.instances[id]
+	if inst == nil || inst.state != StateDormant {
+		state := StateNew
+		if inst != nil {
+			state = inst.state
+		}
+		return ActivateResult{
+				OK:            false,
+				AlreadyActive: inst != nil && inst.state == StateActive,
+				Error:         fmt.Sprintf("activate vm %q in state %s: must be dormant", id, state),
+			},
+			fmt.Errorf("husk: activate vm %q in state %s: must be dormant", id, state)
+	}
+	if err := ctx.Err(); err != nil {
+		return ActivateResult{OK: false, Error: err.Error()}, err
+	}
+	if req.SnapshotDir == "" {
+		return ActivateResult{OK: false, Error: "activate: empty snapshot dir"},
+			fmt.Errorf("husk: activate vm %q: empty snapshot dir", id)
+	}
+
+	memFile := filepath.Join(req.SnapshotDir, "mem")
+	vmStateFile := filepath.Join(req.SnapshotDir, "vmstate")
+
+	start := time.Now()
+
+	// Verify-on-activate gate, with the same prepare-time fast path the single-VM
+	// Activate uses: skip the re-hash only when THIS instance verified this exact
+	// snapshot during its dormant period.
+	if !(inst.prepareVerified && req.SnapshotDir == s.prepareSnapshotDir && req.ExpectedDigest == s.prepareExpectedDigest) {
+		if err := s.verify(req); err != nil {
+			werr := fmt.Errorf("husk: snapshot verification failed for vm %q: %w", id, err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+
+	// Load PAUSED so the rootfs drive can be rebound before the guest runs, then
+	// resume explicitly, exactly as the single-VM path does.
+	if err := inst.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, false, req.NetworkOverrides); err != nil {
+		werr := fmt.Errorf("husk: load snapshot from %s for vm %q: %w", req.SnapshotDir, id, err)
+		return ActivateResult{OK: false, Error: werr.Error()}, werr
+	}
+	if inst.rootfsClonePath != "" {
+		if err := inst.vm.PatchDrive("rootfs", inst.rootfsClonePath); err != nil {
+			werr := fmt.Errorf("husk: rebind rootfs drive to per-activation clone for vm %q: %w", id, err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+	if err := inst.vm.Resume(); err != nil {
+		werr := fmt.Errorf("husk: resume vm %q after rootfs rebind: %w", id, err)
+		return ActivateResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	vsockPath := inst.vm.VsockHostPath(firecracker.VsockRelPath)
+	if err := s.ready(ctx, vsockPath, s.readyTimeout); err != nil {
+		werr := fmt.Errorf("husk: guest not ready after activate for vm %q: %w", id, err)
+		return ActivateResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	// Fork-correctness handshake with a fresh per-VM generation + entropy. Each
+	// instance owns its own generation counter, so two VMs never share it. The
+	// entropy and secret values are held only in memory and are NEVER logged.
+	entropy := make([]byte, entropySize)
+	if _, err := rand.Read(entropy); err != nil {
+		werr := fmt.Errorf("husk: generate fork entropy for vm %q: %w", id, err)
+		return ActivateResult{OK: false, Error: werr.Error()}, werr
+	}
+	inst.generation++
+	if err := s.notify(vsockPath, inst.generation, entropy, req); err != nil {
+		werr := fmt.Errorf("husk: fork-correctness handshake failed for vm %q: %w", id, err)
+		return ActivateResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	if s.onActivated != nil {
+		if err := s.onActivated(vsockPath, req.Token); err != nil {
+			werr := fmt.Errorf("husk: serve sandbox API for activated vm %q: %w", id, err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+
+	latency := time.Since(start)
+	inst.state = StateActive
+	return ActivateResult{
+		OK:        true,
+		VsockPath: vsockPath,
+		LatencyMs: float64(latency.Microseconds()) / 1000.0,
+	}, nil
+}
+
+// closeInstance tears down ONE per-VM instance's VMM and per-activation artifacts
+// and returns it to StateNew, leaving every sibling instance untouched. It is the
+// per-VM analog of the single-VM Close: closing one VM in the pod must never take
+// a sibling down.
+func (s *Stub) closeInstance(id vmID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeInstanceLocked(id)
+}
+
+// closeInstanceLocked is the s.mu-held body of closeInstance, reused by the pod
+// teardown that closes every instance under one lock acquisition.
+func (s *Stub) closeInstanceLocked(id vmID) error {
+	inst := s.instances[id]
+	if inst == nil {
+		return nil
+	}
+
+	// Best effort: reap this instance's rootfs CoW clone so it does not outlive the
+	// VM. Path only is logged on failure; the clone carries no secrets.
+	if inst.rootfsClonePath != "" {
+		if rmErr := os.Remove(inst.rootfsClonePath); rmErr != nil && !os.IsNotExist(rmErr) {
+			fmt.Fprintf(os.Stderr, "husk: remove per-activation rootfs clone %s for vm %q: %v\n", inst.rootfsClonePath, id, rmErr)
+		}
+		inst.rootfsClonePath = ""
+	}
+
+	// Tear down any per-VM egress state this instance held. Multi-VM does not
+	// program the tap/DNS yet (deferred), so these are nil today; the teardown is
+	// here so the field migration is complete and safe when that wiring lands.
+	if inst.dnsProxy != nil {
+		_ = inst.dnsProxy.Shutdown(context.Background())
+		inst.dnsProxy = nil
+	}
+	if s.netRunner != nil && inst.activeTap != "" {
+		_ = teardownEgressFilter(context.Background(), s.netRunner, inst.activeTap)
+		inst.activeTap = ""
+	}
+
+	var err error
+	if inst.vm != nil {
+		err = inst.vm.Close()
+		inst.vm = nil
+	}
+	inst.state = StateNew
+	return err
+}
+
+// closeAllInstances tears down every VM in the pod, the multi-VM analog of the
+// single-VM Close called on pod shutdown. It closes each instance under one lock
+// acquisition and returns the first teardown error, having still attempted every
+// instance so one stuck VM cannot leak the rest.
+func (s *Stub) closeAllInstances() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var firstErr error
+	for id := range s.instances {
+		if err := s.closeInstanceLocked(id); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// meteringMulti returns this pod's CoW-aware metering report with ONE sample per
+// ACTIVE VM, so a multi-VM pod meters every same-tenant fork it hosts (not just
+// one). It mirrors the single-VM Metering per instance: the sample ID is the VM's
+// derived config id (the id the controller maps to an org), the memory split is
+// the live smaps_rollup of that VM's Firecracker pid, and the disk split follows
+// the seed-vs-clone rule. The IO (proc read, file stat) runs OUTSIDE the lock,
+// like the single-VM path, so a slow stat never blocks Activate/Close.
+//
+// SECRET-FREE: the report carries only vm-ids and numeric byte counts.
+func (s *Stub) meteringMulti() metering.Report {
+	type meterInput struct {
+		id    string
+		pid   int
+		seed  string
+		clone string
+		tap   string
+	}
+
+	s.mu.Lock()
+	var inputs []meterInput
+	for id, inst := range s.instances {
+		if inst.state != StateActive {
+			continue
+		}
+		pid := 0
+		if inst.vm != nil {
+			pid = inst.vm.PID()
+		}
+		inputs = append(inputs, meterInput{
+			id:    s.deriveVMConfig(id).ID,
+			pid:   pid,
+			seed:  s.rootfsTemplatePath,
+			clone: inst.rootfsClonePath,
+			tap:   inst.activeTap,
+		})
+	}
+	s.mu.Unlock()
+
+	if len(inputs) == 0 {
+		return metering.Report{}
+	}
+
+	samples := make([]metering.Sample, 0, len(inputs))
+	for _, in := range inputs {
+		memUnique, memShared := s.memStat(in.pid)
+
+		var diskUnique, diskShared int64
+		if in.seed != "" {
+			seedSize := apparentSize(in.seed)
+			diskShared = seedSize
+			if in.clone != "" {
+				if div := apparentSize(in.clone) - seedSize; div > 0 {
+					diskUnique = div
+				}
+			}
+		} else if in.clone != "" {
+			diskUnique = apparentSize(in.clone)
+		}
+
+		var egress int64
+		if in.tap != "" && s.egressBytes != nil {
+			egress = s.egressBytes(in.tap)
+		}
+
+		samples = append(samples, metering.Sample{
+			ID:           in.id,
+			MemoryUnique: memUnique,
+			MemoryShared: memShared,
+			DiskUnique:   diskUnique,
+			DiskShared:   diskShared,
+			EgressBytes:  egress,
+		})
+	}
+	return metering.Aggregate(samples)
+}
+
+// pingInstances checks every prepared VM's Firecracker API socket, the multi-VM
+// analog of the single-VM liveness ping the pod's MonitorVMM drives. It returns
+// an error as soon as any VM is unresponsive (so a dead sibling still flips the
+// pod NotReady) or when no VM is prepared yet. The pings run under the lock's
+// snapshot of the handles taken and released quickly, like the single-VM ping.
+func (s *Stub) pingInstances() error {
+	s.mu.Lock()
+	vms := make([]vmm, 0, len(s.instances))
+	for _, inst := range s.instances {
+		if inst.vm != nil {
+			vms = append(vms, inst.vm)
+		}
+	}
+	s.mu.Unlock()
+
+	if len(vms) == 0 {
+		return fmt.Errorf("husk: no VMM prepared")
+	}
+	for _, vm := range vms {
+		if err := vm.Ping(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/husk/multivm_test.go
+++ b/internal/husk/multivm_test.go
@@ -2,10 +2,253 @@ package husk
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"mitos.run/mitos/internal/firecracker"
 )
+
+// newMultiVMTestStub builds a stub with the multi-VM execution mode ON, using a
+// keyed starter so a test can look up the per-VM fake by the derived VMConfig ID
+// (deriveVMConfig gives each vmID a distinct ID). The other seams are the same
+// no-op fakes the single-VM unit path uses, so these tests exercise the per-VM
+// state machine multiplexing with the mock, no real Firecracker or KVM.
+func newMultiVMTestStub(t *testing.T, vms map[string]*fakeVMM) *Stub {
+	t.Helper()
+	start := func(cfg firecracker.VMConfig) (vmm, error) {
+		vm := &fakeVMM{}
+		vms[cfg.ID] = vm
+		return vm, nil
+	}
+	return New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:   start,
+		Ready:   readyOK,
+		Notify:  (&fakeNotifier{}).notify,
+		Verify:  verifyOK,
+		MultiVM: true,
+	})
+}
+
+// TestMultiVMTwoInstancesReachActiveIndependently proves the core of increment 2
+// of #764: with the flag ON the stub can Prepare+Activate TWO distinct vmIDs and
+// both reach StateActive independently, each keyed in the instances map with its
+// OWN VMM handle and generation counter. It drives the per-VM engine directly
+// (prepareInstance/activateInstance), which the public dispatch routes to.
+func TestMultiVMTwoInstancesReachActiveIndependently(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	const second vmID = "vm-2"
+	for _, id := range []vmID{defaultVMID, second} {
+		if err := s.prepareInstance(context.Background(), id); err != nil {
+			t.Fatalf("prepareInstance(%s): %v", id, err)
+		}
+		res, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"})
+		if err != nil || !res.OK {
+			t.Fatalf("activateInstance(%s): err=%v ok=%v", id, err, res.OK)
+		}
+	}
+
+	if got := s.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("default instance state = %s, want active", got)
+	}
+	if got := s.instances[second].state; got != StateActive {
+		t.Fatalf("second instance state = %s, want active", got)
+	}
+	// Distinct VMM handles: each vmID owns its own Firecracker process (its own
+	// socket/workdir), never a shared one.
+	if s.instances[defaultVMID].vm == s.instances[second].vm {
+		t.Fatal("two vmIDs must own distinct VMM handles")
+	}
+	// Each per-VM generation counter starts at 1 (one reseed per activation).
+	if g := s.instances[defaultVMID].generation; g != 1 {
+		t.Fatalf("default generation = %d, want 1", g)
+	}
+	if g := s.instances[second].generation; g != 1 {
+		t.Fatalf("second generation = %d, want 1", g)
+	}
+	// The two fakes are the two distinct derived-ID VMMs the keyed starter built.
+	if len(vms) != 2 {
+		t.Fatalf("expected 2 distinct started VMMs, got %d: %v", len(vms), vms)
+	}
+	if _, ok := vms["husk-test"]; !ok {
+		t.Fatalf("default vmID must derive the base config ID, got keys %v", vms)
+	}
+	if _, ok := vms["husk-test-vm-2"]; !ok {
+		t.Fatalf("second vmID must derive a distinct per-VM config ID, got keys %v", vms)
+	}
+}
+
+// TestMultiVMCloseOneLeavesOtherActive proves per-VM isolation: closing ONE
+// instance tears down only that VMM and returns it to StateNew, while the other
+// instance stays StateActive with its VMM untouched. This is the isolated
+// state-machine property the density work needs (a sibling dying must not take
+// its siblings down).
+func TestMultiVMCloseOneLeavesOtherActive(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	const second vmID = "vm-2"
+	for _, id := range []vmID{defaultVMID, second} {
+		if err := s.prepareInstance(context.Background(), id); err != nil {
+			t.Fatalf("prepareInstance(%s): %v", id, err)
+		}
+		if _, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+			t.Fatalf("activateInstance(%s): %v", id, err)
+		}
+	}
+
+	if err := s.closeInstance(defaultVMID); err != nil {
+		t.Fatalf("closeInstance(default): %v", err)
+	}
+
+	// The closed instance is torn down (VMM closed, back to StateNew).
+	if !vms["husk-test"].closed {
+		t.Fatal("closing the default instance must tear down its VMM")
+	}
+	if got := s.instances[defaultVMID].state; got != StateNew {
+		t.Fatalf("closed instance state = %s, want new", got)
+	}
+	// The other instance is untouched: still active, its VMM not closed.
+	if vms["husk-test-vm-2"].closed {
+		t.Fatal("closing one instance must NOT close a sibling's VMM")
+	}
+	if got := s.instances[second].state; got != StateActive {
+		t.Fatalf("sibling instance state = %s, want active (unaffected by the other's close)", got)
+	}
+}
+
+// TestMultiVMMeteringReportsBothVMs proves the metering path reports EVERY active
+// VM in the pod, one sample per vmID keyed on its derived id, so a multi-VM pod
+// meters all the same-tenant forks it hosts (not just one).
+func TestMultiVMMeteringReportsBothVMs(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	for _, id := range []vmID{defaultVMID, "vm-2"} {
+		if err := s.prepareInstance(context.Background(), id); err != nil {
+			t.Fatalf("prepareInstance(%s): %v", id, err)
+		}
+		if _, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+			t.Fatalf("activateInstance(%s): %v", id, err)
+		}
+	}
+
+	rep := s.Metering()
+	if len(rep.Sandboxes) != 2 {
+		t.Fatalf("multi-VM metering must report both VMs, got %d samples", len(rep.Sandboxes))
+	}
+	ids := map[string]bool{}
+	for _, sb := range rep.Sandboxes {
+		ids[sb.ID] = true
+	}
+	if !ids["husk-test"] || !ids["husk-test-vm-2"] {
+		t.Fatalf("metering must carry both derived vm-ids, got %v", ids)
+	}
+}
+
+// TestMultiVMSecondActivateFailClosedLeavesFirstActive proves a fail-closed
+// activate of a SECOND VM (its snapshot load fails) never disturbs an
+// already-active sibling: the first stays StateActive, the second stays
+// StateDormant and reports not-OK.
+func TestMultiVMSecondActivateFailClosedLeavesFirstActive(t *testing.T) {
+	// A starter that fails the SECOND VM's snapshot load only.
+	vms := map[string]*fakeVMM{}
+	start := func(cfg firecracker.VMConfig) (vmm, error) {
+		vm := &fakeVMM{}
+		if cfg.ID == "husk-test-vm-2" {
+			vm.loadErr = errors.New("snapshot corrupt")
+		}
+		vms[cfg.ID] = vm
+		return vm, nil
+	}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:   start,
+		Ready:   readyOK,
+		Notify:  (&fakeNotifier{}).notify,
+		Verify:  verifyOK,
+		MultiVM: true,
+	})
+
+	if err := s.prepareInstance(context.Background(), defaultVMID); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+		t.Fatalf("activateInstance(default): %v", err)
+	}
+	if err := s.prepareInstance(context.Background(), "vm-2"); err != nil {
+		t.Fatalf("prepareInstance(vm-2): %v", err)
+	}
+	res, err := s.activateInstance(context.Background(), "vm-2", ActivateRequest{SnapshotDir: "/snap"})
+	if err == nil || res.OK {
+		t.Fatal("second activate must fail closed on a bad snapshot load")
+	}
+
+	if got := s.instances["vm-2"].state; got == StateActive {
+		t.Fatalf("failed-closed second instance must not be active, got %s", got)
+	}
+	if got := s.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("first instance must stay active despite the sibling's failure, got %s", got)
+	}
+}
+
+// TestMultiVMPublicDispatchRoutesToDefault proves the public lifecycle methods
+// (Prepare/Activate/Close/Metering) dispatch to the per-VM engine under the flag:
+// a plain Prepare+Activate with no VMID selector drives the default instance, and
+// Close tears every instance down. This is the compatibility seam: an existing
+// single-entry caller keeps working, now backed by the instances map.
+func TestMultiVMPublicDispatchRoutesToDefault(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	if err := s.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if got := s.instances[defaultVMID].state; got != StateDormant {
+		t.Fatalf("after Prepare default instance = %s, want dormant", got)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap"})
+	if err != nil || !res.OK {
+		t.Fatalf("Activate: err=%v ok=%v", err, res.OK)
+	}
+	if got := s.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("after Activate default instance = %s, want active", got)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := s.instances[defaultVMID].state; got != StateNew {
+		t.Fatalf("after Close default instance = %s, want new", got)
+	}
+	if !vms["husk-test"].closed {
+		t.Fatal("Close must tear the default VMM down")
+	}
+}
+
+// TestMultiVMActivateRoutesByVMID proves the explicit vmID selector on the
+// control request: with the flag on, Activate routes to the instance named by
+// req.VMID (defaulting to defaultVMID when empty), so the control API can address
+// a specific same-tenant VM in the pod.
+func TestMultiVMActivateRoutesByVMID(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	const second vmID = "vm-2"
+	if err := s.prepareInstance(context.Background(), second); err != nil {
+		t.Fatalf("prepareInstance(vm-2): %v", err)
+	}
+	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap", VMID: string(second)})
+	if err != nil || !res.OK {
+		t.Fatalf("Activate(vm-2): err=%v ok=%v", err, res.OK)
+	}
+	if got := s.instances[second].state; got != StateActive {
+		t.Fatalf("VMID-selected instance = %s, want active", got)
+	}
+	// The default instance was never prepared, so it must be untouched.
+	if inst := s.instances[defaultVMID]; inst.state != StateNew {
+		t.Fatalf("unaddressed default instance = %s, want new", inst.state)
+	}
+}
 
 // TestMultiVMFlagDefaultsOff proves the multi-VM execution mode is OFF by
 // default: New(cfg, Options{}) leaves the stub on the single-VM path and

--- a/internal/husk/multivm_test.go
+++ b/internal/husk/multivm_test.go
@@ -347,3 +347,18 @@ func TestSingleVMRoundtripUnchangedWithFlagOff(t *testing.T) {
 		t.Fatal("Close must tear the VMM down")
 	}
 }
+
+// TestMultiVMRejectsUnsafeVMID proves a vmID that could traverse out of the pod
+// workdir is refused before any path is derived from it (issue #772 review).
+func TestMultiVMRejectsUnsafeVMID(t *testing.T) {
+	for _, bad := range []vmID{"../evil", "a/b", "", "with space", "..", ".", "x/../../y"} {
+		if err := checkVMID(bad); err == nil {
+			t.Errorf("checkVMID(%q) = nil, want an error (unsafe vm id must be rejected)", string(bad))
+		}
+	}
+	for _, ok := range []vmID{defaultVMID, "vm1", "fork-0", "a_b-9", "A0"} {
+		if err := checkVMID(ok); err != nil {
+			t.Errorf("checkVMID(%q) = %v, want nil (valid vm id)", string(ok), err)
+		}
+	}
+}

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -697,6 +697,13 @@ func New(cfg firecracker.VMConfig, opts Options) *Stub {
 // the stub is already dormant or active is an error, so a husk never silently
 // leaks a second VMM.
 func (s *Stub) Prepare(ctx context.Context) error {
+	// Multi-VM mode (#764, default off): the lifecycle is multiplexed over the
+	// per-VM instances map, so a plain Prepare brings up the pod's default VM.
+	// prepareInstance locks s.mu itself, so return before taking the lock here.
+	// When multiVM is false the single-VM body below runs byte-for-byte unchanged.
+	if s.multiVM {
+		return s.prepareInstance(ctx, defaultVMID)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.state != StateNew {
@@ -796,6 +803,18 @@ func (s *Stub) Prepare(ctx context.Context) error {
 // leaves the stub NOT active. A failed Activate never reports a usable VM; the
 // caller must treat the husk as unusable.
 func (s *Stub) Activate(ctx context.Context, req ActivateRequest) (ActivateResult, error) {
+	// Multi-VM mode (#764, default off): route to the instance the request names
+	// via req.VMID, defaulting to the pod's single implicit VM for compatibility.
+	// activateInstance locks s.mu itself, so return before taking the lock here.
+	// When multiVM is false the single-VM body below runs byte-for-byte unchanged
+	// and req.VMID is ignored.
+	if s.multiVM {
+		id := defaultVMID
+		if req.VMID != "" {
+			id = vmID(req.VMID)
+		}
+		return s.activateInstance(ctx, id, req)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1452,6 +1471,12 @@ func (s *Stub) State() State {
 // SECRET-FREE: the report carries ONLY the vm-id and numeric byte/second counts,
 // never argv, env, file bytes, or the per-sandbox bearer token.
 func (s *Stub) Metering() metering.Report {
+	// Multi-VM mode (#764, default off): report one sample per active VM in the
+	// pod (meteringMulti locks s.mu itself). When multiVM is false the single-VM
+	// body below runs byte-for-byte unchanged.
+	if s.multiVM {
+		return s.meteringMulti()
+	}
 	s.mu.Lock()
 	if s.state != StateActive {
 		// A dormant/warm pod meters nothing yet: the empty report keeps a scrape a
@@ -1525,6 +1550,11 @@ var ErrVMMDead = errors.New("husk: firecracker VMM is unresponsive")
 // reference under the lock and pings OUTSIDE it so a slow ping never blocks
 // Activate/Close.
 func (s *Stub) pingVMM() error {
+	// Multi-VM mode (#764, default off): ping every prepared VM in the pod. When
+	// multiVM is false the single-VM body below runs byte-for-byte unchanged.
+	if s.multiVM {
+		return s.pingInstances()
+	}
 	s.mu.Lock()
 	vm := s.vm
 	s.mu.Unlock()
@@ -1575,6 +1605,12 @@ func (s *Stub) MonitorVMM(ctx context.Context, interval time.Duration, failures 
 
 // Close tears down the VMM if one was prepared. It is safe to call in any state.
 func (s *Stub) Close() error {
+	// Multi-VM mode (#764, default off): a pod Close tears down EVERY instance
+	// (closeAllInstances locks s.mu itself). When multiVM is false the single-VM
+	// body below runs byte-for-byte unchanged.
+	if s.multiVM {
+		return s.closeAllInstances()
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 


### PR DESCRIPTION
Increment 2 of the multi-VM-per-pod density work (#764, Layer 1 of docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md). Makes the multi-VM path REAL for a SECOND same-tenant VM inside one husk stub, still BEHIND `--multi-vm` (default off).

Flag default off means NO runtime behavior change on the shipped path: the single-VM fields stay the live path and their method bodies are byte-for-byte unchanged. The controller is NOT wired to `--multi-vm`; no production caller sets it.

## Thinking Path

Increment 1 (PR #770) added the scaffold: the `vmInstance` struct, the `vmID` type, `defaultVMID`, `newVMInstance()`, the `MultiVM` Options field + `--multi-vm` flag, and a guarded `instances map[vmID]*vmInstance` (allocated only when MultiVM is set). Nothing read that map at runtime.

This increment makes the map load-bearing under the flag, while keeping the single-VM path untouched:

- Chose a dispatch-at-top seam. Each affected method (Prepare, Activate, Close, Metering, the liveness ping) gets a tiny `if s.multiVM { return s.<perVM>() }` guard BEFORE it takes the single-VM lock. Below the guard, the existing single-VM body is unchanged, so flag-off behavior is byte-identical. This keeps the diff to `internal/husk/stub.go` (a named-human-reviewer path) to five additive guards, no edits to existing logic.
- Put all new logic in a new isolated file `internal/husk/multivm.go`, so the substance is reviewable in one place and the sensitive files stay minimal.
- `deriveVMConfig(id)` gives the default VM the pod's base config unchanged (so a multi-VM pod with one default VM is configured exactly like a single-VM pod) and every OTHER vmID its OWN Firecracker id, workdir, and API/vsock socket nested under the pod workdir, so several Firecracker processes coexist in one pod without colliding on the single fixed socket the single-VM path uses. `cmd/husk-stub/main.go` passes the base pod `--workdir`; the stub derives per-VM subdirs beneath it.
- `ActivateRequest` gains an explicit `vm_id` selector, honored only under `--multi-vm`, defaulting to `defaultVMID`, `omitempty` so it stays off the wire for existing callers.

### Scope split (deliberate, for reviewability)

The plan calls Layer 1 the largest change and a new execution mode. Per the increment's own guidance to split if the full migration is too large for one safe review, this PR lands the map-based state-machine multiplexing proven with the mock VMM. Deferred to a later increment (they need real second-Firecracker + per-VM networking wiring, provable only on the KVM firecracker-test suite):

- Per-VM in-pod egress tap + DNS proxy fan-out in the shared pod netns.
- ForkSnapshot and workspace dehydrate/hydrate keyed by vmID (under the flag these remain on the single-VM fields; no production caller runs multi-VM, so nothing regresses).
- Spawning a second VM by CoW-restoring from a LIVE parent (Layer 2). This increment proves the stub can host two independent VMs from snapshots via the injected starter seam, not a second real Firecracker process.

## Verification

All commands run in the worktree on this branch.

- `go build ./...` : clean (exit 0).
- `go test ./internal/husk/... ./cmd/husk-stub/...` : `ok internal/husk`, `ok cmd/husk-stub`.
- `go test ./internal/controller/...` with envtest (`~/go/bin/setup-envtest use 1.31`, assets 1.31.0-darwin-arm64) : `ok mitos.run/mitos/internal/controller 166.762s`.
- `golangci-lint run --timeout=5m` : only the pre-existing darwin-only `internal/fork/uffd.go:42 pageSizeBytes unused` finding (accepted); nothing else.
- `GOOS=linux golangci-lint run --timeout=5m` : clean.
- `gofmt -l` on all changed files : clean. No em/en dashes.

New tests (mock VMM, TDD, would not compile before the engine existed):

- `TestMultiVMTwoInstancesReachActiveIndependently` : two distinct vmIDs each Prepare+Activate to Active, distinct VMM handles, each generation counter at 1, distinct derived config ids.
- `TestMultiVMCloseOneLeavesOtherActive` : closing one instance tears down only its VMM (back to StateNew) and leaves the sibling StateActive, its VMM untouched.
- `TestMultiVMMeteringReportsBothVMs` : Metering reports one sample per active VM, both derived ids present.
- `TestMultiVMSecondActivateFailClosedLeavesFirstActive` : a fail-closed second activate leaves the first VM active.
- `TestMultiVMPublicDispatchRoutesToDefault` and `TestMultiVMActivateRoutesByVMID` : the public methods dispatch to the per-VM engine and the `vm_id` selector routes correctly.

The increment-1 guards (`TestMultiVMFlagDefaultsOff`, `TestSingleVMRoundtripUnchangedWithFlagOff`) and the full existing husk suite still pass, confirming flag-off is unchanged.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental multi-VM-per-pod execution with independent per-VM lifecycle handling.
  * `Activate` requests can optionally include a `vm_id` selector; omission targets the default instance.
  * Multi-VM mode derives isolated per-instance workdirs/sockets, with per-instance metering and health pings.
* **Bug Fixes**
  * Improved lifecycle isolation: closing or failing one VM won’t disrupt other active siblings (fail-closed activation).
* **Documentation**
  * Clarified inline help for the `--multi-vm` option behavior and expectations.
* **Tests**
  * Expanded coverage for routing, isolation, metering, and rejecting unsafe `vm_id` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->