### PR TITLE
feat(controller): start warm husk pods with --multi-vm when multi-vm-fork is on

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -222,6 +222,7 @@ func main() {
 		NodeRegistry:              nodeRegistry,
 		PeerToken:                 peerToken,
 		EnableHuskPods:            enableHuskPods,
+		MultiVM:                   multiVMFork,
 		HuskStubImage:             huskStubImage,
 		HuskDNSUpstream:           huskDNSUpstream,
 		KVMResourceName:           "mitos.run/kvm",

--- a/internal/controller/husk_build_generation_test.go
+++ b/internal/controller/husk_build_generation_test.go
@@ -159,3 +159,52 @@ func TestHuskPodHasStaleDigestFallsBackToSpecNodeName(t *testing.T) {
 		t.Error("pod with no node information must not be reaped")
 	}
 }
+
+// TestBuildHuskPodMultiVMArgAndLabel proves the L1.7d capability wiring: with
+// HuskPodOptions.MultiVM the built husk pod runs the stub with --multi-vm and
+// carries the mitos.run/multi-vm label huskPodMultiVMCapable reads, and without
+// it neither is present (single-VM default, unchanged).
+func TestBuildHuskPodMultiVMArgAndLabel(t *testing.T) {
+	r := &SandboxPoolReconciler{}
+	pool := genTestPool("mvm-cap", 1)
+
+	on := r.buildHuskPod(pool, pool.Spec.Template, HuskPodOptions{MultiVM: true})
+	if on.Labels[huskMultiVMLabel] != huskMultiVMLabelValue {
+		t.Errorf("MultiVM pod missing %s label, got %v", huskMultiVMLabel, on.Labels)
+	}
+	if !huskPodMultiVMCapable(on) {
+		t.Error("MultiVM pod must be huskPodMultiVMCapable")
+	}
+	if !hasArg(on, "--multi-vm") {
+		t.Errorf("MultiVM pod stub args must include --multi-vm, got %v", huskStubArgs(on))
+	}
+
+	off := r.buildHuskPod(pool, pool.Spec.Template, HuskPodOptions{})
+	if _, ok := off.Labels[huskMultiVMLabel]; ok {
+		t.Error("single-VM pod must not carry the multi-vm label")
+	}
+	if huskPodMultiVMCapable(off) {
+		t.Error("single-VM pod must not be huskPodMultiVMCapable")
+	}
+	if hasArg(off, "--multi-vm") {
+		t.Error("single-VM pod stub args must not include --multi-vm")
+	}
+}
+
+func huskStubArgs(pod *corev1.Pod) []string {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == huskContainerName {
+			return c.Args
+		}
+	}
+	return nil
+}
+
+func hasArg(pod *corev1.Pod, arg string) bool {
+	for _, a := range huskStubArgs(pod) {
+		if a == arg {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -42,6 +42,10 @@ const (
 	// huskLabel marks a pod as a husk pod (vs any other pod the controller may
 	// touch). Both labels together form the warm-pool selector.
 	huskLabel = "mitos.run/husk"
+	// huskMultiVMLabelValue is the value huskMultiVMLabel carries on a pod whose
+	// stub runs --multi-vm (defined in sandboxfork_controller.go), so
+	// huskPodMultiVMCapable can recognize a co-location-capable source pod.
+	huskMultiVMLabelValue = "true"
 	// huskContainerName is the single container in a husk pod.
 	huskContainerName = "husk-stub"
 
@@ -163,6 +167,14 @@ func huskForkRootfsInPodPath() string {
 
 // HuskPodOptions configures the husk pod spec the controller emits.
 type HuskPodOptions struct {
+	// MultiVM starts the husk stub with --multi-vm and labels the pod
+	// mitos.run/multi-vm=true, so the pod can host ADDITIONAL fork-child VMs in
+	// place (the MultiVMFork co-location routing) instead of every fork getting its
+	// own pod. Default off: the stub runs single-VM and huskPodMultiVMCapable
+	// reports false, so a fork always spills to a new pod. Enabling it does not
+	// change a normal claim: Stub.Activate routes a claim with no VMID to the pod's
+	// default VM, byte-for-byte as the single-VM path does.
+	MultiVM bool
 	// StubImage is the container image that runs cmd/husk-stub.
 	StubImage string
 	// DNSUpstream is the comma-separated host:port resolver list (failover order)
@@ -323,6 +335,20 @@ func huskMemoryLimit(memReq, floor resource.Quantity, percent int) resource.Quan
 }
 
 // buildHuskPod builds the warm-pool husk pod for a pool. The pod is
+// huskPodLabels builds a husk pod's label set: the warm-pool selector
+// (huskPoolLabel + huskLabel), plus huskMultiVMLabel when the stub runs
+// --multi-vm so huskPodMultiVMCapable recognizes the pod as a co-location source.
+func huskPodLabels(poolName string, multiVM bool) map[string]string {
+	labels := map[string]string{
+		huskPoolLabel: poolName,
+		huskLabel:     "true",
+	}
+	if multiVM {
+		labels[huskMultiVMLabel] = huskMultiVMLabelValue
+	}
+	return labels
+}
+
 // GenerateName <pool>-husk- in the pool namespace, owner-referenced to the pool
 // for garbage collection, labeled for the warm-pool selector, and runs the
 // dormant stub with a non-privileged securityContext.
@@ -443,6 +469,14 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 		// node, so each pod gets its own clone. $(POD_NAME) is substituted by the
 		// kubelet from the env var, not the shell.
 		"--vm-id", "$(POD_NAME)",
+	}
+
+	// Multi-VM mode: the stub accepts spawn-vm ops to host ADDITIONAL fork-child
+	// VMs in this pod (the MultiVMFork co-location routing). Default off leaves the
+	// stub single-VM. A normal claim is unaffected either way (Activate routes a
+	// VMID-less claim to the pod's default VM).
+	if opts.MultiVM {
+		args = append(args, "--multi-vm")
 	}
 
 	// Name-based egress: when the operator configured DNS upstream(s), pass them
@@ -760,10 +794,7 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: pool.Name + "-husk-",
 			Namespace:    pool.Namespace,
-			Labels: map[string]string{
-				huskPoolLabel: pool.Name,
-				huskLabel:     "true",
-			},
+			Labels: huskPodLabels(pool.Name, opts.MultiVM),
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
@@ -1253,6 +1284,7 @@ func (r *SandboxPoolReconciler) reconcileHuskPods(ctx context.Context, pool *v1.
 			}
 		}
 		opts := HuskPodOptions{
+			MultiVM:         r.MultiVM,
 			StubImage:       r.HuskStubImage,
 			DNSUpstream:     r.HuskDNSUpstream,
 			KVMResourceName: r.KVMResourceName,

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -1327,3 +1327,53 @@ func TestBuildForkChildPodInheritsSourcePodScheduling(t *testing.T) {
 		t.Errorf("fork child nodeAffinity must pin to the source node kvm-node-1; affinity=%v", aff.NodeAffinity)
 	}
 }
+
+// TestReconcileHuskPodsThreadsMultiVM proves the r.MultiVM to opts.MultiVM
+// threading in reconcileHuskPods (L1.7d): a pool reconciled by a MultiVM-enabled
+// reconciler creates warm husk pods that carry the mitos.run/multi-vm capability
+// label, and a MultiVM-off reconciler creates pods without it. This guards the
+// threading line that TestBuildHuskPodMultiVMArgAndLabel (a direct buildHuskPod
+// call) cannot.
+func TestReconcileHuskPodsThreadsMultiVM(t *testing.T) {
+	c := k8sClient
+	const label = "mitos.run/multi-vm"
+
+	pool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "husk-pool-mvm", Namespace: "default"},
+		Spec: v1.SandboxPoolSpec{
+			Template: &v1.PoolTemplateSpec{Image: "python:3.12-slim"},
+			Warm:     &v1.PoolWarm{Min: 1},
+		},
+	}
+	if err := c.Create(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, p := range listHuskPods(t, c, "husk-pool-mvm") {
+			_ = c.Delete(ctx, &p)
+		}
+		_ = c.Delete(ctx, pool)
+	})
+	var got v1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pool), &got); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &controller.SandboxPoolReconciler{
+		Client:          c,
+		NodeRegistry:    controller.NewNodeRegistry(),
+		EnableHuskPods:  true,
+		MultiVM:         true,
+		HuskStubImage:   "mitos-husk-stub:test",
+		KVMResourceName: "mitos.run/kvm",
+	}
+	if _, err := r.ReconcileHuskPodsForTest(ctx, &got, got.Spec.Template); err != nil {
+		t.Fatalf("reconcileHuskPods (multi-vm): %v", err)
+	}
+	pods := waitHuskPodCount(t, c, "husk-pool-mvm", 1)
+	for _, p := range pods {
+		if p.Labels[label] != "true" {
+			t.Fatalf("MultiVM reconciler must stamp %s=true on warm husk pods, got labels %v", label, p.Labels)
+		}
+	}
+}

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -1376,4 +1376,44 @@ func TestReconcileHuskPodsThreadsMultiVM(t *testing.T) {
 			t.Fatalf("MultiVM reconciler must stamp %s=true on warm husk pods, got labels %v", label, p.Labels)
 		}
 	}
+
+	// Negative case: a MultiVM-OFF reconciler must NOT stamp the label. This
+	// catches an inverted-condition regression (label always applied) that the
+	// positive case alone would miss.
+	offPool := &v1.SandboxPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "husk-pool-mvm-off", Namespace: "default"},
+		Spec: v1.SandboxPoolSpec{
+			Template: &v1.PoolTemplateSpec{Image: "python:3.12-slim"},
+			Warm:     &v1.PoolWarm{Min: 1},
+		},
+	}
+	if err := c.Create(ctx, offPool); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, p := range listHuskPods(t, c, "husk-pool-mvm-off") {
+			_ = c.Delete(ctx, &p)
+		}
+		_ = c.Delete(ctx, offPool)
+	})
+	var gotOff v1.SandboxPool
+	if err := c.Get(ctx, client.ObjectKeyFromObject(offPool), &gotOff); err != nil {
+		t.Fatal(err)
+	}
+	rOff := &controller.SandboxPoolReconciler{
+		Client:          c,
+		NodeRegistry:    controller.NewNodeRegistry(),
+		EnableHuskPods:  true,
+		MultiVM:         false,
+		HuskStubImage:   "mitos-husk-stub:test",
+		KVMResourceName: "mitos.run/kvm",
+	}
+	if _, err := rOff.ReconcileHuskPodsForTest(ctx, &gotOff, gotOff.Spec.Template); err != nil {
+		t.Fatalf("reconcileHuskPods (multi-vm off): %v", err)
+	}
+	for _, p := range waitHuskPodCount(t, c, "husk-pool-mvm-off", 1) {
+		if _, ok := p.Labels[label]; ok {
+			t.Fatalf("MultiVM-off reconciler must NOT stamp %s, got labels %v", label, p.Labels)
+		}
+	}
 }

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -39,6 +39,12 @@ type SandboxPoolReconciler struct {
 	// the snapshot is built and each claim forks on a holder, no husk pods. In
 	// cmd/controller this is true by default and turned off by --enable-raw-forkd.
 	EnableHuskPods bool
+	// MultiVM starts this pool's warm husk pods with --multi-vm and the
+	// mitos.run/multi-vm label, so a warm-claimed source pod can host additional
+	// fork-child VMs in place (the MultiVMFork co-location routing). Set from the
+	// same --multi-vm-fork operator flag that enables the routing on the Sandbox
+	// reconciler; default off. A normal claim is unaffected.
+	MultiVM bool
 	// HuskStubImage is the container image that runs cmd/husk-stub in a husk
 	// pod. Only used when EnableHuskPods is true.
 	HuskStubImage string


### PR DESCRIPTION
## Problem

L1.7a/b wired the MultiVMFork fork-routing and per-pod accounting, but co-location only engages for a source pod that `huskPodMultiVMCapable` recognizes: a pod carrying the `mitos.run/multi-vm` label, set on a pod whose stub runs `--multi-vm`. Nothing set that label or passed `--multi-vm` to the stub, so on a real cluster co-location never engaged and every fork still cold-booted a new pod. This is the last capability-wiring piece before the multi-vm fork path can be measured on prod (L1.8).

## Thinking Path

Add `HuskPodOptions.MultiVM`: `buildHuskPod` appends `--multi-vm` to the husk-stub args and stamps the `mitos.run/multi-vm` label (via a new `huskPodLabels` helper) when it is set. Thread it from a new `SandboxPoolReconciler.MultiVM` field, driven in cmd/controller from the SAME `--multi-vm-fork` operator flag that already enables the routing on the Sandbox reconciler, so one flag turns on the whole feature. Default off: the stub stays single-VM and `huskPodMultiVMCapable` reports false, so a fork spills to a new pod exactly as today.

Verified safe for a normal claim: with `--multi-vm` on, `Stub.Activate` routes a claim carrying no VMID to the pod's default VM, byte-for-byte the single-VM body, so an ordinary sandbox is unaffected (and L1.4's KVM test already proved the default VM plus a second VM both run).

## Verification

- `go build ./...` clean.
- `TestBuildHuskPodMultiVMArgAndLabel`: with `MultiVM` the pod has the `mitos.run/multi-vm` label and the `--multi-vm` stub arg and is `huskPodMultiVMCapable`; without it, none are present. Passes under envtest.
- Both golangci-lint invocations (darwin + GOOS=linux) clean. No em or en dashes.

## Model Used

Claude Opus 4.8 (claude-opus-4-8) via Claude Code, driven by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MultiVM support for warm pool “husk” pods. When enabled, warm pods are created with the multi-VM marker label and the corresponding startup option to support MultiVM fork co-location routing; normal (non-MultiVM) behavior is unchanged.

* **Tests**
  * Added/expanded coverage to verify MultiVM labeling, capability detection, and that the multi-VM startup argument is present only when configured.
  * Added validation that husk-pod reconciliation threads the configured MultiVM setting into created warm pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->