### PR TITLE
test(fork): fix ForkErr data race between the mock and capacity tests

### DIFF
--- a/internal/controller/capacity_admission_envtest_test.go
+++ b/internal/controller/capacity_admission_envtest_test.go
@@ -201,7 +201,7 @@ func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
 	// The node has memory headroom so admits() selects it; the forkd Fork RPC is
 	// what rejects, exactly the race the schedule-time count check cannot close.
 	testRegistry.SetNodeMemory("cap-node-3", 16*gib, 0)
-	engine.ForkErr = fork.ErrAtCapacity // -> gRPC ResourceExhausted
+	engine.SetForkErr(fork.ErrAtCapacity) // -> gRPC ResourceExhausted
 
 	makeCapacityFixture(t, "cap3")
 
@@ -227,7 +227,7 @@ func TestClaimRePendsOnForkdResourceExhausted(t *testing.T) {
 
 	// Clearing the reject lets a later reconcile place the claim and go Ready,
 	// proving the re-pend was recoverable (not a dead end).
-	engine.ForkErr = nil
+	engine.SetForkErr(nil)
 	ready := waitForPhase(t, "cap3", v1.SandboxReady, 15*time.Second)
 	if ready.Status.Node != "cap-node-3" {
 		t.Fatalf("ready node = %q, want cap-node-3", ready.Status.Node)
@@ -246,7 +246,7 @@ func TestClaimRePendsOnForkdUnavailable(t *testing.T) {
 	defer stop()
 
 	testRegistry.SetNodeMemory("cap-node-4", 16*gib, 0)
-	engine.ForkErr = status.Error(codes.Unavailable, "node draining")
+	engine.SetForkErr(status.Error(codes.Unavailable, "node draining"))
 
 	makeCapacityFixture(t, "cap4")
 

--- a/internal/fork/mock.go
+++ b/internal/fork/mock.go
@@ -196,6 +196,16 @@ func (e *MockEngine) SetDiskHeadroom(free, total int64) {
 	e.diskTotalBytes = total
 }
 
+// SetForkErr sets (or clears, with nil) the error every Fork returns, under the
+// same lock Fork reads it with. Tests that flip ForkErr while a forkd mock gRPC
+// server is still serving Fork calls MUST use this rather than assigning the
+// field directly, or the unlocked write races the locked read in Fork.
+func (e *MockEngine) SetForkErr(err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ForkErr = err
+}
+
 func (e *MockEngine) Fork(snapshotID, sandboxID string, opts ForkOpts) (*ForkResult, error) {
 	start := time.Now()
 


### PR DESCRIPTION
## What

`go test -race` flagged a data race in the controller envtest suite: `MockEngine.Fork` reads `e.ForkErr` under `e.mu.RLock()`, but the capacity-admission tests assigned `engine.ForkErr` directly (unlocked) while a fake forkd gRPC server was still serving `Fork` calls. The unlocked write raced the locked read.

## Thinking Path

The race (`internal/fork/mock.go:203` read under RLock vs `capacity_admission_envtest_test.go` unlocked write) is pre-existing and timing-dependent: it passed when L1.7c merged but surfaced on the v1.27.0 release run, and a flaky `-race` failure would block every future release. The minimal correct fix is a mutex-guarded setter so the write takes the same lock the read already holds. Added `MockEngine.SetForkErr` (mirrors the existing `SetDiskHeadroom` setter) and routed the three test writes through it. No production behavior changes; this is test-support code plus a test-only call-site change.

## Verification

- `go build ./...` clean
- `go test ./internal/controller/ -run TestClaim -race -count=2` passes (was flagging DATA RACE)
- `golangci-lint run` and `GOOS=linux golangci-lint run` clean on the touched packages
- no em or en dashes in added lines

## Model Used

Claude Opus 4.8 (claude-opus-4-8), running as an autonomous agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of capacity-admission tests by switching to a safer way to toggle simulated engine failures during concurrent requests.
  * Ensured injected failure states can be cleared cleanly before verifying that claims return to a ready state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->