### PR TITLE
feat(controller): account co-located fork VMs against the source pod memory budget

### DIFF
--- a/docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md
+++ b/docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md
@@ -230,6 +230,21 @@ push a pod (or node) past its memory budget PENDS or spills, never overcommits.
 Metering already reports CoW-aware MemoryUnique/MemoryShared, which feeds the
 sizing; the reservation must still be safe at worst case, not the CoW-typical case.
 
+Status (L1.7b, admit-and-spill): the per-pod dimension is implemented. The
+MultiVMFork co-location routing (internal/controller/sandboxfork_controller.go,
+coLocatedForkVMBudget) admits a co-located fork VM only while the source pod's
+memory budget has room at the CoW worst case: the pod holds floor(memory.max /
+per-VM guest RAM) VMs, one slot reserved for the source VM already resident, so at
+most floor(limit / request) - 1 children co-locate. This reserves each co-located
+VM its FULL guest memory, not the CoW-typical dirty set, so a sibling can never OOM
+a sibling. A child past the budget spills to a NEW pod via buildForkChildPod, which
+the node scheduler and the capacity-admission gate account honestly, so the node
+budget is kept by the existing per-pod admission on the spill path (a spill that
+does not fit the node PENDS exactly as an independent claim does). This replaces
+the earlier hardcoded co-location count. Deferred to a follow-up: a dedicated
+node-budget check for the co-located dimension and the grow-the-pod-with-in-place-
+resize option; the current increment lands admit-and-spill on the per-pod budget.
+
 ### Guarantee B: a swarm always survives node loss by reconstructing from durable state
 
 Today Mitos has real multi-node resilience for independent sandboxes: node registry

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "mitos.run/mitos/api/v1"
@@ -41,6 +42,27 @@ func multiVMSource(p *corev1.Pod) {
 	p.Labels[controller.HuskMultiVMLabel] = "true"
 }
 
+// withCoLocationBudget stamps the source husk pod's memory request (the honest
+// per-VM guest RAM) and limit (the pod cgroup memory.max) so the per-pod
+// co-location budget (guarantee A) admits floor(limit/req) - 1 co-located fork
+// VMs, one slot reserved for the source VM already in the pod. The multi-VM tests
+// that exercise co-location stamp a budget large enough for their replicas; the
+// honest worst-case accounting otherwise co-locates NOTHING on a resource-free
+// pod and every child spills to a new pod.
+func withCoLocationBudget(reqMem, limitMem string) func(*corev1.Pod) {
+	return func(p *corev1.Pod) {
+		for i := range p.Spec.Containers {
+			if p.Spec.Containers[i].Name != "husk-stub" {
+				continue
+			}
+			p.Spec.Containers[i].Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(reqMem)},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(limitMem)},
+			}
+		}
+	}
+}
+
 // TestMultiVMForkRoutesToSourcePodWhenEnabled proves the core L1.7a wiring: with
 // the flag ON and a multi-VM-capable source, each fork child is spawned as an
 // additional VM INSIDE the source pod (SpawnVMOnHusk), NO new child pod is created,
@@ -51,7 +73,9 @@ func TestMultiVMForkRoutesToSourcePodWhenEnabled(t *testing.T) {
 	srcClaimName := uniqueName("src-mvm-on")
 	forkName := uniqueName("mvm-on")
 
-	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.1", multiVMSource)
+	// A generous per-pod budget (1280Mi limit / 128Mi per VM = 10 VMs, 9
+	// co-locatable) so both Replicas co-locate into the source pod.
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.1", multiVMSource, withCoLocationBudget("128Mi", "1280Mi"))
 	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
 
 	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
@@ -294,7 +318,7 @@ func TestMultiVMForkSpawnErrorDoesNotWedge(t *testing.T) {
 	srcClaimName := uniqueName("src-mvm-err")
 	forkName := uniqueName("mvm-err")
 
-	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.4", multiVMSource)
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.4", multiVMSource, withCoLocationBudget("128Mi", "1280Mi"))
 	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
 
 	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
@@ -363,17 +387,20 @@ func TestMultiVMForkSpawnErrorDoesNotWedge(t *testing.T) {
 	})
 }
 
-// TestMultiVMForkSpillsPastCapToNewPods proves the conservative L1.7a co-location
-// cap: with the flag on and a multi-VM-capable source, the first
-// MaxCoLocatedForkVMsPerPod children are spawned in the source pod and every
-// child beyond the cap SPILLS to a new child pod (the stand-in for the real
-// per-pod memory accounting deferred to L1.7b).
-func TestMultiVMForkSpillsPastCapToNewPods(t *testing.T) {
+// TestMultiVMForkSpillsPastPodBudgetToNewPods proves the L1.7b per-pod MEMORY
+// accounting (guarantee A): with the flag on and a multi-VM-capable source, fork
+// children co-locate into the source pod ONLY up to the pod's memory budget
+// (floor(memory.max / per-VM guest RAM) - 1, the source VM reserving one slot),
+// and every child beyond that budget SPILLS to a new child pod so the fork never
+// overcommits the pod. The source pod is sized 1024Mi limit / 256Mi per VM = 4
+// VMs total, so exactly 3 children co-locate and the rest spill.
+func TestMultiVMForkSpillsPastPodBudgetToNewPods(t *testing.T) {
 	poolName := uniqueName("pool-mvm-cap")
 	srcClaimName := uniqueName("src-mvm-cap")
 	forkName := uniqueName("mvm-cap")
 
-	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.5", multiVMSource)
+	// 1024Mi / 256Mi = 4 VMs total; one reserved for the source, so 3 co-locate.
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.5", multiVMSource, withCoLocationBudget("256Mi", "1024Mi"))
 	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
 
 	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
@@ -395,8 +422,9 @@ func TestMultiVMForkSpillsPastCapToNewPods(t *testing.T) {
 	setForkMultiVM(true)
 	t.Cleanup(func() { setForkMultiVM(false) })
 
-	capN := int32(controller.MaxCoLocatedForkVMsPerPod)
-	replicas := capN + 2
+	const coLocated = int32(3)
+	const spill = int32(2)
+	replicas := coLocated + spill
 
 	fork := &v1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
@@ -424,18 +452,101 @@ func TestMultiVMForkSpillsPastCapToNewPods(t *testing.T) {
 		return g.Status.ReadyReplicas == replicas
 	})
 
-	// Exactly the over-cap children spilled to new pods; the capped children stay
-	// in the source pod.
+	// Exactly the over-budget children spilled to new pods; the budgeted children
+	// stay co-located in the source pod.
 	var pods corev1.PodList
 	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
 		t.Fatalf("list children: %v", err)
 	}
-	spill := int(replicas - capN)
-	if len(pods.Items) != spill {
-		t.Fatalf("expected %d spilled child pods past the cap, got %d", spill, len(pods.Items))
+	if len(pods.Items) != int(spill) {
+		t.Fatalf("expected %d spilled child pods past the pod memory budget, got %d", spill, len(pods.Items))
 	}
-	if got := atomic.LoadInt32(&spawnCalls); got < capN {
-		t.Fatalf("expected at least %d spawn-vm calls (the co-located children), got %d", capN, got)
+	if got := atomic.LoadInt32(&spawnCalls); got < coLocated {
+		t.Fatalf("expected at least %d spawn-vm calls (the co-located children), got %d", coLocated, got)
+	}
+}
+
+// TestMultiVMForkPodBudgetHoldsOneVMSpills proves the tight edge of guarantee A:
+// a source pod whose memory budget holds only ONE VM (the honest default sizing,
+// 768Mi limit / 512Mi per VM = 1 VM total) co-locates NO fork child, because the
+// single VM slot is already the source. The one fork child SPILLS to a new pod and
+// the spawn-vm seam is never called, so a second full guest is never packed into a
+// pod that cannot hold it.
+func TestMultiVMForkPodBudgetHoldsOneVMSpills(t *testing.T) {
+	poolName := uniqueName("pool-mvm-1vm")
+	srcClaimName := uniqueName("src-mvm-1vm")
+	forkName := uniqueName("mvm-1vm")
+
+	// 768Mi limit / 512Mi per VM = 1 VM total; the source takes it, so 0 co-locate.
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.10", multiVMSource, withCoLocationBudget("512Mi", "768Mi"))
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var spawnCalls int32
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, _ husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		return husk.SpawnVMResult{OK: false, Error: "spawn-vm must not be called when the pod budget holds only the source VM"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var p corev1.PodList
+		_ = k8sClient.List(ctx, &p, listForkChildren(forkName))
+		for i := range p.Items {
+			forceHuskPodReady(t, &p.Items[i])
+		}
+		var g v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &g); err != nil {
+			return false
+		}
+		return g.Status.ReadyReplicas == 1
+	})
+
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods, listForkChildren(forkName)); err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("a pod budget holding only the source VM must spill the child to a new pod, got %d pods", len(pods.Items))
+	}
+	if got := atomic.LoadInt32(&spawnCalls); got != 0 {
+		t.Fatalf("spawn-vm must not be called when the pod budget holds only the source VM; got %d calls", got)
+	}
+
+	var got v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get fork: %v", err)
+	}
+	// The spilled child took the new-pod path, so it carries no source-pod VM record.
+	if len(got.Status.Children) != 1 {
+		t.Fatalf("expected 1 recorded child, got %d", len(got.Status.Children))
+	}
+	if got.Status.Children[0].Pod != "" || got.Status.Children[0].VMID != "" {
+		t.Errorf("spilled child must leave status.Pod/VMID empty, got pod=%q vmId=%q", got.Status.Children[0].Pod, got.Status.Children[0].VMID)
 	}
 }
 
@@ -450,7 +561,7 @@ func TestMultiVMForkFlagFlipOffDoesNotOrphanCoLocatedChild(t *testing.T) {
 	srcClaimName := uniqueName("src-mvm-flip")
 	forkName := uniqueName("mvm-flip")
 
-	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.9", multiVMSource)
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.9", multiVMSource, withCoLocationBudget("128Mi", "1280Mi"))
 	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
 
 	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -122,12 +122,13 @@ type SandboxReconciler struct {
 	// SOURCE pod (SpawnVMOnHusk) instead of a brand-new child pod, when the source
 	// pod is multi-VM capable. EXPERIMENTAL, DEFAULT OFF: off is byte-for-byte the
 	// buildForkChildPod new-pod path, so nothing changes unless an operator opts in
-	// AND the source pod runs a --multi-vm husk stub (huskPodMultiVMCapable). This
-	// increment (L1.7a) is the routing + status wiring + the flag; the per-pod and
-	// node MEMORY ACCOUNTING that lets a fork pend or spill when a pod is full is
-	// deferred to L1.7b, so co-location is gated here at a small fixed cap
-	// (maxCoLocatedForkVMsPerPod) with the remainder spilled to new pods. Only used
-	// when EnableHuskPods is true.
+	// AND the source pod runs a --multi-vm husk stub (huskPodMultiVMCapable).
+	// Co-location is gated by the per-pod MEMORY ACCOUNTING (L1.7b, guarantee A,
+	// coLocatedForkVMBudget): a child co-locates only while the source pod's memory
+	// budget (floor(memory.max / per-VM guest RAM) minus the source VM's own slot)
+	// has room at the CoW worst case, and every child past the budget spills to a
+	// new pod so a fork never overcommits the pod. Only used when EnableHuskPods is
+	// true.
 	MultiVMFork bool
 
 	// spawnVM is the controller->husk spawn-vm seam used by the MultiVMFork routing.

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -67,6 +67,21 @@ type huskVMSpawner func(ctx context.Context, addr string, tlsConf *tls.Config, r
 // capacity-admission gate account honestly, so a fork that cannot fit the node
 // pends there exactly as an independent claim does. The node-level spill-vs-pend
 // refinement for the co-located dimension is deferred to a follow-up increment.
+//
+// SCOPE, and the honest limit today: this budget is computed PER FORK reconcile
+// from the source pod's static resources. It does NOT yet subtract co-located VMs
+// that OTHER SandboxForks targeting the SAME source pod have already placed there,
+// so N concurrent forks of one source can each independently admit up to this
+// budget and over-admit VMs into the pod. The NODE is still not overcommitted:
+// the pod's cgroup memory LIMIT is a hard ceiling the node scheduler already
+// reserved, so an over-admission is caught INSIDE the pod (a co-located guest that
+// would exceed memory.max is OOM-killed, fail-closed at the pod boundary) rather
+// than as a node overcommit. What is missing is a cross-fork SHARED RESERVATION or
+// live-occupancy check so an over-budget co-located child cleanly SPILLS to a new
+// pod instead of risking an intra-pod OOM under concurrent same-source forks. That
+// shared reservation (a race-free occupancy count across forks) is a tracked
+// follow-up; until it lands, guarantee A's per-pod dimension is enforced per fork,
+// not across concurrent forks of one source.
 func coLocatedForkVMBudget(pod *corev1.Pod) int {
 	if pod == nil {
 		return 0

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/husk"
@@ -35,15 +36,63 @@ type huskForkSnapshotRemover func(ctx context.Context, addr string, tlsConf *tls
 // Nil defaults to SpawnVMOnHusk; tests inject a fake.
 type huskVMSpawner func(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error)
 
-// maxCoLocatedForkVMsPerPod is the CONSERVATIVE L1.7a cap on how many fork-child
-// VMs the MultiVMFork routing co-locates INSIDE one source pod before it spills
-// the remaining children back to the safe new-pod path (buildForkChildPod). It is
-// a hardcoded stand-in for the real per-pod and node MEMORY ACCOUNTING that is
-// deferred to L1.7b (guarantee A: account each added VM against a per-pod and node
-// budget, then pend or spill when the pod is full so a fork never overcommits).
-// Until that lands, the fixed cap keeps a fork from stacking an unbounded number
-// of VMs on one host pod's memory.
-const maxCoLocatedForkVMsPerPod = 4
+// coLocatedForkVMBudget reports how many ADDITIONAL fork-child VMs the MultiVMFork
+// routing may safely co-locate INSIDE the source pod alongside the source VM
+// already resident there (L1.7b, guarantee A: a fork never overcommits a pod).
+//
+// The reservation is safe at the CoW WORST case, not the CoW-typical case. A
+// co-located VM shares the parent memory image copy-on-write, so its TYPICAL
+// resident cost is only its private-dirty set (a few MiB). But it MAY dirty up to
+// its whole guest RAM, and memory is non-compressible: if the co-located guests
+// together dirty more than the pod's cgroup memory limit, a sibling OOM-kills a
+// sibling (the user's own live work). So each VM (the source plus every co-located
+// child) is reserved its FULL guest-memory footprint, not the tiny shared-page
+// floor. The honest per-VM guest RAM is the pod's memory REQUEST (Requests[memory],
+// the same no-overcommit defaultHuskMemory-class figure a new husk pod requests);
+// the hard ceiling is the pod's memory LIMIT (Limits[memory], the memory.max the
+// kubelet enforces). The pod therefore holds at most floor(limit / perVM) VMs
+// before a sibling would OOM a sibling. One slot is reserved for the source VM, so
+// the co-location budget is floor(limit / perVM) - 1, floored at 0. A budget of 0
+// means every fork child spills to a new pod.
+//
+// When the source pod does not declare BOTH a memory request and a memory limit on
+// its husk container (a malformed or resource-free pod), the budget is 0: with no
+// provable pod ceiling the fork co-locates nothing and every child spills to a new
+// pod, the conservative safe-at-worst-case default. Real husk pods always carry
+// both (buildHuskPod sets Requests[memory] and Limits[memory]).
+//
+// This replaces the former hardcoded co-location count. It governs the per-pod
+// dimension of guarantee A. The node budget is already honored by the spill path:
+// a spilled child takes buildForkChildPod, which the node scheduler and the
+// capacity-admission gate account honestly, so a fork that cannot fit the node
+// pends there exactly as an independent claim does. The node-level spill-vs-pend
+// refinement for the co-located dimension is deferred to a follow-up increment.
+func coLocatedForkVMBudget(pod *corev1.Pod) int {
+	if pod == nil {
+		return 0
+	}
+	var perVM, limit resource.Quantity
+	found := false
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		if c.Name != huskContainerName {
+			continue
+		}
+		perVM = c.Resources.Requests[corev1.ResourceMemory]
+		limit = c.Resources.Limits[corev1.ResourceMemory]
+		found = true
+		break
+	}
+	if !found || perVM.IsZero() || limit.IsZero() {
+		return 0
+	}
+	total := limit.Value() / perVM.Value()
+	coLocated := total - 1
+	if coLocated < 0 {
+		return 0
+	}
+	return int(coLocated)
+}
 
 // huskMultiVMLabel marks a husk pod whose stub was started with --multi-vm, so the
 // controller may drive a spawn-vm op against it (bring up an ADDITIONAL same-tenant
@@ -521,6 +570,15 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	// silent, safe fallback the design requires.
 	spawnInSourcePod := r.multiVMForkEnabled() && huskPodMultiVMCapable(srcPod)
 
+	// Per-pod memory budget for co-located fork VMs (L1.7b, guarantee A), computed
+	// ONCE for the whole fan-out from the source pod's ACTUAL memory accounting: the
+	// pod holds only floor(memory.max / per-VM guest RAM) VMs safely at the CoW
+	// worst case, one slot reserved for the source VM already resident in the pod.
+	// The first coLocationBudget children co-locate as ADDITIONAL VMs in the source
+	// pod; every child past the budget spills to a new pod so a fork never
+	// overcommits the pod. This replaces the former hardcoded co-location count.
+	coLocationBudget := coLocatedForkVMBudget(srcPod)
+
 	// One fork snapshot per SandboxFork, keyed by the fork name, taken EXACTLY
 	// ONCE and reused for every child across reconcile passes. Children take
 	// several passes to reach Ready; re-snapshotting on each pass would re-pause
@@ -666,15 +724,16 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 			continue
 		}
 
-		// MultiVMFork routing: for the first maxCoLocatedForkVMsPerPod slots of a
+		// MultiVMFork routing: for the first coLocationBudget slots of a
 		// multi-VM-capable source, spawn the child as an ADDITIONAL VM INSIDE the
 		// source pod (spawn-vm op) instead of creating a brand-new child pod. Slots
-		// past the cap fall through to the new-pod path below, the conservative
-		// L1.7a stand-in for the real per-pod/node memory accounting deferred to
-		// L1.7b. When the flag is off or the source is not multi-VM capable
-		// (spawnInSourcePod is false), this branch is never entered and the path
-		// below is byte-for-byte unchanged.
-		if spawnInSourcePod && i < maxCoLocatedForkVMsPerPod {
+		// past the per-pod memory budget fall through to the new-pod path below,
+		// which spills the child to a fresh, honestly node-scheduled pod so a fork
+		// never overcommits the source pod (L1.7b, guarantee A). When the flag is off
+		// or the source is not multi-VM capable (spawnInSourcePod is false), or the
+		// budget is 0, this branch is never entered and the path below is
+		// byte-for-byte unchanged.
+		if spawnInSourcePod && int(i) < coLocationBudget {
 			spawnedChild, ok := r.spawnForkChildInSourcePod(ctx, spawnForkChildArgs{
 				fork:        fork,
 				srcPod:      srcPod,

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -79,10 +79,6 @@ func (r *SandboxReconciler) SetMultiVMForkGateForTest(gate func() bool) {
 // controller_test package, so a test can stamp a source pod as multi-VM capable.
 const HuskMultiVMLabel = huskMultiVMLabel
 
-// MaxCoLocatedForkVMsPerPod exposes the L1.7a co-location cap to the external
-// controller_test package.
-const MaxCoLocatedForkVMsPerPod = maxCoLocatedForkVMsPerPod
-
 // SkipForkLabel restricts the reconciler to sandboxes WITHOUT the given label,
 // for the husk-fork harness; an alias of SkipLabel on the consolidated reconciler.
 func (r *SandboxReconciler) SkipForkLabel(label string) { r.skipLabel(label, "sandbox-fork-raw") }


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the multi-VM-per-pod husk work runs a tenant's fork swarm as many same-tenant VMs inside one session pod.
> - This touches the controller: the MultiVMFork routing in internal/controller/sandboxfork_controller.go, which decides whether a fork child becomes an ADDITIONAL VM spawned inside the source pod or a brand-new child pod.
> - L1.7a shipped that routing behind the --multi-vm-fork flag but gated co-location at a hardcoded maxCoLocatedForkVMsPerPod = 4, a conservative stand-in with no relationship to how much memory the pod can actually hold; stacking N full guests into a pod sized for one can push it past its cgroup memory.max and a sibling OOM-kills a sibling (the user's own live work).
> - Guarantee A of the multinode plan says a fork must never overcommit a pod: account each added VM against a per-pod memory budget, safe at the CoW worst case, and pend or spill when the pod is full. Memory is non-compressible, so this is a hard requirement, not a soft one.
> - This pull request replaces the hardcoded count with a real per-pod memory budget: a fork co-locates a child only while floor(pod memory.max / per-VM guest RAM) minus the source VM's own slot has room, reserving each co-located VM its FULL guest memory (worst case, not the CoW-typical dirty set), and spills the rest to a new honestly node-scheduled pod.
> - The benefit is that a fork can never overcommit a session pod's memory: co-location is bounded by what the pod can actually hold, so no sibling can OOM a sibling, and a pod sized for one VM co-locates nothing and spills every child.

## Linked Issues or Issue Description

No tracked issue. Increment L1.7b of the multi-VM-per-pod husk work, implementing the per-pod dimension of guarantee A (a fork never overcommits a node's memory) from docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md. Problem: L1.7a co-located fork VMs into the source pod up to a hardcoded count with no memory accounting, so a fork could pack more guest RAM into a pod than its cgroup memory limit holds, letting a sibling VM OOM-kill a sibling under worst-case dirtying.

## What Changed

- Added `coLocatedForkVMBudget` in internal/controller/sandboxfork_controller.go: derives the co-location budget from the source pod's actual husk-container memory accounting as `floor(Limits[memory] / Requests[memory]) - 1` (the minus one reserves the source VM already resident in the pod), floored at 0. A malformed or resource-free pod yields 0 (co-locate nothing, spill everything).
- Removed the hardcoded `maxCoLocatedForkVMsPerPod = 4` const and its test-only export `MaxCoLocatedForkVMsPerPod`.
- The MultiVMFork routing now co-locates a child only while `int(i) < coLocationBudget` (computed once per fan-out); slots past the budget fall through to the byte-for-byte-unchanged new-pod spill path.
- Updated the routing comment in sandboxclaim_controller.go to describe the memory budget rather than the fixed cap.
- Tests: reworked TestMultiVMForkSpillsPastPodBudgetToNewPods to drive a precise pod budget (1024Mi limit / 256Mi per VM = 4 total, 3 co-locate, 2 spill); added TestMultiVMForkPodBudgetHoldsOneVMSpills (768Mi / 512Mi = 1 total, 0 co-locate, the one child spills and spawn-vm is never called); added a `withCoLocationBudget` pod mutator and stamped a budget onto the co-location-expecting tests. The flag-off, non-multi-vm-source, spawn-error, and flag-flip-off tests are unchanged in intent and still green.
- Docs: added a Status note to the guarantee A section of the multinode plan describing the landed per-pod admit-and-spill accounting and the deferred node-level refinement.

## Verification

- [x] `go build ./...`: clean (after `go clean -cache` to clear a corrupted local build cache; no code errors).
- [x] `go test ./internal/controller/...` (envtest 1.31 via `~/go/bin/setup-envtest use 1.31`): `ok  mitos.run/mitos/internal/controller  239.522s`. MultiVMFork suite verbose, all 7 pass including TestMultiVMForkSpillsPastPodBudgetToNewPods and TestMultiVMForkPodBudgetHoldsOneVMSpills. The two new tests were confirmed RED against the hardcoded-cap implementation first (TDD), then GREEN after the budget landed.
- [x] `golangci-lint run --timeout=5m`: only the pre-existing darwin-only `internal/fork/uffd.go:42:22: func uffdMapping.pageSizeBytes is unused` finding, nothing new.
- [x] `GOOS=linux golangci-lint run --timeout=5m`: clean, no findings.

## Risks

Low risk. The change is confined to the co-location admission decision of the MultiVMFork routing, which is behind the --multi-vm-fork controller flag (default off); the flag-off path and the non-multi-vm-source fallback are byte-for-byte the existing new-pod path, so nothing changes for the default deployment. When the flag is on, the new budget is strictly more conservative than the old fixed cap under the honest default pod sizing (it co-locates fewer VMs, never more), so the failure mode is spilling a fork to a new pod rather than overcommitting one. This increment lands only the per-pod dimension; a dedicated node-budget check for the co-located dimension and the in-place-pod-resize option are deferred to a follow-up (the spill path already keeps the node honest via the existing scheduler and capacity-admission gate).

## Model Used

Claude Opus (Anthropic), model id claude-opus-4-8, extended thinking enabled. The agent wrote the failing tests first, implemented the budget, and ran the build, envtest suite, and both golangci-lint invocations.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [ ] Threat-model delta not applicable: the security surface (isolation boundary, egress, secrets) is unchanged; this only tightens memory admission.
- [ ] Benchmark run not applicable: no new public number; the change makes an O(1) admission decision at fork time and states no benchmark claim.
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-VM forks now decide source-pod co-location vs spilling using the source pod’s memory request/limit budget, replacing the prior fixed co-location cap.
  * Added edge-case handling so when only the source VM fits the budget, child VMs reliably spill without attempting in-pod co-location.
* **Tests**
  * Updated and expanded envtest coverage to make co-location vs spill behavior deterministic and to validate non-wedging spawn behavior.
* **Documentation**
  * Clarified the “fork never overcommits memory” guarantee with the admit-and-spill approach and budget-based routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->