### PR TITLE
feat(controller): cross-fork co-location reservation so concurrent same-source forks never over-admit

### DIFF
--- a/docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md
+++ b/docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md
@@ -251,10 +251,23 @@ regression where the pure memory budget floored every realistically sized multi-
 pod to 0 co-location (limit = request + modest headroom), so with the flag on every
 fork silently spilled to the new-pod path and a prod canary hit
 re-get-fork-child-pod-not-found. A legacy pod carrying no reservation stamp keeps the
-prior limit-based floor(limit / request) - 1 budget. Deferred to a follow-up: a
-dedicated node-budget check for the co-located dimension and the
-grow-the-pod-with-in-place-resize option (grow the reservation lazily as forks join,
-instead of reserving the bounded max up front).
+prior limit-based floor(limit / request) - 1 budget.
+
+The per-pod budget is now enforced ACROSS CONCURRENT same-source forks, not only per
+fork. coLocatedForkVMBudget is the WHOLE-POD ceiling; the co-location admission
+(reconcileHuskFork) subtracts the co-located VMs OTHER SandboxForks already placed in
+the source pod (coLocatedVMsInPodByOtherForks, reading status.Children[].Pod +
+status.Children[].VMID, the co-location ledger) and admits this fork's children only
+against the REMAINING room, spilling the overflow to a new pod. This closes the former
+per-fork gap where N concurrent forks of one source each admitted up to the full
+ceiling and over-admitted VMs into the pod (an intra-pod OOM risk under memory.max).
+The occupancy read is uncached (APIReader) and the controller reconciles serially
+(default MaxConcurrentReconciles 1), so two same-source forks never evaluate against a
+stale view; the read rounds toward spilling (conservative on error, under-admit never
+over-admit). Deferred to a follow-up: a dedicated node-budget check for the co-located
+dimension, the grow-the-pod-with-in-place-resize option (grow the reservation lazily as
+forks join, instead of reserving the bounded max up front), and a fully race-free
+shared reservation should MaxConcurrentReconciles ever be raised above 1.
 
 ### Guarantee B: a swarm always survives node loss by reconstructing from durable state
 

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -886,3 +886,148 @@ func TestMultiVMForkSpawnActivatesFromParentSnapshotNotTemplate(t *testing.T) {
 		t.Errorf("spawn-vm activated from %q, want the dir the source wrote the fork snapshot to %q (mem + vmstate + the frozen source rootfs live there)", gotSnapDir, writtenSnapDir)
 	}
 }
+
+// TestMultiVMForkConcurrentSameSourceReservesAcrossForks proves the cross-fork
+// reservation (guarantee A across CONCURRENT same-source forks): TWO SandboxForks
+// targeting the SAME source pod, whose per-pod budget holds only ONE co-located VM,
+// together co-locate NO MORE than that one VM. The over-budget fork's child SPILLS
+// to a new pod (a sandbox-<id>-fork-0 pod appears) instead of packing a second full
+// guest into a pod sized for one.
+//
+// This FAILS on origin/main: there the co-location budget is computed PER FORK from
+// the source pod's static resources and does NOT subtract the VMs another fork
+// already placed, so BOTH forks independently see budget 1 and BOTH co-locate: two
+// spawn-vm calls, zero spilled pods, an over-admission into a pod whose memory.max
+// holds one. After the fix each fork subtracts the live cross-fork occupancy, so the
+// second fork sees a remaining budget of 0 and spills.
+func TestMultiVMForkConcurrentSameSourceReservesAcrossForks(t *testing.T) {
+	poolName := uniqueName("pool-mvm-xfork")
+	srcClaimName := uniqueName("src-mvm-xfork")
+	forkAName := uniqueName("mvm-xfork-a")
+	forkBName := uniqueName("mvm-xfork-b")
+
+	// 512Mi limit / 256Mi per VM = 2 VMs total; one reserved for the source VM, so
+	// the pod holds exactly ONE co-located fork VM across ALL forks of it.
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.40", multiVMSource, withCoLocationBudget("256Mi", "512Mi"))
+	if got := controller.CoLocatedForkVMBudgetForTest(srcPod); got != 1 {
+		t.Fatalf("test fixture precondition: source pod budget = %d, want exactly 1 co-located VM", got)
+	}
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	// The SPILLED child legitimately takes the new-pod path and activates, so the
+	// activator must succeed. Only the co-located child uses spawn-vm.
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	var spawnCalls int32
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		atomic.AddInt32(&spawnCalls, 1)
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock"}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	newFork := func(name string) *v1.Sandbox {
+		return &v1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+			},
+			Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+		}
+	}
+	forkA := newFork(forkAName)
+	forkB := newFork(forkBName)
+	if err := k8sClient.Create(ctx, forkA); err != nil {
+		t.Fatalf("create fork A: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, forkA) })
+	if err := k8sClient.Create(ctx, forkB); err != nil {
+		t.Fatalf("create fork B: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, forkB) })
+
+	// Drive both forks to ReadyReplicas == 1, forcing any spilled child pod Ready so
+	// the new-pod path converges.
+	waitUntilForkReady(t, 25*time.Second, func() bool {
+		var pa, pb corev1.PodList
+		_ = k8sClient.List(ctx, &pa, listForkChildren(forkAName))
+		_ = k8sClient.List(ctx, &pb, listForkChildren(forkBName))
+		for i := range pa.Items {
+			forceHuskPodReady(t, &pa.Items[i])
+		}
+		for i := range pb.Items {
+			forceHuskPodReady(t, &pb.Items[i])
+		}
+		var ga, gb v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkAName, Namespace: "default"}, &ga); err != nil {
+			return false
+		}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkBName, Namespace: "default"}, &gb); err != nil {
+			return false
+		}
+		return ga.Status.ReadyReplicas == 1 && gb.Status.ReadyReplicas == 1
+	})
+
+	// Count the co-located VMs and the spilled pods across BOTH forks. A co-located
+	// child records status.Pod == the source pod + a non-empty VMID; a spilled child
+	// leaves both empty and has its own child pod.
+	var coLocated, spilled int
+	for _, name := range []string{forkAName, forkBName} {
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &got); err != nil {
+			t.Fatalf("get fork %s: %v", name, err)
+		}
+		for _, c := range got.Status.Children {
+			if c.Pod == srcPod.Name && c.VMID != "" {
+				coLocated++
+			} else if c.Pod == "" && c.VMID == "" {
+				spilled++
+			} else {
+				t.Fatalf("fork %s child %s has an inconsistent placement record: pod=%q vmId=%q", name, c.Name, c.Pod, c.VMID)
+			}
+		}
+	}
+
+	// The core guarantee: the two forks together NEVER over-admit past the pod budget.
+	if coLocated > 1 {
+		t.Fatalf("cross-fork over-admission: %d co-located VMs in a source pod whose budget holds 1 (concurrent same-source forks must not each admit up to the per-fork budget)", coLocated)
+	}
+	// The pod's one co-location slot IS used (the fix must not regress single-fork
+	// co-location into spilling everything), and the overflow spills.
+	if coLocated != 1 {
+		t.Fatalf("expected exactly 1 co-located VM (the pod's single budgeted slot), got %d", coLocated)
+	}
+	if spilled != 1 {
+		t.Fatalf("expected exactly 1 spilled child (the over-budget fork), got %d", spilled)
+	}
+
+	// The spilled child materialized as a real new pod across the two forks.
+	var pa, pb corev1.PodList
+	if err := k8sClient.List(ctx, &pa, listForkChildren(forkAName)); err != nil {
+		t.Fatalf("list fork A children: %v", err)
+	}
+	if err := k8sClient.List(ctx, &pb, listForkChildren(forkBName)); err != nil {
+		t.Fatalf("list fork B children: %v", err)
+	}
+	if total := len(pa.Items) + len(pb.Items); total != 1 {
+		t.Fatalf("expected exactly 1 spilled child pod across both forks, got %d", total)
+	}
+	// Co-location actually engaged for the one budgeted slot (the fix must not
+	// regress single-fork co-location into spilling everything). The exact spawn-call
+	// count is not asserted: an idempotent re-drive (a lost status write) may re-spawn
+	// the SAME vmID without adding a second VM, so the authoritative over-admission
+	// ceiling is the co-located/spilled record counts above, not the raw call count.
+	if got := atomic.LoadInt32(&spawnCalls); got < 1 {
+		t.Fatalf("expected co-location to engage for the budgeted slot (at least 1 spawn-vm call), got %d", got)
+	}
+}

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -83,20 +83,24 @@ type huskVMSpawner func(ctx context.Context, addr string, tlsConf *tls.Config, r
 // pends there exactly as an independent claim does. The node-level spill-vs-pend
 // refinement for the co-located dimension is deferred to a follow-up increment.
 //
-// SCOPE, and the honest limit today: this budget is computed PER FORK reconcile
-// from the source pod's static resources. It does NOT yet subtract co-located VMs
-// that OTHER SandboxForks targeting the SAME source pod have already placed there,
-// so N concurrent forks of one source can each independently admit up to this
-// budget and over-admit VMs into the pod. The NODE is still not overcommitted:
-// the pod's cgroup memory LIMIT is a hard ceiling the node scheduler already
-// reserved, so an over-admission is caught INSIDE the pod (a co-located guest that
-// would exceed memory.max is OOM-killed, fail-closed at the pod boundary) rather
-// than as a node overcommit. What is missing is a cross-fork SHARED RESERVATION or
-// live-occupancy check so an over-budget co-located child cleanly SPILLS to a new
-// pod instead of risking an intra-pod OOM under concurrent same-source forks. That
-// shared reservation (a race-free occupancy count across forks) is a tracked
-// follow-up; until it lands, guarantee A's per-pod dimension is enforced per fork,
-// not across concurrent forks of one source.
+// SCOPE: this budget is the PER-POD ceiling computed from the source pod's static
+// resources. It is the WHOLE-POD count, not a per-fork slice: the reconcile loop
+// subtracts the co-located VMs OTHER SandboxForks targeting the SAME source pod
+// have ALREADY placed there (coLocatedVMsInPodByOtherForks) before admitting this
+// fork's own children, so the effective budget for a fork is this ceiling minus the
+// live cross-fork occupancy. That closes the former per-fork gap where N concurrent
+// forks of one source each independently admitted up to this ceiling and
+// over-admitted VMs into the pod: the sum across all forks now stays within the
+// ceiling and an over-budget child SPILLS to a new pod (buildForkChildPod) instead
+// of risking an intra-pod OOM. The occupancy read is uncached (APIReader) and the
+// controller reconciles Sandbox objects serially (default MaxConcurrentReconciles
+// 1), so two same-source forks never evaluate occupancy against a stale view; the
+// read is also conservative on error (treat the pod as full and spill), and rounds
+// toward spilling so the guarantee is UNDER-admit, never over-admit. Even had the
+// NODE stayed safe without this (the pod cgroup memory LIMIT is a hard ceiling the
+// scheduler reserved, so an over-admission fails closed as an intra-pod OOM, not a
+// node overcommit), spilling the over-budget child is the correct outcome and is
+// now what happens.
 func coLocatedForkVMBudget(pod *corev1.Pod) int {
 	if pod == nil {
 		return 0
@@ -629,10 +633,37 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	// ONCE for the whole fan-out from the source pod's ACTUAL memory accounting: the
 	// pod holds only floor(memory.max / per-VM guest RAM) VMs safely at the CoW
 	// worst case, one slot reserved for the source VM already resident in the pod.
-	// The first coLocationBudget children co-locate as ADDITIONAL VMs in the source
-	// pod; every child past the budget spills to a new pod so a fork never
-	// overcommits the pod. This replaces the former hardcoded co-location count.
+	// This replaces the former hardcoded co-location count.
 	coLocationBudget := coLocatedForkVMBudget(srcPod)
+
+	// Cross-fork reservation (guarantee A across CONCURRENT same-source forks): the
+	// per-pod budget above is the WHOLE-POD ceiling, so a fork may only co-locate up
+	// to the ceiling MINUS the VMs OTHER SandboxForks already placed in this source
+	// pod. Without this subtraction N concurrent forks of one source each admit up to
+	// the full ceiling and over-admit VMs into the pod (an intra-pod OOM risk under
+	// memory.max). Reading the live occupancy here and admitting this fork's children
+	// only against the REMAINING room makes the sum across all forks stay within the
+	// ceiling; the overflow spills to a new pod exactly as an over-budget single fork
+	// already does. Computed ONCE for the fan-out. Only consulted when this fork is
+	// actually a co-location candidate (flag on, source capable, ceiling > 0); the
+	// flag-off / non-capable / zero-budget paths never list and stay byte-for-byte
+	// unchanged.
+	coLocationBudgetRemaining := coLocationBudget
+	if spawnInSourcePod && coLocationBudget > 0 {
+		otherOccupancy, occErr := r.coLocatedVMsInPodByOtherForks(ctx, fork, srcPod)
+		if occErr != nil {
+			// Conservative on error: treat the pod as full and co-locate nothing this
+			// pass (spill), never over-admit. The children take the honestly
+			// node-scheduled new-pod path and the reconcile requeues.
+			logger.Info("cross-fork co-location occupancy unavailable; co-locating nothing this pass (conservative spill)", "source", srcPod.Name, "detail", occErr.Error())
+			coLocationBudgetRemaining = 0
+		} else {
+			coLocationBudgetRemaining = coLocationBudget - otherOccupancy
+			if coLocationBudgetRemaining < 0 {
+				coLocationBudgetRemaining = 0
+			}
+		}
+	}
 
 	// One fork snapshot per SandboxFork, keyed by the fork name, taken EXACTLY
 	// ONCE and reused for every child across reconcile passes. Children take
@@ -779,16 +810,19 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 			continue
 		}
 
-		// MultiVMFork routing: for the first coLocationBudget slots of a
+		// MultiVMFork routing: for the first coLocationBudgetRemaining slots of a
 		// multi-VM-capable source, spawn the child as an ADDITIONAL VM INSIDE the
-		// source pod (spawn-vm op) instead of creating a brand-new child pod. Slots
-		// past the per-pod memory budget fall through to the new-pod path below,
-		// which spills the child to a fresh, honestly node-scheduled pod so a fork
-		// never overcommits the source pod (L1.7b, guarantee A). When the flag is off
-		// or the source is not multi-VM capable (spawnInSourcePod is false), or the
-		// budget is 0, this branch is never entered and the path below is
-		// byte-for-byte unchanged.
-		if spawnInSourcePod && int(i) < coLocationBudget {
+		// source pod (spawn-vm op) instead of creating a brand-new child pod. The
+		// budget is the whole-pod ceiling MINUS the VMs other same-source forks
+		// already placed there (the cross-fork reservation), so concurrent forks of
+		// one source never over-admit past the pod's memory budget. Slots past the
+		// remaining budget fall through to the new-pod path below, which spills the
+		// child to a fresh, honestly node-scheduled pod so a fork never overcommits
+		// the source pod (L1.7b, guarantee A). When the flag is off or the source is
+		// not multi-VM capable (spawnInSourcePod is false), or the remaining budget is
+		// 0, this branch is never entered and the path below is byte-for-byte
+		// unchanged.
+		if spawnInSourcePod && int(i) < coLocationBudgetRemaining {
 			spawnedChild, ok := r.spawnForkChildInSourcePod(ctx, spawnForkChildArgs{
 				fork:        fork,
 				srcPod:      srcPod,
@@ -913,6 +947,51 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// coLocatedVMsInPodByOtherForks counts the fork-child VMs already co-located
+// INSIDE srcPod by SandboxForks OTHER than self. It is the live cross-fork
+// occupancy the co-location admission subtracts from the per-pod budget so
+// concurrent same-source forks never over-admit past the pod's memory ceiling
+// (guarantee A across forks).
+//
+// A co-located child records status.Children[i].Pod == its host pod and a
+// non-empty status.Children[i].VMID (the new-pod spill path leaves both empty), so
+// those two fields ARE the cross-fork occupancy ledger; no extra bookkeeping is
+// needed. self is excluded because this fork's own co-located slots are governed by
+// the slot loop against the remaining budget (double-counting self would make a
+// fork spill its own already-placed children on a requeue).
+//
+// The list is UNCACHED (APIReader) when available, mirroring deletePendingForkChildPods:
+// a peer fork that co-located a VM one reconcile earlier has persisted its
+// status.Children, but the informer cache may not have observed it yet, and a stale
+// read is exactly the over-admission this guards against. With the controller's
+// serial reconcile (default MaxConcurrentReconciles 1) two same-source forks never
+// evaluate occupancy at the same instant, so the uncached read is an accurate
+// point-in-time count; a caller treats a list error as "full" and spills.
+func (r *SandboxReconciler) coLocatedVMsInPodByOtherForks(ctx context.Context, self *v1.Sandbox, srcPod *corev1.Pod) (int, error) {
+	lister := client.Reader(r.Client)
+	if r.APIReader != nil {
+		lister = r.APIReader
+	}
+	var sandboxes v1.SandboxList
+	if err := lister.List(ctx, &sandboxes, client.InNamespace(self.Namespace)); err != nil {
+		return 0, fmt.Errorf("list sandboxes for cross-fork co-location occupancy of %s/%s: %w", srcPod.Namespace, srcPod.Name, err)
+	}
+	count := 0
+	for i := range sandboxes.Items {
+		s := &sandboxes.Items[i]
+		if s.UID == self.UID {
+			continue
+		}
+		for j := range s.Status.Children {
+			c := &s.Status.Children[j]
+			if c.Pod == srcPod.Name && c.VMID != "" {
+				count++
+			}
+		}
+	}
+	return count, nil
 }
 
 // findHuskPod returns the husk pod named name in ns (a husk claim's

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -837,6 +837,21 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 			if ok {
 				forks = append(forks, spawnedChild)
 				ready++
+				// Persist the co-located child to status IMMEDIATELY, before spawning the
+				// next slot or returning. The cross-fork reservation
+				// (coLocatedVMsInPodByOtherForks) counts co-located VMs from RECORDED
+				// status, so a live VM that exists in srcPod but is not yet recorded would
+				// let a concurrent same-source fork read stale occupancy and over-admit.
+				// Writing after each spawn shrinks that window from the whole fan-out to a
+				// single spawn-then-write. The final batched Status().Update below is then
+				// idempotent (Children already carries this child).
+				fork.Status.Children = forks
+				if err := r.Status().Update(ctx, fork); err != nil {
+					// A conflict means a concurrent writer advanced the fork; returning the
+					// error requeues so the next pass re-reads and recounts occupancy fresh,
+					// never over-admitting.
+					return ctrl.Result{}, err
+				}
 			}
 			// A failed spawn is NOT wedged: the slot is left not-ready with the cause
 			// logged (issue #28), and the reconcile requeues below because

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -843,9 +843,22 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 				// status, so a live VM that exists in srcPod but is not yet recorded would
 				// let a concurrent same-source fork read stale occupancy and over-admit.
 				// Writing after each spawn shrinks that window from the whole fan-out to a
-				// single spawn-then-write. The final batched Status().Update below is then
-				// idempotent (Children already carries this child).
-				fork.Status.Children = forks
+				// single spawn-then-write. The persisted set is the full child ledger, not
+				// the prefix processed so far: `forks` only holds slots 0..i, so any
+				// already-recorded HIGHER-index child (carried forward, appended later in
+				// this loop) must be merged in or an early exit would persist a TRUNCATED
+				// ledger and cross-fork occupancy would under-count.
+				persisted := append([]v1.SandboxChild(nil), forks...)
+				inForks := make(map[string]bool, len(forks))
+				for _, f := range forks {
+					inForks[f.Name] = true
+				}
+				for name, rec := range recorded {
+					if !inForks[name] {
+						persisted = append(persisted, rec)
+					}
+				}
+				fork.Status.Children = persisted
 				if err := r.Status().Update(ctx, fork); err != nil {
 					// A conflict means a concurrent writer advanced the fork; returning the
 					// error requeues so the next pass re-reads and recounts occupancy fresh,


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the controller places fork children.
> - The MultiVMFork routing (internal/controller/sandboxfork_controller.go) now co-locates a fork child as an ADDITIONAL VM inside the source husk pod instead of a new pod, which is live on prod and dropped hosted fork from 6038ms to 728ms.
> - coLocatedForkVMBudget bounds how many co-located VMs a source pod may safely hold (guarantee A: a fork never overcommits a pod's memory). It was computed PER FORK from the pod's static resources.
> - The gap (its own SCOPE comment, and CodeRabbit on #804): the budget did not subtract co-located VMs that OTHER SandboxForks of the SAME source pod already placed, so N concurrent forks of one source could each admit up to the full budget and over-admit VMs into the pod. The node stays safe (the pod cgroup memory LIMIT is a hard ceiling), but an over-admission becomes an intra-pod OOM risk instead of a clean spill.
> - It needs addressing now because co-location is live and concurrent same-source forks are a normal swarm shape; guarantee A must hold ACROSS forks, not just per fork. Serves the L1.7b / guarantee-A section of docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md.
> - This pull request treats the budget as the whole-pod ceiling and subtracts the live cross-fork occupancy (co-located VMs recorded by other forks) before admitting this fork's children, spilling the overflow to a new pod.
> - The benefit is that concurrent forks of one source can never over-admit past the pod's memory budget: the sum across all forks stays within the ceiling and over-budget children spill cleanly instead of risking an intra-pod OOM.

## Linked Issues or Issue Description

Related: #804

Problem: `coLocatedForkVMBudget` is the per-pod co-location ceiling, but the admission decision in `reconcileHuskFork` applied it PER FORK without accounting for co-located VMs other SandboxForks of the same source pod had already placed. Two or more concurrent forks of one source each independently admitted up to the full budget, packing more full-guest VMs into the pod than its `memory.max` reserves. The node scheduler stays honest (the pod memory LIMIT is a hard ceiling), so the failure mode is an intra-pod OOM (fail-closed), but co-location should SPILL the over-budget child to a new pod rather than risk it.

## What Changed

- `internal/controller/sandboxfork_controller.go`: added `coLocatedVMsInPodByOtherForks`, which lists Sandboxes in the namespace via the uncached `APIReader` and counts children co-located in the source pod (`status.Children[].Pod == source pod` and a non-empty `status.Children[].VMID`, the existing co-location ledger), excluding the reconciling fork.
- `reconcileHuskFork` now computes `coLocationBudgetRemaining = coLocatedForkVMBudget(srcPod) - otherOccupancy` and admits co-located children only while `int(i) < coLocationBudgetRemaining`; the rest fall through to the unchanged `buildForkChildPod` spill path. Conservative on a list error (treat the pod as full and spill). Only consulted when the fork is a co-location candidate (flag on, source capable, ceiling > 0), so the flag-off / non-capable / zero-budget paths never list and stay byte-for-byte unchanged.
- `internal/controller/huskfork_multivm_envtest_test.go`: added `TestMultiVMForkConcurrentSameSourceReservesAcrossForks`, which creates TWO SandboxForks of ONE source pod whose budget holds exactly one co-located VM and asserts the total co-located across both forks stays at the budget (1) while the overflow spills to a new pod (1). Fails on origin/main (over-admits 2), passes after the fix.
- `docs/superpowers/plans/2026-07-06-fork-primitive-multinode.md` and the `coLocatedForkVMBudget` doc comment: updated to state the cross-fork reservation now holds and that the whole-pod ceiling is enforced across concurrent same-source forks.

## Verification

- [x] `go build ./...` clean.
- [x] `go test ./internal/controller/... -count=1` (envtest 1.31, `KUBEBUILDER_ASSETS` from `setup-envtest use 1.31`): `ok mitos.run/mitos/internal/controller 238.732s`.
- [x] Fail-before/pass-after proof: with only the controller file reverted to `origin/main` and the new test kept, the test FAILS: `--- FAIL: TestMultiVMForkConcurrentSameSourceReservesAcrossForks ... cross-fork over-admission: 2 co-located VMs in a source pod whose budget holds 1`. With the fix restored it PASSES: `--- PASS: TestMultiVMForkConcurrentSameSourceReservesAcrossForks (2.39s)`.
- [x] `golangci-lint run --timeout=5m` (darwin): only the pre-existing darwin-only `internal/fork/uffd.go:42 unused` finding, unrelated to this change.
- [x] `GOOS=linux golangci-lint run --timeout=5m`: clean.

## Risks

Low risk. The occupancy check runs only on the co-location candidate path (flag on, multi-VM-capable source, ceiling > 0); every other path is byte-for-byte unchanged. The change rounds toward spilling (an acceptable occasional under-admit) and never over-admits; on a list error it spills. Residual TOCTOU exists only if `MaxConcurrentReconciles` is ever raised above the default 1 (reconciles are serial today, so the uncached occupancy read is an accurate point-in-time count); a fully race-free shared reservation is noted as a follow-up in the plan doc. Adds one namespace-scoped Sandbox list per co-locating fork reconcile.

## Model Used

- Provider and model: Claude (Anthropic), Opus 4.8
- Exact model id: claude-opus-4-8
- Reasoning mode: extended thinking enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-VM forks now enforce the whole-pod co-location memory limit consistently across concurrently created forks targeting the same source, preventing over-admission.
  * When live occupancy can’t be read reliably, the system takes the safer placement path to avoid exceeding the budget.
* **Tests**
  * Added an integration test covering concurrent, same-source multi-VM reservation limits across multiple forks.
* **Documentation**
  * Updated the multi-VM co-location admission logic description to reflect the new whole-pod, cross-fork budgeting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->