### PR TITLE
feat(api): add status.vmId to Sandbox for the shared-host multi-vm mapping

### DIFF
--- a/api/v1/sandbox_types.go
+++ b/api/v1/sandbox_types.go
@@ -325,6 +325,13 @@ const (
 	ReasonSecretInheritanceDenied = "SecretInheritanceDenied"
 )
 
+// DefaultVMID is the intra-pod identity of the single primary VM a husk host
+// pod backs on the default single-VM path. The controller stamps it into
+// SandboxStatus.VMID for a normal 1:1 husk-backed sandbox so the (Pod, VMID)
+// host mapping is populated and correct before multi-VM co-location exists. It
+// MUST match the husk stub's primary vmID key (internal/husk defaultVMID).
+const DefaultVMID = "default"
+
 // SandboxStatus consolidates SandboxClaimStatus and SandboxForkStatus.
 type SandboxStatus struct {
 	// Phase is the sandbox lifecycle phase. The phase-name set is carried from
@@ -338,12 +345,29 @@ type SandboxStatus struct {
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
 
-	// Pod is the husk pod name backing the sandbox (for example
+	// Pod is the husk host pod name backing the sandbox (for example
 	// "heartbeat-7f3a-husk"), visible to kubectl, quotas, NetworkPolicy, and
 	// OpenCost. NEW explicit v2 field. On the husk path the node is derivable
 	// from the pod; on the raw-forkd path the node is carried in Node below.
+	// In multi-VM mode a single host pod can back several same-tenant Sandbox
+	// CRs at once: the pod is a shared runtime host BELOW the CRD, which stays
+	// 1:1 with a VM, and each co-located Sandbox is distinguished by VMID
+	// below. Pod stays the host-pod handle in both the single-VM and multi-VM
+	// cases; it is never renamed to a per-VM identity.
 	// +optional
 	Pod string `json:"pod,omitempty"`
+
+	// VMID is the per-VM identity WITHIN the host Pod above. It carries the
+	// default (primary) identity for a one-VM host pod and a distinct value per
+	// co-located VM when a host pod backs several same-tenant Sandboxes in
+	// multi-VM mode. Together (Pod, VMID) map a Sandbox CR to its exact host
+	// process, so "kubectl get sandbox X -o yaml" still traces a sandbox to
+	// where it runs even though "kubectl get pods" no longer maps one pod to
+	// one sandbox. The CRD stays 1:1 with a VM; VMID is the intra-pod
+	// discriminator, not a second sandbox handle. See DefaultVMID for the
+	// single-VM value. NEW v2 field.
+	// +optional
+	VMID string `json:"vmId,omitempty"`
 
 	// Node is the node the sandbox VM runs on. Unchanged from v1alpha1. It is the
 	// engine placement identity distinct from SandboxID: the GC orphan sweep,

--- a/api/v1/sandbox_types_test.go
+++ b/api/v1/sandbox_types_test.go
@@ -1,7 +1,9 @@
 package v1
 
 import (
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -31,13 +33,13 @@ func TestSandboxExposeDeepCopy(t *testing.T) {
 func TestSandboxExposeDeepCopySliceFields(t *testing.T) {
 	original := &Sandbox{}
 	original.Spec.Expose = &SandboxExpose{
-		Port:                 8080,
-		Label:                "openclaw",
-		Sharing:              "private",
-		Network:              []string{"10.0.0.0/8", "192.168.1.0/24"},
-		ForwardAuthURL:       "https://auth.example.com/verify",
-		AllowedPrincipals:    []string{"alice@example.com", "bob@example.com"},
-		AllowedEmailDomains:  []string{"example.com"},
+		Port:                8080,
+		Label:               "openclaw",
+		Sharing:             "private",
+		Network:             []string{"10.0.0.0/8", "192.168.1.0/24"},
+		ForwardAuthURL:      "https://auth.example.com/verify",
+		AllowedPrincipals:   []string{"alice@example.com", "bob@example.com"},
+		AllowedEmailDomains: []string{"example.com"},
 	}
 
 	copied := original.DeepCopy()
@@ -60,5 +62,43 @@ func TestSandboxExposeDeepCopySliceFields(t *testing.T) {
 	copied.Spec.Expose.AllowedEmailDomains[0] = "evil.com"
 	if original.Spec.Expose.AllowedEmailDomains[0] == "evil.com" {
 		t.Fatal("mutating copy AllowedEmailDomains changed original: not a deep copy")
+	}
+}
+
+// TestSandboxStatusVMIDSerializes verifies the new SandboxStatus.VMID field
+// round-trips through JSON under the "vmId" key alongside the host Pod, so the
+// shared-host mapping (Pod, VMID) is observable on the CRD.
+func TestSandboxStatusVMIDSerializes(t *testing.T) {
+	original := &Sandbox{}
+	original.Status.Pod = "heartbeat-7f3a-husk"
+	original.Status.VMID = DefaultVMID
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal Sandbox: %v", err)
+	}
+	if !strings.Contains(string(data), `"vmId":"default"`) {
+		t.Fatalf("marshalled status missing vmId key: %s", data)
+	}
+
+	var decoded Sandbox
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal Sandbox: %v", err)
+	}
+	if decoded.Status.VMID != DefaultVMID {
+		t.Fatalf("VMID round-trip = %q, want %q", decoded.Status.VMID, DefaultVMID)
+	}
+	if decoded.Status.Pod != "heartbeat-7f3a-husk" {
+		t.Fatalf("Pod round-trip = %q, want %q", decoded.Status.Pod, "heartbeat-7f3a-husk")
+	}
+
+	// An empty VMID must omit the key (omitempty), keeping the raw-forkd path
+	// status compact.
+	empty, err := json.Marshal(&Sandbox{})
+	if err != nil {
+		t.Fatalf("marshal empty Sandbox: %v", err)
+	}
+	if strings.Contains(string(empty), "vmId") {
+		t.Fatalf("empty VMID should be omitted, got: %s", empty)
 	}
 }

--- a/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
+++ b/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
@@ -779,10 +779,15 @@ spec:
                 type: string
               pod:
                 description: |-
-                  Pod is the husk pod name backing the sandbox (for example
+                  Pod is the husk host pod name backing the sandbox (for example
                   "heartbeat-7f3a-husk"), visible to kubectl, quotas, NetworkPolicy, and
                   OpenCost. NEW explicit v2 field. On the husk path the node is derivable
                   from the pod; on the raw-forkd path the node is carried in Node below.
+                  In multi-VM mode a single host pod can back several same-tenant Sandbox
+                  CRs at once: the pod is a shared runtime host BELOW the CRD, which stays
+                  1:1 with a VM, and each co-located Sandbox is distinguished by VMID
+                  below. Pod stays the host-pod handle in both the single-VM and multi-VM
+                  cases; it is never renamed to a per-VM identity.
                 type: string
               readyReplicas:
                 description: |-
@@ -809,6 +814,18 @@ spec:
                   and rescaled from the v1alpha1 SandboxClaimStatus.forkTimeMicros.
                 format: int64
                 type: integer
+              vmId:
+                description: |-
+                  VMID is the per-VM identity WITHIN the host Pod above. It carries the
+                  default (primary) identity for a one-VM host pod and a distinct value per
+                  co-located VM when a host pod backs several same-tenant Sandboxes in
+                  multi-VM mode. Together (Pod, VMID) map a Sandbox CR to its exact host
+                  process, so "kubectl get sandbox X -o yaml" still traces a sandbox to
+                  where it runs even though "kubectl get pods" no longer maps one pod to
+                  one sandbox. The CRD stays 1:1 with a VM; VMID is the intra-pod
+                  discriminator, not a second sandbox handle. See DefaultVMID for the
+                  single-VM value. NEW v2 field.
+                type: string
             type: object
         required:
         - spec

--- a/deploy/crds/mitos.run_sandboxes.yaml
+++ b/deploy/crds/mitos.run_sandboxes.yaml
@@ -779,10 +779,15 @@ spec:
                 type: string
               pod:
                 description: |-
-                  Pod is the husk pod name backing the sandbox (for example
+                  Pod is the husk host pod name backing the sandbox (for example
                   "heartbeat-7f3a-husk"), visible to kubectl, quotas, NetworkPolicy, and
                   OpenCost. NEW explicit v2 field. On the husk path the node is derivable
                   from the pod; on the raw-forkd path the node is carried in Node below.
+                  In multi-VM mode a single host pod can back several same-tenant Sandbox
+                  CRs at once: the pod is a shared runtime host BELOW the CRD, which stays
+                  1:1 with a VM, and each co-located Sandbox is distinguished by VMID
+                  below. Pod stays the host-pod handle in both the single-VM and multi-VM
+                  cases; it is never renamed to a per-VM identity.
                 type: string
               readyReplicas:
                 description: |-
@@ -809,6 +814,18 @@ spec:
                   and rescaled from the v1alpha1 SandboxClaimStatus.forkTimeMicros.
                 format: int64
                 type: integer
+              vmId:
+                description: |-
+                  VMID is the per-VM identity WITHIN the host Pod above. It carries the
+                  default (primary) identity for a one-VM host pod and a distinct value per
+                  co-located VM when a host pod backs several same-tenant Sandboxes in
+                  multi-VM mode. Together (Pod, VMID) map a Sandbox CR to its exact host
+                  process, so "kubectl get sandbox X -o yaml" still traces a sandbox to
+                  where it runs even though "kubectl get pods" no longer maps one pod to
+                  one sandbox. The CRD stays 1:1 with a VM; VMID is the intra-pod
+                  discriminator, not a second sandbox handle. See DefaultVMID for the
+                  single-VM value. NEW v2 field.
+                type: string
             type: object
         required:
         - spec

--- a/internal/controller/husk_activation_test.go
+++ b/internal/controller/husk_activation_test.go
@@ -261,6 +261,33 @@ func TestHuskClaimActivatesDormantPod(t *testing.T) {
 	}
 }
 
+// TestHuskClaimStampsHostPodAndVMID proves the husk-backed ready-stamp surfaces
+// the shared-host mapping on the CRD (fork-primitive-multinode plan, "the k8s
+// interface and observability"): status.Pod carries the husk HOST pod name and
+// status.VMID carries the intra-pod VM identity. On today's single-VM path VMID
+// is the default primary identity, so the (Pod, VMID) pair is populated and
+// correct for the 1:1 case; multi-VM co-location lands in a later increment.
+func TestHuskClaimStampsHostPodAndVMID(t *testing.T) {
+	pod := makeDormantHuskPod(t, "husk-vmid-pool", "10.1.2.55")
+
+	act := &fakeActivator{result: husk.ActivateResult{OK: true, VsockPath: "/run/husk/vm/vsock", LatencyMs: 1.0}}
+	setHuskTestActivator(act.activate)
+	t.Cleanup(func() { setHuskTestActivator(nil) })
+
+	claim := makeHuskClaim(t, "husk-vmid", v1.SandboxSpec{})
+
+	got := waitClaimPhase(t, claim.Name, func(c *v1.Sandbox) bool {
+		return c.Status.Phase == v1.SandboxReady
+	})
+
+	if got.Status.Pod != pod.Name {
+		t.Errorf("status.Pod = %q, want the husk host pod %q", got.Status.Pod, pod.Name)
+	}
+	if got.Status.VMID != v1.DefaultVMID {
+		t.Errorf("status.VMID = %q, want the default primary identity %q", got.Status.VMID, v1.DefaultVMID)
+	}
+}
+
 // TestHuskClaimActivateCarriesExpectedDigest proves the controller threads the
 // template's recorded CAS manifest digest (from the NodeRegistry, fed by forkd's
 // GetCapacity) into the ActivateRequest, so the husk stub can re-verify the

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -919,6 +919,14 @@ func (r *SandboxReconciler) reconcileHuskClaim(ctx context.Context, claim *v1.Sa
 	claim.Status.Phase = v1.SandboxReady
 	claim.Status.Endpoint = endpoint
 	claim.Status.Node = pod.Spec.NodeName
+	// Surface the shared-host mapping on the CRD (fork-primitive-multinode plan,
+	// "the k8s interface and observability"): Pod is the husk HOST pod backing
+	// this sandbox and VMID is the intra-pod VM identity. On today's single-VM
+	// path VMID is the default primary identity, so the (Pod, VMID) pair is
+	// populated and correct for the 1:1 case; multi-VM co-location (fork routing)
+	// lands in a later increment. This is a purely additive status write.
+	claim.Status.Pod = pod.Name
+	claim.Status.VMID = v1.DefaultVMID
 	claim.Status.SandboxID = pod.Name
 	claim.Status.StartedAt = &now
 	setCondition(&claim.Status.Conditions, metav1.Condition{

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/cas"
 	"mitos.run/mitos/internal/dnsproxy"
 	"mitos.run/mitos/internal/firecracker"
@@ -67,7 +68,7 @@ type vmID string
 // gives the scaffold instances map a stable key for the one VM a husk pod holds
 // today, so increment 2 of #764 has a well-defined slot to migrate the single-VM
 // state into. The single-VM code path does not use it.
-const defaultVMID vmID = "default"
+const defaultVMID vmID = v1.DefaultVMID
 
 // vmInstance holds the per-VM lifecycle state of one microVM: its lifecycle
 // State, the VMM handle, the fork generation counter, and the per-activation


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through the `mitos.run/v1` CRDs.
> - The controller and the husk host pod are involved: the fork-primitive-multinode plan (Layer 1) runs a tenant's fork swarm as many same-tenant VMs in ONE husk pod for the CoW density win.
> - That decouples the sandbox from the pod: `kubectl get pods` no longer maps one pod to one sandbox, yet the plan's load-bearing decision keeps the Sandbox CRD 1:1 with a VM and makes the pod a shared runtime host below it.
> - The plan requires that mapping to be observable and honest on the CR (operating principle 3: sandboxes are not pods), so `Sandbox.status` must expose which host pod and which VM-in-pod a Sandbox maps to; status already has `pod` but no per-VM identity.
> - This pull request adds `status.vmId` (the intra-pod VM identity) next to the existing `status.pod`, and stamps both on the husk-backed ready path with the default primary identity so the 1:1 case is populated and correct today.
> - The benefit is honest operator traceability: `kubectl get sandbox X -o yaml` traces a sandbox to its exact host process before multi-VM co-location (fork routing) ships in a later increment, with no placement or lifecycle change now.

## Linked Issues or Issue Description

This is increment L1.6 of the multi-VM-per-pod husk work described in
`docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md` (section "The
k8s interface and observability"). It adds only the CRD status field and its
additive population; the fork-routing that co-locates VMs in a shared pod is a
later increment (L1.7). No behavior change to placement or lifecycle.

## What Changed

- Added `VMID string` (`json:"vmId,omitempty"`) to `SandboxStatus` in `api/v1/sandbox_types.go`, documenting it as the per-VM identity within the host pod (default/primary for a single-VM pod, distinct per co-located VM in multi-VM mode).
- Clarified the existing `status.pod` doc to state that in multi-VM mode `pod` is the SHARED HOST pod backing several Sandbox CRs, each distinguished by `vmId`. `pod` is not renamed; the CRD stays 1:1 with a VM.
- Added an exported `DefaultVMID = "default"` constant in `api/v1` and pointed the husk stub's `defaultVMID` at it, so the value stamped by the controller can never drift from the stub's primary vmID key.
- Populated the mapping: on the husk-backed ready path (`reconcileHuskClaim`) the controller now writes `status.pod` (the husk host pod) and `status.vmId` (`DefaultVMID`) alongside the existing status writes. Pure additive status write.
- Regenerated the Sandbox CRD YAML (`deploy/crds` + the Helm chart copy) so `vmId` is in the schema. Deepcopy is unchanged because `vmId` is a value field covered by `*out = *in`.
- Tests (TDD): a JSON round-trip/omitempty check in `api/v1`, and an envtest asserting a reconciled husk-backed sandbox has `status.vmId` populated (the primary identity) alongside `status.pod`.

## Verification

- [x] `go build ./...` (exit 0)
- [x] `make generate manifests` then re-run: no uncommitted generated drift after staging the regenerated files
- [x] `go test ./api/...` -> `ok mitos.run/mitos/api/v1`
- [x] `go test ./internal/husk/...` -> `ok mitos.run/mitos/internal/husk`
- [x] `go test ./internal/controller/...` (envtest, `setup-envtest use 1.31`) -> `ok mitos.run/mitos/internal/controller 229.157s`; new `TestHuskClaimStampsHostPodAndVMID` PASS
- [x] `golangci-lint run --timeout=5m` -> only the pre-existing darwin-only `internal/fork/uffd.go` unused finding, nothing new
- [x] `GOOS=linux golangci-lint run --timeout=5m` -> clean (exit 0)

## Risks

Low risk. The change is an additive status field plus a status write on the
husk-backed ready path; it does not alter placement, scheduling, or lifecycle.
`status.pod` was previously unpopulated on the husk path, so populating it (and
`vmId`) only adds observability the console log path already reads defensively.
Multi-VM population is deferred to fork routing (L1.7).

## Model Used

Claude Opus (Anthropic), model id `claude-opus-4-8`. Used with extended thinking
enabled to plan the increment and drive the TDD/codegen/lint loop.

## Checklist

- [x] PR title is a conventional commit (feat)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (CRD field docs; plan already merged)
- [ ] Threat-model delta (docs/threat-model.md) included if the security surface moved (N/A: additive status field, no security surface change)
- [ ] Benchmark run (bench/) included if the hot path was touched (N/A: no hot-path change)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)
