### PR TITLE
fix(husk): inject /dev/userfaultfd so the live-cow write-protect fork arms on prod (#832)

### DIFF
--- a/cmd/kvm-device-plugin/main.go
+++ b/cmd/kvm-device-plugin/main.go
@@ -45,7 +45,20 @@ const defaultDeviceCount = 100
 // /dev/net/tun: forkd is non-privileged and receives devices only from this
 // plugin, so omitting vhost-vsock makes every fork boot a VM whose guest-agent
 // vsock transport never comes up, and the fork hangs. Do not drop it.
-const defaultDevicePaths = "/dev/kvm,/dev/net/tun,/dev/vhost-vsock"
+//
+// /dev/userfaultfd is injected so the live-cow write-protect fork works on a
+// non-privileged husk pod (issue #832). The patched restore path creates its
+// write-protect userfaultfd via the /dev/userfaultfd device (the userfaultfd
+// crate's device path: open + USERFAULTFD_IOC_NEW), NOT the userfaultfd(2)
+// syscall. The syscall is unreachable in the pod because the container
+// RuntimeDefault seccomp profile denies userfaultfd(2) with EPERM even when
+// CAP_SYS_PTRACE is present (CAP_SYS_PTRACE only satisfies the kernel gate, not
+// the seccomp gate). Injecting the device gives the device-cgroup allow the
+// crate needs and matches what the firecracker-test CI has always proven; the
+// ioctl device path is permitted by the same seccomp profile. Every KVM node
+// runs a kernel that exposes /dev/userfaultfd (present since 6.1), the same
+// homogeneous-node assumption /dev/vhost-vsock already relies on.
+const defaultDevicePaths = "/dev/kvm,/dev/net/tun,/dev/vhost-vsock,/dev/userfaultfd"
 
 func main() {
 	var (
@@ -57,7 +70,7 @@ func main() {
 	)
 	flag.StringVar(&resourceName, "resource-name", "mitos.run/kvm", "Extended resource name the plugin advertises; pods request it under resources.limits")
 	flag.IntVar(&deviceCount, "device-count", 0, "Number of synthetic device slots to advertise when /dev/kvm is present; 0 means auto (a sane default). /dev/kvm is shareable, so this is a soft per-node concurrency cap, not a physical device count")
-	flag.StringVar(&devicePaths, "device-paths", defaultDevicePaths, "Comma-separated host device nodes injected into a requesting container on Allocate (each at the same container path, rw). Includes /dev/vhost-vsock: forkd is non-privileged and needs the host vsock device to build the guest-agent transport, so a fork without it boots a VM that never reaches Ready and hangs.")
+	flag.StringVar(&devicePaths, "device-paths", defaultDevicePaths, "Comma-separated host device nodes injected into a requesting container on Allocate (each at the same container path, rw). Includes /dev/vhost-vsock (forkd needs the host vsock device to build the guest-agent transport) and /dev/userfaultfd (the live-cow write-protect fork creates its userfaultfd via the device path because the container seccomp profile denies the userfaultfd(2) syscall; issue #832).")
 	flag.StringVar(&kubeletDir, "kubelet-dir", "/var/lib/kubelet/device-plugins", "Kubelet device-plugins directory: the plugin serves its socket here and dials the kubelet registry socket (kubelet.sock) here")
 	flag.StringVar(&kvmDevicePath, "kvm-device-path", defaultKVMDevicePath, "Container path the plugin stat(2)s to decide whether KVM is present; the DaemonSet mounts the host /dev read-only here (not over the container /dev)")
 	flag.Parse()

--- a/cmd/kvm-device-plugin/main_test.go
+++ b/cmd/kvm-device-plugin/main_test.go
@@ -11,9 +11,15 @@ import (
 // the regression that left the host with the device but the forkd pod without
 // it, so every fork booted a VM whose guest-agent vsock transport never came up
 // and the fork hung. This guards that default against a silent removal.
-func TestDefaultDevicePathsIncludeVhostVsock(t *testing.T) {
+//
+// /dev/userfaultfd must also stay: the live-cow write-protect fork creates its
+// userfaultfd via the device path (open + ioctl) because the container seccomp
+// profile denies the userfaultfd(2) syscall even with CAP_SYS_PTRACE (issue
+// #832). Without the injected device the restored source cannot arm and every
+// fork silently falls back to the 364ms Full snapshot.
+func TestDefaultDevicePathsIncludeRequiredDevices(t *testing.T) {
 	got := strings.Split(defaultDevicePaths, ",")
-	for _, required := range []string{"/dev/kvm", "/dev/net/tun", "/dev/vhost-vsock"} {
+	for _, required := range []string{"/dev/kvm", "/dev/net/tun", "/dev/vhost-vsock", "/dev/userfaultfd"} {
 		if !slices.Contains(got, required) {
 			t.Errorf("defaultDevicePaths %q is missing required device %q", defaultDevicePaths, required)
 		}

--- a/deploy/charts/mitos/templates/device-plugin-daemonset.yaml
+++ b/deploy/charts/mitos/templates/device-plugin-daemonset.yaml
@@ -41,7 +41,13 @@ spec:
             # /dev/vhost-vsock is required: forkd is non-privileged and gets its
             # devices only from this plugin, so without it a fork boots a VM whose
             # guest-agent vsock transport never comes up and the fork hangs.
-            - --device-paths=/dev/kvm,/dev/net/tun,/dev/vhost-vsock
+            # /dev/userfaultfd lets the live-cow write-protect fork arm on a
+            # non-privileged husk pod (issue #832): the patched restore path
+            # creates its userfaultfd via the device (open + ioctl), because the
+            # container seccomp profile denies the userfaultfd(2) syscall even
+            # with CAP_SYS_PTRACE. This is the device path the firecracker-test
+            # CI has always proven.
+            - --device-paths=/dev/kvm,/dev/net/tun,/dev/vhost-vsock,/dev/userfaultfd
             - --kubelet-dir=/var/lib/kubelet/device-plugins
             # Probe the host /dev/kvm at /host-dev/kvm: the host /dev is mounted
             # read-only at /host-dev, NOT over the container's own /dev.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -123,7 +123,7 @@ open, with a severity on the review rows) is preserved throughout.
 |---|---|---|---|
 | Guest workload | VM guest, untrusted | nothing | nobody |
 | Guest agent - Rust (`guest/agent-rs`) | PID 1 in guest; the SOLE production agent since Phase E (#310). Baked as `/init` by `guest/rootfs/build.sh` and `kvm-test.yaml`. Serves ONLY gRPC on vsock port 53 (AgentGRPCPort); all host callers speak gRPC (SP1.5 merged, Go agent and legacy JSON protocol removed). SECURITY-SENSITIVE: requires named human reviewer; see `docs/security-review-policy.md`. | nothing | forkd / husk stub (gRPC, port 53) |
-| husk pod stub (`cmd/husk-stub`), the DEFAULT runner | unprivileged pod, `/dev/kvm` via device plugin (not `privileged`), drop ALL caps and add only `NET_ADMIN` (in-pod egress firewall, scoped to the pod netns), plus `SYS_PTRACE` ONLY on a live-cow pool (see below), `seccomp: RuntimeDefault`, read-only snapshot mount; the long-lived husk-stub container is NOT privileged | controller (mTLS control channel) | controller |
+| husk pod stub (`cmd/husk-stub`), the DEFAULT runner | unprivileged pod, `/dev/kvm` via device plugin (not `privileged`), drop ALL caps and add only `NET_ADMIN` (in-pod egress firewall, scoped to the pod netns), `seccomp: RuntimeDefault`, read-only snapshot mount; on a live-cow pool the kvm device plugin also injects `/dev/userfaultfd` (see below), no extra capability; the long-lived husk-stub container is NOT privileged | controller (mTLS control channel) | controller |
 | husk `enable-ip-forward` init container (name-egress pools only) | short-lived PRIVILEGED init container on the husk pod; writes `net.ipv4.ip_forward=1` in the shared pod netns and exits BEFORE the workload runs; added only when name-based egress is configured (`--husk-dns-upstream` set) | controller (it is part of the pod spec) | controller |
 | forkd (`cmd/forkd`), the snapshot BUILDER and the raw-forkd fallback | NON-privileged DaemonSet pod (uid 0, `privileged: false`, `allowPrivilegeEscalation: false`, `seccomp: RuntimeDefault`): drops ALL capabilities and adds back ONLY the explicit builder set (`SYS_ADMIN`, `CHOWN`, `SETUID`, `SETGID`, `MKNOD` for the jailer, plus `NET_ADMIN` for the build-time placeholder tap and `DAC_OVERRIDE` so the builder can reopen the template `rootfs.ext4` it wrote after the jailer chowned the shared inode to the per-VM uid, #426; `cmd/forkd/jailer.go` `forkdRequiredCapabilities`). `DAC_OVERRIDE` is negligible marginal authority next to the `CAP_SYS_ADMIN` the builder already holds. The per-VM jailer is ENABLED in the shipped DaemonSet (`deploy/daemon/daemonset.yaml`: `--jailer`/`--chroot-base`/`--uid-range`), so every build/raw-forkd VM runs under a dedicated uid/gid in a per-VM chroot. `/dev/kvm` and `/dev/net/tun` come from the device plugin (`mitos.run/kvm`), NOT a privileged hostPath. (#352) | controller | controller, nodes |
 | controller (`cmd/controller`) | cluster Deployment, CRD + Secrets RBAC | kube-apiserver | forkd, husk pods |
@@ -171,24 +171,33 @@ privileged process and RUN many times by unprivileged pods.
   in the shared pod netns and exits before the workload runs (surface 5); it is
   privileged but one-shot, and the long-lived husk-stub container itself stays
   unprivileged (`NET_ADMIN` only).
-- **Live-cow pools add `CAP_SYS_PTRACE` to the husk-stub, scoped to the pool
-  (issue #832).** The live-cow write-protect fork needs the source Firecracker to
-  create a KERNEL-MODE userfaultfd over its guest RAM (so the KVM guest's own
-  writes fault to the copy-before-unprotect handler). From an unprivileged
-  container the `userfaultfd(2)` syscall for a kernel-mode uffd is gated by
-  `CAP_SYS_PTRACE` (the same check as `sysctl vm.unprivileged_userfaultfd`);
-  `/dev/userfaultfd` is not injected into the pod, so the syscall path is the one
-  used. The controller adds `SYS_PTRACE` to `capabilities.add` ONLY when the pool
-  runs `--live-cow-fork` (`internal/controller/huskpod.go`); a pool that does not
-  use live-cow keeps the minimal `NET_ADMIN`-only set. Blast radius: the capability
-  is confined to the pod (not `privileged`, not `hostPID`, `seccomp: RuntimeDefault`),
-  so the stub can ptrace only processes in its own pod, which it already fully
-  controls; it grants no host, node, or cross-pod authority. It is the fourth
-  documented PSA exception and is added only on the pools that opt into the
-  write-protect fork. Deploy note: the KVM node must permit a kernel-mode
-  userfaultfd (the `CAP_SYS_PTRACE` grant suffices; alternatively a node
-  `vm.unprivileged_userfaultfd=1` sysctl), else the source falls back to the Full
-  snapshot fork (no correctness loss, only the 364ms capture returns).
+- **Live-cow pools get `/dev/userfaultfd` injected by the kvm device plugin, no
+  extra capability (issue #832).** The live-cow write-protect fork needs the source
+  Firecracker to create a KERNEL-MODE userfaultfd over its guest RAM (so the KVM
+  guest's own writes fault to the copy-before-unprotect handler). The patched
+  restore path creates that userfaultfd via the `/dev/userfaultfd` DEVICE (the
+  `userfaultfd` crate's device path: `open` + `USERFAULTFD_IOC_NEW`), NOT the
+  `userfaultfd(2)` syscall. The syscall is unreachable from the husk pod: the
+  container `RuntimeDefault` seccomp profile denies `userfaultfd(2)` with `EPERM`
+  even when `CAP_SYS_PTRACE` is present (reproduced under the exact pod
+  securityContext: root + `CAP_SYS_PTRACE` + `RuntimeDefault` seccomp returns
+  `EPERM`; only `seccomp=unconfined` lets the syscall through). `CAP_SYS_PTRACE`
+  satisfies only the kernel gate (`sysctl vm.unprivileged_userfaultfd`), never the
+  seccomp gate, so the earlier scoped `CAP_SYS_PTRACE` grant never armed a real
+  prod source and is REMOVED. Instead the kvm device plugin (`mitos.run/kvm`)
+  injects `/dev/userfaultfd` alongside `/dev/kvm`, `/dev/net/tun`, and
+  `/dev/vhost-vsock` (`cmd/kvm-device-plugin`, `deploy/charts/mitos/templates/device-plugin-daemonset.yaml`);
+  the device plugin sets the device-cgroup allow a plain hostPath cannot, and the
+  ioctl device path is permitted by the same `RuntimeDefault` seccomp profile. This
+  matches what the `firecracker-test` CI has always proven (it creates the source's
+  uffd via `/dev/userfaultfd`). Blast radius: `/dev/userfaultfd` is a benign misc
+  device that only lets the holder create userfaultfds within its own address
+  space; it grants no host, node, or cross-pod authority, strictly less than the
+  removed `CAP_SYS_PTRACE`, and the husk-stub keeps the minimal `NET_ADMIN`-only
+  capability set. It is injected on every KVM husk pod (the same homogeneous-node
+  device set as `/dev/vhost-vsock`); a node whose kernel lacks `/dev/userfaultfd`
+  (pre-6.1) would fall back to the Full snapshot fork (no correctness loss, only
+  the 364ms capture returns).
 - **forkd-the-builder is the residual host privilege, but it is no longer a
   privileged container (#352).** Building a template snapshot still needs
   `/dev/kvm` and the jailer, so forkd remains the privileged BUILDER role on the

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -550,20 +550,17 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 
 	// Live-cow write-protect needs a KERNEL-MODE userfaultfd over the guest RAM: the
 	// source Firecracker registers UFFD_WP so the KVM guest's own writes fault to the
-	// copy-before-unprotect handler (issue #832). Creating a kernel-mode userfaultfd
-	// from an unprivileged container requires CAP_SYS_PTRACE (the same gate the kernel
-	// applies via `sysctl_unprivileged_userfaultfd`); without it the `userfaultfd(2)`
-	// syscall returns EPERM, the source never offers the write-protect handshake, and
-	// every fork silently falls back to the Full snapshot. `/dev/userfaultfd` is not
-	// injected into the pod, so the source's userfaultfd path is the syscall this
-	// capability gates. It is added ONLY when --live-cow-fork is on, so a pool that
-	// does not use live-cow keeps the minimal NET_ADMIN-only set. Documented as a PSA
-	// exception in docs/threat-model.md; the capability is confined to the pod (not
-	// privileged, not hostPID), so it cannot ptrace another pod's processes.
+	// copy-before-unprotect handler (issue #832). The patched restore path creates
+	// that userfaultfd via the `/dev/userfaultfd` DEVICE (open + USERFAULTFD_IOC_NEW),
+	// NOT the `userfaultfd(2)` syscall: the container RuntimeDefault seccomp profile
+	// denies `userfaultfd(2)` with EPERM even when CAP_SYS_PTRACE is present, because
+	// CAP_SYS_PTRACE satisfies only the kernel gate, not the seccomp gate. The device
+	// is injected into every KVM husk pod by the kvm device plugin (mitos.run/kvm),
+	// which also sets the device-cgroup allow a plain hostPath cannot, and the ioctl
+	// device path is permitted by the same seccomp profile. So the husk-stub keeps the
+	// minimal NET_ADMIN-only capability set: no CAP_SYS_PTRACE is needed on a live-cow
+	// pool. Documented in docs/threat-model.md.
 	huskCaps := []corev1.Capability{"NET_ADMIN"}
-	if opts.LiveCowFork {
-		huskCaps = append(huskCaps, "SYS_PTRACE")
-	}
 
 	// Name-based egress: when the operator configured DNS upstream(s), pass them
 	// to the stub so the per-pod DNS proxy resolves and pins allowlisted names.
@@ -887,8 +884,8 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: pool.Name + "-husk-",
 			Namespace:    pool.Namespace,
-			Labels: huskPodLabels(pool.Name, opts.MultiVM),
-			Annotations: annotations,
+			Labels:       huskPodLabels(pool.Name, opts.MultiVM),
+			Annotations:  annotations,
 		},
 		Spec: corev1.PodSpec{
 			// A husk pod is long-lived: it holds its dormant (then activated) VM

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -238,19 +238,24 @@ func TestBuildHuskPodThreadsLiveCowFork(t *testing.T) {
 	if !argsContain(on.Spec.Containers[0].Args, "--live-cow-fork") {
 		t.Errorf("husk args missing --live-cow-fork when enabled: %v", on.Spec.Containers[0].Args)
 	}
-	// The live-cow write-protect fork needs a kernel-mode userfaultfd, which an
-	// unprivileged container can only create with CAP_SYS_PTRACE (issue #832). It is
-	// added ONLY on the live-cow pod so a non-live-cow pool keeps the minimal cap set.
-	if onCaps := on.Spec.Containers[0].SecurityContext.Capabilities.Add; !capsContain(onCaps, "SYS_PTRACE") || !capsContain(onCaps, "NET_ADMIN") {
-		t.Errorf("live-cow husk Capabilities.Add = %+v, want both NET_ADMIN and SYS_PTRACE", onCaps)
+	// The live-cow write-protect fork creates its userfaultfd via the /dev/userfaultfd
+	// device injected by the kvm device plugin (issue #832), NOT the userfaultfd(2)
+	// syscall the container seccomp profile denies. So a live-cow husk pod keeps the
+	// minimal NET_ADMIN-only capability set and adds NO CAP_SYS_PTRACE: the earlier
+	// CAP_SYS_PTRACE grant satisfied only the kernel gate, never the seccomp gate, and
+	// is not needed by the device path.
+	if onCaps := on.Spec.Containers[0].SecurityContext.Capabilities.Add; capsContain(onCaps, "SYS_PTRACE") {
+		t.Errorf("live-cow husk must NOT add SYS_PTRACE (device path needs no cap); Capabilities.Add = %+v", onCaps)
+	}
+	if onCaps := on.Spec.Containers[0].SecurityContext.Capabilities.Add; len(onCaps) != 1 || !capsContain(onCaps, "NET_ADMIN") {
+		t.Errorf("live-cow husk Capabilities.Add = %+v, want exactly [NET_ADMIN]", onCaps)
 	}
 
 	off := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{StubImage: "img"})
 	if argsContain(off.Spec.Containers[0].Args, "--live-cow-fork") {
 		t.Errorf("husk args must omit --live-cow-fork by default: %v", off.Spec.Containers[0].Args)
 	}
-	// A non-live-cow pod must NOT carry SYS_PTRACE: the capability is scoped to the
-	// pools that actually use the write-protect fork.
+	// A non-live-cow pod also stays NET_ADMIN-only.
 	if offCaps := off.Spec.Containers[0].SecurityContext.Capabilities.Add; capsContain(offCaps, "SYS_PTRACE") {
 		t.Errorf("non-live-cow husk must not add SYS_PTRACE; Capabilities.Add = %+v", offCaps)
 	}


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The live-cow write-protect fork (husk pools, `internal/controller` + `internal/husk` + the patched Firecracker) restores a warm SOURCE VM and arms a userfaultfd write-protect over its guest RAM so a co-located fork takes the vmstate-only snapshot path (create_snapshot ~6ms) instead of the 364ms Full snapshot.
> - On prod the source never armed: the restore path exported its shared memfd but `mitos_wp_offer` logged `MITOS_WP: cannot create write-protect userfaultfd: System error`, so no `MITOS_WP_OFFERED`, and every fork fell back to the Full snapshot (create_snapshot=365ms, fork total ~760ms).
> - Root cause, reproduced under the exact prod pod securityContext (root + `CAP_SYS_PTRACE` + `RuntimeDefault` seccomp): the container seccomp profile denies the `userfaultfd(2)` syscall with `EPERM`; `CAP_SYS_PTRACE` (added in #837) satisfies only the kernel gate, never the seccomp gate. `firecracker-test` CI passed because it makes `/dev/userfaultfd` reachable, so the crate uses the DEVICE path (open + ioctl) the same seccomp profile permits; prod never injected the device.
> - This pull request injects `/dev/userfaultfd` into KVM husk pods via the kvm device plugin (the mechanism that also sets the device-cgroup allow a plain hostPath cannot), and removes the now-dead `CAP_SYS_PTRACE`.
> - The benefit is the restored source arms on prod, forks take the vmstate-only path (create_snapshot drops from 364ms to single-digit ms), and the husk-stub keeps the minimal `NET_ADMIN`-only capability set (strictly less privilege than before).

## Linked Issues or Issue Description

Related: #832

The restored husk source did not arm the live-cow write-protect userfaultfd on prod, so the vmstate-only fork never engaged and every fork silently fell back to the 364ms Full snapshot. Correctness was never at risk (the child inherited disk+mem via the Full snapshot); only the latency win was lost.

## What Changed

- `cmd/kvm-device-plugin/main.go`: add `/dev/userfaultfd` to `defaultDevicePaths` so the plugin injects it (with the device-cgroup allow) into pods that request `mitos.run/kvm`.
- `deploy/charts/mitos/templates/device-plugin-daemonset.yaml`: add `/dev/userfaultfd` to `--device-paths`.
- `internal/controller/huskpod.go`: remove `CAP_SYS_PTRACE` from live-cow husk pods; the device path needs no capability, so the stub stays `NET_ADMIN`-only.
- `docs/threat-model.md`: replace the `CAP_SYS_PTRACE` exception with the `/dev/userfaultfd` device injection and record its blast radius.
- Tests: require `/dev/userfaultfd` in the default device set; assert a live-cow husk pod adds exactly `[NET_ADMIN]` and no `SYS_PTRACE`.

## Verification

- [x] `go test ./cmd/kvm-device-plugin/... ./internal/deviceplugin/...` (green)
- [x] `go test ./internal/controller/ -run TestBuildHuskPod` with envtest 1.31 (green)
- [x] `golangci-lint run --timeout=5m` AND `GOOS=linux golangci-lint run --timeout=5m` on the changed packages (clean)
- [x] Prod evidence: the KVM node has `/dev/userfaultfd` (`crw------- root root 10, 257`); the pod runs uid 0 and can open it. Reproduced the syscall EPERM vs device-path success under the exact prod securityContext.
- [ ] Re-canary after deploy: source logs `MITOS_WP_OFFERED`, create_snapshot drops below 15ms, fork total drops ~360ms (see PR thread). (NOT yet measured: device-plugin change not deployed at PR time; the operator measures this on the post-merge prod canary)

## Risks

Low. `/dev/userfaultfd` is a benign misc device that only lets the holder create userfaultfds in its own address space; it grants strictly less than the removed `CAP_SYS_PTRACE`. It is injected on KVM husk pods that request `mitos.run/kvm`, the same homogeneous-node device set as `/dev/vhost-vsock`; a node whose kernel predates 6.1 (no `/dev/userfaultfd`) simply falls back to the Full snapshot fork with no correctness loss. Off keeps the disk co-location byte-for-byte.

## Model Used

Claude Opus (claude-opus-4-8), extended thinking.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved
- [ ] Benchmark run (bench/) included if the hot path was touched
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live COW mode now uses `/dev/userfaultfd` as part of the required host device set.
  * The device plugin and deployment defaults were updated to advertise the new device path.

* **Bug Fixes**
  * Reduced the security capability footprint for live COW pods by removing the extra ptrace-related capability.
  * Updated behavior to better match systems where the `userfaultfd` syscall is blocked by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
