### PR TITLE
feat(fork): per-stage timing for the co-location fork to find the latency bottleneck

### DIFF
--- a/api/v1/sandbox_types.go
+++ b/api/v1/sandbox_types.go
@@ -437,6 +437,28 @@ type SandboxStatus struct {
 	// +optional
 	CheckpointTime *metav1.Time `json:"checkpointTime,omitempty"`
 
+	// ForkStartedAt is when the husk fork fan-out began its first working
+	// reconcile pass (the source pod resolved Ready and the controller started
+	// the snapshot/spawn work). A hosted co-location fork is LEVEL-TRIGGERED and
+	// reaches Ready across several ~1s requeue passes, so the wall-clock latency
+	// of the whole fork is NOT observable inside one pass; persisting the start
+	// timestamp lets the controller attribute the true end-to-end latency (from
+	// here to Ready) even though the work is split across passes. Set exactly
+	// once and never rewritten. Timing/observability only; it drives no fork
+	// behavior. NEW field.
+	// +optional
+	ForkStartedAt *metav1.Time `json:"forkStartedAt,omitempty"`
+
+	// ForkReconcilePasses counts the husk fork reconcile passes that advanced the
+	// fan-out (each pass that reached a status write). For a level-triggered
+	// controller the pass count is a first-class part of the latency breakdown:
+	// control-plane round-trips (one ~1s requeue per pass) can dominate the
+	// end-to-end fork latency, so the pass count says how much of the total is
+	// requeue wait versus real per-stage work. Timing/observability only. NEW
+	// field.
+	// +optional
+	ForkReconcilePasses int32 `json:"forkReconcilePasses,omitempty"`
+
 	// Conditions are the typed conditions with observedGeneration. Unchanged from
 	// v1alpha1.
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1100,6 +1100,10 @@ func (in *SandboxStatus) DeepCopyInto(out *SandboxStatus) {
 		in, out := &in.CheckpointTime, &out.CheckpointTime
 		*out = (*in).DeepCopy()
 	}
+	if in.ForkStartedAt != nil {
+		in, out := &in.ForkStartedAt, &out.ForkStartedAt
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
+++ b/deploy/charts/mitos/crds/mitos.run_sandboxes.yaml
@@ -773,12 +773,36 @@ spec:
                   pass. Unchanged from v1alpha1.
                 format: date-time
                 type: string
+              forkReconcilePasses:
+                description: |-
+                  ForkReconcilePasses counts the husk fork reconcile passes that advanced the
+                  fan-out (each pass that reached a status write). For a level-triggered
+                  controller the pass count is a first-class part of the latency breakdown:
+                  control-plane round-trips (one ~1s requeue per pass) can dominate the
+                  end-to-end fork latency, so the pass count says how much of the total is
+                  requeue wait versus real per-stage work. Timing/observability only. NEW
+                  field.
+                format: int32
+                type: integer
               forkSnapshotTaken:
                 description: |-
                   ForkSnapshotTaken is the exactly-once fork-snapshot guard for a replicas >
                   1 Sandbox, carried so the controller-restart correctness holds. Maps from
                   SandboxForkStatus.forkSnapshotTaken.
                 type: boolean
+              forkStartedAt:
+                description: |-
+                  ForkStartedAt is when the husk fork fan-out began its first working
+                  reconcile pass (the source pod resolved Ready and the controller started
+                  the snapshot/spawn work). A hosted co-location fork is LEVEL-TRIGGERED and
+                  reaches Ready across several ~1s requeue passes, so the wall-clock latency
+                  of the whole fork is NOT observable inside one pass; persisting the start
+                  timestamp lets the controller attribute the true end-to-end latency (from
+                  here to Ready) even though the work is split across passes. Set exactly
+                  once and never rewritten. Timing/observability only; it drives no fork
+                  behavior. NEW field.
+                format: date-time
+                type: string
               node:
                 description: |-
                   Node is the node the sandbox VM runs on. Unchanged from v1alpha1. It is the

--- a/deploy/crds/mitos.run_sandboxes.yaml
+++ b/deploy/crds/mitos.run_sandboxes.yaml
@@ -773,12 +773,36 @@ spec:
                   pass. Unchanged from v1alpha1.
                 format: date-time
                 type: string
+              forkReconcilePasses:
+                description: |-
+                  ForkReconcilePasses counts the husk fork reconcile passes that advanced the
+                  fan-out (each pass that reached a status write). For a level-triggered
+                  controller the pass count is a first-class part of the latency breakdown:
+                  control-plane round-trips (one ~1s requeue per pass) can dominate the
+                  end-to-end fork latency, so the pass count says how much of the total is
+                  requeue wait versus real per-stage work. Timing/observability only. NEW
+                  field.
+                format: int32
+                type: integer
               forkSnapshotTaken:
                 description: |-
                   ForkSnapshotTaken is the exactly-once fork-snapshot guard for a replicas >
                   1 Sandbox, carried so the controller-restart correctness holds. Maps from
                   SandboxForkStatus.forkSnapshotTaken.
                 type: boolean
+              forkStartedAt:
+                description: |-
+                  ForkStartedAt is when the husk fork fan-out began its first working
+                  reconcile pass (the source pod resolved Ready and the controller started
+                  the snapshot/spawn work). A hosted co-location fork is LEVEL-TRIGGERED and
+                  reaches Ready across several ~1s requeue passes, so the wall-clock latency
+                  of the whole fork is NOT observable inside one pass; persisting the start
+                  timestamp lets the controller attribute the true end-to-end latency (from
+                  here to Ready) even though the work is split across passes. Set exactly
+                  once and never rewritten. Timing/observability only; it drives no fork
+                  behavior. NEW field.
+                format: date-time
+                type: string
               node:
                 description: |-
                   Node is the node the sandbox VM runs on. Unchanged from v1alpha1. It is the

--- a/internal/controller/huskfork_multivm_envtest_test.go
+++ b/internal/controller/huskfork_multivm_envtest_test.go
@@ -158,6 +158,80 @@ func TestMultiVMForkRoutesToSourcePodWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestMultiVMForkRecordsStageTiming proves the per-stage fork timing is wired on
+// the co-location path: after a co-located fork reaches Ready the fork status
+// carries the persisted end-to-end timing anchors (ForkStartedAt stamped once,
+// ForkReconcilePasses counted across the level-triggered passes), and the
+// controller consumes the husk-reported Stages breakdown the spawn-vm fake returns
+// without disturbing the fork. It is the observability wiring check for the
+// ~728 ms hosted fork breakdown; it asserts the timing is emitted, not any value.
+func TestMultiVMForkRecordsStageTiming(t *testing.T) {
+	poolName := uniqueName("pool-mvm-timing")
+	srcClaimName := uniqueName("src-mvm-timing")
+	forkName := uniqueName("mvm-timing")
+
+	srcPod := makeDormantHuskPod(t, poolName, "10.0.8.9", multiVMSource, withCoLocationBudget("128Mi", "1280Mi"))
+	makeForkSourceClaim(t, srcClaimName, poolName, srcPod)
+
+	// The fork-snapshot fake returns a paused-window sub-stage breakdown, exactly
+	// as a real stub does, so the controller logs and observes it.
+	setForkSnapshotter(func(_ context.Context, _ string, _ *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+		return husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir, LatencyMs: 12.0, Stages: map[string]float64{
+			"pause": 0.4, "create_snapshot": 9.0, "rootfs_freeze": 2.0, "resume": 0.6,
+		}}, nil
+	})
+	t.Cleanup(func() { setForkSnapshotter(nil) })
+	setForkActivator(func(_ context.Context, _ string, _ *tls.Config, _ husk.ActivateRequest) (husk.ActivateResult, error) {
+		return husk.ActivateResult{OK: false, Error: "activate must not be called on the spawn-in-source-pod path"}, nil
+	})
+	t.Cleanup(func() { setForkActivator(nil) })
+
+	// The spawn-vm fake returns the prepare + activate sub-stage breakdown the real
+	// stub reports, so the controller assembles the full co-located-child stages.
+	setForkVMSpawner(func(_ context.Context, _ string, _ *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+		return husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + ".sock", LatencyMs: 60.0, Stages: map[string]float64{
+			"fc_boot": 42.0, "rootfs_clone": 3.0, "prepare_total": 46.0,
+			"vmstate_restore": 5.0, "guest_ready": 18.0, "handshake": 2.0,
+		}}, nil
+	})
+	t.Cleanup(func() { setForkVMSpawner(nil) })
+
+	setForkMultiVM(true)
+	t.Cleanup(func() { setForkMultiVM(false) })
+
+	fork := &v1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      forkName,
+			Namespace: "default",
+			Labels:    map[string]string{controller.HuskForkTestLabel: "true"},
+		},
+		Spec: v1.SandboxSpec{Source: v1.SandboxSource{FromSandbox: &v1.FromSandboxSource{Name: srcClaimName}}, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, fork); err != nil {
+		t.Fatalf("create fork: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, fork) })
+
+	waitUntilForkReady(t, 15*time.Second, func() bool {
+		var got v1.Sandbox
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+			return false
+		}
+		return got.Status.ReadyReplicas == 1
+	})
+
+	var got v1.Sandbox
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: forkName, Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get fork: %v", err)
+	}
+	if got.Status.ForkStartedAt == nil {
+		t.Errorf("Status.ForkStartedAt is nil; the end-to-end fork clock was never stamped")
+	}
+	if got.Status.ForkReconcilePasses < 1 {
+		t.Errorf("Status.ForkReconcilePasses = %d, want >= 1 (passes are counted for the level-triggered breakdown)", got.Status.ForkReconcilePasses)
+	}
+}
+
 // TestMultiVMForkOffCreatesNewChildPod proves the default-OFF path is unchanged:
 // with the flag off, a fork still creates a new child pod and never calls the
 // spawn-vm seam, even though the source is multi-VM capable.

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -159,6 +159,25 @@ var (
 		Help:    "Seconds to distribute a template snapshot to a deficit node by pull from a holder, by template. Populated only on the multi-node distribution path.",
 		Buckets: []float64{0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300},
 	}, []string{"template"})
+
+	// forkStageDurationSeconds is the per-stage latency breakdown of a hosted
+	// co-location fork, keyed by a fixed stage label. It is how the ~728 ms p50
+	// hosted fork is attributed to WHAT dominates: the controller observes one
+	// series per boundary it crosses (the fork-snapshot RPC round-trip, each
+	// spawn-vm RPC round-trip, each activate RPC round-trip), the husk-reported
+	// sub-stages inside those RPCs (fc_boot, vmstate_restore, rootfs_clone,
+	// guest_ready, handshake, ...), and the end-to-end total attributed across
+	// the level-triggered reconcile passes (stage "total"). The stage label set
+	// is a small fixed vocabulary (never error text, an id, or a secret), so the
+	// series cardinality is bounded. Buckets span the sub-millisecond floor to a
+	// few seconds so a stage anywhere from a CoW reflink to a cold FC boot lands
+	// in a real bucket. This is the input to targeting the real bottleneck for
+	// the ms-class fork; it changes no fork behavior.
+	forkStageDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "mitos_fork_stage_duration_seconds",
+		Help:    "Per-stage duration of a hosted co-location fork, by stage (controller RPC round-trips, husk sub-stages, and the end-to-end total).",
+		Buckets: []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5},
+	}, []string{"stage"})
 )
 
 func init() {
@@ -180,6 +199,7 @@ func init() {
 		refillLatencySeconds,
 		claimWaitForWarmSeconds,
 		snapshotDistributionLagSeconds,
+		forkStageDurationSeconds,
 	)
 }
 
@@ -275,3 +295,11 @@ func observeRefillLatency(seconds float64) { refillLatencySeconds.Observe(second
 // observeClaimWaitForWarm records seconds a claim waited from creation to
 // activating a warm husk pod.
 func observeClaimWaitForWarm(seconds float64) { claimWaitForWarmSeconds.Observe(seconds) }
+
+// observeForkStage records the duration of one hosted-fork stage. stage must be
+// a fixed label from the per-stage fork breakdown vocabulary (e.g.
+// "fork_snapshot_rpc", "spawn_vm_rpc", "vmstate_restore", "guest_ready",
+// "total"), never error text, an id, or a secret.
+func observeForkStage(stage string, seconds float64) {
+	forkStageDurationSeconds.WithLabelValues(stage).Observe(seconds)
+}

--- a/internal/controller/metrics_internal_test.go
+++ b/internal/controller/metrics_internal_test.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -125,5 +127,48 @@ func TestSnapshotDistributionLagMetric(t *testing.T) {
 	observeSnapshotDistributionLag(tmpl, 1.5)
 	if got := histogramCountByLabel(t, "mitos_snapshot_distribution_lag_seconds", map[string]string{"template": tmpl}); got != 1 {
 		t.Errorf("after one observe, count = %d, want 1", got)
+	}
+}
+
+// TestForkStageTimingMetric asserts the per-stage fork breakdown reaches the
+// mitos_fork_stage_duration_seconds histogram: logForkStage must observe BOTH the
+// controller-side RPC round-trip stage AND every husk-reported sub-stage as its
+// own labeled series, and observeForkStage("total", ...) must record the
+// end-to-end total. This is the check that a single hosted fork emits an
+// attributable breakdown. The metric is unexported, so this is an
+// internal-package test.
+func TestForkStageTimingMetric(t *testing.T) {
+	const rpcStage = "spawn_vm_rpc"
+	// A representative husk sub-stage split of a co-located fork child: fresh
+	// Firecracker boot dominates, the CoW rootfs clone and vmstate restore are
+	// cheap, and the guest-ready wait is the second cost.
+	huskStages := map[string]float64{
+		"fc_boot":         42.0,
+		"rootfs_clone":    3.0,
+		"vmstate_restore": 5.0,
+		"guest_ready":     18.0,
+		"handshake":       2.0,
+	}
+
+	before := map[string]uint64{rpcStage: histogramCountByLabel(t, "mitos_fork_stage_duration_seconds", map[string]string{"stage": rpcStage})}
+	for stage := range huskStages {
+		before[stage] = histogramCountByLabel(t, "mitos_fork_stage_duration_seconds", map[string]string{"stage": stage})
+	}
+
+	logForkStage(logr.Discard(), "fork-timing-test", rpcStage, 71*time.Millisecond, 65.0, huskStages)
+
+	if got := histogramCountByLabel(t, "mitos_fork_stage_duration_seconds", map[string]string{"stage": rpcStage}); got != before[rpcStage]+1 {
+		t.Errorf("round-trip stage %q count = %d, want %d", rpcStage, got, before[rpcStage]+1)
+	}
+	for stage := range huskStages {
+		if got := histogramCountByLabel(t, "mitos_fork_stage_duration_seconds", map[string]string{"stage": stage}); got != before[stage]+1 {
+			t.Errorf("husk sub-stage %q count = %d, want %d", stage, got, before[stage]+1)
+		}
+	}
+
+	beforeTotal := histogramCountByLabel(t, "mitos_fork_stage_duration_seconds", map[string]string{"stage": "total"})
+	observeForkStage("total", 0.728)
+	if got := histogramCountByLabel(t, "mitos_fork_stage_duration_seconds", map[string]string{"stage": "total"}); got != beforeTotal+1 {
+		t.Errorf("total stage count = %d, want %d", got, beforeTotal+1)
 	}
 }

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -198,6 +200,39 @@ func (r *SandboxReconciler) multiVMForkEnabled() bool {
 // huskForkFinalizer guards a husk fork so its node-local fork snapshot is
 // removed from the source pod before the Sandbox object is deleted.
 const huskForkFinalizer = "mitos.run/husk-fork-snapshot"
+
+// logForkStage emits one hosted-fork stage boundary: it logs the controller-side
+// RPC round-trip (network + husk) plus the husk-reported per-stage breakdown of
+// the work inside that RPC, and observes every stage into the
+// mitos_fork_stage_duration_seconds histogram. It is how a SINGLE hosted fork
+// yields an attributable breakdown: at each control op (fork-snapshot, spawn-vm,
+// activate) the round-trip is one series (stage) and the stub's sub-stages
+// (fc_boot, vmstate_restore, guest_ready, ...) are their own series, so the gap
+// between the round-trip and the sub-stage sum is the control-plane / network
+// overhead. name is the fixed round-trip stage label; huskLatencyMs is the stub's
+// own total for the op; huskStages is the stub's sub-stage split (nil for a stub
+// that did not report it, e.g. an older peer or an AlreadyActive re-drive). Only
+// fixed stage names and millisecond durations are logged or labeled: no secret,
+// token, entropy, or id value is ever emitted. Timing/observability only.
+func logForkStage(logger logr.Logger, id, name string, rpc time.Duration, huskLatencyMs float64, huskStages map[string]float64) {
+	observeForkStage(name, rpc.Seconds())
+	kv := []any{
+		"fork", id,
+		"stage", name,
+		"rpcMs", float64(rpc.Microseconds()) / 1000.0,
+		"huskLatencyMs", huskLatencyMs,
+	}
+	names := make([]string, 0, len(huskStages))
+	for stage := range huskStages {
+		names = append(names, stage)
+	}
+	sort.Strings(names)
+	for _, stage := range names {
+		observeForkStage(stage, huskStages[stage]/1000.0)
+		kv = append(kv, stage+"Ms", huskStages[stage])
+	}
+	logger.Info("fork stage timing", kv...)
+}
 
 // reconcileFromSandbox owns the fork engine for a source.fromSandbox Sandbox: a
 // live fork of the named source Sandbox into replicas indexed sibling children,
@@ -601,6 +636,20 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
+	// Attribute the end-to-end fork latency across the level-triggered reconcile
+	// passes. A hosted co-location fork reaches Ready over several ~1s requeue
+	// passes, so no single pass sees the whole wall-clock; stamp the start on the
+	// first working pass (source resolved Ready, source pod reachable) and count
+	// each pass that advances the fan-out to a status write. Both are persisted by
+	// the Status().Update calls this pass already makes, so the total (from
+	// ForkStartedAt to Ready) and the pass count are attributable even though the
+	// work is split across passes. Timing/observability only; drives no behavior.
+	if fork.Status.ForkStartedAt == nil {
+		startNow := metav1.Now()
+		fork.Status.ForkStartedAt = &startNow
+	}
+	fork.Status.ForkReconcilePasses++
+
 	controlPort := r.HuskControlPort
 	if controlPort == 0 {
 		controlPort = HuskControlPort
@@ -683,12 +732,19 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		// read-only at HuskSnapshotDir.
 		tlsConf, err := r.huskDialTLS(snapCtx, fork.Namespace)
 		var snapRes husk.ForkSnapshotResult
+		snapStart := time.Now()
 		if err == nil {
 			snapRes, err = forkSnap(snapCtx, srcAddr, tlsConf, husk.ForkSnapshotRequest{
 				ForkID:      forkID,
 				SnapshotDir: huskForksInPodDir(forkID),
 				PauseSource: fork.Spec.Source.FromSandbox.PauseSource,
 			})
+		}
+		// Time the fork-snapshot RPC round-trip and record the husk-reported
+		// paused-window sub-stages (pause, create_snapshot, rootfs_freeze, resume),
+		// so the one-time source pause cost is attributable in the fork breakdown.
+		if err == nil && snapRes.OK {
+			logForkStage(logger, forkID, "fork_snapshot_rpc", time.Since(snapStart), snapRes.LatencyMs, snapRes.Stages)
 		}
 		if err != nil || !snapRes.OK {
 			msg := "fork snapshot did not complete"
@@ -907,6 +963,7 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		addr := net.JoinHostPort(child.Status.PodIP, strconv.Itoa(controlPort))
 		tlsConf, err := r.huskDialTLS(ctx, fork.Namespace)
 		var actRes husk.ActivateResult
+		actStart := time.Now()
 		if err == nil {
 			actRes, err = activate(ctx, addr, tlsConf, husk.ActivateRequest{
 				// The child reads the FORK snapshot here (its <dataDir>/forks/<fork-id>
@@ -945,6 +1002,15 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 		// stable token persisted above, so ADOPT it as ready rather than retrying a
 		// non-dormant VM forever.
 
+		// New-pod fork child: time the activate RPC round-trip and record the
+		// husk-reported activate sub-stages (vmstate_restore, guest_ready,
+		// handshake, ...). AlreadyActive re-drives carry no fresh stub-side timing
+		// (LatencyMs 0, empty Stages), so this attributes only the pass that did the
+		// real activation work.
+		if actRes.OK {
+			logForkStage(logger, childName, "activate_rpc", time.Since(actStart), actRes.LatencyMs, actRes.Stages)
+		}
+
 		forks = append(forks, v1.SandboxChild{
 			Name:      childName,
 			SandboxID: child.Name,
@@ -973,6 +1039,22 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	if fork.Status.ReadyReplicas < effectiveReplicas(fork) {
 		// Children still coming up; requeue to drive them Ready.
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+	// Fan-out complete: emit the single-fork end-to-end breakdown. The total is
+	// the wall-clock from the first working pass (ForkStartedAt) to Ready NOW,
+	// attributed across the level-triggered reconcile passes, so a level of the
+	// ~728 ms hosted fork that lives in requeue wait between passes (rather than in
+	// any one RPC) is visible as total >> the sum of the per-RPC stages. The
+	// per-stage RPC and husk sub-stage lines were emitted at each boundary above.
+	if fork.Status.ForkStartedAt != nil {
+		total := time.Since(fork.Status.ForkStartedAt.Time)
+		observeForkStage("total", total.Seconds())
+		logger.Info("fork timing complete",
+			"fork", fork.Name,
+			"replicas", effectiveReplicas(fork),
+			"reconcilePasses", fork.Status.ForkReconcilePasses,
+			"totalMs", float64(total.Microseconds())/1000.0,
+		)
 	}
 	return ctrl.Result{}, nil
 }
@@ -1109,6 +1191,7 @@ func (r *SandboxReconciler) spawnForkChildInSourcePod(ctx context.Context, a spa
 	addr := net.JoinHostPort(a.srcPod.Status.PodIP, strconv.Itoa(a.controlPort))
 	tlsConf, err := r.huskDialTLS(ctx, a.fork.Namespace)
 	var spRes husk.SpawnVMResult
+	spawnStart := time.Now()
 	if err == nil {
 		spRes, err = a.spawnVM(ctx, addr, tlsConf, husk.SpawnVMRequest{
 			VMID: vmID,
@@ -1156,6 +1239,16 @@ func (r *SandboxReconciler) spawnForkChildInSourcePod(ctx context.Context, a spa
 	// OK, or AlreadyActive: a prior spawn brought this VM up but its ack or
 	// bookkeeping was lost. Either way the VM is active with the stable token
 	// persisted above, so ADOPT it as ready.
+
+	// Co-located fork child: time the spawn-vm RPC round-trip and record the
+	// husk-reported prepare + activate sub-stages (fc_boot, rootfs_clone,
+	// vmstate_restore, guest_ready, handshake, ...). This is the core of the
+	// hosted co-location fork latency, so its breakdown is the primary signal for
+	// targeting the bottleneck. AlreadyActive re-drives carry no fresh stub-side
+	// timing (LatencyMs 0, empty Stages) and so add nothing to the breakdown.
+	if spRes.OK {
+		logForkStage(logger, a.childName, "spawn_vm_rpc", time.Since(spawnStart), spRes.LatencyMs, spRes.Stages)
+	}
 	return v1.SandboxChild{
 		Name:      a.childName,
 		SandboxID: a.srcPod.Name,

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -118,6 +118,16 @@ type ActivateResult struct {
 	VsockPath string  `json:"vsock_path,omitempty"`
 	LatencyMs float64 `json:"latency_ms"`
 	Error     string  `json:"error,omitempty"`
+	// Stages is the per-stage timing breakdown of this activate, in
+	// milliseconds, keyed by a fixed stage name (verify, egress_filter,
+	// vmstate_restore, resume, guest_ready, handshake, serve_api). It is how the
+	// controller attributes WHAT dominates a hosted fork: the stub already
+	// reported the total LatencyMs, and Stages splits that total across the
+	// steps so a caller sees, for example, that guest_ready is most of it. The
+	// keys are a fixed vocabulary (never a secret or an id), the values carry no
+	// secret, and omitempty keeps a stub that does not fill it off the wire, so
+	// an older peer stays byte-for-byte compatible. Timing/observability only.
+	Stages map[string]float64 `json:"stages,omitempty"`
 	// AlreadyActive is set when Activate was refused because the stub is ALREADY
 	// in the active state (a prior Activate succeeded). It is not OK, but it tells
 	// an idempotent caller that the VM is in fact activated, so a re-drive that
@@ -291,6 +301,13 @@ type ForkSnapshotResult struct {
 	SnapshotDir string  `json:"snapshot_dir,omitempty"`
 	LatencyMs   float64 `json:"latency_ms"`
 	Error       string  `json:"error,omitempty"`
+	// Stages is the per-stage timing breakdown of this fork snapshot, in
+	// milliseconds, keyed by a fixed stage name (pause, create_snapshot,
+	// rootfs_freeze, resume). It splits the total LatencyMs across the paused
+	// checkpoint window so a caller sees whether the snapshot cost is the
+	// CreateSnapshot memory write or the rootfs freeze. Fixed keys, no secret,
+	// omitempty for older-peer compatibility. Timing/observability only.
+	Stages map[string]float64 `json:"stages,omitempty"`
 }
 
 // RemoveForkSnapshotRequest asks the source stub to delete a fork snapshot dir it
@@ -372,6 +389,14 @@ type SpawnVMResult struct {
 	LatencyMs     float64 `json:"latency_ms"`
 	Error         string  `json:"error,omitempty"`
 	AlreadyActive bool    `json:"already_active,omitempty"`
+	// Stages is the per-stage timing breakdown of this spawn-vm, in
+	// milliseconds, merging the prepare sub-stages (fc_boot, verify_prepare,
+	// rootfs_clone) with the activate sub-stages (vmstate_restore, guest_ready,
+	// handshake, ...). A co-located fork child is a fresh Firecracker prepared
+	// then activated INSIDE the source pod, so this breakdown is the core of the
+	// hosted-fork latency the controller reports. Fixed keys, no secret,
+	// omitempty for older-peer compatibility. Timing/observability only.
+	Stages map[string]float64 `json:"stages,omitempty"`
 }
 
 func readSpawnVMRequest(r *bufio.Reader) (SpawnVMRequest, error) {

--- a/internal/husk/control_test.go
+++ b/internal/husk/control_test.go
@@ -72,6 +72,9 @@ func TestActivateResultRoundTrip(t *testing.T) {
 		OK:        true,
 		VsockPath: "/run/husk/vsock.sock",
 		LatencyMs: 4.275,
+		Stages: map[string]float64{
+			"vmstate_restore": 5.0, "guest_ready": 18.0, "handshake": 2.0,
+		},
 	}
 
 	var buf bytes.Buffer
@@ -121,7 +124,9 @@ func TestForkSnapshotRequestRoundTrip(t *testing.T) {
 
 func TestForkSnapshotResultRoundTrip(t *testing.T) {
 	var buf bytes.Buffer
-	want := ForkSnapshotResult{OK: true, SnapshotDir: "/var/lib/mitos/forks/fork-1", LatencyMs: 12.5}
+	want := ForkSnapshotResult{OK: true, SnapshotDir: "/var/lib/mitos/forks/fork-1", LatencyMs: 12.5, Stages: map[string]float64{
+		"pause": 0.4, "create_snapshot": 9.0, "rootfs_freeze": 2.0, "resume": 0.6,
+	}}
 	if err := WriteForkSnapshotResult(&buf, want); err != nil {
 		t.Fatalf("WriteForkSnapshotResult: %v", err)
 	}
@@ -129,7 +134,7 @@ func TestForkSnapshotResultRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadForkSnapshotResult: %v", err)
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("round trip mismatch: got %+v want %+v", got, want)
 	}
 }
@@ -178,6 +183,10 @@ func TestSpawnVMResultRoundTrip(t *testing.T) {
 		VMID:      "fork-7",
 		VsockPath: "/run/husk/fork-7/vsock.sock",
 		LatencyMs: 6.25,
+		Stages: map[string]float64{
+			"fc_boot": 42.0, "rootfs_clone": 3.0, "prepare_total": 46.0,
+			"vmstate_restore": 5.0, "guest_ready": 18.0, "handshake": 2.0,
+		},
 	}
 	var buf bytes.Buffer
 	if err := WriteSpawnVMResult(&buf, want); err != nil {
@@ -187,7 +196,7 @@ func TestSpawnVMResultRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadSpawnVMResult: %v", err)
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("round trip mismatch: got %+v want %+v", got, want)
 	}
 }

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	"mitos.run/mitos/internal/cas"
@@ -155,6 +157,43 @@ func deriveVMNetwork(id vmID, base *vsock.NotifyForkedNetwork) *vsock.NotifyFork
 	return &n
 }
 
+// stageMs returns the milliseconds elapsed since t, the unit the fork stage
+// breakdown records (matching LatencyMs). It is a pure timing helper; it records
+// no secret.
+func stageMs(t time.Time) float64 { return float64(time.Since(t).Microseconds()) / 1000.0 }
+
+// formatStages renders a stage map as a deterministic "name=1.23 name=4.56"
+// string (keys sorted) for a single-line log. It carries only stage names and
+// millisecond durations, never a secret.
+func formatStages(stages map[string]float64) string {
+	if len(stages) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(stages))
+	for name := range stages {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for i, name := range names {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%s=%.2f", name, stages[name])
+	}
+	return b.String()
+}
+
+// recordStage stores dur under name in stages when stages is non-nil. The stage
+// maps are the per-stage fork breakdown the controller logs and observes; a nil
+// map (a caller that did not ask for timing) is a no-op so the fast path stays
+// allocation-free. name is a fixed vocabulary value, never a secret or an id.
+func recordStage(stages map[string]float64, name string, since time.Time) {
+	if stages != nil {
+		stages[name] = stageMs(since)
+	}
+}
+
 // prepareInstance brings up a DORMANT Firecracker VMM for one vmID and records it
 // on the per-VM instance, allocating the instance on first use. It mirrors the
 // single-VM Prepare (state gate, snapshot verify at prepare, per-activation rootfs
@@ -173,7 +212,11 @@ func deriveVMNetwork(id vmID, base *vsock.NotifyForkedNetwork) *vsock.NotifyFork
 // environment at launch. SpawnVM passes the FIRECRACKER_MITOS_CHILD_MEMFD entry
 // here so a co-located live-cow child boots its guest RAM from the parent's shared
 // memfd; every other caller passes none, preserving the prior behavior.
-func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride string, extraEnv ...string) error {
+// stages, when non-nil, is filled with this prepare's per-stage timing (fc_boot,
+// verify_prepare, rootfs_clone) in milliseconds; a nil map disables timing with
+// no allocation. It is written under the instance lock, so a caller reads it only
+// after prepareInstance returns. Timing/observability only.
+func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride string, stages map[string]float64, extraEnv ...string) error {
 	if err := checkVMID(id); err != nil {
 		return err
 	}
@@ -212,10 +255,12 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride s
 			return fmt.Errorf("husk: create per-VM workdir for vm %q: %w", id, err)
 		}
 	}
+	fcBootStart := time.Now()
 	vm, err := s.start(cfg)
 	if err != nil {
 		return fmt.Errorf("husk: prepare dormant VMM for vm %q: %w", id, err)
 	}
+	recordStage(stages, "fc_boot", fcBootStart)
 	inst.vm = vm
 
 	// Snapshot verify at prepare time (pre-paid, dormant), the same fail-closed
@@ -223,6 +268,7 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride s
 	// dir + expected digest. The snapshot is read-only and content-addressed, so
 	// verifying once here is equivalent to verifying at activate.
 	if s.prepareSnapshotDir != "" && s.prepareExpectedDigest != "" {
+		verifyStart := time.Now()
 		for _, name := range []string{"mem", "vmstate"} {
 			f := filepath.Join(s.prepareSnapshotDir, name)
 			if err := waitForFile(ctx, f, rootfsTemplateWait); err != nil {
@@ -239,6 +285,7 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride s
 			inst.vm = nil
 			return fmt.Errorf("husk: prepare-time snapshot verification failed for vm %q: %w", id, err)
 		}
+		recordStage(stages, "verify_prepare", verifyStart)
 		inst.prepareVerified = true
 	}
 
@@ -263,11 +310,13 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride s
 			inst.vm = nil
 			return fmt.Errorf("husk: per-activation rootfs source %s not ready for vm %q: %w", rootfsSrc, id, err)
 		}
+		cloneStart := time.Now()
 		if err := s.reflink(rootfsSrc, clonePath); err != nil {
 			_ = inst.vm.Close()
 			inst.vm = nil
 			return fmt.Errorf("husk: clone per-activation rootfs for vm %q: %w", id, err)
 		}
+		recordStage(stages, "rootfs_clone", cloneStart)
 		inst.rootfsClonePath = clonePath
 	}
 
@@ -330,6 +379,12 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 	vmStateFile := filepath.Join(req.SnapshotDir, "vmstate")
 
 	start := time.Now()
+	// Per-stage timing of the activate, so the controller can attribute WHAT
+	// dominates a hosted fork instead of seeing only the total. Each block below
+	// records its own elapsed under a fixed stage name; mark is reset after each.
+	// Timing/observability only, under the instance lock this method already holds.
+	stages := make(map[string]float64, 6)
+	mark := time.Now()
 
 	// Verify-on-activate gate, with the same prepare-time fast path the single-VM
 	// Activate uses: skip the re-hash only when THIS instance verified this exact
@@ -348,6 +403,8 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 			return ActivateResult{OK: false, Error: werr.Error()}, werr
 		}
 	}
+	recordStage(stages, "verify", mark)
+	mark = time.Now()
 
 	// Per-VM in-pod egress filter. Derive this vmID's OWN /30 (deriveVMNetwork:
 	// the primary VM keeps the base link, every secondary gets a distinct guest
@@ -381,6 +438,8 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 		}}
 		inst.activeTap = tap
 	}
+	recordStage(stages, "egress_filter", mark)
+	mark = time.Now()
 
 	// Load PAUSED so the rootfs drive can be rebound before the guest runs, then
 	// resume explicitly, exactly as the single-VM path does.
@@ -388,6 +447,8 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 		werr := fmt.Errorf("husk: load snapshot from %s for vm %q: %w", req.SnapshotDir, id, err)
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "vmstate_restore", mark)
+	mark = time.Now()
 	if inst.rootfsClonePath != "" {
 		if err := inst.vm.PatchDrive("rootfs", inst.rootfsClonePath); err != nil {
 			werr := fmt.Errorf("husk: rebind rootfs drive to per-activation clone for vm %q: %w", id, err)
@@ -398,12 +459,16 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 		werr := fmt.Errorf("husk: resume vm %q after rootfs rebind: %w", id, err)
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "resume", mark)
+	mark = time.Now()
 
 	vsockPath := inst.vm.VsockHostPath(firecracker.VsockRelPath)
 	if err := s.ready(ctx, vsockPath, s.readyTimeout); err != nil {
 		werr := fmt.Errorf("husk: guest not ready after activate for vm %q: %w", id, err)
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "guest_ready", mark)
+	mark = time.Now()
 
 	// Fork-correctness handshake with a fresh per-VM generation + entropy. Each
 	// instance owns its own generation counter, so two VMs never share it. The
@@ -423,6 +488,8 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 		werr := fmt.Errorf("husk: fork-correctness handshake failed for vm %q: %w", id, err)
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "handshake", mark)
+	mark = time.Now()
 
 	if s.onActivated != nil {
 		if err := s.onActivated(vsockPath, req.Token); err != nil {
@@ -430,13 +497,19 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 			return ActivateResult{OK: false, Error: werr.Error()}, werr
 		}
 	}
+	recordStage(stages, "serve_api", mark)
 
 	latency := time.Since(start)
+	// Structured per-stage timing to the stub log (stderr), so a single activate
+	// is legible on the node even without the controller-side breakdown. Stage
+	// names and durations only; no secret, token, or entropy value is logged.
+	fmt.Fprintf(os.Stderr, "husk: activate vm %q stage timing ms: %s total=%.2f\n", id, formatStages(stages), float64(latency.Microseconds())/1000.0)
 	inst.state = StateActive
 	return ActivateResult{
 		OK:        true,
 		VsockPath: vsockPath,
 		LatencyMs: float64(latency.Microseconds()) / 1000.0,
+		Stages:    stages,
 	}, nil
 }
 
@@ -502,14 +575,27 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 			fmt.Fprintf(os.Stderr, "husk: live-cow fork enabled for co-located child vm %q but no armed live-cow parent; restoring from disk fork snapshot this pass\n", req.VMID)
 		}
 	}
-	if err := s.prepareInstance(ctx, id, rootfsSrcOverride, childMemfdEnv...); err != nil {
+	// Per-stage timing of the whole spawn (prepare + activate), so the controller
+	// attributes WHAT dominates a co-located fork child: fc_boot / rootfs_clone
+	// come from prepare, vmstate_restore / guest_ready / handshake from activate.
+	prepStart := time.Now()
+	prepStages := make(map[string]float64, 3)
+	if err := s.prepareInstance(ctx, id, rootfsSrcOverride, prepStages, childMemfdEnv...); err != nil {
 		return SpawnVMResult{
 			OK:    false,
 			VMID:  req.VMID,
 			Error: fmt.Errorf("husk: spawn-vm prepare vm %q: %w", req.VMID, err).Error(),
 		}
 	}
+	prepStages["prepare_total"] = stageMs(prepStart)
 	res, _ := s.activateInstance(ctx, id, req.Activate)
+	// Merge the prepare and activate stage maps into one breakdown for the spawn.
+	// prepare and activate use disjoint stage names, so neither overwrites the
+	// other; the merged map is what the controller logs and observes.
+	stages := prepStages
+	for name, dur := range res.Stages {
+		stages[name] = dur
+	}
 	return SpawnVMResult{
 		OK:            res.OK,
 		VMID:          req.VMID,
@@ -517,6 +603,7 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 		LatencyMs:     res.LatencyMs,
 		Error:         res.Error,
 		AlreadyActive: res.AlreadyActive,
+		Stages:        stages,
 	}
 }
 
@@ -817,11 +904,18 @@ func (s *Stub) forkSnapshotInstance(ctx context.Context, id vmID, req ForkSnapsh
 	}
 
 	start := time.Now()
+	// Per-stage timing of the paused checkpoint window, so the controller sees
+	// whether the fork-snapshot cost is the CreateSnapshot memory write or the
+	// rootfs freeze. Timing/observability only, under the instance lock.
+	stages := make(map[string]float64, 4)
+	mark := time.Now()
 
 	if err := inst.vm.Pause(); err != nil {
 		werr := fmt.Errorf("husk: pause source vm %q for fork snapshot: %w", id, err)
 		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "pause", mark)
+	mark = time.Now()
 
 	if err := inst.vm.CreateSnapshot(memFile, vmStateFile); err != nil {
 		// Best effort: resume the source so a transient snapshot error does not leave
@@ -833,6 +927,8 @@ func (s *Stub) forkSnapshotInstance(ctx context.Context, id vmID, req ForkSnapsh
 		werr := fmt.Errorf("husk: create fork snapshot in %s for vm %q: %w", req.SnapshotDir, id, err)
 		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "create_snapshot", mark)
+	mark = time.Now()
 
 	// Freeze THIS instance's source rootfs INSIDE the paused window, as a
 	// point-in-time pair with the mem+vmstate checkpoint, exactly as the single-VM
@@ -847,6 +943,8 @@ func (s *Stub) forkSnapshotInstance(ctx context.Context, id vmID, req ForkSnapsh
 			return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 		}
 	}
+	recordStage(stages, "rootfs_freeze", mark)
+	mark = time.Now()
 
 	// ALWAYS resume the source after the checkpoint: the pause is only the brief
 	// quiescence CreateSnapshot requires, and the memory + frozen rootfs are a
@@ -857,12 +955,15 @@ func (s *Stub) forkSnapshotInstance(ctx context.Context, id vmID, req ForkSnapsh
 		werr := fmt.Errorf("husk: resume source vm %q after fork snapshot: %w", id, err)
 		return ForkSnapshotResult{OK: false, Error: werr.Error()}, werr
 	}
+	recordStage(stages, "resume", mark)
 
 	latency := time.Since(start)
+	fmt.Fprintf(os.Stderr, "husk: fork-snapshot vm %q stage timing ms: %s total=%.2f\n", id, formatStages(stages), float64(latency.Microseconds())/1000.0)
 	return ForkSnapshotResult{
 		OK:          true,
 		SnapshotDir: req.SnapshotDir,
 		LatencyMs:   float64(latency.Microseconds()) / 1000.0,
+		Stages:      stages,
 	}, nil
 }
 

--- a/internal/husk/multivm_forksnapshot_test.go
+++ b/internal/husk/multivm_forksnapshot_test.go
@@ -52,6 +52,15 @@ func TestMultiVMForkSnapshotFromDefaultVM(t *testing.T) {
 		t.Fatalf("ForkSnapshot on a multi-vm stub's default VM must be OK, got: %+v", res)
 	}
 
+	// Per-stage fork timing is emitted: the paused-window sub-stages the
+	// controller reads for the hosted-fork breakdown must be present (rootfs_freeze
+	// is skipped here because the mock instance has no per-activation rootfs clone).
+	for _, stage := range []string{"pause", "create_snapshot", "resume"} {
+		if _, ok := res.Stages[stage]; !ok {
+			t.Errorf("ForkSnapshot result missing stage timing %q; got stages %v", stage, res.Stages)
+		}
+	}
+
 	// The DEFAULT instance's VM (not the single-VM s.vm, which is nil under
 	// multi-vm) must have been paused for the checkpoint and resumed afterward.
 	defVM := vms["husk-test"]

--- a/internal/husk/multivm_kvm_test.go
+++ b/internal/husk/multivm_kvm_test.go
@@ -73,7 +73,7 @@ func TestMultiVMTwoRealFirecrackersKVM(t *testing.T) {
 	ids := []vmID{defaultVMID, "vm-2"}
 	vsockByID := map[vmID]string{}
 	for _, id := range ids {
-		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
+		if err := s.prepareInstance(context.Background(), id, "", nil); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		res, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: snapDir})

--- a/internal/husk/multivm_network_test.go
+++ b/internal/husk/multivm_network_test.go
@@ -128,7 +128,7 @@ func TestMultiVMActivateProgramsDistinctTapPerVMID(t *testing.T) {
 
 	const second vmID = "vm-2"
 	for _, id := range []vmID{defaultVMID, second} {
-		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
+		if err := s.prepareInstance(context.Background(), id, "", nil); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		req := ActivateRequest{

--- a/internal/husk/multivm_test.go
+++ b/internal/husk/multivm_test.go
@@ -42,7 +42,7 @@ func TestMultiVMTwoInstancesReachActiveIndependently(t *testing.T) {
 
 	const second vmID = "vm-2"
 	for _, id := range []vmID{defaultVMID, second} {
-		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
+		if err := s.prepareInstance(context.Background(), id, "", nil); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		res, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"})
@@ -92,7 +92,7 @@ func TestMultiVMCloseOneLeavesOtherActive(t *testing.T) {
 
 	const second vmID = "vm-2"
 	for _, id := range []vmID{defaultVMID, second} {
-		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
+		if err := s.prepareInstance(context.Background(), id, "", nil); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		if _, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
@@ -128,7 +128,7 @@ func TestMultiVMMeteringReportsBothVMs(t *testing.T) {
 	s := newMultiVMTestStub(t, vms)
 
 	for _, id := range []vmID{defaultVMID, "vm-2"} {
-		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
+		if err := s.prepareInstance(context.Background(), id, "", nil); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 		if _, err := s.activateInstance(context.Background(), id, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
@@ -172,13 +172,13 @@ func TestMultiVMSecondActivateFailClosedLeavesFirstActive(t *testing.T) {
 		MultiVM: true,
 	})
 
-	if err := s.prepareInstance(context.Background(), defaultVMID, ""); err != nil {
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
 		t.Fatalf("prepareInstance(default): %v", err)
 	}
 	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
 		t.Fatalf("activateInstance(default): %v", err)
 	}
-	if err := s.prepareInstance(context.Background(), "vm-2", ""); err != nil {
+	if err := s.prepareInstance(context.Background(), "vm-2", "", nil); err != nil {
 		t.Fatalf("prepareInstance(vm-2): %v", err)
 	}
 	res, err := s.activateInstance(context.Background(), "vm-2", ActivateRequest{SnapshotDir: "/snap"})
@@ -236,7 +236,7 @@ func TestMultiVMActivateRoutesByVMID(t *testing.T) {
 	s := newMultiVMTestStub(t, vms)
 
 	const second vmID = "vm-2"
-	if err := s.prepareInstance(context.Background(), second, ""); err != nil {
+	if err := s.prepareInstance(context.Background(), second, "", nil); err != nil {
 		t.Fatalf("prepareInstance(vm-2): %v", err)
 	}
 	res, err := s.Activate(context.Background(), ActivateRequest{SnapshotDir: "/snap", VMID: string(second)})
@@ -391,7 +391,7 @@ func TestMultiVMPrepareRunsConcurrentlyPerInstance(t *testing.T) {
 		wg.Add(1)
 		go func(i int, id vmID) {
 			defer wg.Done()
-			errs[i] = s.prepareInstance(context.Background(), id, "")
+			errs[i] = s.prepareInstance(context.Background(), id, "", nil)
 		}(i, id)
 	}
 
@@ -454,7 +454,7 @@ func TestMultiVMActivateRunsConcurrentlyPerInstance(t *testing.T) {
 
 	ids := []vmID{defaultVMID, "vm-2"}
 	for _, id := range ids {
-		if err := s.prepareInstance(context.Background(), id, ""); err != nil {
+		if err := s.prepareInstance(context.Background(), id, "", nil); err != nil {
 			t.Fatalf("prepareInstance(%s): %v", id, err)
 		}
 	}
@@ -518,7 +518,7 @@ func TestMultiVMPrepareRefusedWhileClosing(t *testing.T) {
 	if got := s.instanceFor("late", true); got != nil {
 		t.Fatalf("instanceFor create during closing = %v, want nil (refused)", got)
 	}
-	if err := s.prepareInstance(context.Background(), "late", ""); err == nil {
+	if err := s.prepareInstance(context.Background(), "late", "", nil); err == nil {
 		t.Fatal("prepareInstance during closing = nil error, want a closing error")
 	}
 	// Also refuse re-preparing an id that ALREADY has a map entry (Close leaves
@@ -531,7 +531,7 @@ func TestMultiVMPrepareRefusedWhileClosing(t *testing.T) {
 	if got := s.instanceFor("existing", true); got != nil {
 		t.Fatalf("instanceFor create for an existing entry during closing = %v, want nil (refused)", got)
 	}
-	if err := s.prepareInstance(context.Background(), "existing", ""); err == nil {
+	if err := s.prepareInstance(context.Background(), "existing", "", nil); err == nil {
 		t.Fatal("prepareInstance of an existing entry during closing = nil error, want a closing error")
 	}
 	s.mu.Lock()
@@ -564,7 +564,7 @@ func TestSpawnVMActivationFailureReturnsNotOK(t *testing.T) {
 		MultiVM: true,
 	})
 	// Bring up the primary VM so we can prove it is undisturbed by the failure.
-	if err := s.prepareInstance(context.Background(), defaultVMID, ""); err != nil {
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
 		t.Fatalf("prepareInstance(default): %v", err)
 	}
 	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -741,7 +741,9 @@ func (s *Stub) Prepare(ctx context.Context) error {
 	if s.multiVM {
 		// A plain Prepare brings up the pod's default (source) VM from the pool
 		// template, so the rootfs clone source is the template (empty override).
-		return s.prepareInstance(ctx, defaultVMID, "")
+		// A plain Prepare is a warm-pool prepay, not on the hosted-fork hot path,
+		// so it opts out of the per-stage timing map (nil stages).
+		return s.prepareInstance(ctx, defaultVMID, "", nil)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the hosted co-location fork (a Sandbox forked from a warm husk pod via `controller.MultiVMFork`, spawning the child as an additional VM inside the source pod) is the fork we want to make ms-class.
> - That fork runs about 728 ms p50 on prod, 8.3x faster than the old 6 s new-pod path, but m5 (memory sharing) did not move it, so the real bottleneck is unknown and has to be measured, not guessed.
> - The path is a level-triggered controller reconcile (SandboxFork) driving three husk control ops (fork-snapshot, spawn-vm, activate) over mTLS, each of which does real per-stage work on the node (FC boot, vmstate restore, rootfs CoW clone, guest-ready wait, handshake); today the stub reports only a single per-op total and the controller reports nothing per stage.
> - Because the fork reaches Ready across several ~1s requeue passes, the wall-clock latency is not observable inside any one reconcile pass, so a chunk of the 728 ms could be requeue wait rather than any RPC and would be invisible.
> - This pull request instruments the whole path: the stub returns a per-stage `Stages` breakdown on each control result, and the controller times every RPC round-trip, persists the end-to-end start timestamp and pass count, and emits both structured per-stage logs and a `mitos_fork_stage_duration_seconds{stage}` histogram.
> - The benefit is that a single hosted fork now yields an attributable breakdown (which stage dominates, and how much of the total is requeue wait between passes), which is the input to targeting the real bottleneck for the ms-class fork.

## Linked Issues or Issue Description

No tracking issue. Problem: the hosted co-location fork is ~728 ms p50 and the dominant stage is unmeasured; m5 did not move it. There was no per-stage timing on either the controller orchestration (RPC round-trips, level-triggered reconcile passes) or the husk-side VM work (FC boot, vmstate restore, rootfs clone, guest-ready), so the bottleneck could not be attributed. This adds measurement only, no behavior change.

## What Changed

Husk side (`internal/husk`):
- Added an omitempty `Stages map[string]float64` to `ActivateResult`, `SpawnVMResult`, and `ForkSnapshotResult` (backward compatible on the JSON control wire; an older peer just omits it).
- `activateInstance` records `verify`, `egress_filter`, `vmstate_restore`, `resume`, `guest_ready`, `handshake`, `serve_api`.
- `prepareInstance` records `fc_boot`, `verify_prepare`, `rootfs_clone`; `SpawnVM` merges the prepare and activate maps (plus `prepare_total`) into one co-located-child breakdown.
- `forkSnapshotInstance` records `pause`, `create_snapshot`, `rootfs_freeze`, `resume`.
- Each op logs one stage-timing line to the stub log (stderr). Stage names and millisecond durations only; no secret, token, or entropy value.

Controller side (`internal/controller`):
- `logForkStage` times each control-op round-trip (`fork_snapshot_rpc`, `spawn_vm_rpc`, `activate_rpc`), logs it with the husk sub-stages, and observes every stage into the histogram.
- New status anchors `Status.ForkStartedAt` (stamped once) and `Status.ForkReconcilePasses` (counted per advancing pass); on Ready the controller logs `fork timing complete` with `reconcilePasses` and `totalMs` and observes stage `total`.
- New histogram `mitos_fork_stage_duration_seconds{stage}` on the controller-runtime registry (fixed low-cardinality stage labels, sub-ms to seconds buckets).
- API status fields added; deepcopy and CRDs (`deploy/crds`, Helm chart copy) regenerated.

Tests:
- `internal/husk/control_test.go`: `Stages` round-trips through the codec on all three results.
- `internal/husk/multivm_forksnapshot_test.go`: the stub populates `pause`, `create_snapshot`, `resume`.
- `internal/controller/metrics_internal_test.go`: `logForkStage`/`observeForkStage` observe the RPC stage, every husk sub-stage, and `total`.
- `internal/controller/huskfork_multivm_envtest_test.go`: a co-located fork persists `ForkStartedAt` and `ForkReconcilePasses` and consumes the husk `Stages` without disturbing the fork.

### How to read a single fork's breakdown

From the logs of ONE fork: the controller emits `fork stage timing` lines at each boundary, e.g. `stage=fork_snapshot_rpc rpcMs=... create_snapshotMs=... rootfs_freezeMs=...`, then `stage=spawn_vm_rpc rpcMs=... fc_bootMs=... rootfs_cloneMs=... vmstate_restoreMs=... guest_readyMs=... handshakeMs=...`, and finally `fork timing complete reconcilePasses=N totalMs=...`. The stub also logs its own `husk: ... stage timing ms:` line per op. From metrics: `histogram_quantile(0.5, sum by (stage,le) (rate(mitos_fork_stage_duration_seconds_bucket[5m])))` gives the p50 per stage; `total` minus the sum of the RPC stages is the requeue wait between level-triggered passes.

## Verification

Ran in the worktree on this branch:
- `go build ./...`: clean.
- `go test ./internal/husk/...`: ok (includes the new `Stages` round-trip and stub-populates-stages assertions).
- `eval $(~/go/bin/setup-envtest use 1.31 -p env) && go test ./internal/controller/...`: ok, 244s (includes the new internal metric test and the co-location timing envtest).
- `GOOS=linux golangci-lint run --timeout=5m`: clean (this is the invocation CI enforces).
- `golangci-lint run --timeout=5m` (darwin): clean for the changed packages; the whole-tree darwin run reports one PRE-EXISTING finding, `internal/fork/uffd.go:42 pageSizeBytes unused`, which this branch does not touch (`git diff --name-only origin/main` excludes it). It is a darwin-only false positive because the caller is linux-tagged; the GOOS=linux run (and CI) is clean.
- `controller-gen object` and `controller-gen crd` regenerated deepcopy and CRDs; no manual edits.

Not run: real per-stage NUMBERS. envtest and the kind e2e paths use the mock engine (no KVM, no real Firecracker), so they exercise the wiring and the `Stages` plumbing but cannot produce a true FC-boot / vmstate-restore breakdown. The real millisecond breakdown of the 728 ms is PENDING a deploy to a KVM cluster (the firecracker-test / cluster-e2e paths, or prod), where these logs and the histogram will attribute it. This PR is the instrumentation that makes that breakdown readable.

## Risks

Low risk, measurement only. No fork behavior changes: the `Stages` map is omitempty and additive on the wire (older peers ignore it), the timing captures are plain `time.Now()` deltas under locks already held, and the two new status fields are optional and drive no reconcile decision. The per-pass status writes were already happening; `ForkReconcilePasses` rides them. Secret discipline preserved: only fixed stage names and durations are logged or labeled.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, acting as an autonomous Claude Code agent. No other model involved.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (CRD descriptions regenerated from the typed comments)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (not moved: timing only, no new surface)
- [x] Benchmark run (bench/) included if the hot path was touched (no perf claim made; this PR adds no number to README/bench, it measures)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer fork status timing details, including when fork processing started and how many passes advanced it.
  * Improved visibility into multi-VM operations with per-stage timing breakdowns for snapshot, activation, and VM spawn flows.
  * Exposed stage-duration metrics so fork progress can be monitored more precisely.

* **Bug Fixes**
  * Preserved and correctly recorded timing details in status updates and control responses for fork workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->