### PR TITLE
fix(husk): co-located fork restores from the parent snapshot so the child inherits

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -2627,6 +2627,30 @@ jobs:
           sudo chmod 666 /dev/kvm || true
           go test ./internal/husk/ -run TestMultiVMTwoRealFirecrackersKVM -count=1 -v
 
+      # Co-located fork inheritance proof (prod-canary bug). With --multi-vm ON, a
+      # hosted fork that CO-LOCATES the child as an additional VM inside the source
+      # pod (the spawn-vm path) MUST restore the PARENT'S memory + disk, not boot a
+      # fresh template VM. The bug shipped because the co-located child activated from
+      # the pool TEMPLATE (fast because it SKIPPED the restore a fork requires), so a
+      # file written to the parent AND the parent's live in-memory state were BOTH
+      # absent in the child. This test drives the SAME Stub.SpawnVM path the controller
+      # uses and spawns two co-located children on ONE real source stub: a bug-repro
+      # child from the template (inherits nothing) and a fixed child from the fork
+      # snapshot (reads back the marker FILE = disk, and a far-larger /proc/uptime =
+      # memory). It runs BOTH the two-Firecracker test above and the fork-snapshot
+      # restore test in the same invocation so all three multi-VM KVM proofs are
+      # exercised. Gates on /dev/kvm + MITOS_KVM_HUSK_SNAPSHOT_DIR + the template
+      # rootfs the bench phase laid down, and skips cleanly otherwise.
+      - name: Multi-VM husk, co-located fork inherits the parent memory and disk
+        timeout-minutes: 15
+        env:
+          MITOS_KVM_HUSK_SNAPSHOT_DIR: /tmp/mitos-test/bench-data/templates/bench/snapshot
+          MITOS_KVM_FIRECRACKER: /usr/local/bin/firecracker
+        run: |
+          set -e
+          sudo chmod 666 /dev/kvm || true
+          go test ./internal/husk/ -run 'TestColocatedForkInheritsSourceStateKVM|TestMultiVMForkSnapshotDefaultVMKVM' -count=1 -v
+
       # Husk activate-correctness proof (#18). The fork-correctness phase above
       # proves the GUEST mechanism (distinct RNG + clock resync) when the host
       # sends NotifyForked directly via test-agent. THIS phase proves the same

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -398,6 +398,28 @@ on delete; the child pods are owner-ref'd to the fork and reaped by Kubernetes G
 Residual: a compromised controller can drive a fork-snapshot of any husk pod it
 can reach, the same residual already stated for activate (Surface 2).
 
+Co-located fork child (MultiVMFork routing, `--multi-vm-fork`): when the source
+pod runs a `--multi-vm` stub, the controller may bring a fork child up as an
+ADDITIONAL VM INSIDE the source pod (the `SpawnVM` control op) instead of a new
+child pod. The co-located child restores from the SAME node-local fork snapshot
+`<dataDir>/forks/<fork-id>` (mem + vmstate + the frozen source rootfs at
+`<fork-id>/rootfs.ext4`) that the new-pod child restores from, carried in the
+`SpawnVM` request as `Activate.ForkSnapshot=true` with `SnapshotDir` pointing at
+that dir. It keeps the identical trust posture: the fork snapshot is NOT
+content-addressed, so the co-located activate skips the content-addressed verify
+exactly as the new-pod child does with `--allow-unverified-snapshots` (the
+artifact is root-owned and never tenant-writable, and re-hashing would gate on a
+digest a live fork does not have). Per-VM independence holds: each co-located
+child gets its OWN per-activation rootfs CoW clone of the frozen source rootfs and
+its OWN bearer token, so its guest writes never cross to a sibling or back to the
+source, which shares only the read-only fork snapshot as a restore image. The
+per-VM in-pod egress filter (`internal/husk` `deriveVMNetwork` + `applyEgressFilter`)
+and the full fail-closed RNG/clock reseed handshake run for the co-located child
+too, so a co-located child is never less isolated than a one-pod-per-child fork.
+Before this fix the co-located child activated from the pool TEMPLATE snapshot, so
+it inherited NEITHER the parent's memory NOR its disk: a correctness violation, not
+an isolation gap, now closed.
+
 ### Husk workspace hydrate/dehydrate (W4 transport on the husk path)
 
 A bound claim's `/workspace` is persisted and restored over TWO new control ops on

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -823,7 +823,9 @@ func TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate(t *testing.T) {
 		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
 	})
 	t.Cleanup(func() { setForkSnapshotter(nil) })
+	var activateCalls int32
 	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		atomic.AddInt32(&activateCalls, 1)
 		return husk.ActivateResult{OK: false, Error: "activate must not be called on the co-location path"}, nil
 	})
 	t.Cleanup(func() { setForkActivator(nil) })
@@ -865,6 +867,9 @@ func TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate(t *testing.T) {
 		return got.Status.ReadyReplicas == 1
 	})
 
+	if got := atomic.LoadInt32(&activateCalls); got != 0 {
+		t.Fatalf("single-VM activate must never be called on the co-location path, got %d calls (a spawn-vm + activate double path would corrupt the fork)", got)
+	}
 	if got := atomic.LoadInt32(&spawnCalls); got < 1 {
 		t.Fatalf("expected at least one spawn-vm call, got %d", got)
 	}

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -792,3 +792,92 @@ func TestMultiVMForkCoLocatesRealisticWarmPod(t *testing.T) {
 		t.Errorf("child status.VMID is empty, want the spawned vmID")
 	}
 }
+
+// TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate is the wiring guard for
+// the prod-canary co-located-fork correctness bug. A co-located child spawned via the
+// spawn-vm op MUST activate from the PARENT FORK SNAPSHOT (the dir the source stub
+// wrote mem + vmstate + the frozen source rootfs to), NOT from the pool template
+// mounted at HuskSnapshotDir. On origin/main the spawn-vm ActivateRequest carried
+// SnapshotDir = HuskSnapshotDir (the template) with no ForkSnapshot flag, so the
+// co-located child booted a fresh template VM that inherited neither the parent's
+// memory nor its disk. This test captures the exact dir the source wrote its fork
+// snapshot to (the ForkSnapshotter fake echoes req.SnapshotDir) and asserts the
+// spawn-vm activate targets that SAME dir with ForkSnapshot=true, so a regression that
+// reverts the wiring to the template is caught in go-test, not only on real KVM.
+func TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate(t *testing.T) {
+	poolName := uniqueName("pool-mvm-snap")
+	srcClaimName := uniqueName("src-mvm-snap")
+	forkName := uniqueName("mvm-snap")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.30", multiVMSource, withCoLocationBudget("128Mi", "1280Mi"))
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	// Capture the dir the source stub was asked to WRITE the fork snapshot to. The
+	// co-located child must later ACTIVATE from exactly this dir.
+	var mu sync.Mutex
+	var writtenSnapDir string
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		mu.Lock()
+		writtenSnapDir = req.SnapshotDir
+		mu.Unlock()
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: false, Error: "activate must not be called on the co-location path"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var gotSnapDir string
+	var gotForkSnapshot bool
+	var spawnCalls int32
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		mu.Lock()
+		gotSnapDir = req.Activate.SnapshotDir
+		gotForkSnapshot = req.Activate.ForkSnapshot
+		mu.Unlock()
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyReplicas == 1
+	})
+
+	if got := atomic.LoadInt32(&spawnCalls); got < 1 {
+		t.Fatalf("expected at least one spawn-vm call, got %d", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !gotForkSnapshot {
+		t.Errorf("spawn-vm ActivateRequest.ForkSnapshot = false, want true (co-located child must restore the node-local fork snapshot, not the content-addressed template)")
+	}
+	if gotSnapDir == controller.HuskSnapshotDir {
+		t.Errorf("spawn-vm activated from HuskSnapshotDir %q (the pool TEMPLATE mount); the co-located child must activate from the PARENT fork snapshot dir instead (the prod-canary bug)", controller.HuskSnapshotDir)
+	}
+	if gotSnapDir == "" || gotSnapDir != writtenSnapDir {
+		t.Errorf("spawn-vm activated from %q, want the dir the source wrote the fork snapshot to %q (mem + vmstate + the frozen source rootfs live there)", gotSnapDir, writtenSnapDir)
+	}
+}

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -1006,10 +1006,23 @@ func (r *SandboxReconciler) spawnForkChildInSourcePod(ctx context.Context, a spa
 		spRes, err = a.spawnVM(ctx, addr, tlsConf, husk.SpawnVMRequest{
 			VMID: vmID,
 			Activate: husk.ActivateRequest{
-				// The spawned VM reads the FORK snapshot the source already produced,
-				// mounted read-only at HuskSnapshotDir in the source pod. No
-				// ExpectedDigest: the fork snapshot is node-local, not content-addressed.
-				SnapshotDir: HuskSnapshotDir,
+				// The spawned VM restores from the PARENT FORK SNAPSHOT the source stub
+				// wrote to its in-pod forks dir (huskForksInPodDir: mem + vmstate + the
+				// frozen source rootfs at <dir>/rootfs.ext4), NOT the pool template.
+				// HuskSnapshotDir in the SOURCE pod resolves to the pool TEMPLATE
+				// snapshot (the source is a warm pod), so activating from it booted a
+				// FRESH template VM that inherited NEITHER the parent's memory NOR its
+				// disk: the co-located fork was fast precisely because it skipped the
+				// restore a fork requires (the prod-canary correctness bug). Pointing at
+				// the fork snapshot dir restores the parent's memory + filesystem, exactly
+				// as the new-pod fork child does from <DataDir>/forks/<ForkSnapshotID>.
+				SnapshotDir: huskForksInPodDir(a.fork.Name),
+				// ForkSnapshot tells the source stub this is a CO-LOCATED fork child: clone
+				// the child's rootfs from the FROZEN source rootfs the fork snapshot carries
+				// (inherit the DISK) and skip the content-addressed verify a node-local fork
+				// snapshot has no digest for, mirroring the new-pod fork child's
+				// --allow-unverified-snapshots. Without it the child booted the template.
+				ForkSnapshot: true,
 				// Inherit the SAME network posture the new-pod fork child gets from the
 				// source pool template (issue #760), so a co-located child is never less
 				// isolated than a one-pod-per-child fork.

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -89,6 +89,23 @@ type ActivateRequest struct {
 	// pod's single implicit VM, so an existing activate stays byte-for-byte
 	// compatible. It is a node-local identifier, not a secret.
 	VMID string `json:"vm_id,omitempty"`
+	// ForkSnapshot marks this activate as restoring a CO-LOCATED fork CHILD from a
+	// node-local FORK snapshot (the spawn-vm path), NOT the pool template. When set,
+	// the multi-VM stub:
+	//   (a) clones the child's per-activation rootfs from the FROZEN source rootfs
+	//       the fork snapshot carries at SnapshotDir/rootfs.ext4 instead of the pool
+	//       template rootfs, so the child inherits the parent's DISK, and
+	//   (b) skips the content-addressed verify gate, because a fork snapshot is a
+	//       LIVE node-local artifact the source stub wrote in the SAME pod/node trust
+	//       boundary during a paused CreateSnapshot and is NOT content-addressed
+	//       (there is no digest to verify against). This is the exact posture the
+	//       new-pod fork child runs with (--allow-unverified-snapshots); the
+	//       fork-correctness RNG/clock reseed handshake still runs, fail-closed.
+	// Combined with SnapshotDir pointing at the fork snapshot dir, the co-located
+	// child restores the parent's MEMORY + FILESYSTEM instead of booting a fresh
+	// template VM. Default false keeps every template activate byte-for-byte
+	// unchanged. It is a node-local flag, not a secret.
+	ForkSnapshot bool `json:"fork_snapshot,omitempty"`
 }
 
 // ActivateResult is the control reply. OK is true only when the snapshot loaded

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -160,7 +160,15 @@ func deriveVMNetwork(id vmID, base *vsock.NotifyForkedNetwork) *vsock.NotifyFork
 // clone) but scoped to ONE entry in the instances map, so preparing a second VM
 // never touches the first. Fail closed: any error tears the dormant VMM down and
 // leaves the instance out of StateDormant.
-func (s *Stub) prepareInstance(ctx context.Context, id vmID) error {
+//
+// rootfsSrcOverride selects the file the per-activation rootfs CoW clone is made
+// FROM. Empty (every template activate) clones from the pool template rootfs
+// (s.rootfsTemplatePath), the prior behavior byte-for-byte. A CO-LOCATED fork child
+// passes the FROZEN source rootfs the fork snapshot carries (SnapshotDir/rootfs.ext4)
+// so the child inherits the parent's DISK instead of the pristine template, the
+// co-located analog of the new-pod fork child's --rootfs pointing at the frozen
+// source rootfs.
+func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride string) error {
 	if err := checkVMID(id); err != nil {
 		return err
 	}
@@ -226,20 +234,26 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID) error {
 
 	// Per-activation rootfs CoW clone, scoped to this VM's derived id so two VMs in
 	// the pod never share or overwrite a rootfs clone. Same primitive and dormant
-	// pre-paid timing as the single-VM Prepare.
-	if s.rootfsTemplatePath != "" && s.rootfsCoWDir != "" {
+	// pre-paid timing as the single-VM Prepare. The clone SOURCE is the pool template
+	// rootfs by default; a CO-LOCATED fork child overrides it with the frozen source
+	// rootfs the fork snapshot carries so the child inherits the parent's DISK.
+	rootfsSrc := s.rootfsTemplatePath
+	if rootfsSrcOverride != "" {
+		rootfsSrc = rootfsSrcOverride
+	}
+	if rootfsSrc != "" && s.rootfsCoWDir != "" {
 		clonePath := filepath.Join(s.rootfsCoWDir, cfg.ID, "rootfs.ext4")
 		if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
 			_ = inst.vm.Close()
 			inst.vm = nil
 			return fmt.Errorf("husk: create per-activation rootfs dir for vm %q: %w", id, err)
 		}
-		if err := waitForFile(ctx, s.rootfsTemplatePath, rootfsTemplateWait); err != nil {
+		if err := waitForFile(ctx, rootfsSrc, rootfsTemplateWait); err != nil {
 			_ = inst.vm.Close()
 			inst.vm = nil
-			return fmt.Errorf("husk: per-activation rootfs template %s not ready for vm %q: %w", s.rootfsTemplatePath, id, err)
+			return fmt.Errorf("husk: per-activation rootfs source %s not ready for vm %q: %w", rootfsSrc, id, err)
 		}
-		if err := s.reflink(s.rootfsTemplatePath, clonePath); err != nil {
+		if err := s.reflink(rootfsSrc, clonePath); err != nil {
 			_ = inst.vm.Close()
 			inst.vm = nil
 			return fmt.Errorf("husk: clone per-activation rootfs for vm %q: %w", id, err)
@@ -309,8 +323,16 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 
 	// Verify-on-activate gate, with the same prepare-time fast path the single-VM
 	// Activate uses: skip the re-hash only when THIS instance verified this exact
-	// snapshot during its dormant period.
-	if !(inst.prepareVerified && req.SnapshotDir == s.prepareSnapshotDir && req.ExpectedDigest == s.prepareExpectedDigest) {
+	// snapshot during its dormant period. A CO-LOCATED fork child (req.ForkSnapshot)
+	// restores a node-local FORK snapshot the source stub produced in the SAME
+	// pod/node trust boundary; it is NOT content-addressed (there is no recorded
+	// digest to verify against), so the content-addressed verify is skipped exactly
+	// as the new-pod fork child does with --allow-unverified-snapshots. The
+	// fork-correctness RNG/clock reseed handshake below still runs, fail-closed.
+	switch {
+	case req.ForkSnapshot:
+		// node-local fork snapshot: skip the content-addressed verify (no digest).
+	case !(inst.prepareVerified && req.SnapshotDir == s.prepareSnapshotDir && req.ExpectedDigest == s.prepareExpectedDigest):
 		if err := s.verify(req); err != nil {
 			werr := fmt.Errorf("husk: snapshot verification failed for vm %q: %w", id, err)
 			return ActivateResult{OK: false, Error: werr.Error()}, werr
@@ -438,7 +460,16 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 	if err := checkVMID(id); err != nil {
 		return SpawnVMResult{OK: false, VMID: req.VMID, Error: err.Error()}
 	}
-	if err := s.prepareInstance(ctx, id); err != nil {
+	// A CO-LOCATED fork child clones its rootfs from the FROZEN source rootfs the
+	// fork snapshot carries at SnapshotDir/rootfs.ext4 (inherit the parent's DISK),
+	// NOT the pool template rootfs. Empty otherwise, so a non-fork spawn keeps the
+	// template clone. This mirrors the new-pod fork child, whose --rootfs points at
+	// the same frozen source rootfs (huskForkRootfsInPodPath).
+	rootfsSrcOverride := ""
+	if req.Activate.ForkSnapshot && req.Activate.SnapshotDir != "" {
+		rootfsSrcOverride = filepath.Join(req.Activate.SnapshotDir, "rootfs.ext4")
+	}
+	if err := s.prepareInstance(ctx, id, rootfsSrcOverride); err != nil {
 		return SpawnVMResult{
 			OK:    false,
 			VMID:  req.VMID,

--- a/internal/husk/multivm_kvm_test.go
+++ b/internal/husk/multivm_kvm_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -72,7 +73,7 @@ func TestMultiVMTwoRealFirecrackersKVM(t *testing.T) {
 	ids := []vmID{defaultVMID, "vm-2"}
 	vsockByID := map[vmID]string{}
 	for _, id := range ids {
-		if err := s.prepareInstance(context.Background(), id); err != nil {
+		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		res, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: snapDir})
@@ -235,6 +236,208 @@ func TestMultiVMForkSnapshotDefaultVMKVM(t *testing.T) {
 	if strings.TrimSpace(got) != "forked-child-alive" {
 		t.Fatalf("forked child guest exec = %q, want %q (the restored fork must run)", strings.TrimSpace(got), "forked-child-alive")
 	}
+}
+
+// TestColocatedForkInheritsSourceStateKVM is the KVM acceptance bar for the
+// prod-canary co-located-fork correctness bug: with --multi-vm ON, a hosted fork
+// that CO-LOCATES the child as an ADDITIONAL VM INSIDE the source pod (the spawn-vm
+// path the controller drives via SpawnVM) MUST restore the PARENT'S memory AND disk,
+// not boot a fresh template VM.
+//
+// The bug: the co-located child was spawned from the pool TEMPLATE snapshot (and its
+// rootfs cloned from the template rootfs), so a file written to the parent AND the
+// parent's live in-memory state were BOTH ABSENT in the child. The co-location was
+// fast precisely because it SKIPPED the restore a fork requires. The fix routes the
+// spawn-vm ActivateRequest at the FORK snapshot (mem + vmstate + the FROZEN source
+// rootfs at SnapshotDir/rootfs.ext4) with ForkSnapshot=true, so the child inherits
+// the parent.
+//
+// This test proves BOTH the bug and the fix ON THE SAME KVM RUNNER by spawning two
+// co-located children in one source stub:
+//
+//   - a BUG-REPRO child from the TEMPLATE snapshot (ForkSnapshot=false), the exact
+//     request the old wiring sent: it inherits NEITHER the marker file NOR the
+//     advanced uptime, and
+//   - a FIXED child from the FORK snapshot (ForkSnapshot=true), the request the fix
+//     sends: it reads back the marker file (DISK inheritance from the frozen source
+//     rootfs) AND a MUCH larger /proc/uptime (MEMORY inheritance from the fork memory
+//     checkpoint; uptime lives only in guest RAM and is never on disk).
+//
+// The mock/envtest fakes never restore real state, so this KVM proof is the only
+// gate that catches the bug; the controller-level envtest asserts the WIRING (the
+// spawn carries the parent fork snapshot dir + ForkSnapshot, not the template).
+//
+// GATED and skips cleanly unless /dev/kvm exists AND MITOS_KVM_HUSK_SNAPSHOT_DIR is
+// set AND the template rootfs is present next to the snapshot (the bench template
+// lays it out at <snapshot dir>/../rootfs.ext4), so a darwin dev box or any non-KVM
+// runner never asserts and is never a fake pass.
+func TestColocatedForkInheritsSourceStateKVM(t *testing.T) {
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		t.Skip("skipping co-located-fork inheritance proof: /dev/kvm not available (needs a KVM runner)")
+	}
+	snapDir := os.Getenv("MITOS_KVM_HUSK_SNAPSHOT_DIR")
+	if snapDir == "" {
+		t.Skip("skipping co-located-fork inheritance proof: set MITOS_KVM_HUSK_SNAPSHOT_DIR (the KVM CI sets it)")
+	}
+	for _, name := range []string{"mem", "vmstate"} {
+		if _, err := os.Stat(filepath.Join(snapDir, name)); err != nil {
+			t.Skipf("skipping co-located-fork inheritance proof: snapshot file %s not present: %v", name, err)
+		}
+	}
+	// The bench template lays the source rootfs next to the snapshot subdir
+	// (<data>/templates/<id>/rootfs.ext4, one level up from the snapshot dir). The
+	// source stub needs its OWN CoW clone of it so its writes are captured by the
+	// fork snapshot's frozen rootfs; without a real rootfs there is nothing to
+	// inherit, so skip rather than assert.
+	templateRootfs := filepath.Join(filepath.Dir(snapDir), "rootfs.ext4")
+	if _, err := os.Stat(templateRootfs); err != nil {
+		t.Skipf("skipping co-located-fork inheritance proof: template rootfs %s not present: %v", templateRootfs, err)
+	}
+	fcBin := os.Getenv("MITOS_KVM_FIRECRACKER")
+	if fcBin == "" {
+		fcBin = "/usr/local/bin/firecracker"
+	}
+
+	ctx := context.Background()
+
+	// One --multi-vm source stub with a per-activation rootfs CoW so the source VM
+	// writes its OWN clone (captured by the fork snapshot) and each co-located child
+	// gets its own independent clone. AllowUnverified mirrors the CI snapshot's
+	// unsigned manifest, exactly like the other husk KVM tests.
+	src := New(firecracker.VMConfig{
+		ID:             "husk-colo-src",
+		FirecrackerBin: fcBin,
+		WorkDir:        t.TempDir(),
+		VcpuCount:      1,
+		MemSizeMib:     256,
+	}, Options{
+		AllowUnverified:    true,
+		ReadyTimeout:       30 * time.Second,
+		MultiVM:            true,
+		RootfsTemplatePath: templateRootfs,
+		RootfsCoWDir:       t.TempDir(),
+	})
+	defer func() { _ = src.Close() }()
+
+	// Bring up the source (default) VM from the template snapshot.
+	if err := src.Prepare(ctx); err != nil {
+		t.Fatalf("source Prepare: %v", err)
+	}
+	sres, err := src.Activate(ctx, ActivateRequest{SnapshotDir: snapDir})
+	if err != nil || !sres.OK {
+		t.Fatalf("source Activate: err=%v res=%+v", err, sres)
+	}
+	srcAgent, err := kvmConnectAgent(sres.VsockPath)
+	if err != nil {
+		t.Fatalf("connect source agent: %v", err)
+	}
+	defer srcAgent.Close() //nolint:errcheck // best-effort teardown
+
+	// Write a UNIQUE marker file to the source rootfs and sync it onto the block
+	// device so the fork snapshot's FROZEN rootfs carries it (the DISK signal). A
+	// template boot never has this file.
+	const markerPath = "/mitos-colo-marker.txt"
+	marker := fmt.Sprintf("colo-inherit-%d", time.Now().UnixNano())
+	if _, err := kvmExecOK(srcAgent, fmt.Sprintf("printf %s > %s && /bin/busybox sync", marker, markerPath)); err != nil {
+		t.Fatalf("write+sync marker in source: %v", err)
+	}
+
+	// Let the source's guest clock advance well past the template's baked uptime, so
+	// a child that restores the FORK memory reads a MUCH larger /proc/uptime than a
+	// child that boots the template. Uptime lives only in guest RAM, so it is a clean
+	// MEMORY-inheritance signal that no disk write can fake.
+	time.Sleep(9 * time.Second)
+
+	// Fork snapshot the source's default VM: pause -> mem+vmstate -> freeze the
+	// source rootfs clone to <forkDir>/rootfs.ext4 -> resume. This is the exact
+	// artifact the controller's fork-snapshot op produces in the source pod.
+	forkDir := filepath.Join(t.TempDir(), "fork-snap")
+	fres, err := src.ForkSnapshot(ctx, ForkSnapshotRequest{ForkID: "colo-child", SnapshotDir: forkDir})
+	if err != nil || !fres.OK {
+		t.Fatalf("source ForkSnapshot must succeed on KVM: err=%v res=%+v", err, fres)
+	}
+	for _, name := range []string{"mem", "vmstate", "rootfs.ext4"} {
+		if _, err := os.Stat(filepath.Join(forkDir, name)); err != nil {
+			t.Fatalf("fork snapshot did not write %s (needed for co-located inheritance): %v", name, err)
+		}
+	}
+
+	// BUG-REPRO co-located child: the OLD wiring's request, activating from the
+	// TEMPLATE snapshot with ForkSnapshot=false. It clones the TEMPLATE rootfs and
+	// loads TEMPLATE memory, so it inherits nothing. Driving it here proves on the
+	// SAME runner that the pre-fix wiring loses the parent's state.
+	bugRes := src.SpawnVM(ctx, SpawnVMRequest{
+		VMID:     "colo-bug",
+		Activate: ActivateRequest{SnapshotDir: snapDir},
+	})
+	if !bugRes.OK {
+		t.Fatalf("bug-repro spawn (template) must still boot a fresh VM: %+v", bugRes)
+	}
+	bugAgent, err := kvmConnectAgent(bugRes.VsockPath)
+	if err != nil {
+		t.Fatalf("connect bug-repro child agent: %v", err)
+	}
+	defer bugAgent.Close() //nolint:errcheck // best-effort teardown
+
+	// FIXED co-located child: the request the fix sends, activating from the FORK
+	// snapshot with ForkSnapshot=true. SpawnVM clones the FROZEN source rootfs at
+	// forkDir/rootfs.ext4 and loads the fork mem+vmstate, so the child inherits the
+	// parent's disk AND memory. This is the identical SpawnVM path the controller
+	// drives (SpawnVMOnHusk -> Stub.SpawnVM -> activateInstance).
+	fixRes := src.SpawnVM(ctx, SpawnVMRequest{
+		VMID:     "colo-fix",
+		Activate: ActivateRequest{SnapshotDir: forkDir, ForkSnapshot: true},
+	})
+	if !fixRes.OK {
+		t.Fatalf("fixed co-located spawn from the fork snapshot must succeed: %+v", fixRes)
+	}
+	fixAgent, err := kvmConnectAgent(fixRes.VsockPath)
+	if err != nil {
+		t.Fatalf("connect fixed child agent: %v", err)
+	}
+	defer fixAgent.Close() //nolint:errcheck // best-effort teardown
+
+	// DISK inheritance: the fixed child reads back the marker; the bug-repro child
+	// does not (the file never existed on the template rootfs).
+	readMarker := func(agent *guestgrpc.Client) string {
+		out, _ := kvmExecOK(agent, fmt.Sprintf("cat %s 2>/dev/null || true", markerPath))
+		return strings.TrimSpace(out)
+	}
+	if got := readMarker(bugAgent); got == marker {
+		t.Fatalf("bug-repro child unexpectedly has the source marker %q; the template path should NOT inherit disk", marker)
+	}
+	if got := readMarker(fixAgent); got != marker {
+		t.Fatalf("DISK inheritance FAILED: fixed co-located child read %q, want the source marker %q (frozen source rootfs not restored)", got, marker)
+	}
+
+	// MEMORY inheritance: the fixed child's uptime is far ahead of the bug-repro
+	// child's, which sits at the template's baked uptime. The 9s the source ran
+	// before the fork snapshot separates them; a 4s floor absorbs scheduling slack.
+	bugUptime := kvmReadUptime(t, bugAgent)
+	fixUptime := kvmReadUptime(t, fixAgent)
+	if fixUptime <= bugUptime+4 {
+		t.Fatalf("MEMORY inheritance FAILED: fixed child uptime %.2fs must be well ahead of the template-boot bug-repro child %.2fs (fork memory checkpoint not restored)", fixUptime, bugUptime)
+	}
+}
+
+// kvmReadUptime reads the guest's /proc/uptime and returns the first field (seconds
+// since the guest booted) as a float. It fails the test on a transport or parse
+// error so a broken read is never silently treated as zero uptime.
+func kvmReadUptime(t *testing.T, agent *guestgrpc.Client) float64 {
+	t.Helper()
+	out, err := kvmExecOK(agent, "cat /proc/uptime")
+	if err != nil {
+		t.Fatalf("read /proc/uptime: %v", err)
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		t.Fatalf("empty /proc/uptime output %q", out)
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		t.Fatalf("parse uptime %q: %v", fields[0], err)
+	}
+	return v
 }
 
 // kvmConnectAgent dials the guest agent's gRPC service on the vsock UDS with a

--- a/internal/husk/multivm_network_test.go
+++ b/internal/husk/multivm_network_test.go
@@ -128,7 +128,7 @@ func TestMultiVMActivateProgramsDistinctTapPerVMID(t *testing.T) {
 
 	const second vmID = "vm-2"
 	for _, id := range []vmID{defaultVMID, second} {
-		if err := s.prepareInstance(context.Background(), id); err != nil {
+		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		req := ActivateRequest{

--- a/internal/husk/multivm_test.go
+++ b/internal/husk/multivm_test.go
@@ -42,7 +42,7 @@ func TestMultiVMTwoInstancesReachActiveIndependently(t *testing.T) {
 
 	const second vmID = "vm-2"
 	for _, id := range []vmID{defaultVMID, second} {
-		if err := s.prepareInstance(context.Background(), id); err != nil {
+		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		res, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"})
@@ -92,7 +92,7 @@ func TestMultiVMCloseOneLeavesOtherActive(t *testing.T) {
 
 	const second vmID = "vm-2"
 	for _, id := range []vmID{defaultVMID, second} {
-		if err := s.prepareInstance(context.Background(), id); err != nil {
+		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		if _, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
@@ -128,7 +128,7 @@ func TestMultiVMMeteringReportsBothVMs(t *testing.T) {
 	s := newMultiVMTestStub(t, vms)
 
 	for _, id := range []vmID{defaultVMID, "vm-2"} {
-		if err := s.prepareInstance(context.Background(), id); err != nil {
+		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		if _, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
@@ -172,13 +172,13 @@ func TestMultiVMSecondActivateFailClosedLeavesFirstActive(t *testing.T) {
 		MultiVM: true,
 	})
 
-	if err := s.prepareInstance(context.Background(), defaultVMID); err != nil {
+	if err := s.prepareInstance(context.Background(), defaultVMID, ""); err != nil {
 		t.Fatalf("prepareInstance(default): %v", err)
 	}
 	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
 		t.Fatalf("activateInstance(default): %v", err)
 	}
-	if err := s.prepareInstance(context.Background(), "vm-2"); err != nil {
+	if err := s.prepareInstance(context.Background(), "vm-2", ""); err != nil {
 		t.Fatalf("prepareInstance(vm-2): %v", err)
 	}
 	res, err := s.activateInstance(context.Background(), "vm-2", ActivateRequest{SnapshotDir: "/snap"})
@@ -236,7 +236,7 @@ func TestMultiVMActivateRoutesByVMID(t *testing.T) {
 	s := newMultiVMTestStub(t, vms)
 
 	const second vmID = "vm-2"
-	if err := s.prepareInstance(context.Background(), second); err != nil {
+	if err := s.prepareInstance(context.Background(), second, ""); err != nil {
 		t.Fatalf("prepareInstance(vm-2): %v", err)
 	}
 	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap", VMID: string(second)})
@@ -391,7 +391,7 @@ func TestMultiVMPrepareRunsConcurrentlyPerInstance(t *testing.T) {
 		wg.Add(1)
 		go func(i int, id vmID) {
 			defer wg.Done()
-			errs[i] = s.prepareInstance(context.Background(), id)
+			errs[i] = s.prepareInstance(context.Background(), id, "")
 		}(i, id)
 	}
 
@@ -454,7 +454,7 @@ func TestMultiVMActivateRunsConcurrentlyPerInstance(t *testing.T) {
 
 	ids := []vmID{defaultVMID, "vm-2"}
 	for _, id := range ids {
-		if err := s.prepareInstance(context.Background(), id); err != nil {
+		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 	}
@@ -518,7 +518,7 @@ func TestMultiVMPrepareRefusedWhileClosing(t *testing.T) {
 	if got := s.instanceFor("late", true); got != nil {
 		t.Fatalf("instanceFor create during closing = %v, want nil (refused)", got)
 	}
-	if err := s.prepareInstance(context.Background(), "late"); err == nil {
+	if err := s.prepareInstance(context.Background(), "late", ""); err == nil {
 		t.Fatal("prepareInstance during closing = nil error, want a closing error")
 	}
 	// Also refuse re-preparing an id that ALREADY has a map entry (Close leaves
@@ -531,7 +531,7 @@ func TestMultiVMPrepareRefusedWhileClosing(t *testing.T) {
 	if got := s.instanceFor("existing", true); got != nil {
 		t.Fatalf("instanceFor create for an existing entry during closing = %v, want nil (refused)", got)
 	}
-	if err := s.prepareInstance(context.Background(), "existing"); err == nil {
+	if err := s.prepareInstance(context.Background(), "existing", ""); err == nil {
 		t.Fatal("prepareInstance of an existing entry during closing = nil error, want a closing error")
 	}
 	s.mu.Lock()
@@ -564,7 +564,7 @@ func TestSpawnVMActivationFailureReturnsNotOK(t *testing.T) {
 		MultiVM: true,
 	})
 	// Bring up the primary VM so we can prove it is undisturbed by the failure.
-	if err := s.prepareInstance(context.Background(), defaultVMID); err != nil {
+	if err := s.prepareInstance(context.Background(), defaultVMID, ""); err != nil {
 		t.Fatalf("prepareInstance(default): %v", err)
 	}
 	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -714,7 +714,9 @@ func (s *Stub) Prepare(ctx context.Context) error {
 	// prepareInstance locks s.mu itself, so return before taking the lock here.
 	// When multiVM is false the single-VM body below runs byte-for-byte unchanged.
 	if s.multiVM {
-		return s.prepareInstance(ctx, defaultVMID)
+		// A plain Prepare brings up the pod's default (source) VM from the pool
+		// template, so the rootfs clone source is the template (empty override).
+		return s.prepareInstance(ctx, defaultVMID, "")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; a hosted fork must give the child the parent's live state.
> - The MultiVMFork routing (controller `--multi-vm-fork` + a `--multi-vm` husk pod) makes a fork CO-LOCATE the child as an additional VM inside the source pod (fast, no new pod, `status.pod == source`) instead of spilling to a new child pod.
> - A prod canary found the co-located child inherited NEITHER the source's disk NOR its memory: a file written and an in-memory value set in the parent were BOTH absent in the child. The co-located fork was fast precisely because it SKIPPED the restore a fork requires: a correctness violation.
> - It needs fixing now because co-location is the shipping fast path for hosted fork; a fork that silently drops the parent's state is worse than a slow fork. Prior fixes shipped broken because no REAL-KVM inheritance test gated it.
> - This pull request routes the co-located spawn-vm activate at the PARENT fork snapshot (mem + vmstate + the frozen source rootfs) instead of the pool template, and adds the missing real-KVM inheritance test.
> - The benefit is a co-located fork that actually forks: the child restores the parent's memory and filesystem, at co-location speed, and a regression is now caught on real KVM and in go-test.

## Linked Issues or Issue Description

No tracked public issue. The bug: with controller `--multi-vm-fork` ON and a multi-VM-capable warm pool, a hosted fork co-locates the child as a VM in the source pod, but the co-located child boots a FRESH VM from the pool TEMPLATE, inheriting neither the parent's disk nor its memory. Reproduction on prod: write `/tmp/mark.txt` and set an in-memory value in the parent, fork, and both are absent in the child.

## What Changed

- Confirmed root cause: `spawnForkChildInSourcePod` sent the spawn-vm `ActivateRequest` with `SnapshotDir = HuskSnapshotDir`, which inside the SOURCE (warm) pod resolves to the pool TEMPLATE snapshot mount, and the multi-VM stub cloned the child rootfs from the pool TEMPLATE rootfs. So the co-located child restored the TEMPLATE, not the parent. The parent fork snapshot (mem + vmstate + the frozen source rootfs) lives at `huskForksInPodDir(fork.Name)` in the source pod and was never used.
- Controller (`internal/controller/sandboxfork_controller.go`): the co-located spawn-vm activate now points `SnapshotDir` at the parent fork snapshot dir `huskForksInPodDir(fork.Name)` and sets `ForkSnapshot=true`, mirroring how the new-pod fork child restores from `<DataDir>/forks/<ForkSnapshotID>`.
- Husk (`internal/husk/control.go`, `multivm.go`, `stub.go`): a new `ActivateRequest.ForkSnapshot` flag makes the multi-VM path (a) clone the child's per-activation rootfs from the FROZEN source rootfs the fork snapshot carries at `SnapshotDir/rootfs.ext4` (inherit the DISK), and (b) skip the content-addressed verify a node-local fork snapshot has no digest for, the same posture the new-pod fork child runs with (`--allow-unverified-snapshots`). The per-VM in-pod egress filter and the fail-closed RNG/clock reseed handshake still run.
- The single-VM / template / new-pod paths are byte-for-byte unchanged: `ForkSnapshot` defaults false and `omitempty` keeps it off the wire; `prepareInstance` clones the template when the override is empty.
- Test (real KVM, the gate that was missing): `internal/husk/multivm_kvm_test.go` `TestColocatedForkInheritsSourceStateKVM` drives the SAME `Stub.SpawnVM` path the controller uses. On ONE source stub it writes+syncs a unique marker to the source rootfs and lets the guest clock advance, takes the fork snapshot, then spawns TWO co-located children: a bug-repro child from the TEMPLATE (old wiring, inherits nothing) and a fixed child from the FORK snapshot. It asserts the fixed child reads back the marker (DISK) and a far-larger `/proc/uptime` (MEMORY), while the bug-repro child has neither. Gated on `/dev/kvm` + `MITOS_KVM_HUSK_SNAPSHOT_DIR`, skips otherwise. Wired into the `firecracker-test` CI job (kvm-test.yaml).
- Test (go-test wiring guard): `internal/controller` `TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate` asserts the spawn-vm `ActivateRequest` carries the parent fork snapshot dir (not `HuskSnapshotDir`) with `ForkSnapshot=true`.
- `docs/threat-model.md`: records the co-located child's verify/isolation posture (same node-local trust boundary as the new-pod fork child; per-VM CoW clone + own token; never less isolated).

## Verification

All commands run in this branch on a clean checkout of `origin/main`:

- `go build ./...` : clean.
- `go test -race ./internal/husk/...` : `ok mitos.run/mitos/internal/husk`.
- `go test ./internal/controller/...` (envtest, `setup-envtest use 1.31`) : `ok mitos.run/mitos/internal/controller 237.517s`.
- `golangci-lint run --timeout=5m` : clean except the pre-existing darwin-only `internal/fork/uffd.go` unused finding (invisible to the linux run, acceptable).
- `GOOS=linux golangci-lint run --timeout=5m` : clean (exit 0).
- TDD proof the wiring guard catches the regression: with the fix reverted, `TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate` FAILS with `spawn-vm activated from HuskSnapshotDir "/var/lib/mitos/snapshot" (the pool TEMPLATE mount) ... want the dir the source wrote the fork snapshot to "/var/lib/mitos/forks/<fork>"`; with the fix it PASSES.
- The real-KVM inheritance test (`TestColocatedForkInheritsSourceStateKVM`) skips cleanly on the darwin dev box (no `/dev/kvm`); it runs and asserts inheritance in the `firecracker-test` CI job, which is where this class of bug had to be caught. On `origin/main` this test cannot even compile (the `ForkSnapshot` field does not exist), and its in-test bug-repro child from the template demonstrates the exact non-inheritance failure on the same runner.

## Risks

Low risk. The change is gated behind the existing `--multi-vm-fork` + multi-VM-pod path (default off); every other activate (template warm claim, new-pod fork child, single-VM) is byte-for-byte unchanged because `ForkSnapshot` defaults false. The verify skip for the co-located child matches the already-shipped new-pod fork child posture (node-local, root-owned, never tenant-writable, not content-addressed), so it does not widen the trust boundary. Touches the named-human-reviewer security paths `internal/husk` and `internal/controller`, so it needs a human security review before merge.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, agentic coding via Claude Code with extended thinking. All commands in Verification were actually executed; no results were fabricated.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved
- [ ] Benchmark run (bench/) included if the hot path was touched (no hot-path perf change; co-location speed is unchanged, only correctness)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-VM forked instances can now inherit state (memory and disk) from the correct parent snapshot when spawned alongside the source VM.

* **Bug Fixes**
  * Fixed co-located forked VMs starting from the wrong snapshot, and missing parent memory/disk state.
  * Improved fork-snapshot activation so restore/verification behavior matches the intended snapshot mode.

* **Documentation**
  * Clarified fork snapshot inheritance behavior for multi-VM routing.

* **Tests**
  * Added integration and KVM coverage for co-located fork inheritance and snapshot activation behavior, plus workflow validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->