### PR TITLE
test(controller): settle on NoCapacity reason before asserting in capacity envtests

### DIFF
--- a/internal/controller/capacity_admission_envtest_test.go
+++ b/internal/controller/capacity_admission_envtest_test.go
@@ -82,6 +82,7 @@ func waitForPhase(t *testing.T, name string, want v1.SandboxPhase, timeout time.
 // assert against the settled state and never race a transient reason.
 func waitForSettledNoCapacity(t *testing.T, name string) v1.Sandbox {
 	t.Helper()
+	waitForPhase(t, name, v1.SandboxPending, 15*time.Second)
 	waitForReadyReason(t, name, "NoCapacity")
 	return getClaim(t, name)
 }
@@ -106,8 +107,7 @@ func TestClaimPendsThenReadyOnFreedCapacity(t *testing.T) {
 	makeCapacityFixture(t, "cap1")
 
 	// The claim must pend (not Ready, not Failed) while capacity is exhausted.
-	pending := waitForPhase(t, "cap1", v1.SandboxPending, 15*time.Second)
-	pending = waitForSettledNoCapacity(t, "cap1")
+	pending := waitForSettledNoCapacity(t, "cap1")
 	if got := counterValue(t, "mitos_claim_pending_total", nil); got <= pendingBefore {
 		t.Fatalf("claim_pending_total = %v, want > %v", got, pendingBefore)
 	}
@@ -205,8 +205,7 @@ func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
 
 	makeCapacityFixture(t, "cap3")
 
-	pending := waitForPhase(t, "cap3", v1.SandboxPending, 15*time.Second)
-	pending = waitForSettledNoCapacity(t, "cap3")
+	pending := waitForSettledNoCapacity(t, "cap3")
 	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
 	if cond == nil || cond.Reason != "NoCapacity" {
 		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)
@@ -251,8 +250,7 @@ func TestClaimRePendsOnForkdUnavailable(t *testing.T) {
 
 	makeCapacityFixture(t, "cap4")
 
-	pending := waitForPhase(t, "cap4", v1.SandboxPending, 15*time.Second)
-	pending = waitForSettledNoCapacity(t, "cap4")
+	pending := waitForSettledNoCapacity(t, "cap4")
 	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
 	if cond == nil || cond.Reason != "NoCapacity" {
 		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)

--- a/internal/controller/capacity_admission_envtest_test.go
+++ b/internal/controller/capacity_admission_envtest_test.go
@@ -97,6 +97,11 @@ func TestClaimPendsThenReadyOnFreedCapacity(t *testing.T) {
 
 	// The claim must pend (not Ready, not Failed) while capacity is exhausted.
 	pending := waitForPhase(t, "cap1", v1.SandboxPending, 15*time.Second)
+	// The claim can transiently pend with PoolNotFound before its pool is visible
+	// to the reconciler cache; wait for the reason to SETTLE to NoCapacity, then
+	// re-fetch, so the assertions below never race a transient reason.
+	waitForReadyReason(t, "cap1", "NoCapacity")
+	pending = getClaim(t, "cap1")
 	if got := counterValue(t, "mitos_claim_pending_total", nil); got <= pendingBefore {
 		t.Fatalf("claim_pending_total = %v, want > %v", got, pendingBefore)
 	}
@@ -195,6 +200,11 @@ func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
 	makeCapacityFixture(t, "cap3")
 
 	pending := waitForPhase(t, "cap3", v1.SandboxPending, 15*time.Second)
+	// The claim can transiently pend with PoolNotFound before its pool is visible
+	// to the reconciler cache; wait for the reason to SETTLE to NoCapacity, then
+	// re-fetch, so the assertions below never race a transient reason.
+	waitForReadyReason(t, "cap3", "NoCapacity")
+	pending = getClaim(t, "cap3")
 	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
 	if cond == nil || cond.Reason != "NoCapacity" {
 		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)
@@ -240,6 +250,11 @@ func TestClaimRePendsOnForkdUnavailable(t *testing.T) {
 	makeCapacityFixture(t, "cap4")
 
 	pending := waitForPhase(t, "cap4", v1.SandboxPending, 15*time.Second)
+	// The claim can transiently pend with PoolNotFound before its pool is visible
+	// to the reconciler cache; wait for the reason to SETTLE to NoCapacity, then
+	// re-fetch, so the assertions below never race a transient reason.
+	waitForReadyReason(t, "cap4", "NoCapacity")
+	pending = getClaim(t, "cap4")
 	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
 	if cond == nil || cond.Reason != "NoCapacity" {
 		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)

--- a/internal/controller/capacity_admission_envtest_test.go
+++ b/internal/controller/capacity_admission_envtest_test.go
@@ -76,6 +76,16 @@ func waitForPhase(t *testing.T, name string, want v1.SandboxPhase, timeout time.
 	return last
 }
 
+// waitForSettledNoCapacity waits for the claim's Ready reason to settle to
+// NoCapacity (a claim can transiently pend with PoolNotFound before its pool is
+// visible to the reconciler cache) and returns the re-fetched claim, so callers
+// assert against the settled state and never race a transient reason.
+func waitForSettledNoCapacity(t *testing.T, name string) v1.Sandbox {
+	t.Helper()
+	waitForReadyReason(t, name, "NoCapacity")
+	return getClaim(t, name)
+}
+
 // TestClaimPendsThenReadyOnFreedCapacity drives the capacity-aware admission
 // path: the only node reports a full memory budget, so the claim pends with a
 // NoCapacity condition (not Ready, not Failed); freeing the node lets the claim
@@ -97,11 +107,7 @@ func TestClaimPendsThenReadyOnFreedCapacity(t *testing.T) {
 
 	// The claim must pend (not Ready, not Failed) while capacity is exhausted.
 	pending := waitForPhase(t, "cap1", v1.SandboxPending, 15*time.Second)
-	// The claim can transiently pend with PoolNotFound before its pool is visible
-	// to the reconciler cache; wait for the reason to SETTLE to NoCapacity, then
-	// re-fetch, so the assertions below never race a transient reason.
-	waitForReadyReason(t, "cap1", "NoCapacity")
-	pending = getClaim(t, "cap1")
+	pending = waitForSettledNoCapacity(t, "cap1")
 	if got := counterValue(t, "mitos_claim_pending_total", nil); got <= pendingBefore {
 		t.Fatalf("claim_pending_total = %v, want > %v", got, pendingBefore)
 	}
@@ -200,11 +206,7 @@ func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
 	makeCapacityFixture(t, "cap3")
 
 	pending := waitForPhase(t, "cap3", v1.SandboxPending, 15*time.Second)
-	// The claim can transiently pend with PoolNotFound before its pool is visible
-	// to the reconciler cache; wait for the reason to SETTLE to NoCapacity, then
-	// re-fetch, so the assertions below never race a transient reason.
-	waitForReadyReason(t, "cap3", "NoCapacity")
-	pending = getClaim(t, "cap3")
+	pending = waitForSettledNoCapacity(t, "cap3")
 	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
 	if cond == nil || cond.Reason != "NoCapacity" {
 		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)
@@ -250,11 +252,7 @@ func TestClaimRePendsOnForkdUnavailable(t *testing.T) {
 	makeCapacityFixture(t, "cap4")
 
 	pending := waitForPhase(t, "cap4", v1.SandboxPending, 15*time.Second)
-	// The claim can transiently pend with PoolNotFound before its pool is visible
-	// to the reconciler cache; wait for the reason to SETTLE to NoCapacity, then
-	// re-fetch, so the assertions below never race a transient reason.
-	waitForReadyReason(t, "cap4", "NoCapacity")
-	pending = getClaim(t, "cap4")
+	pending = waitForSettledNoCapacity(t, "cap4")
 	cond := meta.FindStatusCondition(pending.Status.Conditions, "Ready")
 	if cond == nil || cond.Reason != "NoCapacity" {
 		t.Fatalf("Ready condition = %+v, want reason NoCapacity (re-pend, not terminal)", cond)


### PR DESCRIPTION
## Problem

TestClaimRePendsOnForkdUnavailable (and the sibling capacity-admission tests) flaked in go-test with `Ready reason = PoolNotFound, want NoCapacity`. Observed on #796 CI though #796 is docs-only, so it is a flake, not a regression. Same envtest eventual-consistency family as the status-retry flake fixed in #793 (already merged).

## Thinking Path

The tests asserted the Ready condition reason immediately after the claim reached Pending via waitForPhase, which returns on the FIRST Pending observation. A claim can transiently pend with reason PoolNotFound before its pool is visible to the reconciler's cached client, then settle to NoCapacity once the pool appears and the node is full / forkd is unavailable. The one-shot assert raced that transient. Fix: at all three NoCapacity sites (cap1, cap3, cap4), wait for the reason to SETTLE to NoCapacity (reusing the existing waitForReadyReason poll helper) then re-fetch the claim before the detailed assertions.

## Verification

- go vet clean.
- The capacity-admission tests (TestClaimRePendsOnForkdUnavailable + TestClaimPendsThenReadyOnFreedCapacity + the NoCapacity tests) run green 3x in a row under envtest (setup-envtest 1.31).
- Test-only; no production code. No em or en dashes.

## Model Used

Claude Fable 5 (claude-fable-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved capacity-admission test reliability by waiting for the claim’s “Ready” condition to fully settle to the expected “NoCapacity” state before assertions.
  * Updated related test flows to re-check the claim immediately after it enters pending, reducing flakiness when capacity is unavailable and preventing transient status/condition changes from affecting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->