### PR TITLE
feat(helm): add controller.multiVMFork value to render --multi-vm-fork

### DIFF
--- a/deploy/charts/mitos/templates/controller-deployment.yaml
+++ b/deploy/charts/mitos/templates/controller-deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.controller.multiVMFork (not .Values.controller.enableHuskPods) }}
+{{- fail "controller.multiVMFork requires controller.enableHuskPods: the multi-vm fork routing co-locates a fork child in a warm husk pod, which only exists on the husk-pods path. Set enableHuskPods: true or multiVMFork: false." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/charts/mitos/templates/controller-deployment.yaml
+++ b/deploy/charts/mitos/templates/controller-deployment.yaml
@@ -36,6 +36,9 @@ spec:
             {{- if .Values.controller.enableHuskPods }}
             - --enable-husk-pods
             {{- end }}
+            {{- if .Values.controller.multiVMFork }}
+            - --multi-vm-fork
+            {{- end }}
             - --husk-stub-image={{ include "mitos.image" (dict "root" . "image" .Values.huskStub.image) }}
             - --husk-data-dir={{ .Values.controller.huskDataDir }}
             {{- if .Values.controller.huskDnsUpstream }}

--- a/deploy/charts/mitos/values.schema.json
+++ b/deploy/charts/mitos/values.schema.json
@@ -160,6 +160,10 @@
           "description": "Render --enable-husk-pods so each SandboxPool maintains a warm pool of pre-scheduled husk pods.",
           "type": "boolean"
         },
+        "multiVMFork": {
+          "description": "EXPERIMENTAL, default off. Render --multi-vm-fork so a fork child co-locates as an additional VM inside a multi-VM-capable source husk pod instead of a new pod, and warm husk pods start with --multi-vm. Only meaningful with enableHuskPods.",
+          "type": "boolean"
+        },
         "huskDataDir": {
           "description": "Value for --husk-data-dir, the node template snapshot root the husk pods mount; must match forkd's --data-dir.",
           "type": "string"

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -53,6 +53,12 @@ controller:
   # When true, render --enable-husk-pods so each SandboxPool maintains a warm
   # pool of pre-scheduled husk pods. When false, the flag is omitted.
   enableHuskPods: true
+  # EXPERIMENTAL, default off. When true, render --multi-vm-fork: a hosted fork
+  # child co-locates as an additional VM inside a multi-VM-capable source husk
+  # pod (the spawn-vm control op) instead of a brand-new child pod, and warm husk
+  # pods start with --multi-vm so they are co-location-capable. Off is the
+  # unchanged new-pod-per-fork path. Only meaningful with enableHuskPods.
+  multiVMFork: false
   # Value for --husk-data-dir: the node template snapshot root the husk pods
   # mount; must match forkd's --data-dir.
   huskDataDir: /var/lib/mitos


### PR DESCRIPTION
## Problem

The `--multi-vm-fork` controller flag (Layer 1 multi-vm fork routing, #803 to #805) has no chart knob, so an operator cannot enable it. This adds it so a canary can turn it on.

## Thinking Path

Add `controller.multiVMFork` (default false) to values.yaml and render `--multi-vm-fork` in controller-deployment.yaml under an `{{- if }}` guard, mirroring the existing `--enable-husk-pods` conditional. Off omits the arg entirely, so the default rendering is byte-for-byte unchanged and the new-pod-per-fork path is preserved. Only meaningful with `enableHuskPods`.

## Verification

values.yaml parses as valid YAML. The template conditional mirrors the established `enableHuskPods` pattern; the helm-lint CI job renders and validates the chart. No em or en dashes.

## Model Used

Claude Opus 4.8 (claude-opus-4-8) via Claude Code, driven by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Helm chart setting (`controller.multiVMFork`, default: off) to use co-located multi-VM hosted forks when creating new forks.
  * When enabled, the controller automatically activates the related multi-VM fork behavior.
  * Marked as **experimental** in the chart schema and only applies when husk pods are enabled (`controller.enableHuskPods: true`).
* **Bug Fixes / Validation**
  * Added validation to prevent enabling `multiVMFork` without husk pods, producing a clear rendering error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->