### PR TITLE
fix(husk): route ForkSnapshot through the default instance state under multi-vm

### DIFF
--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"regexp"
 	"time"
 
+	"mitos.run/mitos/internal/cas"
 	"mitos.run/mitos/internal/firecracker"
 	"mitos.run/mitos/internal/metering"
 	"mitos.run/mitos/internal/netconf"
 	"mitos.run/mitos/internal/vsock"
+	"mitos.run/mitos/internal/workspace"
 )
 
 // validVMID is the allowlist a vmID must satisfy before it is ever used to
@@ -669,4 +672,285 @@ func (s *Stub) pingInstances() error {
 		}
 	}
 	return nil
+}
+
+// resumeInstanceAfterFork resumes ONE per-VM instance's source VM after a fork
+// snapshot with the SAME bounded retry the single-VM resumeSourceAfterFork uses,
+// but scoped to inst.vm: a TRANSIENT resume error must not leave a tenant's live
+// source frozen (the v1.24.1 stuck-paused incident). It retries resumeMaxAttempts
+// times, resumeRetryBackoff apart, returns nil as soon as one resume succeeds, and
+// on total failure emits a distinct error-level log and fires the onSourceLeftPaused
+// marker so a source left paused is observable. The caller holds inst.mu.
+func (s *Stub) resumeInstanceAfterFork(id vmID, inst *vmInstance) error {
+	var err error
+	for attempt := 0; attempt < resumeMaxAttempts; attempt++ {
+		if attempt > 0 {
+			s.backoffSleep(resumeRetryBackoff)
+		}
+		if err = inst.vm.Resume(); err == nil {
+			return nil
+		}
+	}
+	fmt.Fprintf(os.Stderr, "husk: source vm %q left paused after fork snapshot: resume failed after %d attempts: %v\n", id, resumeMaxAttempts, err)
+	if s.onSourceLeftPaused != nil {
+		s.onSourceLeftPaused()
+	}
+	return err
+}
+
+// forkSnapshotInstance snapshots ONE per-VM instance's running VM, scoped to one
+// entry in the instances map. It is the per-VM analog of the single-VM
+// ForkSnapshot and mirrors it exactly (pause -> create snapshot -> freeze rootfs
+// inside the paused window -> ALWAYS resume the source), but gates on inst.state
+// and drives inst.vm.
+//
+// This is the fix for the L1.8 prod canary: under --multi-vm the CLAIM path
+// advanced the DEFAULT instance's state to Active (activateInstance), NOT the
+// single-VM s.state, which stays StateNew. The single-VM ForkSnapshot's
+// `s.state != StateActive` gate therefore saw StateNew and refused EVERY fork of a
+// multi-vm source with "fork-snapshot in state new: must be active", timing out
+// the hosted fork loop. Routing through the default instance reads the state
+// Activate set, exactly as Metering/Close/pingVMM already multiplex.
+//
+// FAIL CLOSED: it requires inst StateActive; a pause, snapshot-create, rootfs-freeze,
+// or resume failure returns OK=false plus an error, and on a snapshot or freeze
+// failure it still attempts to resume the source so a transient error never leaves a
+// live sandbox frozen. The fork id and snapshot paths carry no secrets.
+func (s *Stub) forkSnapshotInstance(ctx context.Context, id vmID, req ForkSnapshotRequest) (ForkSnapshotResult, error) {
+	if err := checkVMID(id); err != nil {
+		return ForkSnapshotResult{OK: false, Error: err.Error()}, err
+	}
+	// Fork does NOT create an instance: a missing entry reads as StateNew and is
+	// refused, mirroring activateInstance.
+	inst := s.instanceFor(id, false)
+	if inst == nil {
+		werr := fmt.Errorf("husk: fork-snapshot vm %q in state %s: must be active", id, StateNew)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	if inst.state != StateActive {
+		return ForkSnapshotResult{OK: false, Error: fmt.Sprintf("fork-snapshot vm %q in state %s: must be active", id, inst.state)},
+			fmt.Errorf("husk: fork-snapshot vm %q in state %s: must be active", id, inst.state)
+	}
+	if err := ctx.Err(); err != nil {
+		return ForkSnapshotResult{OK: false, Error: err.Error()}, err
+	}
+	if req.SnapshotDir == "" {
+		return ForkSnapshotResult{OK: false, Error: "fork-snapshot: empty snapshot dir"},
+			fmt.Errorf("husk: fork-snapshot vm %q: empty snapshot dir", id)
+	}
+	if err := s.confineToForksDir(req.SnapshotDir); err != nil {
+		return ForkSnapshotResult{OK: false, Error: err.Error()}, err
+	}
+
+	memFile := filepath.Join(req.SnapshotDir, "mem")
+	vmStateFile := filepath.Join(req.SnapshotDir, "vmstate")
+	if err := os.MkdirAll(req.SnapshotDir, 0o755); err != nil {
+		werr := fmt.Errorf("husk: create fork snapshot dir %s: %w", req.SnapshotDir, err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	start := time.Now()
+
+	if err := inst.vm.Pause(); err != nil {
+		werr := fmt.Errorf("husk: pause source vm %q for fork snapshot: %w", id, err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	if err := inst.vm.CreateSnapshot(memFile, vmStateFile); err != nil {
+		// Best effort: resume the source so a transient snapshot error does not leave
+		// a tenant's live sandbox frozen. Here the snapshot already failed, so the
+		// resume error is not surfaced.
+		_ = inst.vm.Resume()
+		werr := fmt.Errorf("husk: create fork snapshot in %s for vm %q: %w", req.SnapshotDir, id, err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	// Freeze THIS instance's source rootfs INSIDE the paused window, as a
+	// point-in-time pair with the mem+vmstate checkpoint, exactly as the single-VM
+	// ForkSnapshot does. Skipped when this instance has no per-activation clone (the
+	// mock/CI paths). On failure the source is resumed (never leave a tenant's live
+	// sandbox frozen) before failing closed. The path carries no secret.
+	if inst.rootfsClonePath != "" {
+		frozenRootfs := filepath.Join(req.SnapshotDir, "rootfs.ext4")
+		if err := s.reflink(inst.rootfsClonePath, frozenRootfs); err != nil {
+			_ = s.resumeInstanceAfterFork(id, inst)
+			werr := fmt.Errorf("husk: freeze source rootfs for fork snapshot vm %q: %w", id, err)
+			return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+
+	// ALWAYS resume the source after the checkpoint: the pause is only the brief
+	// quiescence CreateSnapshot requires, and the memory + frozen rootfs are a
+	// consistent point-in-time pair, so the source is safe to run again. Leaving it
+	// paused was the v1.24.1 production bug. The resume is retried a few times so a
+	// transient blip does not recreate that stuck-paused incident.
+	if err := s.resumeInstanceAfterFork(id, inst); err != nil {
+		werr := fmt.Errorf("husk: resume source vm %q after fork snapshot: %w", id, err)
+		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	latency := time.Since(start)
+	return ForkSnapshotResult{
+		OK:          true,
+		SnapshotDir: req.SnapshotDir,
+		LatencyMs:   float64(latency.Microseconds()) / 1000.0,
+	}, nil
+}
+
+// dialWorkspaceAgentVM resolves the guest-agent bulk-tar transport for a SPECIFIC
+// per-VM handle (an instance's inst.vm under --multi-vm) and returns it plus a
+// close hook. It is the per-VM analog of the single-VM dialWorkspaceAgent, which
+// reads s.vm; under --multi-vm s.vm is nil and the VM lives on the instance, so the
+// workspace ops resolve the transport from inst.vm here instead. The caller holds
+// the instance lock.
+func (s *Stub) dialWorkspaceAgentVM(vm vmm) (workspace.VsockTransport, func(), error) {
+	vsockPath := vm.VsockHostPath(s.vsockRelPath)
+	agent, err := s.wsTransport(vsockPath)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("husk: connect guest agent for workspace transfer: %w", err)
+	}
+	closeHook := func() {}
+	if c, ok := agent.(io.Closer); ok {
+		closeHook = func() { _ = c.Close() }
+	}
+	return agent, closeHook, nil
+}
+
+// dehydrateWorkspaceInstance captures ONE per-VM instance's guest /workspace into
+// the node CAS, scoped to one entry in the instances map. It is the per-VM analog
+// of the single-VM DehydrateWorkspace and mirrors it exactly, but gates on
+// inst.state and dials inst.vm. Same L1.8 fix class as forkSnapshotInstance: the
+// single-VM DehydrateWorkspace gates on s.state (StateNew under --multi-vm) and
+// dials s.vm (nil), so on a multi-vm pod it refused with "dehydrate-workspace in
+// state new: must be active"; routing through the default instance uses the state
+// and VM Activate set.
+//
+// FAIL CLOSED: it requires inst StateActive and a configured node CAS. The manifest
+// digest is a content address, NOT a secret; workspace CONTENT bytes are never
+// logged. The instance stays StateActive throughout.
+func (s *Stub) dehydrateWorkspaceInstance(ctx context.Context, id vmID, req DehydrateWorkspaceRequest) (DehydrateWorkspaceResult, error) {
+	if err := checkVMID(id); err != nil {
+		return DehydrateWorkspaceResult{OK: false, Error: err.Error()}, err
+	}
+	inst := s.instanceFor(id, false)
+	if inst == nil {
+		werr := fmt.Errorf("husk: dehydrate-workspace vm %q in state %s: must be active", id, StateNew)
+		return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	if inst.state != StateActive {
+		werr := fmt.Errorf("husk: dehydrate-workspace vm %q in state %s: must be active", id, inst.state)
+		return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	if err := ctx.Err(); err != nil {
+		return DehydrateWorkspaceResult{OK: false, Error: err.Error()}, err
+	}
+	if s.casStore == nil {
+		werr := fmt.Errorf("husk: dehydrate-workspace: no node CAS configured; set --cas-dir so the stub can persist a workspace revision")
+		return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	agent, closeAgent, err := s.dialWorkspaceAgentVM(inst.vm)
+	if err != nil {
+		return DehydrateWorkspaceResult{OK: false, Error: err.Error()}, err
+	}
+	defer closeAgent()
+
+	start := time.Now()
+	digest, err := workspace.Dehydrate(ctx, agent, s.casStore, req.ExcludePaths, req.CapturePaths)
+	if err != nil {
+		werr := fmt.Errorf("husk: dehydrate workspace: %w", err)
+		return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	if err := digest.Validate(); err != nil {
+		werr := fmt.Errorf("husk: dehydrate workspace produced an invalid content digest: %w", err)
+		return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	// Optional content-hash diff against the parent head, computed from the two
+	// manifests in the node CAS via the SAME stub-level helper the single-VM path
+	// uses; it never materializes chunk bytes. An error names manifests/digests
+	// (content addresses), never content.
+	var diff *workspace.Diff
+	if req.ParentManifestDigest != "" {
+		parent := cas.Digest(req.ParentManifestDigest)
+		if err := parent.Validate(); err != nil {
+			werr := fmt.Errorf("husk: dehydrate workspace: invalid parent manifest digest: %w", err)
+			return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+		}
+		d, derr := s.diffManifests(parent, digest)
+		if derr != nil {
+			werr := fmt.Errorf("husk: dehydrate workspace: compute diff against parent: %w", derr)
+			return DehydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+		}
+		diff = &d
+	}
+
+	latency := time.Since(start)
+	return DehydrateWorkspaceResult{
+		OK:             true,
+		ManifestDigest: string(digest),
+		Diff:           diff,
+		LatencyMs:      float64(latency.Microseconds()) / 1000.0,
+	}, nil
+}
+
+// hydrateWorkspaceInstance restores a node-CAS manifest into ONE per-VM instance's
+// guest /workspace, the inverse of dehydrateWorkspaceInstance and the per-VM analog
+// of the single-VM HydrateWorkspace. Same L1.8 fix class: it gates on inst.state
+// and dials inst.vm instead of s.state / s.vm.
+//
+// FAIL CLOSED: it requires inst StateActive, a configured node CAS, and a valid
+// content-address manifest digest. Workspace CONTENT bytes are never logged. The
+// instance stays StateActive throughout.
+func (s *Stub) hydrateWorkspaceInstance(ctx context.Context, id vmID, req HydrateWorkspaceRequest) (HydrateWorkspaceResult, error) {
+	if err := checkVMID(id); err != nil {
+		return HydrateWorkspaceResult{OK: false, Error: err.Error()}, err
+	}
+	inst := s.instanceFor(id, false)
+	if inst == nil {
+		werr := fmt.Errorf("husk: hydrate-workspace vm %q in state %s: must be active", id, StateNew)
+		return HydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	if inst.state != StateActive {
+		werr := fmt.Errorf("husk: hydrate-workspace vm %q in state %s: must be active", id, inst.state)
+		return HydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	if err := ctx.Err(); err != nil {
+		return HydrateWorkspaceResult{OK: false, Error: err.Error()}, err
+	}
+	if s.casStore == nil {
+		werr := fmt.Errorf("husk: hydrate-workspace: no node CAS configured; set --cas-dir so the stub can restore a workspace revision")
+		return HydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	digest := cas.Digest(req.ManifestDigest)
+	if err := digest.Validate(); err != nil {
+		werr := fmt.Errorf("husk: hydrate-workspace: %w", err)
+		return HydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+
+	agent, closeAgent, err := s.dialWorkspaceAgentVM(inst.vm)
+	if err != nil {
+		return HydrateWorkspaceResult{OK: false, Error: err.Error()}, err
+	}
+	defer closeAgent()
+
+	start := time.Now()
+	if err := workspace.Hydrate(ctx, agent, s.casStore, digest); err != nil {
+		werr := fmt.Errorf("husk: hydrate workspace: %w", err)
+		return HydrateWorkspaceResult{OK: false, Error: werr.Error()}, werr
+	}
+	latency := time.Since(start)
+	return HydrateWorkspaceResult{
+		OK:        true,
+		LatencyMs: float64(latency.Microseconds()) / 1000.0,
+	}, nil
 }

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -761,9 +761,11 @@ func (s *Stub) forkSnapshotInstance(ctx context.Context, id vmID, req ForkSnapsh
 
 	if err := inst.vm.CreateSnapshot(memFile, vmStateFile); err != nil {
 		// Best effort: resume the source so a transient snapshot error does not leave
-		// a tenant's live sandbox frozen. Here the snapshot already failed, so the
-		// resume error is not surfaced.
-		_ = inst.vm.Resume()
+		// a tenant's live sandbox frozen. The snapshot already failed, so the resume
+		// error is not surfaced, but the bounded retry + stuck-paused marker still
+		// apply here (a transient resume blip on this branch must not silently leave
+		// the source paused, the v1.24.1 incident class).
+		_ = s.resumeInstanceAfterFork(id, inst)
 		werr := fmt.Errorf("husk: create fork snapshot in %s for vm %q: %w", req.SnapshotDir, id, err)
 		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}

--- a/internal/husk/multivm_forksnapshot_test.go
+++ b/internal/husk/multivm_forksnapshot_test.go
@@ -1,0 +1,145 @@
+package husk
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"mitos.run/mitos/internal/cas"
+	"mitos.run/mitos/internal/workspace"
+)
+
+// TestMultiVMForkSnapshotFromDefaultVM is the L1.8 prod-canary regression: with
+// --multi-vm ON, the CLAIM path (Activate) advances the DEFAULT instance's state
+// to Active via activateInstance, NOT the single-VM s.state, which stays
+// StateNew. Before the fix the public ForkSnapshot still gated on s.state and so
+// refused EVERY fork of a multi-vm source with "fork-snapshot in state new: must
+// be active", timing out the hosted fork loop. After the fix ForkSnapshot routes
+// through the default instance under --multi-vm and reads the state Activate set,
+// so a fork of a multi-vm stub's default VM SUCCEEDS.
+//
+// This test FAILS on origin/main (ForkSnapshot has no multi-VM branch) and PASSES
+// once ForkSnapshot routes through forkSnapshotInstance(defaultVMID).
+func TestMultiVMForkSnapshotFromDefaultVM(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	ctx := context.Background()
+	// Drive the PUBLIC lifecycle so the multi-VM dispatch (not the per-instance
+	// helpers directly) is exercised: Prepare -> Activate route to the default
+	// instance, leaving s.state StateNew but inst.state StateActive.
+	if err := s.Prepare(ctx); err != nil {
+		t.Fatalf("Prepare (multi-vm default): %v", err)
+	}
+	if res, err := s.Activate(ctx, ActivateRequest{SnapshotDir: "/snap"}); err != nil || !res.OK {
+		t.Fatalf("Activate (multi-vm default): err=%v res=%+v", err, res)
+	}
+	// The single-VM state field is deliberately still StateNew: the whole point of
+	// the bug is that ForkSnapshot must NOT read it under multi-vm.
+	if s.state != StateNew {
+		t.Fatalf("precondition: single-VM s.state must stay StateNew under multi-vm, got %s", s.state)
+	}
+	if got := s.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("precondition: default instance must be active, got %s", got)
+	}
+
+	dir := t.TempDir()
+	res, err := s.ForkSnapshot(ctx, ForkSnapshotRequest{ForkID: "fork-1", SnapshotDir: dir})
+	if err != nil {
+		t.Fatalf("ForkSnapshot on a multi-vm stub's default VM must succeed, got err: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("ForkSnapshot on a multi-vm stub's default VM must be OK, got: %+v", res)
+	}
+
+	// The DEFAULT instance's VM (not the single-VM s.vm, which is nil under
+	// multi-vm) must have been paused for the checkpoint and resumed afterward.
+	defVM := vms["husk-test"]
+	if defVM == nil {
+		t.Fatalf("expected the default VM fake under derived id husk-test, got keys %v", vms)
+	}
+	if !defVM.paused {
+		t.Fatalf("the default instance's VM was not paused for the fork snapshot")
+	}
+	if !defVM.resumed {
+		t.Fatalf("the default instance's VM was not resumed after the fork snapshot")
+	}
+	if defVM.snapMem != filepath.Join(dir, "mem") || defVM.snapState != filepath.Join(dir, "vmstate") {
+		t.Fatalf("fork snapshot written to wrong paths: mem=%s state=%s", defVM.snapMem, defVM.snapState)
+	}
+	// The default instance stays Active throughout: it still owns its VM.
+	if got := s.instances[defaultVMID].state; got != StateActive {
+		t.Fatalf("default instance must remain active after fork snapshot, got %s", got)
+	}
+}
+
+// TestMultiVMForkSnapshotRequiresActiveDefaultInstance proves the routed
+// ForkSnapshot still fails closed under --multi-vm when the default instance is
+// NOT active (only prepared): the gate now reads inst.state, so a dormant default
+// VM is refused with a must-be-active error and its VM is never paused.
+func TestMultiVMForkSnapshotRequiresActiveDefaultInstance(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+
+	ctx := context.Background()
+	if err := s.Prepare(ctx); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	// No Activate: the default instance is StateDormant.
+	res, err := s.ForkSnapshot(ctx, ForkSnapshotRequest{ForkID: "f", SnapshotDir: t.TempDir()})
+	if err == nil || res.OK {
+		t.Fatalf("fork snapshot of a non-active default VM must fail closed: err=%v res=%+v", err, res)
+	}
+	if vms["husk-test"].paused {
+		t.Fatalf("a refused fork snapshot must not pause the default VM")
+	}
+}
+
+// TestMultiVMWorkspaceRoutesToDefaultInstance proves the same class of fix for the
+// workspace ops: under --multi-vm, DehydrateWorkspace and HydrateWorkspace route
+// through the DEFAULT instance's state and VM instead of the single-VM s.state
+// (StateNew) / s.vm (nil). Before the fix both refused with "state new: must be
+// active" on a multi-vm pod; after the fix they run against the active default VM.
+func TestMultiVMWorkspaceRoutesToDefaultInstance(t *testing.T) {
+	store, err := cas.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("cas.New: %v", err)
+	}
+	src := &fakeWorkspaceAgent{tar: tarOf(t, map[string]string{"main.go": "package main"})}
+	// A stub in multi-VM mode whose DEFAULT instance is active with a fake VM, but
+	// whose single-VM s.state / s.vm are the zero value (StateNew / nil), exactly as
+	// New(Options{MultiVM:true}) leaves them after a routed Activate.
+	s := &Stub{
+		multiVM:      true,
+		vsockRelPath: "v.sock",
+		casStore:     store,
+		wsTransport:  func(string) (workspace.VsockTransport, error) { return src, nil },
+		instances:    map[vmID]*vmInstance{defaultVMID: {state: StateActive, vm: &fakeVMM{}}},
+	}
+
+	dres, err := s.DehydrateWorkspace(context.Background(), DehydrateWorkspaceRequest{})
+	if err != nil || !dres.OK {
+		t.Fatalf("DehydrateWorkspace on a multi-vm stub's default VM must succeed: err=%v res=%+v", err, dres)
+	}
+	d := cas.Digest(dres.ManifestDigest)
+	if err := d.Validate(); err != nil {
+		t.Fatalf("dehydrate produced an invalid manifest digest: %v", err)
+	}
+
+	// Hydrate the captured manifest back into a fresh multi-vm stub's default VM.
+	dst := &fakeWorkspaceAgent{}
+	s2 := &Stub{
+		multiVM:      true,
+		vsockRelPath: "v.sock",
+		casStore:     store,
+		wsTransport:  func(string) (workspace.VsockTransport, error) { return dst, nil },
+		instances:    map[vmID]*vmInstance{defaultVMID: {state: StateActive, vm: &fakeVMM{}}},
+	}
+	hres, err := s2.HydrateWorkspace(context.Background(), HydrateWorkspaceRequest{ManifestDigest: dres.ManifestDigest})
+	if err != nil || !hres.OK {
+		t.Fatalf("HydrateWorkspace on a multi-vm stub's default VM must succeed: err=%v res=%+v", err, hres)
+	}
+	if dst.untarPath != workspace.WorkspacePath {
+		t.Fatalf("hydrate must untar into %s, got %s", workspace.WorkspacePath, dst.untarPath)
+	}
+}

--- a/internal/husk/multivm_kvm_test.go
+++ b/internal/husk/multivm_kvm_test.go
@@ -124,6 +124,119 @@ func TestMultiVMTwoRealFirecrackersKVM(t *testing.T) {
 	}
 }
 
+// TestMultiVMForkSnapshotDefaultVMKVM is the KVM acceptance bar for the L1.8 prod
+// canary: it FORKS a --multi-vm husk stub's DEFAULT VM end to end on a REAL
+// Firecracker (prepare -> activate -> fork-snapshot), then proves the produced
+// child snapshot is a real, restorable checkpoint by activating a SECOND --multi-vm
+// stub from it and exec-ing in the restored guest. TestMultiVMTwoRealFirecrackersKVM
+// above only proves two VMs ACTIVATE; it never forks a multi-vm stub, which is
+// exactly the coverage gap that let the bug ship.
+//
+// The bug: under --multi-vm the CLAIM path (Activate) advances the DEFAULT
+// INSTANCE's state, not the single-VM s.state, which stays StateNew. On origin/main
+// ForkSnapshot gated on s.state and so refused EVERY fork of a multi-vm source with
+// "fork-snapshot in state new: must be active", timing out the hosted fork loop.
+// After the fix ForkSnapshot routes through the default instance and succeeds here.
+//
+// It is GATED and skips cleanly unless /dev/kvm exists AND the SAME asset env vars
+// TestMultiVMTwoRealFirecrackersKVM uses are set (MITOS_KVM_HUSK_SNAPSHOT_DIR, plus
+// MITOS_KVM_FIRECRACKER), so on a darwin dev box or any non-KVM runner it never
+// asserts and is never a fake pass.
+func TestMultiVMForkSnapshotDefaultVMKVM(t *testing.T) {
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		t.Skip("skipping multi-vm fork-snapshot e2e: /dev/kvm not available (needs a KVM runner)")
+	}
+	snapDir := os.Getenv("MITOS_KVM_HUSK_SNAPSHOT_DIR")
+	if snapDir == "" {
+		t.Skip("skipping multi-vm fork-snapshot e2e: set MITOS_KVM_HUSK_SNAPSHOT_DIR (the KVM CI sets it)")
+	}
+	for _, name := range []string{"mem", "vmstate"} {
+		if _, err := os.Stat(filepath.Join(snapDir, name)); err != nil {
+			t.Skipf("skipping multi-vm fork-snapshot e2e: snapshot file %s not present: %v", name, err)
+		}
+	}
+	fcBin := os.Getenv("MITOS_KVM_FIRECRACKER")
+	if fcBin == "" {
+		fcBin = "/usr/local/bin/firecracker"
+	}
+
+	// newStub builds a real --multi-vm husk stub, each with its OWN base workdir so
+	// the source and the child never collide on a Firecracker API socket or vsock
+	// UDS. Same machine sizing and AllowUnverified as TestMultiVMTwoRealFirecrackersKVM.
+	newStub := func(id string) *Stub {
+		workdir := filepath.Join(t.TempDir(), id)
+		if err := os.MkdirAll(workdir, 0o755); err != nil {
+			t.Fatalf("mkdir workdir for %s: %v", id, err)
+		}
+		return New(firecracker.VMConfig{
+			ID:             id,
+			FirecrackerBin: fcBin,
+			WorkDir:        workdir,
+			VcpuCount:      1,
+			MemSizeMib:     256,
+		}, Options{
+			AllowUnverified: true,
+			ReadyTimeout:    30 * time.Second,
+			MultiVM:         true,
+		})
+	}
+
+	ctx := context.Background()
+
+	// Source: a --multi-vm stub whose DEFAULT VM is activated from the template
+	// snapshot. Under --multi-vm the single-VM s.state stays StateNew (activateInstance
+	// advanced the DEFAULT INSTANCE), which is the state ForkSnapshot must NOT read.
+	src := newStub("husk-fork-src")
+	defer func() { _ = src.Close() }()
+	if err := src.Prepare(ctx); err != nil {
+		t.Fatalf("source Prepare (multi-vm default): %v", err)
+	}
+	if res, err := src.Activate(ctx, ActivateRequest{SnapshotDir: snapDir}); err != nil || !res.OK {
+		t.Fatalf("source Activate (multi-vm default): err=%v res=%+v", err, res)
+	}
+	if src.state != StateNew {
+		t.Fatalf("precondition: single-VM s.state must stay StateNew under multi-vm, got %s", src.state)
+	}
+
+	// Fork the source's default VM. On origin/main this returned OK=false with
+	// "fork-snapshot in state new: must be active"; after the fix it routes through
+	// the default instance and writes a restorable child checkpoint.
+	childDir := filepath.Join(t.TempDir(), "child-snapshot")
+	fres, err := src.ForkSnapshot(ctx, ForkSnapshotRequest{ForkID: "child-1", SnapshotDir: childDir})
+	if err != nil || !fres.OK {
+		t.Fatalf("ForkSnapshot of a multi-vm stub's default VM must succeed on KVM: err=%v res=%+v", err, fres)
+	}
+	for _, name := range []string{"mem", "vmstate"} {
+		if _, err := os.Stat(filepath.Join(childDir, name)); err != nil {
+			t.Fatalf("fork snapshot did not write %s: %v", name, err)
+		}
+	}
+
+	// Child: a fresh --multi-vm stub activates its DEFAULT VM from the fork snapshot
+	// and its guest answers, proving the fork of a multi-vm stub actually restores.
+	child := newStub("husk-fork-child")
+	defer func() { _ = child.Close() }()
+	if err := child.Prepare(ctx); err != nil {
+		t.Fatalf("child Prepare (from fork snapshot): %v", err)
+	}
+	cres, err := child.Activate(ctx, ActivateRequest{SnapshotDir: childDir})
+	if err != nil || !cres.OK {
+		t.Fatalf("child Activate from the fork snapshot must succeed: err=%v res=%+v", err, cres)
+	}
+	client, err := kvmConnectAgent(cres.VsockPath)
+	if err != nil {
+		t.Fatalf("connect agent in the forked child: %v", err)
+	}
+	defer client.Close() //nolint:errcheck // best-effort teardown
+	got, err := kvmExecOK(client, "printf forked-child-alive")
+	if err != nil {
+		t.Fatalf("exec in the forked child guest: %v", err)
+	}
+	if strings.TrimSpace(got) != "forked-child-alive" {
+		t.Fatalf("forked child guest exec = %q, want %q (the restored fork must run)", strings.TrimSpace(got), "forked-child-alive")
+	}
+}
+
 // kvmConnectAgent dials the guest agent's gRPC service on the vsock UDS with a
 // bounded retry.
 func kvmConnectAgent(udsPath string) (*guestgrpc.Client, error) {

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -1087,6 +1087,18 @@ func (s *Stub) resumeSourceAfterFork() error {
 }
 
 func (s *Stub) ForkSnapshot(ctx context.Context, req ForkSnapshotRequest) (ForkSnapshotResult, error) {
+	// Multi-VM mode (#764, default off): the source this snapshots is the pod's
+	// DEFAULT VM, whose lifecycle state lives on the per-VM instances map (Activate
+	// advanced inst.state, NOT the single-VM s.state, which stays StateNew). Route
+	// to the default instance so the must-be-active gate reads the state Activate
+	// set; otherwise EVERY fork of a multi-vm source failed "state new: must be
+	// active" (the L1.8 prod canary). Mirrors the Activate/Metering/Close/pingVMM
+	// multiplexing. forkSnapshotInstance locks the instance itself, so return before
+	// taking s.mu. When multiVM is false the single-VM body below runs byte-for-byte
+	// unchanged.
+	if s.multiVM {
+		return s.forkSnapshotInstance(ctx, defaultVMID, req)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1205,6 +1217,14 @@ func (s *Stub) RemoveForkSnapshot(req ForkSnapshotRequest) error {
 // digest is a content address, NOT a secret; workspace CONTENT bytes are never
 // logged or returned in an error. The stub stays StateActive throughout.
 func (s *Stub) DehydrateWorkspace(ctx context.Context, req DehydrateWorkspaceRequest) (DehydrateWorkspaceResult, error) {
+	// Multi-VM mode (#764, default off): capture the pod's DEFAULT VM, whose state
+	// and VM live on the per-VM instances map (s.state stays StateNew and s.vm nil
+	// under multiVM). Route to the default instance so the op runs against the VM
+	// Activate brought up, not the unused single-VM fields. Same L1.8 fix class as
+	// ForkSnapshot. When multiVM is false the single-VM body below is unchanged.
+	if s.multiVM {
+		return s.dehydrateWorkspaceInstance(ctx, defaultVMID, req)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1301,6 +1321,14 @@ func (s *Stub) diffManifests(parent, child cas.Digest) (workspace.Diff, error) {
 // is a content address, NOT a secret; workspace CONTENT bytes are never logged.
 // The stub stays StateActive throughout.
 func (s *Stub) HydrateWorkspace(ctx context.Context, req HydrateWorkspaceRequest) (HydrateWorkspaceResult, error) {
+	// Multi-VM mode (#764, default off): restore into the pod's DEFAULT VM, whose
+	// state and VM live on the per-VM instances map (s.state stays StateNew and s.vm
+	// nil under multiVM). Route to the default instance so the op runs against the VM
+	// Activate brought up. Same L1.8 fix class as ForkSnapshot. When multiVM is false
+	// the single-VM body below is unchanged.
+	if s.multiVM {
+		return s.hydrateWorkspaceInstance(ctx, defaultVMID, req)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; each sandbox VM lives in its own husk pod driven by `internal/husk`.
> - The multi-VM-per-pod density work (#764, `Options.MultiVM`, default off) multiplexes the husk lifecycle over a per-VM `instances` map so one pod can host many same-tenant forks.
> - That work wired the CLAIM path: `Stub.Activate` routes to `activateInstance(defaultVMID)`, which advances the DEFAULT instance's state to `StateActive` in the map. It did NOT migrate the fork/workspace ops, which still read the single-VM `s.state` field.
> - Under multi-vm `s.state` never leaves `StateNew` (Activate touched `inst.state`, not `s.state`), so `Stub.ForkSnapshot`'s `s.state != StateActive` gate saw `StateNew` and refused every fork with "fork-snapshot in state new: must be active". The hosted fork-the-winner loop timed out on every fork of a multi-vm source.
> - The L1.8 prod canary caught exactly this (root cause confirmed in controller logs); CI missed it because the multi-VM tests only proved two VMs ACTIVATE and never forked a multi-vm stub.
> - This pull request routes `ForkSnapshot` (and the same-class `DehydrateWorkspace` / `HydrateWorkspace`) through the default instance under multi-vm, mirroring how `Activate`/`Metering`/`Close`/`pingVMM` already multiplex, and adds the fork-on-a-multivm-stub tests CI lacked.
> - The benefit is that forks (and workspace persistence) from a multi-vm source pod work instead of timing out, with the flag-off single-VM path unchanged.

## Linked Issues or Issue Description

No public issue exists for this canary finding, so the problem is described here per the bug-report form.

- What happened: with a husk pod running in `--multi-vm` mode (`Options.MultiVM`), every fork from that source pod times out.
- Root cause: `Stub.Activate` multiplexes the CLAIM path to `activateInstance(defaultVMID)`, which sets the DEFAULT instance's `inst.state` to `StateActive`. `Stub.ForkSnapshot` still checked the single-VM `s.state`, which stays `StateNew` under multi-vm, so it failed closed with `fork-snapshot in state new: must be active` on every fork.
- Expected: a fork from a multi-vm source pod's default VM produces a restorable snapshot, exactly as it does on the single-VM path.
- Scope: `Options.MultiVM` defaults off and no production caller sets it for the single-VM path, so the flag-off behavior is unchanged.

Related: #764 (multi-VM-per-pod execution mode).

## What Changed

- `internal/husk/stub.go`: `ForkSnapshot`, `DehydrateWorkspace`, and `HydrateWorkspace` now take a top-of-function `if s.multiVM { return s.<op>Instance(ctx, defaultVMID, req) }` branch, mirroring the existing `Activate`/`Metering`/`Close`/`pingVMM` multiplexing. The single-VM (flag-off) bodies are byte-for-byte unchanged.
- `internal/husk/multivm.go`: added `forkSnapshotInstance`, `dehydrateWorkspaceInstance`, `hydrateWorkspaceInstance`, plus the per-instance `resumeInstanceAfterFork` (same bounded resume-retry the single-VM path uses so a fork never leaves the source paused) and `dialWorkspaceAgentVM` (dials `inst.vm`, since `s.vm` is nil under multi-vm). Each gates on `inst.state`, drives `inst.vm`, and fails closed exactly as its single-VM analog.
- Audit result: `RemoveForkSnapshot` has no `s.state` gate and touches no VM, so it is correct in both modes and left unchanged. `State()` is a getter, not an op gate, and is out of scope.
- Tests: `internal/husk/multivm_forksnapshot_test.go` (new) proves ForkSnapshot succeeds on a `--multi-vm` stub's default VM after Prepare + Activate, and that DehydrateWorkspace/HydrateWorkspace route to the default instance; `internal/husk/multivm_kvm_test.go` (extended) adds `TestMultiVMForkSnapshotDefaultVMKVM`, which forks a `--multi-vm` stub's default VM end to end on real Firecracker (prepare, activate, fork-snapshot) and activates a child from the produced snapshot, exec-ing in the restored guest.

## Verification

Run in the worktree at `origin/main` (v1.26.0):

- Fail-before / pass-after of the new mock test (the exact CI gap):
  - On origin/main code: `TestMultiVMForkSnapshotFromDefaultVM` FAILS with `ForkSnapshot on a multi-vm stub's default VM must succeed, got err: husk: fork-snapshot in state new: must be active`; `TestMultiVMWorkspaceRoutesToDefaultInstance` FAILS with `husk: dehydrate-workspace in state new: must be active`.
  - After the fix: both PASS.
- `go build ./...`: passes (a first run hit a local-disk ENOSPC; `go clean -cache && go clean -testcache` then a clean build, per the documented recovery).
- `go test -race ./internal/husk/...`: `ok  mitos.run/mitos/internal/husk  4.589s` (the KVM test skips on non-KVM darwin, as designed).
- `golangci-lint run --timeout=5m`: only the pre-existing darwin-only `internal/fork/uffd.go:42 func (m uffdMapping) pageSizeBytes is unused` finding; nothing new.
- `GOOS=linux golangci-lint run --timeout=5m`: clean.

The KVM test was not executed locally (this dev host is darwin with no `/dev/kvm`); it is gated to skip cleanly there and runs in the `firecracker-test` job, reusing the same `MITOS_KVM_HUSK_SNAPSHOT_DIR` / `MITOS_KVM_FIRECRACKER` contract and the `kvmConnectAgent` / `kvmExecOK` helpers the existing `TestMultiVMTwoRealFirecrackersKVM` already uses.

## Risks

Low risk. The change adds only a top-of-function multi-vm branch to three ops and self-contained per-instance helpers that mirror the audited single-VM logic; the flag-off single-VM path is unchanged and is the only path any production caller exercises today. `Options.MultiVM` defaults off. No secret values are logged or placed in errors (the ops carry only fork ids, node-local snapshot paths, and content-address digests). Failure behavior is preserved: ForkSnapshot still fails closed on a non-active default instance and always resumes the source (bounded retry) so a fork never leaves a tenant's live source paused.

## Model Used

Claude Opus 4.8 (Anthropic), exact model id `claude-opus-4-8`, run in an agentic coding harness with extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [ ] Docs updated in the same PR (no doc change: the security surface and threat model are unchanged; this restores the intended fork behavior under an already-documented default-off flag)
- [ ] Threat-model delta (docs/threat-model.md) included if the security surface moved (surface unchanged)
- [ ] Benchmark run (bench/) included if the hot path was touched (no bench-relevant number changed; the fix removes a fail-closed refusal, it does not alter the snapshot hot path)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-VM pods can now create fork snapshots and transfer workspace contents via the active default VM.
  * Snapshot and workspace operations now route through the correct per-VM instance in multi-VM mode.

* **Bug Fixes**
  * Fork snapshot and workspace actions only proceed when the targeted VM instance is active.
  * Improved recovery to ensure sources resume even if snapshot/freeze steps fail.
  * Added stronger validation around snapshot and workspace transfer state.

* **Tests**
  * Added regression and KVM acceptance coverage for multi-VM default VM routing and restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->