### PR TITLE
feat(controller): route a fork to a VM in the source pod behind a flag

### DIFF
--- a/api/v1/sandbox_types.go
+++ b/api/v1/sandbox_types.go
@@ -459,6 +459,22 @@ type SandboxChild struct {
 	// StartupLatencyMs is the child's fork latency in milliseconds.
 	// +optional
 	StartupLatencyMs int64 `json:"startupLatencyMs,omitempty"`
+
+	// Pod is the husk host pod backing this child when it was spawned as an
+	// ADDITIONAL VM inside an existing (shared) source pod rather than getting its
+	// own pod (the multi-VM fork routing, controller flag default off). Empty on
+	// the default one-pod-per-child path, where SandboxID already names the child's
+	// own pod. Together with VMID it maps a co-located child to its exact host
+	// process, mirroring SandboxStatus.Pod / SandboxStatus.VMID. NEW v2 field.
+	// +optional
+	Pod string `json:"pod,omitempty"`
+
+	// VMID is the per-VM identity of this child WITHIN Pod above when it was
+	// spawned into a shared source pod (multi-VM fork routing). Empty on the
+	// default one-pod-per-child path (the child owns its whole pod, so the pod
+	// name is its handle). NEW v2 field.
+	// +optional
+	VMID string `json:"vmId,omitempty"`
 }
 
 // SandboxBudgetSpend reports the capability-budget accounting (issue #25).

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -58,6 +58,7 @@ func main() {
 	var maxPendingDuration time.Duration
 	var enableHuskPods bool
 	var enableRawForkd bool
+	var multiVMFork bool
 	var huskStubImage string
 	var huskDNSUpstream string
 	var huskControlPort int
@@ -87,6 +88,7 @@ func main() {
 	flag.StringVar(&otlpEndpoint, "otlp-endpoint", "", "OTLP gRPC endpoint (host:port) for OpenTelemetry trace export. Empty disables tracing (zero cost). Spans carry ids, counts, and timings only; never secret values")
 	flag.BoolVar(&enableHuskPods, "enable-husk-pods", true, "Pod-native default (issue #18): each SandboxPool builds the template snapshot AND maintains a warm pool of pre-scheduled husk pods pinned to the snapshot-holding nodes; claims activate a dormant husk pod in place. This is the default; pass --enable-raw-forkd to fall back to the fork-per-claim path. Ignored when --enable-raw-forkd or --mock is set (both force raw-forkd).")
 	flag.BoolVar(&enableRawForkd, "enable-raw-forkd", false, "Fallback run path: build the snapshot and fork per claim on a holder node (no husk pods). Off by default (the husk pod-native path runs). --mock implies this. husk-pods needs real KVM nodes; raw-forkd is the path the mock/dev overlay uses.")
+	flag.BoolVar(&multiVMFork, "multi-vm-fork", false, "EXPERIMENTAL, DEFAULT OFF: route a hosted fork child into an ADDITIONAL VM spawned INSIDE the source husk pod (the spawn-vm control op) instead of a brand-new child pod, when the source pod is multi-VM capable (its stub runs --multi-vm). OFF is byte-for-byte the current new-pod-per-fork path, so nothing changes unless you opt in AND the source pod is multi-VM capable; a non-capable source silently falls back to a new pod. This wires the routing + status (child status.pod = source pod, status.vmId = the spawned VM); the per-pod and node memory accounting that pends or spills a fork when a pod is full is a follow-up, so co-location is capped conservatively and the remainder spills to new pods. Only used with --enable-husk-pods.")
 	flag.StringVar(&huskStubImage, "husk-stub-image", "mitos-husk-stub:latest", "Container image that runs the dormant-VMM stub in a husk pod. Only used with --enable-husk-pods.")
 	flag.StringVar(&huskDNSUpstream, "husk-dns-upstream", "", "Comma-separated DNS resolver list (host:port) the husk-stub per-pod DNS proxy forwards allowlisted name queries to, tried in failover order (recommended: 1.1.1.1:53,8.8.8.8:53). Empty leaves name-based egress off (IP:port allowlists still enforced). Use a public resolver, not cluster DNS, so untrusted sandboxes cannot resolve internal service names.")
 	flag.IntVar(&huskControlPort, "husk-control-port", controller.HuskControlPort, "TCP port the husk stub serves the mTLS network control on; the controller dials podIP:port to activate a dormant husk pod. Only used with --enable-husk-pods.")
@@ -249,6 +251,7 @@ func main() {
 		NodeRegistry:       nodeRegistry,
 		MaxPendingDuration: maxPendingDuration,
 		EnableHuskPods:     enableHuskPods,
+		MultiVMFork:        multiVMFork,
 		HuskControlPort:    huskControlPort,
 		HuskStubImage:      huskStubImage,
 		HuskDNSUpstream:    huskDNSUpstream,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -294,6 +294,14 @@ func main() {
 		logger.Info("workspace memory snapshots: disabled (default); a checkpoint-on-terminate fails loud. Pass --workspace-memory-snapshots to enable resumable heads")
 	}
 
+	if multiVMFork && !enableHuskPods {
+		logger.Info("WARNING: --multi-vm-fork is on but --enable-husk-pods is off; multi-vm fork routing only applies to husk pods, so the flag is a no-op on the raw-forkd path")
+	} else if multiVMFork {
+		logger.Info("multi-vm fork routing: ENABLED (experimental); a fork child co-locates as an additional VM inside a multi-VM-capable source pod (spawn-vm op) instead of a new pod, capped conservatively until per-pod memory accounting lands; a non-capable source falls back to a new pod")
+	} else {
+		logger.Info("multi-vm fork routing: disabled (default); every fork child gets its own pod. Pass --multi-vm-fork to co-locate fork children in a multi-VM-capable source pod")
+	}
+
 	if enableHuskPods {
 		logger.Info("workspace transport: husk delegation ENABLED; a sandbox's /workspace hydrate/dehydrate is delegated to the husk-stub control op (the node owns the VM vsock + node CAS); the controller commits the revision and advances the head")
 	}

--- a/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
+++ b/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
@@ -628,6 +628,15 @@ spec:
                     phase:
                       description: Phase is the child's lifecycle phase.
                       type: string
+                    pod:
+                      description: |-
+                        Pod is the husk host pod backing this child when it was spawned as an
+                        ADDITIONAL VM inside an existing (shared) source pod rather than getting its
+                        own pod (the multi-VM fork routing, controller flag default off). Empty on
+                        the default one-pod-per-child path, where SandboxID already names the child's
+                        own pod. Together with VMID it maps a co-located child to its exact host
+                        process, mirroring SandboxStatus.Pod / SandboxStatus.VMID. NEW v2 field.
+                      type: string
                     sandboxID:
                       description: SandboxID is the child's engine-side identifier.
                       type: string
@@ -636,6 +645,13 @@ spec:
                         milliseconds.
                       format: int64
                       type: integer
+                    vmId:
+                      description: |-
+                        VMID is the per-VM identity of this child WITHIN Pod above when it was
+                        spawned into a shared source pod (multi-VM fork routing). Empty on the
+                        default one-pod-per-child path (the child owns its whole pod, so the pod
+                        name is its handle). NEW v2 field.
+                      type: string
                   required:
                   - endpoint
                   - name

--- a/deploy/crds/mitos.run_sandboxes.yaml
+++ b/deploy/crds/mitos.run_sandboxes.yaml
@@ -628,6 +628,15 @@ spec:
                     phase:
                       description: Phase is the child's lifecycle phase.
                       type: string
+                    pod:
+                      description: |-
+                        Pod is the husk host pod backing this child when it was spawned as an
+                        ADDITIONAL VM inside an existing (shared) source pod rather than getting its
+                        own pod (the multi-VM fork routing, controller flag default off). Empty on
+                        the default one-pod-per-child path, where SandboxID already names the child's
+                        own pod. Together with VMID it maps a co-located child to its exact host
+                        process, mirroring SandboxStatus.Pod / SandboxStatus.VMID. NEW v2 field.
+                      type: string
                     sandboxID:
                       description: SandboxID is the child's engine-side identifier.
                       type: string
@@ -636,6 +645,13 @@ spec:
                         milliseconds.
                       format: int64
                       type: integer
+                    vmId:
+                      description: |-
+                        VMID is the per-VM identity of this child WITHIN Pod above when it was
+                        spawned into a shared source pod (multi-VM fork routing). Empty on the
+                        default one-pod-per-child path (the child owns its whole pod, so the pod
+                        name is its handle). NEW v2 field.
+                      type: string
                   required:
                   - endpoint
                   - name

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -477,14 +477,28 @@ The op FAILS CLOSED on the flag: a stub NOT started with `--multi-vm` refuses
 spawn-vm, so a single-VM pod is never driven to host a second VM. The spawned VM
 lands on its OWN tap + /30 + default-deny egress chain derived from the vmID (the
 per-VM network isolation in the multi-VM-per-pod row of Surface 2, Guest to guest), so a
-co-located VM's egress cannot cross into a sibling's. This is DEFAULT OFF and the
-controller is NOT wired to call it (the fork-routing that drives it is a later
-increment), so the shipped surface is unchanged: nothing spawns a second VM in
-production today. Residual: a compromised controller can drive a spawn-vm against
-any multi-VM husk pod it can reach, the same residual already stated for activate
-and fork-snapshot (Surface 2); and it inherits the shared-pod-netns residual of
-the multi-VM-per-pod mode (Surface 2, Guest to guest), which is why it stays flag-gated behind that
-mode's per-VM tap + /30 isolation and a named security review before it ships.
+co-located VM's egress cannot cross into a sibling's. This is DEFAULT OFF. The
+controller CAN now drive it behind its own default-off flag (`--multi-vm-fork`,
+`SandboxReconciler.MultiVMFork`): when on AND the source husk pod is multi-VM
+capable (its stub runs `--multi-vm`, recorded by the `mitos.run/multi-vm` pod
+label), a hosted fork child is spawned as an ADDITIONAL VM inside the SOURCE pod
+instead of a new child pod (`internal/controller/sandboxfork_controller.go`
+`spawnForkChildInSourcePod`), threading the SAME snapshot + network + egress posture
+the new-pod fork child inherits and reusing the SAME mTLS control channel and
+fork-snapshot flow; the child's `status.pod`/`status.vmId`/`status.node` record the
+shared host. The flag is DEFAULT OFF, and off is byte-for-byte the new-pod path, so
+the shipped surface is unchanged: nothing spawns a second VM in production today. A
+non-capable source silently falls back to the new-pod path, and a spawn failure
+fails toward a clear pending (logged, requeued), never a silent hang. The
+CONSERVATIVE increment caps co-location per pod at a small fixed number
+(`maxCoLocatedForkVMsPerPod`) and spills the rest to new pods; the real per-pod and
+node MEMORY ACCOUNTING that bounds how many VMs a pod may hold (so a fork can never
+overcommit a host) is a named follow-up (L1.7b). Residual: a compromised controller
+can drive a spawn-vm against any multi-VM husk pod it can reach, the same residual
+already stated for activate and fork-snapshot (Surface 2); and it inherits the
+shared-pod-netns residual of the multi-VM-per-pod mode (Surface 2, Guest to guest),
+which is why it stays flag-gated behind that mode's per-VM tap + /30 isolation and a
+named security review before it ships.
 
 **Surface 4: the DEVICE `/dev/kvm`.** KVM access is injected by the device plugin
 (`cmd/kvm-device-plugin`, `internal/deviceplugin`): the pod requests

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -1,0 +1,440 @@
+package controller_test
+
+// Envtest coverage for the MultiVMFork routing (L1.7a): a hosted fork child routed
+// into an ADDITIONAL VM spawned INSIDE the source pod (the spawn-vm control op)
+// instead of a brand-new child pod, behind the controller MultiVMFork flag
+// (default OFF).
+//
+// The routing takes effect ONLY when the flag is on AND the source pod is multi-VM
+// capable (its stub runs --multi-vm, recorded by the mitos.run/multi-vm pod label).
+// With the flag off, or a non-capable source, the fork keeps the byte-for-byte
+// new-pod path. A spawn failure never wedges the child: the slot stays not-ready
+// with the cause logged and the reconcile requeues, and a later successful spawn
+// converges.
+//
+// envtest has no kubelet, so the source pod is forced Running+Ready and the
+// fork-snapshot / activate / spawn-vm transports run through the suite's swappable
+// fakes.
+
+import (
+	"context"
+	"crypto/tls"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "mitos.run/mitos/api/v1"
+	"mitos.run/mitos/internal/controller"
+	"mitos.run/mitos/internal/husk"
+)
+
+// multiVMSource stamps the mitos.run/multi-vm capability label so the source pod is
+// a spawn-vm candidate.
+func multiVMSource(p *corev1.Pod) {
+	if p.Labels == nil {
+		p.Labels = map[string]string{}
+	}
+	p.Labels[controller.HuskMultiVMLabel] = "true"
+}
+
+// TestMultiVMForkRoutesToSourcePodWhenEnabled proves the core L1.7a wiring: with
+// the flag ON and a multi-VM-capable source, each fork child is spawned as an
+// additional VM INSIDE the source pod (SpawnVMOnHusk), NO new child pod is created,
+// and the recorded child carries status.Pod = the source pod, status.VMID = the
+// spawned vmID, and status.Node = the source node.
+func TestMultiVMForkRoutesToSourcePodWhenEnabled(t *testing.T) {
+	poolName := uniqueName("pool-mvm-on")
+	srcClaimName := uniqueName("src-mvm-on")
+	forkName := uniqueName("mvm-on")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.1", multiVMSource)
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	// A fork activator that fails loud: if the routing wrongly took the new-pod
+	// path, the child would go through activate and never reach Ready, so the test
+	// would fail instead of passing on the wrong path.
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: false, Error: "activate must not be called on the spawn-in-source-pod path"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var spawnCalls int32
+	var gotVMIDs sync.Map
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		gotVMIDs.Store(req.VMID, req.Activate.Token)
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 2},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyReplicas == 2
+	})
+
+	// No new child pod was created: the children live inside the source pod.
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("MultiVMFork must not create child pods; got %d", len(pods.Items))
+	}
+	if got := atomic.LoadInt32(&spawnCalls); got < 2 {
+		t.Fatalf("expected at least 2 spawn-vm calls for Replicas=2, got %d", got)
+	}
+
+	var got v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get fork: %v", err)
+	}
+	if len(got.Status.Children) != 2 {
+		t.Fatalf("expected 2 recorded children, got %d", len(got.Status.Children))
+	}
+	for _, c := range got.Status.Children {
+		if c.Pod != srcPod.Name {
+			t.Errorf("child %s status.Pod = %q, want the source pod %q", c.Name, c.Pod, srcPod.Name)
+		}
+		if c.VMID == "" {
+			t.Errorf("child %s status.VMID is empty, want the spawned vmID", c.Name)
+		}
+		if c.Node != srcPod.Spec.NodeName {
+			t.Errorf("child %s status.Node = %q, want the source node %q", c.Name, c.Node, srcPod.Spec.NodeName)
+		}
+		if _, ok := gotVMIDs.Load(c.VMID); !ok {
+			t.Errorf("child %s status.VMID %q was never passed to spawn-vm", c.Name, c.VMID)
+		}
+	}
+}
+
+// TestMultiVMForkOffCreatesNewChildPod proves the default-OFF path is unchanged:
+// with the flag off, a fork still creates a new child pod and never calls the
+// spawn-vm seam, even though the source is multi-VM capable.
+func TestMultiVMForkOffCreatesNewChildPod(t *testing.T) {
+	poolName := uniqueName("pool-mvm-off")
+	srcClaimName := uniqueName("src-mvm-off")
+	forkName := uniqueName("mvm-off")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.2", multiVMSource)
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var spawnCalls int32
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, _ husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		return husk.SpawnVMResult{OK: false, Error: "spawn-vm must not be called with the flag off"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	// Flag OFF (the default). Assert explicitly rather than rely on the default.
+	setForkMultiVM(false)
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var p corev1.PodList
+		_ = k8sClient.List(ctx, &p, listForkChildren(forkName))
+		for i := range p.Items {
+			forceHuskPodReady(t, &p.Items[i])
+		}
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyReplicas == 1
+	})
+
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("flag-off fork must create exactly 1 child pod, got %d", len(pods.Items))
+	}
+	if got := atomic.LoadInt32(&spawnCalls); got != 0 {
+		t.Fatalf("spawn-vm must not be called with the flag off; got %d calls", got)
+	}
+
+	var got v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get fork: %v", err)
+	}
+	// The unchanged path records the child pod as SandboxID and leaves Pod/VMID empty.
+	if len(got.Status.Children) != 1 {
+		t.Fatalf("expected 1 recorded child, got %d", len(got.Status.Children))
+	}
+	if got.Status.Children[0].Pod != "" || got.Status.Children[0].VMID != "" {
+		t.Errorf("flag-off child must leave status.Pod/VMID empty, got pod=%q vmId=%q", got.Status.Children[0].Pod, got.Status.Children[0].VMID)
+	}
+}
+
+// TestMultiVMForkNonMultiVMSourceFallsBack proves the capability gate: with the
+// flag ON but a source pod that is NOT multi-VM capable (no mitos.run/multi-vm
+// label), the fork silently falls back to the new-pod path and never calls
+// spawn-vm.
+func TestMultiVMForkNonMultiVMSourceFallsBack(t *testing.T) {
+	poolName := uniqueName("pool-mvm-nc")
+	srcClaimName := uniqueName("src-mvm-nc")
+	forkName := uniqueName("mvm-nc")
+
+	// No multiVMSource mutator: the source stub is single-VM.
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.3")
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var spawnCalls int32
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, _ husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		return husk.SpawnVMResult{OK: false, Error: "spawn-vm must not be called for a non-multi-vm source"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var p corev1.PodList
+		_ = k8sClient.List(ctx, &p, listForkChildren(forkName))
+		for i := range p.Items {
+			forceHuskPodReady(t, &p.Items[i])
+		}
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyReplicas == 1
+	})
+
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("non-multi-vm source must fall back to a new child pod, got %d pods", len(pods.Items))
+	}
+	if got := atomic.LoadInt32(&spawnCalls); got != 0 {
+		t.Fatalf("spawn-vm must not be called for a non-multi-vm source; got %d calls", got)
+	}
+}
+
+// TestMultiVMForkSpawnErrorDoesNotWedge proves a spawn failure is never a silent
+// hang: while the spawn-vm seam fails, the child stays not-ready (ReadyReplicas
+// stays 0) and NO new child pod is silently created; once the seam recovers, the
+// fork converges. This exercises the "fail toward a clear pending, never a silent
+// hang" requirement.
+func TestMultiVMForkSpawnErrorDoesNotWedge(t *testing.T) {
+	poolName := uniqueName("pool-mvm-err")
+	srcClaimName := uniqueName("src-mvm-err")
+	forkName := uniqueName("mvm-err")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.4", multiVMSource)
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: false, Error: "activate must not be called on the spawn path"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var failing atomic.Bool
+	failing.Store(true)
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		if failing.Load() {
+			return husk.SpawnVMResult{OK: false, VMID: req.VMID, Error: "spawn refused: transient"}, nil
+		}
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	// Let several requeue passes elapse while spawn fails: the child must stay
+	// not-ready and NO child pod may be silently created (the fork snapshot ran, so
+	// the loop is being driven).
+	time.Sleep(3 * time.Second)
+
+	var got v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get fork: %v", err)
+	}
+	if got.Status.ReadyReplicas != 0 {
+		t.Fatalf("child must stay not-ready while spawn fails, got ReadyReplicas=%d", got.Status.ReadyReplicas)
+	}
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("a failing spawn must not silently create a child pod; got %d", len(pods.Items))
+	}
+
+	// Recover the spawn seam: the fork must now converge (a clean retry, not a wedge).
+	failing.Store(false)
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var g v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &g); err != nil {
+			return false
+		}
+		return g.Status.ReadyReplicas == 1
+	})
+}
+
+// TestMultiVMForkSpillsPastCapToNewPods proves the conservative L1.7a co-location
+// cap: with the flag on and a multi-VM-capable source, the first
+// MaxCoLocatedForkVMsPerPod children are spawned in the source pod and every
+// child beyond the cap SPILLS to a new child pod (the stand-in for the real
+// per-pod memory accounting deferred to L1.7b).
+func TestMultiVMForkSpillsPastCapToNewPods(t *testing.T) {
+	poolName := uniqueName("pool-mvm-cap")
+	srcClaimName := uniqueName("src-mvm-cap")
+	forkName := uniqueName("mvm-cap")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.5", multiVMSource)
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var spawnCalls int32
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	capN := int32(controller.MaxCoLocatedForkVMsPerPod)
+	replicas := capN + 2
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: replicas},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 20*time.Second, func() bool {
+		var p corev1.PodList
+		_ = k8sClient.List(ctx, &p, listForkChildren(forkName))
+		for i := range p.Items {
+			forceHuskPodReady(t, &p.Items[i])
+		}
+		var g v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &g); err != nil {
+			return false
+		}
+		return g.Status.ReadyReplicas == replicas
+	})
+
+	// Exactly the over-cap children spilled to new pods; the capped children stay
+	// in the source pod.
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	spill := int(replicas - capN)
+	if len(pods.Items) != spill {
+		t.Fatalf("expected %d spilled child pods past the cap, got %d", spill, len(pods.Items))
+	}
+	if got := atomic.LoadInt32(&spawnCalls); got < capN {
+		t.Fatalf("expected at least %d spawn-vm calls (the co-located children), got %d", capN, got)
+	}
+}

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -438,3 +438,97 @@ func TestMultiVMForkSpillsPastCapToNewPods(t *testing.T) {
 		t.Fatalf("expected at least %d spawn-vm calls (the co-located children), got %d", capN, got)
 	}
 }
+
+// TestMultiVMForkFlagFlipOffDoesNotOrphanCoLocatedChild proves the CodeRabbit
+// Major fix: a slot already spawned INSIDE the source pod is carried forward on a
+// later reconcile even after --multi-vm-fork is flipped OFF (a controller
+// restart with the flag off), and does NOT fall to the new-pod branch and create
+// an orphan pod that status never references. Without hoisting the recorded-slot
+// check above the routing branches, that flip would leak a KVM device slot.
+func TestMultiVMForkFlagFlipOffDoesNotOrphanCoLocatedChild(t *testing.T) {
+	poolName := uniqueName("pool-mvm-flip")
+	srcClaimName := uniqueName("src-mvm-flip")
+	forkName := uniqueName("mvm-flip")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.9", multiVMSource)
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: false, Error: "activate must not be called for an already-recorded co-located child"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	// Phase 1: flag ON, the child co-locates in the source pod (no child pod).
+	setForkMultiVM(true)
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyReplicas == 1
+	})
+	var afterOn v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &afterOn); err != nil {
+		t.Fatalf("get fork: %v", err)
+	}
+	if len(afterOn.Status.Children) != 1 || afterOn.Status.Children[0].Pod != srcPod.Name {
+		t.Fatalf("phase 1: child must be recorded in the source pod, got %+v", afterOn.Status.Children)
+	}
+
+	// Phase 2: flip the flag OFF and force a reconcile (annotation bump). The
+	// already-co-located slot must be carried forward, NOT re-routed to a new pod.
+	setForkMultiVM(false)
+	var live v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &live); err != nil {
+		t.Fatalf("re-get fork: %v", err)
+	}
+	if live.Annotations == nil {
+		live.Annotations = map[string]string{}
+	}
+	live.Annotations["test.mitos.run/rereconcile"] = "1"
+	if err := k8sClient.Update(ctx, &live); err != nil {
+		t.Fatalf("bump fork to force reconcile: %v", err)
+	}
+
+	// Give the reconcile loop time to run; assert NO child pod was ever created and
+	// the child record still points at the source pod (never re-routed).
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		var pods corev1.PodList
+		if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+			t.Fatalf("list children: %v", err)
+		}
+		if len(pods.Items) != 0 {
+			t.Fatalf("flag-flip-off must NOT create an orphan child pod for an already-co-located slot; got %d", len(pods.Items))
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	var afterFlip v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &afterFlip); err != nil {
+		t.Fatalf("get fork after flip: %v", err)
+	}
+	if len(afterFlip.Status.Children) != 1 || afterFlip.Status.Children[0].Pod != srcPod.Name || afterFlip.Status.Children[0].VMID == "" {
+		t.Fatalf("after flip, the co-located child record must be unchanged (source pod + vmID), got %+v", afterFlip.Status.Children)
+	}
+}

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -118,6 +118,27 @@ type SandboxReconciler struct {
 	forkSnapshot       huskForkSnapshotter
 	removeForkSnapshot huskForkSnapshotRemover
 
+	// MultiVMFork routes a husk fork child into an ADDITIONAL VM spawned INSIDE the
+	// SOURCE pod (SpawnVMOnHusk) instead of a brand-new child pod, when the source
+	// pod is multi-VM capable. EXPERIMENTAL, DEFAULT OFF: off is byte-for-byte the
+	// buildForkChildPod new-pod path, so nothing changes unless an operator opts in
+	// AND the source pod runs a --multi-vm husk stub (huskPodMultiVMCapable). This
+	// increment (L1.7a) is the routing + status wiring + the flag; the per-pod and
+	// node MEMORY ACCOUNTING that lets a fork pend or spill when a pod is full is
+	// deferred to L1.7b, so co-location is gated here at a small fixed cap
+	// (maxCoLocatedForkVMsPerPod) with the remainder spilled to new pods. Only used
+	// when EnableHuskPods is true.
+	MultiVMFork bool
+
+	// spawnVM is the controller->husk spawn-vm seam used by the MultiVMFork routing.
+	// Nil defaults to SpawnVMOnHusk; tests inject a fake.
+	spawnVM huskVMSpawner
+
+	// multiVMForkGate, when non-nil, overrides MultiVMFork so a test can toggle the
+	// routing race-safely on the shared reconciler (the field itself is never
+	// mutated after setup). Nil (the production default) reads MultiVMFork. Tests only.
+	multiVMForkGate func() bool
+
 	// KMS is the envelope-encryption Wrapper used to wrap a template's at-rest DEK
 	// on the fork path (an idempotent read of the controller-owned Secret created
 	// at build time). REQUIRED when any reconciled template is Encrypted;

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -652,6 +652,20 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	for i := int32(0); i < effectiveReplicas(fork); i++ {
 		childName := fmt.Sprintf("%s-fork-%d", fork.Name, i)
 
+		// A slot activated in a prior pass is carried forward as-is BEFORE any
+		// routing decision, so its fate is decided once and independently of the
+		// current flag state. Without this hoist, a slot recorded via the
+		// spawn-in-source-pod path would fall to the new-pod branch after a
+		// --multi-vm-fork flip-to-off (controller restart) and ensureForkChildPod
+		// would create a brand-new pod for a childName that status never references
+		// (the carried-forward source-pod record wins), leaking a KVM slot until the
+		// fork is GC'd. Idempotent per slot; never re-activates a live child VM.
+		if info, ok := recorded[childName]; ok {
+			forks = append(forks, info)
+			ready++
+			continue
+		}
+
 		// MultiVMFork routing: for the first maxCoLocatedForkVMsPerPod slots of a
 		// multi-VM-capable source, spawn the child as an ADDITIONAL VM INSIDE the
 		// source pod (spawn-vm op) instead of creating a brand-new child pod. Slots
@@ -661,13 +675,6 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		// (spawnInSourcePod is false), this branch is never entered and the path
 		// below is byte-for-byte unchanged.
 		if spawnInSourcePod && i < maxCoLocatedForkVMsPerPod {
-			// Already activated in a prior pass: carry it forward, do not re-spawn a
-			// non-dormant VM (idempotent per slot, mirroring the new-pod path).
-			if info, ok := recorded[childName]; ok {
-				forks = append(forks, info)
-				ready++
-				continue
-			}
 			spawnedChild, ok := r.spawnForkChildInSourcePod(ctx, spawnForkChildArgs{
 				fork:        fork,
 				srcPod:      srcPod,
@@ -691,17 +698,12 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		}
 
 		// Get-or-create the child pod for this slot (idempotent by the stable name).
+		// The recorded-slot carry-forward is hoisted above the routing branches, so a
+		// slot already activated (in-source-pod or in its own pod) never reaches here
+		// and this only runs for a genuinely new slot on the new-pod path.
 		child, err := r.ensureForkChildPod(ctx, fork, srcPod, childName, opts)
 		if err != nil {
 			logger.Error(err, "create fork child pod failed", "child", childName)
-			continue
-		}
-
-		// Already activated in a prior pass: carry the recorded info forward and
-		// skip re-activation (idempotent per slot).
-		if info, ok := recorded[childName]; ok {
-			forks = append(forks, info)
-			ready++
 			continue
 		}
 

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -28,6 +30,62 @@ type huskForkSnapshotter func(ctx context.Context, addr string, tlsConf *tls.Con
 // huskForkSnapshotRemover is the controller->husk remove-fork-snapshot seam. Nil
 // defaults to RemoveForkSnapshotOnHusk; tests inject a fake.
 type huskForkSnapshotRemover func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error)
+
+// huskVMSpawner is the controller->husk spawn-vm seam (the MultiVMFork routing).
+// Nil defaults to SpawnVMOnHusk; tests inject a fake.
+type huskVMSpawner func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error)
+
+// maxCoLocatedForkVMsPerPod is the CONSERVATIVE L1.7a cap on how many fork-child
+// VMs the MultiVMFork routing co-locates INSIDE one source pod before it spills
+// the remaining children back to the safe new-pod path (buildForkChildPod). It is
+// a hardcoded stand-in for the real per-pod and node MEMORY ACCOUNTING that is
+// deferred to L1.7b (guarantee A: account each added VM against a per-pod and node
+// budget, then pend or spill when the pod is full so a fork never overcommits).
+// Until that lands, the fixed cap keeps a fork from stacking an unbounded number
+// of VMs on one host pod's memory.
+const maxCoLocatedForkVMsPerPod = 4
+
+// huskMultiVMLabel marks a husk pod whose stub was started with --multi-vm, so the
+// controller may drive a spawn-vm op against it (bring up an ADDITIONAL same-tenant
+// VM in that pod). Only a pod carrying this label is a candidate for the MultiVMFork
+// routing; every other source pod falls back to the new-pod path. The label is the
+// controller-visible record that the pod is multi-VM capable, paired with the
+// --multi-vm stub arg (a single-VM stub fails a spawn-vm op closed regardless).
+const huskMultiVMLabel = "mitos.run/multi-vm"
+
+// huskPodMultiVMCapable reports whether a husk pod's stub runs with --multi-vm, so
+// a spawn-vm op against it can succeed. A nil pod or a pod without the label is not
+// capable, so the MultiVMFork routing falls back to a new child pod.
+func huskPodMultiVMCapable(pod *corev1.Pod) bool {
+	return pod != nil && pod.Labels[huskMultiVMLabel] == "true"
+}
+
+// forkChildVMID derives the node-local vmID for a fork child co-located in the
+// source pod from the child's stable slot name. The husk stub validates a spawned
+// vmID against checkVMID (^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$) and derives this VM's
+// per-VM socket, tap, and workdir from it, so the id must be a safe node-local
+// identifier and unique WITHIN the source pod. The child slot name
+// ("<fork>-fork-<i>") is already node-local-unique and uses only [a-z0-9-]; cap it
+// with a short content-hash suffix so a long source sandbox name still yields a
+// <=64-char id that never collides across forks sharing one source pod.
+func forkChildVMID(childName string) string {
+	const maxLen = 64
+	if len(childName) <= maxLen {
+		return childName
+	}
+	sum := sha256.Sum256([]byte(childName))
+	suffix := hex.EncodeToString(sum[:])[:8]
+	return childName[:maxLen-1-len(suffix)] + "-" + suffix
+}
+
+// multiVMForkEnabled reports whether the MultiVMFork routing is on, honoring the
+// test gate override so a test can toggle it race-safely on the shared reconciler.
+func (r *SandboxReconciler) multiVMForkEnabled() bool {
+	if r.multiVMForkGate != nil {
+		return r.multiVMForkGate()
+	}
+	return r.MultiVMFork
+}
 
 // huskForkFinalizer guards a husk fork so its node-local fork snapshot is
 // removed from the source pod before the Sandbox object is deleted.
@@ -451,6 +509,17 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	if activate == nil {
 		activate = ActivateHuskPod
 	}
+	spawnVM := r.spawnVM
+	if spawnVM == nil {
+		spawnVM = SpawnVMOnHusk
+	}
+
+	// MultiVMFork routing decision, computed ONCE for the whole fan-out. The
+	// spawn-in-source-pod path is taken only when the flag is on AND the source pod
+	// is multi-VM capable (its stub runs --multi-vm); otherwise every child takes
+	// the byte-for-byte-unchanged new-pod path below. A non-capable source is the
+	// silent, safe fallback the design requires.
+	spawnInSourcePod := r.multiVMForkEnabled() && huskPodMultiVMCapable(srcPod)
 
 	// One fork snapshot per SandboxFork, keyed by the fork name, taken EXACTLY
 	// ONCE and reused for every child across reconcile passes. Children take
@@ -582,6 +651,44 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	var forks []v1.SandboxChild
 	for i := int32(0); i < effectiveReplicas(fork); i++ {
 		childName := fmt.Sprintf("%s-fork-%d", fork.Name, i)
+
+		// MultiVMFork routing: for the first maxCoLocatedForkVMsPerPod slots of a
+		// multi-VM-capable source, spawn the child as an ADDITIONAL VM INSIDE the
+		// source pod (spawn-vm op) instead of creating a brand-new child pod. Slots
+		// past the cap fall through to the new-pod path below, the conservative
+		// L1.7a stand-in for the real per-pod/node memory accounting deferred to
+		// L1.7b. When the flag is off or the source is not multi-VM capable
+		// (spawnInSourcePod is false), this branch is never entered and the path
+		// below is byte-for-byte unchanged.
+		if spawnInSourcePod && i < maxCoLocatedForkVMsPerPod {
+			// Already activated in a prior pass: carry it forward, do not re-spawn a
+			// non-dormant VM (idempotent per slot, mirroring the new-pod path).
+			if info, ok := recorded[childName]; ok {
+				forks = append(forks, info)
+				ready++
+				continue
+			}
+			spawnedChild, ok := r.spawnForkChildInSourcePod(ctx, spawnForkChildArgs{
+				fork:        fork,
+				srcPod:      srcPod,
+				source:      source,
+				childName:   childName,
+				template:    template,
+				netCfg:      netCfg,
+				sandboxPort: sandboxPort,
+				controlPort: controlPort,
+				spawnVM:     spawnVM,
+			})
+			if ok {
+				forks = append(forks, spawnedChild)
+				ready++
+			}
+			// A failed spawn is NOT wedged: the slot is left not-ready with the cause
+			// logged (issue #28), and the reconcile requeues below because
+			// ReadyReplicas < Replicas. It never silently hangs and never weakens the
+			// new-pod fallback for the OFF path.
+			continue
+		}
 
 		// Get-or-create the child pod for this slot (idempotent by the stable name).
 		child, err := r.ensureForkChildPod(ctx, fork, srcPod, childName, opts)
@@ -725,6 +832,103 @@ func (r *SandboxReconciler) ensureForkChildPod(ctx context.Context, fork *v1.San
 		return nil, fmt.Errorf("re-get fork child pod %s: %w", name, err)
 	}
 	return &existing, nil
+}
+
+// spawnForkChildArgs bundles the inputs for spawnForkChildInSourcePod so the
+// slot-loop call site stays readable.
+type spawnForkChildArgs struct {
+	fork        *v1.Sandbox
+	srcPod      *corev1.Pod
+	source      *v1.Sandbox
+	childName   string
+	template    *v1.PoolTemplateSpec
+	netCfg      huskNetworkConfig
+	sandboxPort int
+	controlPort int
+	spawnVM     huskVMSpawner
+}
+
+// spawnForkChildInSourcePod brings up a fork child as an ADDITIONAL VM inside the
+// SOURCE husk pod (the spawn-vm control op) rather than creating a new child pod.
+// It is the MultiVMFork routing's per-slot worker and the co-located analog of the
+// new-pod ensureForkChildPod + activate pair: it mints and persists the child's
+// stable bearer token FIRST (issue #183: a lost spawn ack must re-drive with the
+// token the VM already holds, and AlreadyActive lets us adopt it), then asks the
+// source stub to spawn a new vmID activating from the SAME fork snapshot the source
+// already produced, threading the SAME network + egress posture the new-pod fork
+// child inherits (issue #760) so a co-located child is never less isolated. The
+// spawned VM runs the same fail-closed RNG/clock reseed handshake activate runs, so
+// the fork-correctness handshake is preserved.
+//
+// It returns (child, true) with status.Pod = the source pod, status.VMID = the
+// spawned vmID, and status.Node = the source node when the VM is up (OK or the
+// idempotent AlreadyActive), and (_, false) when the spawn did not complete this
+// pass. A false is a clean not-ready-yet signal the caller requeues on; it NEVER
+// wedges and NEVER weakens the new-pod fallback. The mTLS control channel and the
+// fork-snapshot flow are unchanged; SpawnVMOnHusk refuses a nil TLS config so the
+// secret-bearing Activate never rides an unauthenticated channel.
+func (r *SandboxReconciler) spawnForkChildInSourcePod(ctx context.Context, a spawnForkChildArgs) (v1.SandboxChild, bool) {
+	logger := log.FromContext(ctx)
+
+	vmID := forkChildVMID(a.childName)
+	endpoint := net.JoinHostPort(a.srcPod.Status.PodIP, strconv.Itoa(a.sandboxPort))
+
+	// Persist a STABLE token BEFORE spawning (issue #183): a spawn ack or the
+	// post-spawn bookkeeping can be lost, leaving the VM ACTIVE while the controller
+	// did not record it. Reusing the same token on a re-drive lets AlreadyActive
+	// adopt the running VM instead of looping.
+	apiToken, err := ensureForkChildToken(ctx, r.Client, a.fork, a.childName+tokenSecretSuffix, endpoint)
+	if err != nil {
+		logger.Error(err, "fork child token secret write failed", "child", a.childName)
+		return v1.SandboxChild{}, false
+	}
+
+	addr := net.JoinHostPort(a.srcPod.Status.PodIP, strconv.Itoa(a.controlPort))
+	tlsConf, err := r.huskDialTLS(ctx, a.fork.Namespace)
+	var spRes husk.SpawnVMResult
+	if err == nil {
+		spRes, err = a.spawnVM(ctx, addr, tlsConf, husk.SpawnVMRequest{
+			VMID: vmID,
+			Activate: husk.ActivateRequest{
+				// The spawned VM reads the FORK snapshot the source already produced,
+				// mounted read-only at HuskSnapshotDir in the source pod. No
+				// ExpectedDigest: the fork snapshot is node-local, not content-addressed.
+				SnapshotDir: HuskSnapshotDir,
+				// Inherit the SAME network posture the new-pod fork child gets from the
+				// source pool template (issue #760), so a co-located child is never less
+				// isolated than a one-pod-per-child fork.
+				Network:      huskNotifyNetwork(a.template),
+				Egress:       a.netCfg.Egress,
+				Allow:        a.netCfg.Allow,
+				BlockNetwork: a.netCfg.BlockNetwork,
+				AllowCIDRs:   a.netCfg.AllowCIDRs,
+				Inbound:      a.netCfg.Inbound,
+				InboundCIDRs: a.netCfg.InboundCIDRs,
+				Token:        apiToken,
+			},
+		})
+	}
+	if err != nil {
+		logger.Info("fork child spawn-in-source-pod failed, will retry", "child", a.childName, "detail", err.Error())
+		return v1.SandboxChild{}, false
+	}
+	if !spRes.OK && !spRes.AlreadyActive {
+		// Surface WHY (issue #28 LLM-legible errors) rather than a bare retry.
+		logger.Info("fork child spawn-in-source-pod failed, will retry", "child", a.childName, "detail", spRes.Error)
+		return v1.SandboxChild{}, false
+	}
+	// OK, or AlreadyActive: a prior spawn brought this VM up but its ack or
+	// bookkeeping was lost. Either way the VM is active with the stable token
+	// persisted above, so ADOPT it as ready.
+	return v1.SandboxChild{
+		Name:      a.childName,
+		SandboxID: a.srcPod.Name,
+		Endpoint:  endpoint,
+		Node:      a.source.Status.Node,
+		Pod:       a.srcPod.Name,
+		VMID:      vmID,
+		Phase:     v1.SandboxReady,
+	}, true
 }
 
 // finalizeHuskFork removes the node-local fork snapshot from the source husk pod

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -184,6 +184,10 @@ var (
 	forkSnapshotter     func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error)
 	forkActivator       func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error)
 	forkSnapshotRemover func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error)
+	forkVMSpawner       func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error)
+	// forkMultiVMEnabled is the race-safe MultiVMFork toggle the suite's shared husk
+	// reconciler reads through its gate; a MultiVMFork test flips it per-case.
+	forkMultiVMEnabled bool
 
 	// wsTransferMu guards the swappable workspace hydrate/dehydrate fakes the
 	// suite's raw claim reconciler drives. Tests set them via setWSTransfer.
@@ -451,6 +455,40 @@ func currentForkSnapshotRemover() func(ctx context.Context, addr string, tlsConf
 	return forkSnapshotRemover
 }
 
+// setForkVMSpawner / currentForkVMSpawner swap the spawn-vm seam the suite's husk
+// reconciler dials through when the MultiVMFork routing spawns a child in the source
+// pod.
+func setForkVMSpawner(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error)) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	forkVMSpawner = fn
+}
+
+func currentForkVMSpawner() func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	if forkVMSpawner == nil {
+		return func(context.Context, string, *tls.Config, husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+			return husk.SpawnVMResult{OK: false, Error: "no fork vm spawner installed"}, nil
+		}
+	}
+	return forkVMSpawner
+}
+
+// setForkMultiVM / currentForkMultiVM toggle the MultiVMFork routing on the suite's
+// shared husk reconciler race-safely (a MultiVMFork test sets it per-case).
+func setForkMultiVM(on bool) {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	forkMultiVMEnabled = on
+}
+
+func currentForkMultiVM() bool {
+	forkSnapshotterMu.Lock()
+	defer forkSnapshotterMu.Unlock()
+	return forkMultiVMEnabled
+}
+
 // syncBuffer is a concurrency-safe io.Writer that accumulates everything
 // written and lets a test snapshot the bytes.
 type syncBuffer struct {
@@ -652,6 +690,13 @@ func TestMain(m *testing.M) {
 	huskClaim.SetForkSnapshotRemoverForTest(func(c context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
 		return currentForkSnapshotRemover()(c, addr, tlsConf, req)
 	})
+	// The MultiVMFork routing: the spawn-vm seam and a race-safe gate a per-case
+	// test flips. The gate defaults off, so every existing fork test keeps the
+	// byte-for-byte new-pod path.
+	huskClaim.SetForkVMSpawnerForTest(func(c context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		return currentForkVMSpawner()(c, addr, tlsConf, req)
+	})
+	huskClaim.SetMultiVMForkGateForTest(currentForkMultiVM)
 	huskClaim.SetCheckpointForTest(func(c context.Context, claim *v1.Sandbox, pod *corev1.Pod) (bool, error) {
 		if fn := currentHuskTestCheckpointer(); fn != nil {
 			return fn(c, claim, pod)

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -62,6 +62,27 @@ func (r *SandboxReconciler) SetForkSnapshotRemoverForTest(fn func(ctx context.Co
 	r.removeForkSnapshot = fn
 }
 
+// SetForkVMSpawnerForTest installs the spawn-vm seam the MultiVMFork routing dials
+// through (tests only).
+func (r *SandboxReconciler) SetForkVMSpawnerForTest(fn func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error)) {
+	r.spawnVM = fn
+}
+
+// SetMultiVMForkGateForTest installs the race-safe MultiVMFork toggle a test flips
+// per-case on the shared reconciler (tests only). A nil gate reads the MultiVMFork
+// field.
+func (r *SandboxReconciler) SetMultiVMForkGateForTest(gate func() bool) {
+	r.multiVMForkGate = gate
+}
+
+// HuskMultiVMLabel exposes the multi-VM-capable husk pod label to the external
+// controller_test package, so a test can stamp a source pod as multi-VM capable.
+const HuskMultiVMLabel = huskMultiVMLabel
+
+// MaxCoLocatedForkVMsPerPod exposes the L1.7a co-location cap to the external
+// controller_test package.
+const MaxCoLocatedForkVMsPerPod = maxCoLocatedForkVMsPerPod
+
 // SkipForkLabel restricts the reconciler to sandboxes WITHOUT the given label,
 // for the husk-fork harness; an alias of SkipLabel on the consolidated reconciler.
 func (r *SandboxReconciler) SkipForkLabel(label string) { r.skipLabel(label, "sandbox-fork-raw") }


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the husk pod-native path is the default runner.
> - The controller owns hosted forks: reconcileHuskFork snapshots the source pod's running VM once, then for each replica creates a brand-new child husk pod pinned to the source node that activates from that snapshot.
> - That new-pod-per-fork is the measured cost of a hosted fork; the husk multi-VM engine (Options.MultiVM) and the spawn-vm control op (OpSpawnVM, Stub.SpawnVM, SpawnVMOnHusk) exist to bring up an additional VM inside a running pod, but nothing in the controller drives them, so a fork always pays for a fresh pod.
> - The multi-VM-per-pod work needs the controller wired to route a fork into the source pod, conservatively and behind a flag, before any memory accounting or warm-pool multi-VM launch can build on it.
> - This pull request adds a default-off controller flag (--multi-vm-fork / SandboxReconciler.MultiVMFork) that, when on AND the source pod is multi-VM capable, spawns the fork child as an additional VM inside the source pod (spawn-vm) instead of a new child pod, recording status.pod / status.vmId / status.node for the shared host; off is byte-for-byte the current path.
> - The benefit is the controller-side seam for cheaper hosted forks lands reviewable and safe: nothing ships by default, a non-capable source or a spawn failure falls back cleanly, and the real per-pod memory accounting is scoped as an explicit follow-up (L1.7b).

## Linked Issues or Issue Description

This is increment L1.7a of the multi-VM-per-pod husk work. It builds on the merged husk multi-VM engine (Options.MultiVM), the spawn-vm control op (OpSpawnVM, Stub.SpawnVM, SpawnVMOnHusk), and status.vmId on Sandbox (#802).

Problem: every hosted fork creates a fresh husk pod pinned to the source node that activates from a disk snapshot. The husk engine can already spawn an additional VM inside a running pod, but the controller was never wired to route a fork there, so a fork always pays the new-pod cost.

## What Changed

- api: `SandboxChild` gains optional `pod` and `vmId` fields so a fork child co-located in the source pod maps to its exact host process (empty on the default new-pod path). Regenerated CRDs.
- controller: new default-off flag `--multi-vm-fork` (`SandboxReconciler.MultiVMFork`). When on AND the source husk pod is multi-VM capable (its stub runs `--multi-vm`, recorded by the `mitos.run/multi-vm` pod label), `reconcileHuskFork` routes each fork child through the new `spawnForkChildInSourcePod` (spawn-vm against the source pod) instead of `buildForkChildPod`. Child records `status.pod` = source pod, `status.vmId` = spawned VM, `status.node` = source node.
- controller: conservative co-location cap `maxCoLocatedForkVMsPerPod`; children past the cap spill to new pods (stand-in for the real memory accounting, L1.7b).
- controller: fallbacks preserve safety. A non-capable source silently falls back to the new-pod path; a spawn failure fails toward a clear pending (logged, requeued), never a silent hang; the mTLS auth and fork-snapshot flow are unchanged; the child inherits the same network + egress posture (issue #760) and the stable-token idempotency (issue #183) the new-pod fork child has.
- cmd/controller: wire the flag (default false).
- tests (envtest, fakes): routing-on-with-capable-source spawns with no new pod and sets child pod/vmId/node; flag-off still creates a new child pod and never calls spawn-vm; a non-multi-vm source falls back even with the flag on; a spawn error does not wedge the child and converges on recovery; over-cap children spill to new pods.
- docs/threat-model.md: the controller can now drive spawn-vm into a shared pod behind the default-off flag; the residual and the deferred memory accounting are noted.

## Verification

- [x] `go build ./...` (exit 0)
- [x] `go test ./internal/controller/...` (envtest via `~/go/bin/setup-envtest use 1.31`): `ok mitos.run/mitos/internal/controller 232.240s`
- [x] `go test ./internal/husk/...`: `ok mitos.run/mitos/internal/husk 3.518s`
- [x] `golangci-lint run --timeout=5m`: only the pre-existing darwin-only `internal/fork/uffd.go:42` unused finding, nothing new
- [x] `GOOS=linux golangci-lint run --timeout=5m`: clean (no findings)
- [x] New tests pass in isolation: `go test ./internal/controller/ -run TestMultiVMFork` (exit 0)

## Risks

Low risk. The flag defaults OFF, and OFF is byte-for-byte the existing `buildForkChildPod` new-pod path (the routing branch is never entered), so no shipped behavior changes. When on, the routing only engages for a source pod explicitly marked multi-VM capable (`mitos.run/multi-vm`), which no production warm pod carries today, so the path is inert in prod until a later increment launches multi-VM warm pods. A spawn failure requeues with the cause logged rather than wedging or overcommitting. The known gap, stated honestly: this increment caps co-location at a fixed number and spills the rest to new pods; the real per-pod and node memory accounting that guarantees a fork never overcommits a host is deferred to L1.7b and must land before multi-VM forks carry production load.

## Model Used

- Provider/model: Claude Opus 4.8 (Anthropic)
- Exact model id: claude-opus-4-8
- Reasoning mode: extended thinking enabled
- Used as the coding agent that wrote the code, tests, and this description; all commands (build, envtest, husk tests, both golangci-lint invocations) were run and their real output is quoted above.

## Checklist

- [x] PR title is a conventional commit (feat)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included (security surface moved)
- [ ] Benchmark run (bench/) included if the hot path was touched (N/A: no hot path benchmarked; the flag is default off and the routing is proven with fakes, not a measured latency claim)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental multi-VM fork mode for sandboxes, optionally routing eligible forked children into the existing source pod.
  * Exposed additional fork child status details, including the backing pod and VM identity (empty on the default one-pod-per-child path).

* **Bug Fixes**
  * Prevented fork progress from stalling when in-pod VM spawning fails; forks recover and can fall back to the standard behavior.
  * Added spillover behavior when the co-location cap is reached and ensured flag changes don’t orphan already co-located children.

* **Documentation**
  * Updated the threat model to reflect the new multi-VM fork behavior and its gated risk assumptions.

* **Tests**
  * Added end-to-end controller coverage for multi-VM fork routing, spillover, failures, and flag flip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->