### PR TITLE
feat(husk): add the spawn-vm control op to add a VM to a running pod

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -468,14 +468,14 @@ activate (`internal/husk/multivm.go` `SpawnVM` -> `prepareInstance` +
 The op FAILS CLOSED on the flag: a stub NOT started with `--multi-vm` refuses
 spawn-vm, so a single-VM pod is never driven to host a second VM. The spawned VM
 lands on its OWN tap + /30 + default-deny egress chain derived from the vmID (the
-per-VM network isolation in the multi-VM-per-pod row of section 7), so a
+per-VM network isolation in the multi-VM-per-pod row of Surface 2, Guest to guest), so a
 co-located VM's egress cannot cross into a sibling's. This is DEFAULT OFF and the
 controller is NOT wired to call it (the fork-routing that drives it is a later
 increment), so the shipped surface is unchanged: nothing spawns a second VM in
 production today. Residual: a compromised controller can drive a spawn-vm against
 any multi-VM husk pod it can reach, the same residual already stated for activate
 and fork-snapshot (Surface 2); and it inherits the shared-pod-netns residual of
-the multi-VM-per-pod mode (section 7), which is why it stays flag-gated behind that
+the multi-VM-per-pod mode (Surface 2, Guest to guest), which is why it stays flag-gated behind that
 mode's per-VM tap + /30 isolation and a named security review before it ships.
 
 **Surface 4: the DEVICE `/dev/kvm`.** KVM access is injected by the device plugin

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -449,6 +449,35 @@ the warm-pool/shared-CAS model (a warm pod is built before a claim binds, so its
 eventual workspace is unknown at mount time) and need cluster-e2e and a named
 security reviewer, so they are deliberately not rushed here.
 
+### Husk spawn-vm (add a VM to a running pod, multi-VM path)
+
+A `spawn-vm` control op asks a RUNNING husk pod to bring up an ADDITIONAL
+same-tenant VM (a new vmID) INSIDE the same pod, using the experimental
+multi-VM-per-pod engine (`Options.MultiVM`, #764). It rides the SAME
+op-dispatched mTLS channel as activate, fork-snapshot, and the workspace ops,
+authorized to the controller identity ONLY (`internal/husk.ServeTLS` plus
+`AuthorizeControllerIdentity`); the auth is NOT weakened for it. The request
+carries the new VM's id plus the same activation inputs an activate takes
+(snapshot dir/source and expected digest, per-fork network, egress policy and
+allowlists, inbound policy, env, secrets, token), so like activate it CAN carry
+tenant SECRETS; those are never logged. The stub validates the vmID with the
+`checkVMID` allowlist BEFORE deriving any per-VM socket, workdir, tap, or /30 from
+it, so a traversing id can never spawn a VM, then runs the per-VM prepare +
+activate (`internal/husk/multivm.go` `SpawnVM` -> `prepareInstance` +
+`activateInstance`), which fails closed per instance and never disturbs a sibling.
+The op FAILS CLOSED on the flag: a stub NOT started with `--multi-vm` refuses
+spawn-vm, so a single-VM pod is never driven to host a second VM. The spawned VM
+lands on its OWN tap + /30 + default-deny egress chain derived from the vmID (the
+per-VM network isolation in the multi-VM-per-pod row of section 7), so a
+co-located VM's egress cannot cross into a sibling's. This is DEFAULT OFF and the
+controller is NOT wired to call it (the fork-routing that drives it is a later
+increment), so the shipped surface is unchanged: nothing spawns a second VM in
+production today. Residual: a compromised controller can drive a spawn-vm against
+any multi-VM husk pod it can reach, the same residual already stated for activate
+and fork-snapshot (Surface 2); and it inherits the shared-pod-netns residual of
+the multi-VM-per-pod mode (section 7), which is why it stays flag-gated behind that
+mode's per-VM tap + /30 isolation and a named security review before it ships.
+
 **Surface 4: the DEVICE `/dev/kvm`.** KVM access is injected by the device plugin
 (`cmd/kvm-device-plugin`, `internal/deviceplugin`): the pod requests
 `mitos.run/kvm` like any extended resource and the kubelet bind-mounts

--- a/internal/controller/huskclient.go
+++ b/internal/controller/huskclient.go
@@ -157,6 +157,46 @@ func HydrateWorkspaceOnHusk(ctx context.Context, addr string, tlsConf *tls.Confi
 	return res, nil
 }
 
+// SpawnVMOnHusk dials a husk stub's network control at addr over mTLS and runs
+// the spawn-vm op: it asks a RUNNING husk pod to bring up an ADDITIONAL
+// same-tenant VM (req.VMID) inside the same pod using the experimental multi-VM
+// engine, then returns the spawned VM's result (its vsock path when OK). The
+// husk stub fails the op closed unless it runs with --multi-vm, so a single-VM pod
+// is never driven to host a second VM.
+//
+// SECURITY: req.Activate carries tenant SECRETS (Secrets, Token), so the channel
+// MUST be mTLS. tlsConf pins the husk server identity and presents the controller
+// client certificate the husk server authorizes; a nil tlsConf is refused so the
+// control surface is never driven unauthenticated. Secret VALUES are never logged
+// here: errors carry only the operation, the address, and the transport error,
+// never the request payload; the returned SpawnVMResult.Error likewise never
+// carries secrets (the stub guarantees this).
+func SpawnVMOnHusk(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+	if tlsConf == nil {
+		return husk.SpawnVMResult{}, fmt.Errorf("spawn-vm on husk %s: refusing to drive the control channel unauthenticated", addr)
+	}
+	dialer := &tls.Dialer{Config: tlsConf}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return husk.SpawnVMResult{}, fmt.Errorf("dial husk control %s: %w", addr, err)
+	}
+	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if err := husk.WriteControlOp(conn, husk.OpSpawnVM); err != nil {
+		return husk.SpawnVMResult{}, fmt.Errorf("send spawn-vm op to %s: %w", addr, err)
+	}
+	if err := husk.WriteSpawnVMRequest(conn, req); err != nil {
+		return husk.SpawnVMResult{}, fmt.Errorf("send spawn-vm request to %s: %w", addr, err)
+	}
+	res, err := husk.ReadSpawnVMResult(conn)
+	if err != nil {
+		return husk.SpawnVMResult{}, fmt.Errorf("read spawn-vm result from %s: %w", addr, err)
+	}
+	return res, nil
+}
+
 // RemoveForkSnapshotOnHusk dials the source husk stub and asks it to delete a
 // fork snapshot dir it previously created (the GC counterpart of
 // ForkSnapshotOnHusk). It is best-effort from the caller's perspective: the

--- a/internal/controller/huskclient_test.go
+++ b/internal/controller/huskclient_test.go
@@ -128,6 +128,16 @@ func (s *fakeHuskServer) handle(conn net.Conn) {
 		s.calls++
 		s.mu.Unlock()
 		_ = husk.WriteForkSnapshotResult(conn, husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir, LatencyMs: 2.0})
+	case husk.OpSpawnVM:
+		req, rerr := husk.ReadSpawnVMRequestReader(br)
+		if rerr != nil {
+			return
+		}
+		s.mu.Lock()
+		s.calls++
+		s.gotSecret = req.Activate.Secrets["API_KEY"]
+		s.mu.Unlock()
+		_ = husk.WriteSpawnVMResult(conn, husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + "/vsock.sock", LatencyMs: 3.0})
 	default:
 		req, rerr := husk.ReadActivateRequestReader(br)
 		if rerr != nil {
@@ -189,6 +199,46 @@ func TestForkSnapshotOnHuskRefusesWithoutTLS(t *testing.T) {
 	_, err := ForkSnapshotOnHusk(context.Background(), "127.0.0.1:1", nil, husk.ForkSnapshotRequest{ForkID: "f", SnapshotDir: "/d"})
 	if err == nil {
 		t.Fatalf("ForkSnapshotOnHusk must refuse a nil TLS config")
+	}
+}
+
+func TestSpawnVMOnHuskRoundTrip(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newFakeHuskServer(t, p)
+	defer s.stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := SpawnVMOnHusk(ctx, s.addr, p.clientConf, husk.SpawnVMRequest{
+		VMID: "fork-7",
+		Activate: husk.ActivateRequest{
+			SnapshotDir: "/var/lib/mitos/forks/fork-7",
+			Secrets:     map[string]string{"API_KEY": "s3cr3t-value"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SpawnVMOnHusk: %v", err)
+	}
+	if !res.OK || res.VMID != "fork-7" || res.VsockPath != "/run/husk/fork-7/vsock.sock" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	// The spawn-vm request carried its activation secret over mTLS.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.gotSecret != "s3cr3t-value" {
+		t.Fatalf("husk did not receive the spawn-vm activation secret over mTLS")
+	}
+}
+
+func TestSpawnVMOnHuskRefusesWithoutTLS(t *testing.T) {
+	// A nil TLS config must be refused so the activation secrets a spawn-vm carries
+	// never ride an unauthenticated channel; no dial is attempted.
+	_, err := SpawnVMOnHusk(context.Background(), "127.0.0.1:1", nil, husk.SpawnVMRequest{
+		VMID:     "fork-7",
+		Activate: husk.ActivateRequest{Secrets: map[string]string{"API_KEY": "leak-me"}},
+	})
+	if err == nil {
+		t.Fatalf("SpawnVMOnHusk must refuse a nil TLS config")
 	}
 }
 

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -158,6 +158,10 @@ const (
 	// OpHydrateWorkspace restores a node-CAS manifest into the active VM's
 	// /workspace.
 	OpHydrateWorkspace = "hydrate-workspace"
+	// OpSpawnVM brings up an ADDITIONAL same-tenant VM (a new vmID) in a running
+	// husk pod using the experimental multi-VM engine. It is honored ONLY when the
+	// stub runs with --multi-vm; a single-VM stub fails it closed.
+	OpSpawnVM = "spawn-vm"
 )
 
 // WriteControlOp writes the op envelope line that precedes a request.
@@ -211,6 +215,13 @@ func ReadActivateRequestReader(r *bufio.Reader) (ActivateRequest, error) {
 // ReadForkSnapshotRequestReader decodes one ForkSnapshotRequest from a shared reader.
 func ReadForkSnapshotRequestReader(r *bufio.Reader) (ForkSnapshotRequest, error) {
 	return readForkSnapshotRequest(r)
+}
+
+// ReadSpawnVMRequestReader decodes one SpawnVMRequest from a shared reader.
+// Exported for the controller-side client and tests that pipeline op + request
+// on one connection.
+func ReadSpawnVMRequestReader(r *bufio.Reader) (SpawnVMRequest, error) {
+	return readSpawnVMRequest(r)
 }
 
 // readLineReader decodes one newline-delimited JSON value from a shared reader,
@@ -307,6 +318,73 @@ func ReadRemoveForkSnapshotRequest(r io.Reader) (RemoveForkSnapshotRequest, erro
 	var req RemoveForkSnapshotRequest
 	err := readLine(r, &req)
 	return req, err
+}
+
+// SpawnVMRequest asks a RUNNING husk pod to bring up an ADDITIONAL same-tenant VM
+// (a new vmID) inside the same pod, using the experimental multi-VM engine
+// (Options.MultiVM, #764). The stub prepares a dormant per-VM Firecracker for
+// VMID then activates it from Activate, so a spawn-vm is a prepare + activate of
+// one more VM in a pod that is already serving.
+//
+// VMID names the NEW VM to spawn. It is the authoritative routing selector: the
+// stub validates it with checkVMID and derives this VM's per-VM socket, workdir,
+// tap, and /30 from it, so it must be a safe node-local identifier (never a path
+// traversal). Activate carries the SAME activation inputs a plain activate takes
+// (snapshot dir/source and expected digest, per-fork network, egress policy and
+// allowlists, inbound policy, secrets, env, token); its own VMID field is not the
+// selector and is ignored, the top-level VMID governs. Activate.Secrets and
+// Activate.Token are SECRETS: they ride the mTLS control channel and are NEVER
+// logged.
+type SpawnVMRequest struct {
+	VMID     string          `json:"vm_id"`
+	Activate ActivateRequest `json:"activate"`
+}
+
+// SpawnVMResult is the control reply for a spawn-vm op. It mirrors the fields
+// activateInstance returns for the new VM. OK is true only when the additional VM
+// prepared, loaded its snapshot, and its guest agent answered over vsock.
+// VsockPath is the host UDS path of the newly spawned guest agent (only meaningful
+// when OK). VMID echoes which VM this result is for. LatencyMs is the activate
+// wall time. AlreadyActive is set when the spawn was refused because that vmID is
+// already active. Error carries actionable remediation text when OK is false; it
+// never carries secrets.
+type SpawnVMResult struct {
+	OK            bool    `json:"ok"`
+	VMID          string  `json:"vm_id,omitempty"`
+	VsockPath     string  `json:"vsock_path,omitempty"`
+	LatencyMs     float64 `json:"latency_ms"`
+	Error         string  `json:"error,omitempty"`
+	AlreadyActive bool    `json:"already_active,omitempty"`
+}
+
+func readSpawnVMRequest(r *bufio.Reader) (SpawnVMRequest, error) {
+	var req SpawnVMRequest
+	err := readLineReader(r, &req)
+	return req, err
+}
+
+// WriteSpawnVMRequest writes a SpawnVMRequest as one JSON line.
+func WriteSpawnVMRequest(w io.Writer, req SpawnVMRequest) error {
+	return writeLine(w, req)
+}
+
+// ReadSpawnVMRequest reads one line-delimited SpawnVMRequest.
+func ReadSpawnVMRequest(r io.Reader) (SpawnVMRequest, error) {
+	var req SpawnVMRequest
+	err := readLine(r, &req)
+	return req, err
+}
+
+// WriteSpawnVMResult writes a SpawnVMResult as one JSON line.
+func WriteSpawnVMResult(w io.Writer, res SpawnVMResult) error {
+	return writeLine(w, res)
+}
+
+// ReadSpawnVMResult reads one line-delimited SpawnVMResult.
+func ReadSpawnVMResult(r io.Reader) (SpawnVMResult, error) {
+	var res SpawnVMResult
+	err := readLine(r, &res)
+	return res, err
 }
 
 // DehydrateWorkspaceRequest asks a husk stub holding a RUNNING (active) VM to

--- a/internal/husk/control_test.go
+++ b/internal/husk/control_test.go
@@ -133,3 +133,76 @@ func TestForkSnapshotResultRoundTrip(t *testing.T) {
 		t.Fatalf("round trip mismatch: got %+v want %+v", got, want)
 	}
 }
+
+func TestSpawnVMRequestRoundTrip(t *testing.T) {
+	want := SpawnVMRequest{
+		VMID: "fork-7",
+		Activate: ActivateRequest{
+			SnapshotDir:    "/var/lib/mitos/forks/fork-7",
+			ExpectedDigest: "sha256:abc",
+			Egress:         "deny",
+			Allow:          []string{"api.example.com:443"},
+			Env:            map[string]string{"LANG": "C"},
+			Secrets:        map[string]string{"API_KEY": "s3cr3t-value"},
+			Token:          "bearer-token",
+			Network: &vsock.NotifyForkedNetwork{
+				GuestIP:   "10.0.0.2",
+				GatewayIP: "10.0.0.1",
+				PrefixLen: 30,
+			},
+			NetworkOverrides: []firecracker.NetworkOverride{
+				{IfaceID: "eth0", HostDevName: "tap-fork-7"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteSpawnVMRequest(&buf, want); err != nil {
+		t.Fatalf("WriteSpawnVMRequest: %v", err)
+	}
+	if !bytes.HasSuffix(buf.Bytes(), []byte("\n")) {
+		t.Fatalf("WriteSpawnVMRequest did not newline-terminate: %q", buf.String())
+	}
+	got, err := ReadSpawnVMRequest(&buf)
+	if err != nil {
+		t.Fatalf("ReadSpawnVMRequest: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestSpawnVMResultRoundTrip(t *testing.T) {
+	want := SpawnVMResult{
+		OK:        true,
+		VMID:      "fork-7",
+		VsockPath: "/run/husk/fork-7/vsock.sock",
+		LatencyMs: 6.25,
+	}
+	var buf bytes.Buffer
+	if err := WriteSpawnVMResult(&buf, want); err != nil {
+		t.Fatalf("WriteSpawnVMResult: %v", err)
+	}
+	got, err := ReadSpawnVMResult(&buf)
+	if err != nil {
+		t.Fatalf("ReadSpawnVMResult: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip mismatch: got %+v want %+v", got, want)
+	}
+}
+
+func TestSpawnVMResultErrorRoundTrip(t *testing.T) {
+	want := SpawnVMResult{OK: false, VMID: "fork-7", Error: "spawn-vm prepare vm \"fork-7\": boom"}
+	var buf bytes.Buffer
+	if err := WriteSpawnVMResult(&buf, want); err != nil {
+		t.Fatalf("WriteSpawnVMResult: %v", err)
+	}
+	got, err := ReadSpawnVMResult(&buf)
+	if err != nil {
+		t.Fatalf("ReadSpawnVMResult: %v", err)
+	}
+	if got.OK || got.Error != want.Error {
+		t.Fatalf("error result mismatch: got %+v want %+v", got, want)
+	}
+}

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -405,6 +405,54 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 	}, nil
 }
 
+// SpawnVM brings up an ADDITIONAL same-tenant VM (a new vmID) in a running husk
+// pod: it prepares a dormant per-VM Firecracker for req.VMID then activates it
+// from req.Activate, returning the activated guest's vsock path. It is the server
+// side of the spawn-vm control op (netcontrol.go OpSpawnVM).
+//
+// It FAILS CLOSED on the flag: a stub NOT started with --multi-vm refuses to spawn
+// a VM. The single-VM path owns exactly ONE VM and must never be driven to host a
+// second, so a spawn-vm misdirected at a single-VM pod is rejected here rather
+// than silently starting a second Firecracker. The vmID is validated with
+// checkVMID before any path is derived from it (an unsafe or empty id is refused
+// up front, before prepareInstance touches the filesystem). Any prepare or
+// activate failure returns OK=false with actionable text and leaves no
+// half-spawned VM active; prepareInstance and activateInstance are each
+// fail-closed per instance and never disturb a sibling.
+//
+// req.Activate carries the same activation inputs a plain Activate takes,
+// including SECRETS (Secrets, Token); those ride the mTLS control channel and are
+// NEVER logged here.
+func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
+	if !s.multiVM {
+		return SpawnVMResult{
+			OK:    false,
+			VMID:  req.VMID,
+			Error: "husk: spawn-vm refused: this pod is not running in multi-VM mode",
+		}
+	}
+	id := vmID(req.VMID)
+	if err := checkVMID(id); err != nil {
+		return SpawnVMResult{OK: false, VMID: req.VMID, Error: err.Error()}
+	}
+	if err := s.prepareInstance(ctx, id); err != nil {
+		return SpawnVMResult{
+			OK:    false,
+			VMID:  req.VMID,
+			Error: fmt.Errorf("husk: spawn-vm prepare vm %q: %w", req.VMID, err).Error(),
+		}
+	}
+	res, _ := s.activateInstance(ctx, id, req.Activate)
+	return SpawnVMResult{
+		OK:            res.OK,
+		VMID:          req.VMID,
+		VsockPath:     res.VsockPath,
+		LatencyMs:     res.LatencyMs,
+		Error:         res.Error,
+		AlreadyActive: res.AlreadyActive,
+	}
+}
+
 // closeInstance tears down ONE per-VM instance's VMM and per-activation artifacts
 // and returns it to StateNew, leaving every sibling instance untouched. It is the
 // per-VM analog of the single-VM Close: closing one VM in the pod must never take

--- a/internal/husk/multivm_test.go
+++ b/internal/husk/multivm_test.go
@@ -541,3 +541,53 @@ func TestMultiVMPrepareRefusedWhileClosing(t *testing.T) {
 		t.Fatal("a vm was added to the instances map during closing; it would outlive Close")
 	}
 }
+
+// TestSpawnVMActivationFailureReturnsNotOK proves the full SpawnVM path reports
+// a failure fail-closed when activation errors: the spawned VM's snapshot load
+// fails, so SpawnVM returns OK=false carrying the activation error, the instance
+// is not left Active, and an already-active sibling is undisturbed.
+func TestSpawnVMActivationFailureReturnsNotOK(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	start := func(cfg firecracker.VMConfig) (vmm, error) {
+		vm := &fakeVMM{}
+		if cfg.ID == "husk-test-fork-9" {
+			vm.loadErr = errors.New("snapshot corrupt")
+		}
+		vms[cfg.ID] = vm
+		return vm, nil
+	}
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:   start,
+		Ready:   readyOK,
+		Notify:  (&fakeNotifier{}).notify,
+		Verify:  verifyOK,
+		MultiVM: true,
+	})
+	// Bring up the primary VM so we can prove it is undisturbed by the failure.
+	if err := s.prepareInstance(context.Background(), defaultVMID); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+		t.Fatalf("activateInstance(default): %v", err)
+	}
+
+	res := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     "fork-9",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if res.OK {
+		t.Fatal("SpawnVM must report not-OK when activation fails")
+	}
+	if res.Error == "" {
+		t.Fatal("a failed SpawnVM must carry the activation error")
+	}
+	if res.VMID != "fork-9" {
+		t.Fatalf("SpawnVM result VMID = %q, want fork-9", res.VMID)
+	}
+	if got := s.instances["fork-9"].state; got == StateActive {
+		t.Fatalf("a fail-closed spawned instance must not be active, got %s", got)
+	}
+	if got := s.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("the primary instance must stay active despite the spawn failure, got %s", got)
+	}
+}

--- a/internal/husk/netcontrol.go
+++ b/internal/husk/netcontrol.go
@@ -184,6 +184,20 @@ func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize 
 		if werr := WriteHydrateWorkspaceResult(conn, res); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write hydrate-workspace result: %v\n", werr)
 		}
+	case OpSpawnVM:
+		req, rerr := readSpawnVMRequest(br)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: read spawn-vm request: %v\n", rerr)
+			return
+		}
+		// SpawnVM fails closed on a non-multi-vm stub and validates req.VMID with
+		// checkVMID before deriving any path from it, so a single-VM pod never
+		// spawns a second VM and an unsafe vmID is refused. The request payload
+		// (env/secrets/token) is never logged.
+		res := stub.SpawnVM(ctx, req)
+		if werr := WriteSpawnVMResult(conn, res); werr != nil {
+			fmt.Fprintf(os.Stderr, "husk control: write spawn-vm result: %v\n", werr)
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "husk control: unknown control op %q\n", op)
 	}

--- a/internal/husk/netcontrol_test.go
+++ b/internal/husk/netcontrol_test.go
@@ -187,6 +187,152 @@ func TestServeTLSDispatchesForkSnapshot(t *testing.T) {
 	}
 }
 
+// spawnVMClient runs the controller-side spawn-vm exchange directly (mirroring
+// internal/controller.SpawnVMOnHusk, kept here so the husk test does not import
+// the controller). It dials over mTLS, writes the op + request, reads the result.
+func spawnVMClient(t *testing.T, addr string, clientConf *tls.Config, req SpawnVMRequest) (SpawnVMResult, error) {
+	t.Helper()
+	dialer := &tls.Dialer{Config: clientConf}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return SpawnVMResult{}, err
+	}
+	defer conn.Close()
+	if err := WriteControlOp(conn, OpSpawnVM); err != nil {
+		return SpawnVMResult{}, err
+	}
+	if err := WriteSpawnVMRequest(conn, req); err != nil {
+		return SpawnVMResult{}, err
+	}
+	return ReadSpawnVMResult(conn)
+}
+
+// TestServeTLSDispatchesSpawnVM proves the spawn-vm control op end to end: a
+// SpawnVMRequest written by the client is read by the server dispatch and drives
+// prepareInstance + activateInstance for the named vmID on a MultiVM stub, so an
+// ADDITIONAL same-tenant VM comes up in the running pod and the result carries its
+// vsock path.
+func TestServeTLSDispatchesSpawnVM(t *testing.T) {
+	p := newNetTestPKI(t)
+	vms := map[string]*fakeVMM{}
+	stub := newMultiVMTestStub(t, vms)
+	// The pod is already serving its primary VM.
+	if err := stub.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if _, err := stub.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+		t.Fatalf("Activate default: %v", err)
+	}
+
+	addr, stop := startServer(t, stub, p)
+	defer stop()
+
+	const second = "fork-7"
+	res, err := spawnVMClient(t, addr, p.clientConf(t, p.ctrlCert), SpawnVMRequest{
+		VMID:     second,
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if err != nil {
+		t.Fatalf("spawn-vm over mTLS: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("spawn-vm not OK: %q", res.Error)
+	}
+	if res.VsockPath == "" {
+		t.Fatalf("spawn-vm result missing vsock path: %+v", res)
+	}
+	if res.VMID != second {
+		t.Fatalf("spawn-vm result VMID = %q, want %q", res.VMID, second)
+	}
+	// The additional VM prepared + activated in the pod, its own instance.
+	if got := stub.instances[vmID(second)].state; got != StateActive {
+		t.Fatalf("spawned instance state = %s, want active", got)
+	}
+	// The primary VM is undisturbed and the spawned VM owns a distinct VMM.
+	if got := stub.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("primary instance state = %s, want active", got)
+	}
+	if _, ok := vms["husk-test-fork-7"]; !ok {
+		t.Fatalf("spawned vmID must derive a distinct per-VM config ID, got keys %v", vms)
+	}
+}
+
+// TestServeTLSSpawnVMRejectedOnSingleVMStub proves the fail-closed flag gate: a
+// spawn-vm op against a stub NOT running in multi-VM mode is refused, and no VM is
+// spawned. The single-VM pod owns exactly one VM and must never be driven to host
+// a second over the wire.
+func TestServeTLSSpawnVMRejectedOnSingleVMStub(t *testing.T) {
+	p := newNetTestPKI(t)
+	stub := newTestStubWithNotifier(t, &fakeVMM{}, readyOK, &fakeNotifier{})
+	if stub.multiVM {
+		t.Fatal("newTestStubWithNotifier must be single-VM")
+	}
+	if err := stub.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	addr, stop := startServer(t, stub, p)
+	defer stop()
+
+	res, err := spawnVMClient(t, addr, p.clientConf(t, p.ctrlCert), SpawnVMRequest{
+		VMID:     "fork-7",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if err != nil {
+		t.Fatalf("spawn-vm exchange: %v", err)
+	}
+	if res.OK {
+		t.Fatalf("spawn-vm on a single-VM stub must fail closed, got OK: %+v", res)
+	}
+	if !strings.Contains(res.Error, "multi-VM") {
+		t.Fatalf("spawn-vm rejection must name the multi-VM gate, got %q", res.Error)
+	}
+	// No instances scaffold is allocated on the single-VM path, so nothing spawned.
+	if stub.instances != nil {
+		t.Fatalf("single-VM stub must not spawn a VM (instances = %v)", stub.instances)
+	}
+	// The pod's one VM is undisturbed by the refused spawn.
+	if stub.State() != StateDormant {
+		t.Fatalf("single-VM pod state = %s, want dormant (refused spawn must not touch it)", stub.State())
+	}
+}
+
+// TestServeTLSSpawnVMRejectsInvalidVMID proves an unsafe vmID is refused
+// fail-closed by the checkVMID gate before any per-VM path is derived from it, so
+// a traversing id can never spawn a VM over the control channel.
+func TestServeTLSSpawnVMRejectsInvalidVMID(t *testing.T) {
+	p := newNetTestPKI(t)
+	vms := map[string]*fakeVMM{}
+	stub := newMultiVMTestStub(t, vms)
+	addr, stop := startServer(t, stub, p)
+	defer stop()
+
+	res, err := spawnVMClient(t, addr, p.clientConf(t, p.ctrlCert), SpawnVMRequest{
+		VMID:     "../evil",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if err != nil {
+		t.Fatalf("spawn-vm exchange: %v", err)
+	}
+	if res.OK {
+		t.Fatalf("spawn-vm with an unsafe vmID must fail closed, got OK: %+v", res)
+	}
+	if !strings.Contains(res.Error, "invalid vm id") {
+		t.Fatalf("spawn-vm rejection must name the invalid vm id, got %q", res.Error)
+	}
+	// No instance was created for the unsafe id, and no VM was started for it.
+	stub.mu.Lock()
+	_, exists := stub.instances["../evil"]
+	stub.mu.Unlock()
+	if exists {
+		t.Fatal("an instance was created for an unsafe vmID")
+	}
+	if len(vms) != 0 {
+		t.Fatalf("no VMM must start for a rejected vmID, got %v", vms)
+	}
+}
+
 func TestServeTLSDispatchesDehydrateAndHydrateWorkspace(t *testing.T) {
 	// A serving stub holding an ACTIVE fake VM answers dehydrate-workspace then
 	// hydrate-workspace over the mTLS control channel: the dehydrate captures the


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the husk pod is the default runner and drives its VM in-pod over an mTLS control channel authorized to the controller identity only.
> - This change is in `internal/husk` (the in-pod stub protocol + server dispatch) and `internal/controller` (the controller-side control client), the surface between the controller and a running husk pod.
> - L1.1 through L1.4 built the multi-VM-per-pod engine behind `Options.MultiVM` (default OFF): the per-vmID `instances` map, per-instance locks, `deriveVMConfig` / `deriveVMNetwork`, and `prepareInstance` + `activateInstance` that bring up a REAL second Firecracker for a vmID. But nothing on the control protocol can ASK a running pod to bring up an additional VM: the engine has no wire verb.
> - The multinode fork primitive (#764, docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md) needs a controller-driven way to place more than one same-tenant fork in one pod instead of one pod per VM; the protocol verb has to land before the reconcile can route forks to it.
> - This pull request adds the `spawn-vm` control op: the wire types + helpers, the fail-closed server handler that runs the multi-VM prepare + activate for a new vmID, and the controller-side client, all over the SAME mTLS channel as the existing ops.
> - The benefit is the protocol and both endpoints for adding a VM to a running pod exist and are tested, so the later fork-routing increment only has to wire the reconcile, with no protocol churn and no shipped behavior change today.

## Linked Issues or Issue Description

Related: #764

This is increment L1.5 of the multi-VM-per-pod husk work: the PROTOCOL + server handler + client for a new authenticated `spawn-vm` control op, so the controller can later ask an existing husk pod to bring up an additional same-tenant VM (a new vmID) in that same pod using the L1.4 multi-VM engine, rather than always one pod per VM. This increment is flag-gated and controller-not-wired.

## What Changed

- `internal/husk/control.go`: add `OpSpawnVM = "spawn-vm"`, the `SpawnVMRequest` (a `VMID` plus the existing `ActivateRequest` shape as the activation inputs; its `Activate.VMID` is not the selector, the top-level `VMID` governs) and `SpawnVMResult` (OK, VMID, VsockPath, LatencyMs, Error, AlreadyActive), with `Write`/`Read` wire helpers and a `ReadSpawnVMRequestReader` bufio variant mirroring the fork-snapshot helpers.
- `internal/husk/multivm.go`: add `Stub.SpawnVM`, which FAILS CLOSED on the flag (a non-multi-vm stub refuses to spawn a VM), validates the vmID with the existing `checkVMID` gate before any path is derived from it, then runs `prepareInstance` then `activateInstance` for that vmID.
- `internal/husk/netcontrol.go`: add the `case OpSpawnVM` dispatch on the SAME op-dispatched mTLS control channel (controller identity only); the request payload (env/secrets/token) is never logged.
- `internal/controller/huskclient.go`: add `SpawnVMOnHusk` mirroring `ForkSnapshotOnHusk`: refuse a nil TLS config, dial mTLS, write the op + request, read the result, wrap errors.
- Tests (TDD): wire encode/decode round trips for `SpawnVMRequest`/`SpawnVMResult`; a server-dispatch round trip that a client-written `SpawnVMRequest` drives `prepareInstance` + `activateInstance` for the vmID on a MultiVM stub and returns a VsockPath; a fail-closed rejection of `spawn-vm` on a NON-MultiVM stub; a fail-closed rejection of an invalid vmID by `checkVMID`; and controller-client round-trip + nil-TLS-refusal tests.
- `docs/threat-model.md`: note the new authenticated `spawn-vm` control op surface.

## Verification

- [x] `go build ./...` : clean (exit 0).
- [x] `go test -race ./internal/husk/...` : `ok mitos.run/mitos/internal/husk 4.796s`.
- [x] `go test ./internal/controller/...` (envtest via `~/go/bin/setup-envtest use 1.31`) : `ok mitos.run/mitos/internal/controller 228.123s`.
- [x] `golangci-lint run --timeout=5m` : only the pre-existing darwin-only `internal/fork/uffd.go:42:22: func uffdMapping.pageSizeBytes is unused` finding; nothing new.
- [x] `GOOS=linux golangci-lint run --timeout=5m` : clean (exit 0).

## Risks

Low risk. `Options.MultiVM` defaults OFF and no production caller sets it; the controller reconcile is NOT wired to call `SpawnVMOnHusk`, so nothing spawns a second VM in production today. The single-VM path is untouched (the new op is a new switch case; the flag-off lifecycle is byte-for-byte unchanged). The op is fail-closed: a non-multi-vm stub refuses it, an unsafe vmID is refused by `checkVMID` before any path is derived, and it rides the same controller-identity mTLS channel as the existing ops, so auth is not weakened.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, run as an autonomous coding agent (extended thinking enabled).

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved
- [ ] Benchmark run (bench/) included if the hot path was touched (N/A: no hot path touched; the flag-off single-VM path is unchanged)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental support for spawning an additional VM inside a running pod when multi-VM mode is enabled.
  * Introduced a new control-channel “spawn-vm” operation with request/response handling for VM readiness details.
* **Bug Fixes**
  * Requests now fail safely when multi-VM mode is disabled.
  * Added stricter VM ID validation to reject unsafe values.
  * Improved error handling for spawn control connection, request/response, and activation failures.
* **Tests**
  * Added round-trip and end-to-end coverage for spawn-vm success, rejection, and activation-failure fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->