### PR TITLE
refactor(husk): cut the egress_filter fork stage (apply shared nft table once + batch per-VM commands)

### DIFF
--- a/internal/husk/multivm_network_test.go
+++ b/internal/husk/multivm_network_test.go
@@ -168,12 +168,13 @@ func TestMultiVMActivateProgramsDistinctTapPerVMID(t *testing.T) {
 	// applied for each VM (one egress chain per instance).
 	var madeDefault, madeSecond, metadataBlocks int
 	for _, c := range rr.calls {
-		// ip tuntap add <tap> mode tap
-		if len(c.argv) >= 4 && c.argv[0] == "ip" && c.argv[1] == "tuntap" && c.argv[2] == "add" {
-			switch c.argv[3] {
-			case wantDefaultTap:
+		// The tap is created by an `ip -batch -` line: `tuntap add <tap> mode tap`
+		// (the per-command execs are collapsed into one batched ip process).
+		if len(c.argv) >= 2 && c.argv[0] == "ip" && c.argv[1] == "-batch" {
+			if strings.Contains(c.stdin, "tuntap add "+wantDefaultTap+" mode tap") {
 				madeDefault++
-			case wantSecondTap:
+			}
+			if strings.Contains(c.stdin, "tuntap add "+wantSecondTap+" mode tap") {
 				madeSecond++
 			}
 		}

--- a/internal/husk/netfilter.go
+++ b/internal/husk/netfilter.go
@@ -74,10 +74,13 @@ type netfilterRunner func(ctx context.Context, argv []string, stdin string) erro
 
 // applyEgressFilter brings up the VM's tap and installs its default-deny egress
 // chain (with the unconditional metadata block) in the husk pod netns. It is
-// the single-VM-per-pod analog of internal/network.setup: create the tap,
-// assign the host IP, bring it up, apply the idempotent shared table, then this
-// VM's per-tap chain. A malformed allowlist fails the whole call (fail-closed:
-// a VM never comes up with a half-applied filter).
+// the single-VM-per-pod analog of internal/network.setup. To keep the fork hot
+// path cheap it collapses the ~8 sequential fork+exec of ip/nft into just three
+// processes: one idempotent tap pre-delete, one `ip -batch` that creates the tap
+// + assigns the host IP + brings it up + binds the resolver, and one atomic
+// `nft -f` that applies the shared table, this VM's per-tap chain, the SNAT, the
+// shared input table, and this tap's input chain. A malformed allowlist fails
+// the whole call (fail-closed: a VM never comes up with a half-applied filter).
 func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwarding func() error, cfg NetfilterConfig) (err error) {
 	enforceable, _, err := netconf.SplitAllowList(cfg.Allow)
 	if err != nil {
@@ -104,16 +107,15 @@ func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwardin
 	// first so creation is idempotent; best-effort, since "not found" is the
 	// normal case on a clean activation.
 	_ = run(ctx, netconf.LinkDelArgs(cfg.Tap), "")
-	if err := run(ctx, netconf.TapAddArgs(cfg.Tap), ""); err != nil {
-		return fmt.Errorf("husk netfilter: create tap %s: %w", cfg.Tap, err)
-	}
-	// The tap now exists. Its name is deterministic per template, so if ANY step
-	// below fails we MUST remove the tap (and any partial chain state) or the next
-	// activation attempt fails right here at tap creation with EBUSY (Device or
-	// resource busy), which masks the real first-attempt error and permanently
-	// poisons the warm pod (issue #428). Tear down idempotently on every error
-	// path; the original error is preserved as the named return so the true
-	// root-cause step error is surfaced, not the EBUSY of a later retry.
+	// Arm the fail-closed teardown BEFORE the batched tap setup below. The
+	// ip -batch invocation may create the tap and then fail on a LATER line in the
+	// SAME process, which would leak the tap: its name is deterministic per
+	// template, so a leak makes the next activation fail right at tap creation
+	// with EBUSY (Device or resource busy), masking the real first-attempt error
+	// and permanently poisoning the warm pod (issue #428). Tearing down on every
+	// error path removes a partially created tap (link del of an absent tap is an
+	// ignored no-op), and the original error is preserved as the named return so
+	// the true root-cause step error is surfaced, not the EBUSY of a later retry.
 	defer func() {
 		if err != nil {
 			// Detached from ctx so cleanup still runs when the failure was a
@@ -122,23 +124,27 @@ func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwardin
 			_ = teardownEgressFilter(context.WithoutCancel(ctx), run, cfg.Tap)
 		}
 	}()
-	if err := run(ctx, netconf.AddrAddArgs(cfg.HostIP, cfg.Tap), ""); err != nil {
-		return fmt.Errorf("husk netfilter: assign host ip to tap %s: %w", cfg.Tap, err)
+	// One ip process instead of ~4: create the tap, assign the host /30, bring the
+	// link up, and (single-VM DNS path) bind the in-pod resolver /32. ip -batch
+	// aborts on the first failing line and exits non-zero, so a partial tap setup
+	// fails the whole call (fail-closed) and triggers the teardown armed above.
+	// The resolver bind lets the per-pod DNS proxy listen on the tap so the guest's
+	// queries are delivered locally instead of forwarded out (now ip_forward is on).
+	if err := run(ctx, netconf.IPBatchArgs(), netconf.RenderIPBatch(cfg.Tap, cfg.HostIP, cfg.ResolverIP)); err != nil {
+		return fmt.Errorf("husk netfilter: set up tap %s: %w", cfg.Tap, err)
 	}
-	if err := run(ctx, netconf.LinkUpArgs(cfg.Tap), ""); err != nil {
-		return fmt.Errorf("husk netfilter: bring tap %s up: %w", cfg.Tap, err)
-	}
-	// Bind the in-pod DNS resolver address to the tap so the per-pod DNS proxy can
-	// listen on it and the guest's queries (sent to it via the tap gateway) are
-	// delivered locally instead of being forwarded out (now that ip_forward is on).
-	if cfg.ResolverIP != nil {
-		if err := run(ctx, netconf.ResolverAddrAddArgs(cfg.ResolverIP, cfg.Tap), ""); err != nil {
-			return fmt.Errorf("husk netfilter: bind resolver %s to tap %s: %w", cfg.ResolverIP, cfg.Tap, err)
-		}
-	}
-	if err := run(ctx, netconf.NftApplyArgs(), netconf.RenderSharedTable()); err != nil {
-		return fmt.Errorf("husk netfilter: apply shared egress table: %w", err)
-	}
+	// One nft process instead of ~5, applied as a SINGLE atomic transaction:
+	//   - the pod-global shared forward table (idempotent skeleton),
+	//   - this VM's per-tap egress chain (metadata drop + allowlist + counter),
+	//   - the guest SNAT (masquerade) so allowed return traffic is routable,
+	//   - the shared input table, and this tap's input chain (pod-local guard).
+	// Every statement is an idempotent `add`/`flush` of a named object, so a
+	// second CO-LOCATED VM's transaction re-adds the pod-global skeleton without
+	// disturbing the first VM's per-tap chain, counter, or dispatch element: the
+	// shared table is shared, each VM keeps its OWN tap + default-deny chain +
+	// counter. nft applies the whole file atomically, so a malformed allowlist or
+	// any rejected statement installs NOTHING (fail-closed: a VM never comes up
+	// half-filtered), and the teardown above removes the tap.
 	chain := netconf.RenderSandboxChainSpec(netconf.ChainSpec{
 		Tap:          cfg.Tap,
 		GuestIP:      cfg.GuestIP,
@@ -152,24 +158,6 @@ func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwardin
 		// (#211) can read this sandbox's egress bytes. Passive: no verdict.
 		Counter: true,
 	})
-	if err := run(ctx, netconf.NftApplyArgs(), chain); err != nil {
-		return fmt.Errorf("husk netfilter: apply egress chain for tap %s: %w", cfg.Tap, err)
-	}
-	// Source-NAT the guest's allowed egress to the pod address so return traffic
-	// for an allowed connection can find its way back; without it the private /30
-	// source is unroutable beyond the tap and every allowed connection hangs.
-	if err := run(ctx, netconf.NftApplyArgs(), netconf.RenderMasquerade(cfg.GuestIP)); err != nil {
-		return fmt.Errorf("husk netfilter: apply masquerade for guest %s: %w", cfg.GuestIP, err)
-	}
-	// Input-path guard: the forward chain above governs transit traffic, but a
-	// packet the guest sends to a pod-LOCAL address (the tap gateway, the resolver,
-	// the husk-stub sandbox API and mTLS control listeners) is delivered on the
-	// input hook, which the forward chain never sees. Install the input base chain
-	// and this tap's input chain so the guest can reach ONLY the resolver on 53 and
-	// nothing else pod-local, regardless of egress policy.
-	if err := run(ctx, netconf.NftApplyArgs(), netconf.RenderSharedInputTable()); err != nil {
-		return fmt.Errorf("husk netfilter: apply shared input table: %w", err)
-	}
 	inputChain := netconf.RenderSandboxInputChainSpec(netconf.InputChainSpec{
 		Tap:          cfg.Tap,
 		GuestIP:      cfg.GuestIP,
@@ -177,8 +165,15 @@ func applyEgressFilter(ctx context.Context, run netfilterRunner, enableForwardin
 		Inbound:      cfg.Inbound,
 		InboundCIDRs: cfg.InboundCIDRs,
 	})
-	if err := run(ctx, netconf.NftApplyArgs(), inputChain); err != nil {
-		return fmt.Errorf("husk netfilter: apply input chain for tap %s: %w", cfg.Tap, err)
+	// Each Render* returns a newline-terminated block, so concatenation yields one
+	// well-formed nft ruleset file. Order matters within the transaction: the
+	// shared forward table (which defines the dispatch map) precedes the chain that
+	// adds a dispatch element into it, and the shared input table precedes this
+	// tap's input chain, so every forward reference resolves inside the transaction.
+	nftDoc := netconf.RenderSharedTable() + chain + netconf.RenderMasquerade(cfg.GuestIP) +
+		netconf.RenderSharedInputTable() + inputChain
+	if err := run(ctx, netconf.NftApplyArgs(), nftDoc); err != nil {
+		return fmt.Errorf("husk netfilter: apply egress filter for tap %s: %w", cfg.Tap, err)
 	}
 	return nil
 }

--- a/internal/husk/netfilter_test.go
+++ b/internal/husk/netfilter_test.go
@@ -72,31 +72,98 @@ func TestApplyEgressFilterRendersDenyChainWithMetadataBlock(t *testing.T) {
 	if !forwardingEnabled {
 		t.Error("applyEgressFilter did not enable IPv4 forwarding")
 	}
-	// Expect: idempotent tap delete, tap add, addr add, link up, resolver addr
-	// add, shared table apply, sandbox chain apply, masquerade apply, shared input
-	// table apply, sandbox input chain apply.
-	if len(rr.calls) != 10 {
-		t.Fatalf("got %d calls, want 10: %+v", len(rr.calls), rr.calls)
+	// The fork hot path is collapsed to THREE processes: the idempotent tap
+	// pre-delete, one `ip -batch` (tap create + host IP + link up + resolver
+	// bind), and one atomic `nft -f` (shared table + chain + SNAT + input table +
+	// input chain).
+	if len(rr.calls) != 3 {
+		t.Fatalf("got %d calls, want 3 (link del, ip -batch, nft -f): %+v", len(rr.calls), rr.calls)
+	}
+	if got := strings.Join(rr.calls[0].argv, " "); got != "ip link del sbtap0" {
+		t.Errorf("first call must be the idempotent tap pre-delete, got %q", got)
+	}
+	// The ip -batch call carries the tap setup on stdin (no per-command execs).
+	batchArgv := strings.Join(rr.calls[1].argv, " ")
+	if batchArgv != "ip -batch -" {
+		t.Errorf("second call must be ip -batch -, got %q", batchArgv)
+	}
+	batchStdin := rr.calls[1].stdin
+	if !strings.Contains(batchStdin, "tuntap add sbtap0 mode tap") {
+		t.Errorf("ip batch missing tap create:\n%s", batchStdin)
+	}
+	if !strings.Contains(batchStdin, "addr add 10.200.0.1/30 dev sbtap0") {
+		t.Errorf("ip batch missing host IP assignment:\n%s", batchStdin)
+	}
+	if !strings.Contains(batchStdin, "link set sbtap0 up") {
+		t.Errorf("ip batch missing link up:\n%s", batchStdin)
 	}
 	// The resolver IP is bound to the tap as a /32 so the per-pod DNS proxy can
 	// listen on it and the guest's queries are delivered locally.
-	resolverArgv := strings.Join(rr.calls[4].argv, " ")
-	if !strings.Contains(resolverArgv, "169.254.1.1/32") || !strings.Contains(resolverArgv, "sbtap0") {
-		t.Errorf("resolver IP not bound to tap as /32: %v", rr.calls[4].argv)
+	if !strings.Contains(batchStdin, "addr add 169.254.1.1/32 dev sbtap0") {
+		t.Errorf("resolver IP not bound to tap as /32:\n%s", batchStdin)
 	}
-	chainStdin := rr.calls[6].stdin
-	if !strings.Contains(chainStdin, "ip daddr 169.254.169.254 drop") {
-		t.Errorf("chain missing metadata block:\n%s", chainStdin)
+	// The nft call carries the full ruleset (shared table + chain + SNAT + input)
+	// as one atomic document on stdin.
+	nftArgv := strings.Join(rr.calls[2].argv, " ")
+	if nftArgv != "nft -f -" {
+		t.Errorf("third call must be nft -f -, got %q", nftArgv)
 	}
-	if !strings.Contains(chainStdin, "ip daddr 10.0.0.5 tcp dport 5432 accept") {
-		t.Errorf("chain missing static allow:\n%s", chainStdin)
+	nftStdin := rr.calls[2].stdin
+	if !strings.Contains(nftStdin, "ip daddr 169.254.169.254 drop") {
+		t.Errorf("nft doc missing metadata block:\n%s", nftStdin)
 	}
-	if !strings.Contains(chainStdin, netconf.SandboxChainName("sbtap0")) {
-		t.Errorf("chain not named for tap:\n%s", chainStdin)
+	if !strings.Contains(nftStdin, "ip daddr 10.0.0.5 tcp dport 5432 accept") {
+		t.Errorf("nft doc missing static allow:\n%s", nftStdin)
 	}
-	masqStdin := rr.calls[7].stdin
-	if !strings.Contains(masqStdin, "ip saddr 10.200.0.2 masquerade") {
-		t.Errorf("missing masquerade for guest source:\n%s", masqStdin)
+	if !strings.Contains(nftStdin, netconf.SandboxChainName("sbtap0")) {
+		t.Errorf("nft doc missing chain named for tap:\n%s", nftStdin)
+	}
+	if !strings.Contains(nftStdin, "ip saddr 10.200.0.2 masquerade") {
+		t.Errorf("nft doc missing masquerade for guest source:\n%s", nftStdin)
+	}
+}
+
+// TestApplyEgressFilterBatchesExecs pins the exec-count reduction and proves the
+// batched processes carry EXACTLY the same commands the per-command builders
+// would have run: the ip batch equals RenderIPBatch and the nft document equals
+// the concatenation of the shared table, per-tap chain, SNAT, shared input
+// table, and per-tap input chain. This is the regression guard for the perf
+// change (was ~8-10 execs/VM, now 3) and its correctness (identical ruleset).
+func TestApplyEgressFilterBatchesExecs(t *testing.T) {
+	rr := &recordingRunner{}
+	cfg := NetfilterConfig{
+		Tap:        "sbtap0",
+		GuestIP:    net.ParseIP("10.200.0.2"),
+		HostIP:     net.ParseIP("10.200.0.1"),
+		Egress:     v1.EgressDeny,
+		Allow:      []string{"10.0.0.5:5432"},
+		ResolverIP: net.ParseIP("169.254.1.1"),
+	}
+	if err := applyEgressFilter(context.Background(), rr.run, func() error { return nil }, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(rr.calls) != 3 {
+		t.Fatalf("want 3 execs (link del, ip -batch, nft -f), got %d: %+v", len(rr.calls), rr.calls)
+	}
+	// The ip -batch stdin is byte-for-byte RenderIPBatch (single source of truth).
+	wantBatch := netconf.RenderIPBatch(cfg.Tap, cfg.HostIP, cfg.ResolverIP)
+	if rr.calls[1].stdin != wantBatch {
+		t.Errorf("ip batch stdin mismatch:\n got=%q\nwant=%q", rr.calls[1].stdin, wantBatch)
+	}
+	// The nft stdin is the concatenation of the same renders the unbatched path
+	// applied one at a time, so the installed ruleset is unchanged.
+	chain := netconf.RenderSandboxChainSpec(netconf.ChainSpec{
+		Tap: cfg.Tap, GuestIP: cfg.GuestIP, Egress: cfg.Egress,
+		Allow:      []netconf.HostPort{{IP: net.ParseIP("10.0.0.5"), Port: 5432}},
+		ResolverIP: cfg.ResolverIP, Counter: true,
+	})
+	inputChain := netconf.RenderSandboxInputChainSpec(netconf.InputChainSpec{
+		Tap: cfg.Tap, GuestIP: cfg.GuestIP, ResolverIP: cfg.ResolverIP,
+	})
+	wantNft := netconf.RenderSharedTable() + chain + netconf.RenderMasquerade(cfg.GuestIP) +
+		netconf.RenderSharedInputTable() + inputChain
+	if rr.calls[2].stdin != wantNft {
+		t.Errorf("nft doc mismatch:\n got=%q\nwant=%q", rr.calls[2].stdin, wantNft)
 	}
 }
 
@@ -117,20 +184,20 @@ func TestApplyEgressFilterInstallsInputGuard(t *testing.T) {
 	if err := applyEgressFilter(context.Background(), rr.run, func() error { return nil }, cfg); err != nil {
 		t.Fatal(err)
 	}
-	// The last two applies are the shared input table and this tap's input chain.
-	inputTable := rr.calls[8].stdin
-	if !strings.Contains(inputTable, "type filter hook input") {
-		t.Errorf("shared input table not applied:\n%s", inputTable)
+	// The shared input table and this tap's input chain are folded into the single
+	// atomic nft document (the third and last exec).
+	nftStdin := rr.calls[len(rr.calls)-1].stdin
+	if !strings.Contains(nftStdin, "type filter hook input") {
+		t.Errorf("shared input table not applied:\n%s", nftStdin)
 	}
-	inputChain := rr.calls[9].stdin
-	if !strings.Contains(inputChain, "ip saddr 10.200.0.2 ip daddr 169.254.1.1 udp dport 53 accept") {
-		t.Errorf("input chain missing resolver allow:\n%s", inputChain)
+	if !strings.Contains(nftStdin, "ip saddr 10.200.0.2 ip daddr 169.254.1.1 udp dport 53 accept") {
+		t.Errorf("input chain missing resolver allow:\n%s", nftStdin)
 	}
-	if !strings.Contains(inputChain, "ip saddr 10.200.0.2 drop") {
-		t.Errorf("input chain missing guest-to-pod-local drop:\n%s", inputChain)
+	if !strings.Contains(nftStdin, "ip saddr 10.200.0.2 drop") {
+		t.Errorf("input chain missing guest-to-pod-local drop:\n%s", nftStdin)
 	}
-	if !strings.Contains(inputChain, netconf.SandboxInputChainName("sbtap0")) {
-		t.Errorf("input chain not named for tap:\n%s", inputChain)
+	if !strings.Contains(nftStdin, netconf.SandboxInputChainName("sbtap0")) {
+		t.Errorf("input chain not named for tap:\n%s", nftStdin)
 	}
 }
 
@@ -178,8 +245,9 @@ func TestApplyEgressFilterRejectsMalformedAllow(t *testing.T) {
 // retry fail at tap creation with EBUSY and masks the real first-attempt error.
 func TestApplyEgressFilterTearsDownTapOnPartialFailure(t *testing.T) {
 	stepErr := errors.New("RTNETLINK answers: operation not permitted")
-	// Call index 0 is the idempotent tap delete; index 1 is the tap add; index 2
-	// is the host-IP assignment, the first step after the tap exists. Fail there.
+	// Call index 0 is the idempotent tap pre-delete; index 1 is the ip -batch that
+	// CREATES the tap; index 2 is the nft apply, the first step after the tap
+	// exists. Fail there to prove a post-create failure still tears the tap down.
 	rr := &failingRunner{failAt: 2, err: stepErr}
 	cfg := NetfilterConfig{
 		Tap:     "sbtapdeadbeef",

--- a/internal/netconf/commands.go
+++ b/internal/netconf/commands.go
@@ -3,6 +3,7 @@ package netconf
 import (
 	"fmt"
 	"net"
+	"strings"
 )
 
 // This file holds pure argv builders for the host networking commands. No
@@ -39,6 +40,42 @@ func ResolverAddrAddArgs(resolverIP net.IP, tap string) []string {
 // LinkDelArgs builds the argv to remove the tap: ip link del <tap>.
 func LinkDelArgs(tap string) []string {
 	return []string{"ip", "link", "del", tap}
+}
+
+// IPBatchArgs builds the argv to run several ip subcommands from stdin in ONE
+// process: ip -batch -. Each stdin line is one ip subcommand WITHOUT the
+// leading "ip" (see RenderIPBatch). Batch mode aborts on the first failing line
+// and exits non-zero, so a partially applied tap setup fails the whole call
+// (fail-closed): the caller tears the tap down on any error. This replaces the
+// ~4 separate fork+exec of ip on the fork hot path with a single one.
+func IPBatchArgs() []string {
+	return []string{"ip", "-batch", "-"}
+}
+
+// RenderIPBatch renders the newline-delimited command list fed to `ip -batch -`
+// (IPBatchArgs) that brings this VM's tap up: create the tap, assign the host
+// side of the /30, set the link up, and (single-VM DNS path) bind the in-pod
+// resolver /32. Each line is the argv of the matching single-command builder
+// (TapAddArgs, AddrAddArgs, LinkUpArgs, ResolverAddrAddArgs) with the leading
+// "ip" stripped, so the batched and unbatched forms share one source of truth
+// and cannot drift. The idempotent pre-create tap delete is intentionally NOT
+// batched here: its "not found" is the normal case and must not abort the batch.
+func RenderIPBatch(tap string, hostIP, resolverIP net.IP) string {
+	cmds := [][]string{
+		TapAddArgs(tap),
+		AddrAddArgs(hostIP, tap),
+		LinkUpArgs(tap),
+	}
+	if resolverIP != nil {
+		cmds = append(cmds, ResolverAddrAddArgs(resolverIP, tap))
+	}
+	var b strings.Builder
+	for _, c := range cmds {
+		// Drop the leading "ip": ip -batch reads bare subcommands, one per line.
+		b.WriteString(strings.Join(c[1:], " "))
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // NftApplyArgs builds the argv to apply a rendered ruleset from stdin:

--- a/internal/netconf/commands_test.go
+++ b/internal/netconf/commands_test.go
@@ -38,6 +38,41 @@ func TestLinkDelArgs(t *testing.T) {
 	}
 }
 
+func TestIPBatchArgs(t *testing.T) {
+	got := IPBatchArgs()
+	want := []string{"ip", "-batch", "-"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("IPBatchArgs = %v, want %v", got, want)
+	}
+}
+
+// TestRenderIPBatchWithResolver proves the batch document is exactly the four
+// per-command builders (tap add, host addr, link up, resolver addr) with the
+// leading "ip" stripped, one per line, so the batched and unbatched forms cannot
+// drift. Each line must be a bare `ip -batch` subcommand (no "ip" prefix).
+func TestRenderIPBatchWithResolver(t *testing.T) {
+	got := RenderIPBatch("sbtap0", net.ParseIP("10.200.0.1"), net.ParseIP("169.254.1.1"))
+	want := "tuntap add sbtap0 mode tap\n" +
+		"addr add 10.200.0.1/30 dev sbtap0\n" +
+		"link set sbtap0 up\n" +
+		"addr add 169.254.1.1/32 dev sbtap0\n"
+	if got != want {
+		t.Errorf("RenderIPBatch =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestRenderIPBatchNoResolver proves the multi-VM path (no ResolverIP) omits the
+// resolver bind line and emits only the three setup commands.
+func TestRenderIPBatchNoResolver(t *testing.T) {
+	got := RenderIPBatch("sbtap0", net.ParseIP("10.200.0.1"), nil)
+	want := "tuntap add sbtap0 mode tap\n" +
+		"addr add 10.200.0.1/30 dev sbtap0\n" +
+		"link set sbtap0 up\n"
+	if got != want {
+		t.Errorf("RenderIPBatch (no resolver) =\n%q\nwant\n%q", got, want)
+	}
+}
+
 func TestNftApplyArgs(t *testing.T) {
 	got := NftApplyArgs()
 	want := []string{"nft", "-f", "-"}


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The husk-stub programs each forked VM's in-pod network isolation (`internal/husk` -> `internal/netconf`) during activate, recorded as the `egress_filter` stage.
> - Today `applyEgressFilter` runs ~8-10 sequential fork+exec of `ip`/`nft` per VM (one per command), so `egress_filter` costs ~76ms on the source activate + ~88ms on the co-located child (~163ms/fork on prod).
> - That cost is paid on every disk-restore fork and is independent of the live-cow memory work, so cutting it helps the current fork path directly; it serves ROADMAP.md "production hardening / fork hot path".
> - This pull request collapses those execs into three processes (idempotent tap pre-delete, one `ip -batch`, one atomic `nft -f`) while keeping each VM's own tap + /30 + default-deny chain + counter and the exact allowlist/CIDR/DNS/SNAT behavior.
> - The benefit is ~5-7 fewer fork+exec per VM on the fork hot path with the same fail-closed network isolation.

## Linked Issues or Issue Description

Related: #832 (item 2: cut the `egress_filter` fork stage). The stage was ~163ms/fork on prod, dominated by ~8-10 sequential `ip`/`nft` process launches per VM.

## What Changed

- `internal/netconf/commands.go`: added `IPBatchArgs()` (`ip -batch -`) and `RenderIPBatch(tap, hostIP, resolverIP)`, which builds the batch document by reusing the existing per-command builders (`TapAddArgs`/`AddrAddArgs`/`LinkUpArgs`/`ResolverAddrAddArgs`) with the leading `ip` stripped, so batched and unbatched forms share one source of truth.
- `internal/husk/netfilter.go`: `applyEgressFilter` now runs (1) the idempotent tap pre-delete, (2) one `ip -batch` for tap create + host IP + link up + resolver bind, and (3) one atomic `nft -f` for the shared table + per-tap egress chain + SNAT + shared input table + per-tap input chain. Teardown-on-error is armed BEFORE the batch so a batch that creates the tap then fails still tears it down (issue #428).
- Tests: rewrote the `applyEgressFilter` unit tests for the 3-exec shape, added `TestApplyEgressFilterBatchesExecs` asserting the batched `ip`/`nft` documents are byte-for-byte equal to the concatenation of the per-command renders (ruleset unchanged), updated `multivm_network_test.go` tap detection to read the batch stdin, and added `netconf` tests for the new builders.

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/husk/... ./internal/netconf/...` (green; includes the two-co-located-VM isolation test `TestMultiVMActivateProgramsDistinctTapPerVMID` and the batched-exec / input-guard assertions)
- [x] `golangci-lint run --timeout=5m` and `GOOS=linux golangci-lint run --timeout=5m` (clean for `internal/husk` + `internal/netconf`; the pre-existing `internal/fork/uffd.go` native-only unused finding is unrelated to this change and clean under GOOS=linux)
- [ ] firecracker-test (KVM isolation gate) via CI

Exec count per VM: ~8-10 -> 3 (link del, one `ip -batch`, one `nft -f`).

## Risks

Low-to-moderate: this is a named-reviewer security path (network isolation). The installed ruleset is provably unchanged (the batched documents equal the prior per-command renders), each VM keeps its own isolated tap + default-deny chain + counter, and the change is more fail-closed than before (nft applies atomically, teardown armed before the batch). The KVM two-tap isolation gate (firecracker-test) is the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Model Used

Claude Opus 4.8 (claude-opus-4-8), via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network setup now uses consolidated batched commands, reducing the number of setup steps needed during VM activation.
  * Support was added for combining multiple firewall changes into a single atomic update.

* **Bug Fixes**
  * Improved cleanup on partial setup failures so later activation attempts are less likely to hit tap-creation conflicts.
  * Adjusted network setup handling for cases with and without a resolver IP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->