### PR TITLE
feat(controller): wire --live-cow-child-import so the vmstate-only fork engages

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -60,6 +60,7 @@ func main() {
 	var enableRawForkd bool
 	var multiVMFork bool
 	var liveCowFork bool
+	var liveCowChildImport bool
 	var huskStubImage string
 	var huskDNSUpstream string
 	var huskControlPort int
@@ -91,6 +92,7 @@ func main() {
 	flag.BoolVar(&enableRawForkd, "enable-raw-forkd", false, "Fallback run path: build the snapshot and fork per claim on a holder node (no husk pods). Off by default (the husk pod-native path runs). --mock implies this. husk-pods needs real KVM nodes; raw-forkd is the path the mock/dev overlay uses.")
 	flag.BoolVar(&multiVMFork, "multi-vm-fork", false, "EXPERIMENTAL, DEFAULT OFF: route a hosted fork child into an ADDITIONAL VM spawned INSIDE the source husk pod (the spawn-vm control op) instead of a brand-new child pod, when the source pod is multi-VM capable (its stub runs --multi-vm). OFF is byte-for-byte the current new-pod-per-fork path, so nothing changes unless you opt in AND the source pod is multi-VM capable; a non-capable source silently falls back to a new pod. This wires the routing + status (child status.pod = source pod, status.vmId = the spawned VM); the per-pod and node memory accounting that pends or spills a fork when a pod is full is a follow-up, so co-location is capped conservatively and the remainder spills to new pods. Only used with --enable-husk-pods.")
 	flag.BoolVar(&liveCowFork, "live-cow-fork", false, "EXPERIMENTAL, DEFAULT OFF: start warm husk pods with --live-cow-fork so a CO-LOCATED fork child shares the PARENT's resident guest memory (patched Firecracker memfd + userfaultfd write-protect) instead of restoring from the disk fork snapshot (milestone m4b), driving the hosted fork toward sub-100ms. SEPARATE from --multi-vm-fork so it can be deployed off and canaried independently. OFF is byte-for-byte the current disk co-location. The co-located child still falls back to the disk restore where the child-side memfd import is not yet complete, so turning it on never breaks a fork; it is a no-op off Linux (userfaultfd write-protect is Linux-only). Only meaningful with --enable-husk-pods.")
+	flag.BoolVar(&liveCowChildImport, "live-cow-child-import", false, "EXPERIMENTAL, DEFAULT OFF: with --live-cow-fork on, opt warm husk pods onto the VMSTATE-ONLY fork capture (skip the ~364ms disk mem write) so a co-located child boots its guest RAM from the source shared memfd instead of the disk fork snapshot. REQUIRES a child-side-import patched Firecracker; off keeps the armed source writing the disk mem so every child restores from disk and no fork hangs. Only meaningful with --live-cow-fork and --enable-husk-pods.")
 	flag.StringVar(&huskStubImage, "husk-stub-image", "mitos-husk-stub:latest", "Container image that runs the dormant-VMM stub in a husk pod. Only used with --enable-husk-pods.")
 	flag.StringVar(&huskDNSUpstream, "husk-dns-upstream", "", "Comma-separated DNS resolver list (host:port) the husk-stub per-pod DNS proxy forwards allowlisted name queries to, tried in failover order (recommended: 1.1.1.1:53,8.8.8.8:53). Empty leaves name-based egress off (IP:port allowlists still enforced). Use a public resolver, not cluster DNS, so untrusted sandboxes cannot resolve internal service names.")
 	flag.IntVar(&huskControlPort, "husk-control-port", controller.HuskControlPort, "TCP port the husk stub serves the mTLS network control on; the controller dials podIP:port to activate a dormant husk pod. Only used with --enable-husk-pods.")
@@ -226,6 +228,7 @@ func main() {
 		EnableHuskPods:            enableHuskPods,
 		MultiVM:                   multiVMFork,
 		LiveCowFork:               liveCowFork,
+		LiveCowChildImport:        liveCowChildImport,
 		HuskStubImage:             huskStubImage,
 		HuskDNSUpstream:           huskDNSUpstream,
 		KVMResourceName:           "mitos.run/kvm",
@@ -257,6 +260,7 @@ func main() {
 		EnableHuskPods:     enableHuskPods,
 		MultiVMFork:        multiVMFork,
 		LiveCowFork:        liveCowFork,
+		LiveCowChildImport: liveCowChildImport,
 		HuskControlPort:    huskControlPort,
 		HuskStubImage:      huskStubImage,
 		HuskDNSUpstream:    huskDNSUpstream,

--- a/deploy/charts/mitos/templates/controller-deployment.yaml
+++ b/deploy/charts/mitos/templates/controller-deployment.yaml
@@ -4,6 +4,9 @@
 {{- if and .Values.controller.liveCowFork (not .Values.controller.enableHuskPods) }}
 {{- fail "controller.liveCowFork requires controller.enableHuskPods: live-cow fork rides the warm husk pod spec, which only exists on the husk-pods path. Set enableHuskPods: true or liveCowFork: false." }}
 {{- end }}
+{{- if and .Values.controller.liveCowChildImport (not .Values.controller.liveCowFork) }}
+{{- fail "controller.liveCowChildImport requires controller.liveCowFork: the child-side memfd import only applies to an armed live-cow fork. Set liveCowFork: true or liveCowChildImport: false." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -47,6 +50,9 @@ spec:
             {{- end }}
             {{- if .Values.controller.liveCowFork }}
             - --live-cow-fork
+            {{- end }}
+            {{- if .Values.controller.liveCowChildImport }}
+            - --live-cow-child-import
             {{- end }}
             - --husk-stub-image={{ include "mitos.image" (dict "root" . "image" .Values.huskStub.image) }}
             - --husk-data-dir={{ .Values.controller.huskDataDir }}

--- a/deploy/charts/mitos/values.schema.json
+++ b/deploy/charts/mitos/values.schema.json
@@ -184,6 +184,10 @@
           "description": "EXPERIMENTAL, default off. Render --live-cow-fork so warm husk pods share the parent's resident guest memory with a co-located fork child (patched Firecracker memfd + userfaultfd write-protect) instead of restoring from the disk fork snapshot. SEPARATE from multiVMFork so it canaries independently; off is byte-for-byte the disk co-location and on fails closed to the disk restore where the child-side import is not yet complete. Only meaningful with enableHuskPods.",
           "type": "boolean"
         },
+        "liveCowChildImport": {
+          "description": "EXPERIMENTAL, default off. With liveCowFork on, render --live-cow-child-import so an armed live-cow fork takes the vmstate-only capture (skip the ~364ms disk mem write) and the co-located child boots its guest RAM from the source shared memfd. Requires a child-side-import patched Firecracker; off keeps the armed source writing the disk mem.",
+          "type": "boolean"
+        },
         "huskDataDir": {
           "description": "Value for --husk-data-dir, the node template snapshot root the husk pods mount; must match forkd's --data-dir.",
           "type": "string"

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -69,6 +69,13 @@ controller:
   # where the child-side memfd import is not yet complete, so it never breaks a
   # fork. Only meaningful with enableHuskPods.
   liveCowFork: false
+
+  # EXPERIMENTAL, default off. When true (and liveCowFork on), render
+  # --live-cow-child-import so an armed live-cow fork takes the vmstate-only capture
+  # (skip the ~364ms disk mem write) and the co-located child boots its guest RAM
+  # from the source shared memfd. Requires a child-side-import patched Firecracker;
+  # off keeps the armed source writing the disk mem so every child restores from disk.
+  liveCowChildImport: false
   # Value for --husk-data-dir: the node template snapshot root the husk pods
   # mount; must match forkd's --data-dir.
   huskDataDir: /var/lib/mitos

--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -190,6 +190,12 @@ type HuskPodOptions struct {
 	// (milestone m4b). Default off and SEPARATE from MultiVM so it canaries
 	// independently; off keeps the co-located fork on the disk restore byte-for-byte.
 	LiveCowFork bool
+	// LiveCowChildImport starts the husk stub with --live-cow-child-import so an
+	// armed live-cow fork takes the VMSTATE-ONLY capture (skip the ~364ms disk mem
+	// write) and the co-located child boots its guest RAM from the source shared
+	// memfd. REQUIRES LiveCowFork on and a child-side-import Firecracker binary;
+	// default off, fails closed to the disk restore.
+	LiveCowChildImport bool
 	// MultiVMForkVMs is the number of ADDITIONAL fork-child VMs a multi-VM pod
 	// reserves node memory for up front (beyond the source VM), so the co-location
 	// routing has room to co-locate that many children before a fork spills to a new
@@ -546,6 +552,9 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 	// import is not yet complete, so it never breaks a fork.
 	if opts.LiveCowFork {
 		args = append(args, "--live-cow-fork")
+	}
+	if opts.LiveCowChildImport {
+		args = append(args, "--live-cow-child-import")
 	}
 
 	// Live-cow write-protect needs a KERNEL-MODE userfaultfd over the guest RAM: the
@@ -1376,16 +1385,17 @@ func (r *SandboxPoolReconciler) reconcileHuskPods(ctx context.Context, pool *v1.
 			}
 		}
 		opts := HuskPodOptions{
-			MultiVM:         r.MultiVM,
-			LiveCowFork:     r.LiveCowFork,
-			MultiVMForkVMs:  r.MultiVMForkVMs,
-			StubImage:       r.HuskStubImage,
-			DNSUpstream:     r.HuskDNSUpstream,
-			KVMResourceName: r.KVMResourceName,
-			SnapshotID:      poolTemplateID(pool),
-			DataDir:         r.DataDir,
-			TLSSecretName:   r.HuskTLSSecretName,
-			CASecretName:    r.HuskCASecretName,
+			MultiVM:            r.MultiVM,
+			LiveCowFork:        r.LiveCowFork,
+			LiveCowChildImport: r.LiveCowChildImport,
+			MultiVMForkVMs:     r.MultiVMForkVMs,
+			StubImage:          r.HuskStubImage,
+			DNSUpstream:        r.HuskDNSUpstream,
+			KVMResourceName:    r.KVMResourceName,
+			SnapshotID:         poolTemplateID(pool),
+			DataDir:            r.DataDir,
+			TLSSecretName:      r.HuskTLSSecretName,
+			CASecretName:       r.HuskCASecretName,
 			// dedicatedNodes (#172): pin this pool's husk pods to the tenant's
 			// dedicated node set. Merged onto the KVM nodeSelector + snapshot-node
 			// affinity below.

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -229,6 +229,22 @@ func TestBuildHuskPodThreadsDNSUpstream(t *testing.T) {
 // so a co-located fork child can share the parent's resident guest memory, and
 // with it OFF (the default, every deployment today) the flag is absent so the pod
 // is byte-for-byte the current disk co-location.
+func TestBuildHuskPodThreadsLiveCowChildImport(t *testing.T) {
+	r := &controller.SandboxPoolReconciler{}
+	pool := &v1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	tmpl := &v1.PoolTemplateSpec{}
+
+	on := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{StubImage: "img", LiveCowFork: true, LiveCowChildImport: true})
+	if !argsContain(on.Spec.Containers[0].Args, "--live-cow-child-import") {
+		t.Errorf("husk args missing --live-cow-child-import when enabled: %v", on.Spec.Containers[0].Args)
+	}
+
+	off := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{StubImage: "img", LiveCowFork: true})
+	if argsContain(off.Spec.Containers[0].Args, "--live-cow-child-import") {
+		t.Errorf("husk args must omit --live-cow-child-import by default: %v", off.Spec.Containers[0].Args)
+	}
+}
+
 func TestBuildHuskPodThreadsLiveCowFork(t *testing.T) {
 	r := &controller.SandboxPoolReconciler{}
 	pool := &v1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -141,6 +141,10 @@ type SandboxReconciler struct {
 	// child-side memfd import lands, so turning it on never breaks a fork.
 	LiveCowFork bool
 
+	// LiveCowChildImport mirrors the husk-stub --live-cow-child-import capability so
+	// fork routing is consistent with the pod flag. DEFAULT OFF; requires LiveCowFork.
+	LiveCowChildImport bool
+
 	// spawnVM is the controller->husk spawn-vm seam used by the MultiVMFork routing.
 	// Nil defaults to SpawnVMOnHusk; tests inject a fake.
 	spawnVM huskVMSpawner

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -51,6 +51,10 @@ type SandboxPoolReconciler struct {
 	// --live-cow-fork operator flag; DEFAULT OFF and SEPARATE from MultiVM so it
 	// canaries independently. A normal claim is unaffected.
 	LiveCowFork bool
+	// LiveCowChildImport passes --live-cow-child-import to warm husk pods so an armed
+	// live-cow fork takes the vmstate-only capture and the child boots from the source
+	// memfd. DEFAULT OFF; requires LiveCowFork and a child-import Firecracker binary.
+	LiveCowChildImport bool
 	// MultiVMForkVMs is how many co-located fork VMs a multi-VM warm pod reserves
 	// node memory for up front (beyond the source VM), so the co-location routing
 	// has room before a fork spills to a new pod. Only consulted when MultiVM is set;


### PR DESCRIPTION
## Thinking Path
The child-side memfd import (#844, FC sha 7d02b374) is KVM-proven: the co-located child boots its guest RAM from the source shared memfd, create_snapshot drops 364ms -> ~4ms, no leak, working guest. But the controller only threaded `--live-cow-fork` to husk pods, never `--live-cow-child-import`, so on prod an armed source still wrote the 364ms disk mem and the vmstate-only capture never engaged. This threads the child-import capability end to end, parallel to liveCowFork, so an operator can enable it.

## Changes
- `cmd/controller/main.go`: `--live-cow-child-import` flag; set on both the SandboxPool and SandboxClaim reconcilers.
- `internal/controller`: `LiveCowChildImport` on HuskPodOptions + both reconcilers; append `--live-cow-child-import` to the husk pod args when set.
- `deploy/charts/mitos`: `controller.liveCowChildImport` value (+ schema), the controller-deployment arg, and a guard that rejects `liveCowChildImport` without `liveCowFork` (the import only applies to an armed fork).
- Default OFF; enabling BOTH flags takes the co-located fork onto the vmstate-only path.

## Verification
- `TestBuildHuskPodThreadsLiveCowChildImport`: the flag flows into the husk pod spec on, absent off (envtest green).
- `helm template` renders both args with both values on; the guard fires (clear error) with liveCowChildImport on + liveCowFork off.
- go build, both golangci-lint invocations clean, no dashes.

## Model Used
Claude Opus 4.8 (claude-opus-4-8), Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental controller/chart option to enable a new live-cow child import mode.
  * This option is now available in deployment configuration and is passed through to running controller pods.
  * When enabled, the system can use the new child import behavior for supported live-cow workflows.

* **Bug Fixes**
  * Added validation to prevent enabling the new mode without the required live-cow fork setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->