### PR TITLE
feat(husk): lazy UFFD child import so the vmstate-only fork actually drops fork latency

### DIFF
--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -137,6 +137,22 @@ image. The m2 mechanism closes it with userfaultfd write-protect
   bytes), an untouched page live from the shared memfd (still fork-time bytes, cheap
   CoW). Either way the child sees a consistent point-in-time-T image.
 
+Child side, PER FAULT (lazy UFFD import). The co-located child now boots its guest
+RAM LAZILY through Firecracker's native userfaultfd backend (the husk-side handler
+`internal/fork/childuffd*.go`), faulting only its working set instead of eagerly
+copying the whole guest RAM, so the vmstate-only source win is not eaten by an
+equal-and-opposite child copy. The per-page source selection above then runs PER
+FAULT with a fault-time re-check that preserves the no-leak invariant: on a page
+fault the handler reads the LIVE frozen bit; a frozen page is served from FROZEN
+(fork-time bytes, stable forever once the WP handler wrote them); a not-yet-frozen
+page is served from the live source memfd (still fork-time, since an unfrozen page is
+provably unwritten because the WP handler freezes BEFORE it lets a write land), and
+then the bit is RE-CHECKED after the live read so a page frozen concurrently is
+overridden from FROZEN. So a resumed source's post-fork overwrite is always served as
+its fork-time value, never the mutated value. Unit-tested over a real userfaultfd in
+`internal/fork` `TestChildUFFDLazyImportComposesAndNoLeak` and end to end on KVM in
+`internal/husk` `TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM`.
+
 The ordering FREEZE -> COPY -> UNPROTECT is the whole correctness argument: because
 the copy completes before the unprotect, there is no window in which the parent's
 new value is visible while the fork-time value is lost (the torn-read hazard is

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -645,6 +645,54 @@ Trust and residual, stated honestly:
   (default OFF): with the flag off the source still writes the disk mem and the child
   restores from disk, so a pod running the m5 binary with the flag off is byte-for-byte
   the disk co-location.
+- LAZY child import (the fork-latency fix). The eager child copy above skips the
+  ~364ms source mem-file write but then EAGERLY copies the whole guest RAM (e.g.
+  256MiB) into the child's anonymous RAM at restore, so the child `vmstate_restore`
+  grows from ~20ms to ~391ms and the vmstate-only fork is latency-NEUTRAL: the cost
+  just moves from the source to the child. The husk now imports the child's guest RAM
+  LAZILY instead: it restores the co-located child through Firecracker's NATIVE
+  userfaultfd memory backend (`mem_backend.backend_type=Uffd`, stock Firecracker, NO
+  child patch and NO `FIRECRACKER_MITOS_CHILD_MEMFD` env), pointing `/snapshot/load`
+  at a husk-side handler socket, and a new handler
+  (`internal/fork/childuffd*.go`, `fork.StartChildUFFDHandler`, driven by
+  `Stub.loadSnapshotChildUFFD`) fills each faulting guest page ON DEMAND. The child
+  therefore copies only the pages its working set touches (a few MiB), so its restore
+  drops back to milliseconds and the source-side win is finally realized end to end.
+  Trust and residual, stated honestly:
+  - The handler reads ONLY the parent's own m1-exported guest memfd, this pod's
+    PRIVATE FROZEN memfd, and this pod's LIVE frozen-bitmap memfd, each opened through
+    the SAME identity-verified `/proc/<pid>/fd/<fd>` reopen the eager import uses
+    (`openProcFdVerified`: the target must be a memfd of the expected name with a
+    matching `(st_ino, st_dev)`, so a recycled PID fails closed). It maps the parent
+    memfd READ-ONLY (`MAP_SHARED` `PROT_READ`), so it opens no write channel into the
+    source, and writes ONLY into the guest RAM Firecracker registered, via
+    `UFFDIO_COPY` of a private staging page it composed. It makes NO host-path write.
+  - Its only external input is the region layout Firecracker itself sends over the
+    PRIVATE per-VM backend socket plus the uffd (`SCM_RIGHTS`), the same
+    `GuestRegionUffdMapping` handshake the issue #167 UFFD restore backend already
+    uses. The socket is host-local and per-VM, not reachable by the guest; it adds NO
+    new tenant-facing input.
+  - NO LEAK, checked PER FAULT: for each faulting page the handler consults the LIVE
+    frozen bit AT FAULT TIME. A frozen page is served from FROZEN at its fork-time
+    value; a not-yet-frozen page is served from the live source memfd (still the
+    fork-time value, because the WP handler freezes a page BEFORE it lets the source's
+    write land), then the bit is RE-CHECKED after the live read and, if it flipped, the
+    page is overridden from FROZEN. So a resumed source's post-fork overwrite is always
+    served as its fork-time value, never the mutated value, closing the leak window the
+    eager copy avoided by privatizing everything up front. The point-in-time-T
+    inheritance + no-leak is unit-tested over a real userfaultfd in
+    `TestChildUFFDLazyImportComposesAndNoLeak` and end to end on KVM in
+    `TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM` (child boots
+    from the source memfd with NO disk mem, child `vmstate_restore` well below 100ms,
+    fork-time sentinel read back after the source overwrote it).
+  - Fail-closed: the lazy path is taken ONLY when the source armed AND
+    `LiveCowChildImport` is on (the vmstate-only fork wrote no disk mem, so the child
+    MUST import); any handshake or handler-start failure fails the spawn rather than
+    serving a half-restored guest. Off the armed path (flag off, no armed parent, or a
+    non-Linux host where `StartChildUFFDHandler` returns `ErrChildUFFDUnsupported`) the
+    child restores from the disk mem byte-for-byte. The handler is Closed at instance
+    teardown (`closeInstanceBody`), AFTER the child Firecracker is gone, so its Serve
+    loop unblocks and its source-view munmaps race nothing.
 - Source-side arming (milestone m6b): the parent-side handler is now BOUND to the
   running source VM in production. When a source (default) VM launches under
   `--live-cow-fork` with a real workdir, `prepareInstance` calls

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -670,8 +670,14 @@ Trust and residual, stated honestly:
   - Its only external input is the region layout Firecracker itself sends over the
     PRIVATE per-VM backend socket plus the uffd (`SCM_RIGHTS`), the same
     `GuestRegionUffdMapping` handshake the issue #167 UFFD restore backend already
-    uses. The socket is host-local and per-VM, not reachable by the guest; it adds NO
-    new tenant-facing input.
+    uses. The socket is host-local and per-VM (a fixed-length 64-bit vmID hash under
+    the pod workdir, so two co-located children never collide on one socket), not
+    reachable by the guest; it adds NO new tenant-facing input. Because this socket IS
+    the child's memory backend, `Receive` accepts ONLY the expected peer: it checks the
+    connecting process's `SO_PEERCRED` uid against the husk's own uid (the child
+    Firecracker runs as that uid) and fails closed on a mismatch, so a hostile local
+    process that raced the real child to connect cannot supply its own uffd + regions
+    and drive `UFFDIO_COPY` into memory it controls.
   - NO LEAK, checked PER FAULT: for each faulting page the handler consults the LIVE
     frozen bit AT FAULT TIME. A frozen page is served from FROZEN at its fork-time
     value; a not-yet-frozen page is served from the live source memfd (still the
@@ -686,13 +692,19 @@ Trust and residual, stated honestly:
     from the source memfd with NO disk mem, child `vmstate_restore` well below 100ms,
     fork-time sentinel read back after the source overwrote it).
   - Fail-closed: the lazy path is taken ONLY when the source armed AND
-    `LiveCowChildImport` is on (the vmstate-only fork wrote no disk mem, so the child
-    MUST import); any handshake or handler-start failure fails the spawn rather than
-    serving a half-restored guest. Off the armed path (flag off, no armed parent, or a
-    non-Linux host where `StartChildUFFDHandler` returns `ErrChildUFFDUnsupported`) the
-    child restores from the disk mem byte-for-byte. The handler is Closed at instance
-    teardown (`closeInstanceBody`), AFTER the child Firecracker is gone, so its Serve
-    loop unblocks and its source-view munmaps race nothing.
+    `LiveCowChildImport` is on. On THAT path the fork went vmstate-only and wrote NO
+    disk mem, so there is NO disk fallback: any handshake, handler-start, or load
+    failure FAILS THE SPAWN (`OK=false`) rather than serving a half-restored guest, and
+    no wait hangs (the load, the handshake, and the Serve result all race so any one
+    failing unblocks the rest). The disk-mem restore is the fallback only where a mem
+    file EXISTS, i.e. when child-import is OFF: then the source wrote a Full fork
+    snapshot with a `mem` file and the child restores from it byte-for-byte (the
+    `TestForkSnapshotLiveCowArmedFullFallbackColocatedChildKVM` posture). A non-Linux
+    host (`StartChildUFFDHandler` returns `ErrChildUFFDUnsupported`) or a pod with no
+    armed parent never sets the plan, so it takes that same disk restore. The handler
+    is Closed at instance teardown (`closeInstanceBody`), AFTER the child Firecracker is
+    gone, and Close WAITS for any in-flight fault (a `serveMu` write lock) before it
+    munmaps the source views, so a fault never dereferences an unmapped view.
 - Source-side arming (milestone m6b): the parent-side handler is now BOUND to the
   running source VM in production. When a source (default) VM launches under
   `--live-cow-fork` with a real workdir, `prepareInstance` calls

--- a/internal/fork/childuffd.go
+++ b/internal/fork/childuffd.go
@@ -1,0 +1,86 @@
+package fork
+
+import "errors"
+
+// ErrChildUFFDUnsupported is returned by StartChildUFFDHandler off Linux (the lazy
+// child import needs userfaultfd + memfd + /proc fd re-open, all Linux-only). The
+// live-cow child-import path fails closed to the disk-snapshot restore in that
+// case, exactly like ErrLiveCowUnsupported on the parent side.
+var ErrChildUFFDUnsupported = errors.New("fork: lazy live-cow child UFFD import requires Linux userfaultfd")
+
+// This file holds the platform-independent seam of the live copy-on-write
+// (live-cow) LAZY child-side memfd import: a co-located fork child boots its guest
+// RAM through Firecracker's NATIVE userfaultfd restore backend, faulting only the
+// working set it actually touches instead of eagerly copying the whole guest RAM.
+//
+// Why this exists (the fork-latency fix). The shipped child import
+// (ComposeChildFromImport / the FIRECRACKER_MITOS_CHILD_MEMFD restore patch) is a
+// vmstate-only fork: it skips the source's ~364ms mem-file write (issue #832). But
+// it then EAGERLY copies the whole guest RAM (e.g. 256MiB) from the parent's live
+// memfd into the child's private anonymous RAM at restore, so the child's
+// vmstate_restore grows from ~20ms to ~391ms and the fork is latency-NEUTRAL: the
+// cost just moved from the source snapshot to the child restore.
+//
+// The eager copy exists to avoid a leak: a lazily file-backed MAP_PRIVATE of the
+// RESUMED source's live memfd reads back any page the source rewrites after the
+// fork but before the child faults it (a torn kernel image). The LAZY UFFD import
+// closes that hole differently: the child restores with anonymous RAM registered
+// to a userfaultfd (Firecracker's stock Uffd backend), and a husk-side handler
+// fills each faulting page ON DEMAND by composing the SAME per-page source
+// selection ComposeChildFromImport does, but PER FAULT: a page the parent's WP
+// handler has FROZEN (bit set at fault time) is served from the FROZEN memfd at
+// its fork-time value; every other page is served from the LIVE source memfd,
+// which still holds the fork-time value because the WP handler freezes a page
+// BEFORE it lets the source's write land. Checking the frozen bit AT FAULT time
+// (with a re-check after reading the live page) means a source post-fork overwrite
+// is always served as its fork-time value, never the mutated value. The child pays
+// only the faults for its working set (a few MiB), so the child restore drops back
+// to milliseconds and the vmstate-only fork's source win is finally realized end
+// to end.
+//
+// This uses Firecracker's NATIVE Uffd restore backend (MemBackendType::Uffd), so
+// NO Firecracker patch is needed on the child side: the husk points
+// /snapshot/load at the handler's unix socket via mem_backend.backend_path, and
+// Firecracker creates the guest userfaultfd and hands it to the handler over that
+// socket (the same GuestRegionUffdMapping SCM_RIGHTS handshake the issue #167 UFFD
+// backend already uses). The SOURCE side is unchanged (still the m1 memfd export +
+// m2 write-protect offer).
+//
+// SECURITY (internal/fork is a named-reviewer path). The handler reads ONLY the
+// parent's own exported guest memfd and this pod's private FROZEN + bitmap memfds,
+// each identity-verified on reopen (openProcFdVerified, PID-reuse fail-closed), and
+// writes ONLY into the guest RAM Firecracker registered, via UFFDIO_COPY. It makes
+// no host-path write and copies no secret out of the guest. The whole path is dark
+// unless --live-cow-fork armed the parent AND a co-located fork child spawn opted
+// in; off, the child restores from the disk snapshot byte-for-byte. See
+// docs/threat-model.md and docs/fork-correctness.md.
+
+// ChildUFFDHandle is the husk-side lazy UFFD fault handler for one co-located
+// live-cow fork child. It is created bound to its unix socket
+// (StartChildUFFDHandler) BEFORE the child Firecracker's /snapshot/load, which is
+// what drives Firecracker to connect; Receive completes the GuestRegionUffdMapping
+// handshake (the child's userfaultfd + region layout) once Firecracker connects;
+// Serve fills each faulting guest page from the composed source (FROZEN memfd for a
+// frozen page, the live source memfd otherwise) for the life of the child; Close
+// tears the handler down. The Linux implementation is childUFFDHandler
+// (childuffd_linux.go); off Linux StartChildUFFDHandler returns
+// ErrChildUFFDUnsupported and nothing here runs (the child falls back to the disk
+// restore, fail-closed).
+type ChildUFFDHandle interface {
+	// Receive accepts the child Firecracker's connection and reads the child
+	// userfaultfd + region layout (the GuestRegionUffdMapping SCM_RIGHTS handshake).
+	// Run it concurrently with the child /snapshot/load.
+	Receive() error
+	// Serve runs the page-fault loop until Close: each faulting guest page is
+	// UFFDIO_COPYed in from the composed source (FROZEN at its fork-time value for a
+	// frozen page, the live source memfd otherwise), checking the frozen bit AT
+	// FAULT time so a source post-fork overwrite never leaks in.
+	Serve() error
+	// FaultCount returns how many page faults Serve has filled so far (the child's
+	// working-set size), the measure that the lazy import faults only a few MiB
+	// instead of eagerly copying the whole guest RAM.
+	FaultCount() int64
+	// Close tears the handler down (closes the child uffd, unblocking Serve; munmaps
+	// the source views; removes the socket). Idempotent.
+	Close() error
+}

--- a/internal/fork/childuffd_linux.go
+++ b/internal/fork/childuffd_linux.go
@@ -1,0 +1,347 @@
+//go:build linux
+
+package fork
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// This is the Linux side of the lazy live-cow child-side UFFD import (see
+// childuffd.go for the design and the fork-latency argument). The handler binds a
+// unix socket the child Firecracker's stock Uffd restore backend connects to,
+// receives the child's userfaultfd + region layout, and fills each faulting guest
+// page ON DEMAND by composing the SAME per-page source selection
+// composeChildGuestMemory does eagerly, but PER FAULT and with a fault-time frozen
+// re-check so a resumed source's post-fork write never leaks into the child.
+//
+// It reads the parent's shared memfd, the handler's FROZEN memfd, and the LIVE
+// frozen bitmap memfd through the identity-verified /proc reopen the eager import
+// already uses (openProcFdVerified), so it inherits the same PID-reuse fail-closed
+// guarantees. It writes nowhere on the host filesystem: it only UFFDIO_COPYs
+// composed source bytes into the guest RAM Firecracker registered.
+
+// childUFFDHandler owns the lazy UFFD backend for one co-located fork child.
+// Lifecycle: StartChildUFFDHandler (open+mmap the source/frozen/bitmap views, bind
+// the socket) -> Receive (accept the child Firecracker, read its uffd + regions)
+// -> Serve (goroutine, compose-and-fill faults for the life of the child) -> Close.
+type childUFFDHandler struct {
+	sockPath string
+	ln       *net.UnixListener
+
+	// Source views, all mapped for the whole guest RAM (import.Bytes). live is the
+	// parent's shared memfd (a resumed source keeps writing it; a not-yet-frozen page
+	// still holds its fork-time value because the WP handler freezes before a write
+	// lands); frozen holds the fork-time bytes of every page the WP handler froze;
+	// bm is the LIVE 1-bit-per-page selector (bit set = source that page from frozen).
+	live   []byte
+	frozen []byte
+	bm     []byte
+
+	bytes    uint64
+	pageSize uint64
+
+	// stage is a private anonymous page the Serve loop composes into before the
+	// UFFDIO_COPY, so the copy source is a single stable off-heap address (never a
+	// moving Go slice) and the compose can override a live page with the frozen page
+	// atomically from Firecracker's point of view (UFFDIO_COPY fills a page once).
+	stage []byte
+
+	mu      sync.Mutex
+	uffd    int
+	regions []uffdMapping
+	closed  bool
+
+	// uffdFile wraps the child uffd so Serve's read is driven by the Go runtime
+	// poller: a blocking read(2) on the raw uffd is not interrupted when Close closes
+	// it, but uffdFile.Close() unblocks a poller-driven Read cleanly. The raw uffd is
+	// retained for the UFFDIO_COPY ioctl (which ignores O_NONBLOCK).
+	uffdFile *os.File
+
+	// served counts the page faults Serve has filled (the child's working set).
+	served int64
+}
+
+// StartChildUFFDHandler opens + identity-verifies + mmaps the three source views a
+// co-located fork child needs (the parent shared memfd, the FROZEN memfd, and the
+// LIVE frozen bitmap memfd, all from the armed WP handler's ChildImport) and binds
+// the backend unix socket the child Firecracker's Uffd restore backend connects to
+// (passed as mem_backend.backend_path on /snapshot/load). It MUST be called before
+// the child /snapshot/load, because Firecracker connects to the socket during the
+// load. The returned handler is ready for Receive.
+func StartChildUFFDHandler(sockPath string, imp ChildMemfdImport) (ChildUFFDHandle, error) {
+	if sockPath == "" {
+		return nil, fmt.Errorf("childuffd: empty backend socket path")
+	}
+	if err := imp.validate(); err != nil {
+		return nil, fmt.Errorf("childuffd: invalid import: %w", err)
+	}
+	pageSize := imp.PageSize
+	bmBytes := frozenBitmapBytes(imp.Bytes, pageSize)
+	if bmBytes == 0 {
+		return nil, fmt.Errorf("childuffd: zero frozen bitmap size")
+	}
+
+	// Reopen + identity-verify the three descriptors the parent exported, the same
+	// mechanism (and the same fail-closed PID-reuse guarantees) the eager
+	// ComposeChildFromImport uses. The parent guest memfd is created by Firecracker,
+	// so require only that the reopened target is a memfd (empty want name) and its
+	// inode identity matches; FROZEN and the bitmap are the handler's own named memfds.
+	parentFd, closeParent, err := openProcFdVerified(imp.ParentPID, imp.ParentFD, "", imp.ParentIno, imp.ParentDev)
+	if err != nil {
+		return nil, fmt.Errorf("childuffd: open parent memfd: %w", err)
+	}
+	defer closeParent()
+	frozenFd, closeFrozen, err := openProcFdVerified(imp.FrozenPID, imp.FrozenFD, frozenMemfdName, imp.FrozenIno, imp.FrozenDev)
+	if err != nil {
+		return nil, fmt.Errorf("childuffd: open frozen memfd: %w", err)
+	}
+	defer closeFrozen()
+	bmFd, closeBM, err := openProcFdVerified(imp.BitmapPID, imp.BitmapFD, frozenBitmapName, imp.BitmapIno, imp.BitmapDev)
+	if err != nil {
+		return nil, fmt.Errorf("childuffd: open frozen bitmap memfd: %w", err)
+	}
+	defer closeBM()
+
+	// live is MAP_SHARED read-only so the handler reads the source's CURRENT bytes at
+	// fault time: a page the source has not rewritten since the fork still holds its
+	// fork-time value, and a page it DID rewrite is served from frozen instead (the
+	// frozen bit is set before that write lands). frozen + bm are the fork-time image
+	// and its live selector.
+	live, err := unix.Mmap(parentFd, 0, int(imp.Bytes), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("childuffd: mmap parent memfd: %w", err)
+	}
+	frozen, err := unix.Mmap(frozenFd, 0, int(imp.Bytes), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		_ = unix.Munmap(live)
+		return nil, fmt.Errorf("childuffd: mmap frozen memfd: %w", err)
+	}
+	bm, err := unix.Mmap(bmFd, 0, int(bmBytes), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		_ = unix.Munmap(live)
+		_ = unix.Munmap(frozen)
+		return nil, fmt.Errorf("childuffd: mmap frozen bitmap memfd: %w", err)
+	}
+	stage, err := unix.Mmap(-1, 0, int(pageSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS)
+	if err != nil {
+		_ = unix.Munmap(live)
+		_ = unix.Munmap(frozen)
+		_ = unix.Munmap(bm)
+		return nil, fmt.Errorf("childuffd: mmap stage page: %w", err)
+	}
+
+	// Remove a stale socket so the bind does not fail with EADDRINUSE after a crashed
+	// prior spawn (matches the WP handler and restore-handler cleanup).
+	_ = os.Remove(sockPath)
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: sockPath, Net: "unix"})
+	if err != nil {
+		_ = unix.Munmap(live)
+		_ = unix.Munmap(frozen)
+		_ = unix.Munmap(bm)
+		_ = unix.Munmap(stage)
+		return nil, fmt.Errorf("childuffd: listen %s: %w", sockPath, err)
+	}
+	return &childUFFDHandler{
+		sockPath: sockPath,
+		ln:       ln,
+		live:     live,
+		frozen:   frozen,
+		bm:       bm,
+		bytes:    imp.Bytes,
+		pageSize: pageSize,
+		stage:    stage,
+		uffd:     -1,
+	}, nil
+}
+
+// Receive accepts the child Firecracker's connection and reads the single
+// GuestRegionUffdMapping handshake message: the region layout (JSON body) and the
+// child userfaultfd (SCM_RIGHTS). It reuses the same wire decode the WP handshake
+// uses (recvUffdHandshake). Run it concurrently with the child /snapshot/load.
+func (h *childUFFDHandler) Receive() error {
+	conn, err := h.ln.AcceptUnix()
+	if err != nil {
+		return fmt.Errorf("childuffd: accept: %w", err)
+	}
+	defer conn.Close()
+
+	uffdFD, regions, err := recvUffdHandshake(conn)
+	if err != nil {
+		return err
+	}
+
+	// Wrap the uffd in an *os.File so Serve's read runs on the Go runtime poller
+	// (Close unblocks it cleanly). The raw h.uffd alias is used only for UFFDIO_COPY,
+	// which ignores O_NONBLOCK; the file OWNS the fd so Close never double-closes it.
+	uffdFile := os.NewFile(uintptr(uffdFD), "childuffd-uffd")
+
+	h.mu.Lock()
+	h.uffd = uffdFD
+	h.uffdFile = uffdFile
+	h.regions = regions
+	h.mu.Unlock()
+	return nil
+}
+
+// Serve runs the child page-fault loop until Close. On each fault it composes the
+// faulting page's fork-time bytes into the stage page and UFFDIO_COPYs them into
+// the guest. It returns when the child uffd is closed (Close) or on a fatal error.
+func (h *childUFFDHandler) Serve() error {
+	h.mu.Lock()
+	uffdFile := h.uffdFile
+	h.mu.Unlock()
+	if uffdFile == nil {
+		return fmt.Errorf("childuffd: Serve before handshake")
+	}
+	var msg uffdMsg
+	msgBuf := (*[unsafe.Sizeof(msg)]byte)(unsafe.Pointer(&msg))[:]
+	for {
+		// Poller-driven read: blocks until a fault message is ready, and returns a
+		// clean ErrClosed when Close closes uffdFile (a raw read(2) would hang).
+		nread, err := uffdFile.Read(msgBuf)
+		if err != nil {
+			if errors.Is(err, os.ErrClosed) {
+				return nil
+			}
+			h.mu.Lock()
+			closed := h.closed
+			h.mu.Unlock()
+			if closed {
+				return nil
+			}
+			return fmt.Errorf("childuffd: read uffd: %w", err)
+		}
+		if nread != int(unsafe.Sizeof(msg)) || msg.Event != uffdEventPagefault {
+			// REMOVE/REMAP/UNMAP events need no page fill; ignore them.
+			continue
+		}
+		if err := h.serveFault(msg.PfAddress); err != nil {
+			return err
+		}
+	}
+}
+
+// serveFault fills one faulting guest page at host address addr: it composes the
+// page's fork-time bytes into the stage page (FROZEN for a frozen page, the live
+// source memfd otherwise, with a fault-time re-check that closes the leak window)
+// and UFFDIO_COPYs the stage page into the guest.
+func (h *childUFFDHandler) serveFault(addr uint64) error {
+	h.mu.Lock()
+	regions := h.regions
+	uffd := h.uffd
+	h.mu.Unlock()
+	if uffd < 0 {
+		return fmt.Errorf("childuffd: serveFault before handshake")
+	}
+	pageSize := h.pageSize
+	pageBase, fileOffset, ok := fileOffsetForAddr(regions, addr, pageSize)
+	if !ok {
+		// A fault outside the registered range: skip it (defensive).
+		return nil
+	}
+	if fileOffset+pageSize > h.bytes {
+		return fmt.Errorf("childuffd: fault page [%#x,+%#x) past guest RAM %#x (addr=%#x)", fileOffset, pageSize, h.bytes, addr)
+	}
+	if fileOffset+pageSize > uint64(len(h.live)) || fileOffset+pageSize > uint64(len(h.frozen)) {
+		return fmt.Errorf("childuffd: fault page [%#x,+%#x) past mapped source views (live=%d frozen=%d)", fileOffset, pageSize, len(h.live), len(h.frozen))
+	}
+	pageIdx := fileOffset / pageSize
+
+	// PER-FAULT frozen composite (the no-leak invariant). If the page is frozen, its
+	// fork-time bytes are in FROZEN, stable forever (the WP handler writes FROZEN then
+	// sets the bit, once, before it unprotects and lets the source write land). If it
+	// is not frozen, the source has provably not written it since the fork (still
+	// write-protected), so the live memfd holds the fork-time value: copy it. Then
+	// RE-CHECK the bit: a concurrent freeze between the read above and the copy could
+	// have set the bit and let the source's write land into live, so a set bit now
+	// means the value we copied might be the source's NEW value; override it with the
+	// FROZEN fork-time bytes. Either way the stage ends holding the fork-time value.
+	if testFrozenBit(h.bm, pageIdx) {
+		copy(h.stage, h.frozen[fileOffset:fileOffset+pageSize])
+	} else {
+		copy(h.stage, h.live[fileOffset:fileOffset+pageSize])
+		if testFrozenBit(h.bm, pageIdx) {
+			copy(h.stage, h.frozen[fileOffset:fileOffset+pageSize])
+		}
+	}
+
+	if err := h.copyPage(pageBase, pageSize); err != nil {
+		return err
+	}
+	atomic.AddInt64(&h.served, 1)
+	return nil
+}
+
+// copyPage UFFDIO_COPYs pageSize composed bytes from the stage page into the guest
+// at dst. An already-present page (EEXIST) is treated as success: it only means the
+// page was filled meanwhile, which is the desired end state.
+func (h *childUFFDHandler) copyPage(dst, pageSize uint64) error {
+	arg := uffdioCopyArg{
+		Dst: dst,
+		Src: uint64(uintptr(unsafe.Pointer(&h.stage[0]))),
+		Len: pageSize,
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(h.uffd), uintptr(uffdioCopy), uintptr(unsafe.Pointer(&arg)))
+	if errno != 0 {
+		if errno == unix.EEXIST {
+			return nil
+		}
+		return fmt.Errorf("childuffd: UFFDIO_COPY dst=%#x len=%#x: %w", dst, pageSize, errno)
+	}
+	return nil
+}
+
+// FaultCount returns the number of page faults Serve has filled (the child's
+// working set). Safe to call concurrently.
+func (h *childUFFDHandler) FaultCount() int64 { return atomic.LoadInt64(&h.served) }
+
+// Close tears the handler down: it closes the child uffd (unblocking Serve's
+// poller-driven read), the socket, removes the socket path, and munmaps the source
+// views and the stage page. Idempotent.
+func (h *childUFFDHandler) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	if h.ln != nil {
+		_ = h.ln.Close()
+	}
+	// Closing the file unblocks Serve's poller-driven Read and closes the uffd fd it
+	// owns. Clear the raw alias without a second unix.Close (double close).
+	if h.uffdFile != nil {
+		_ = h.uffdFile.Close()
+		h.uffdFile = nil
+		h.uffd = -1
+	} else if h.uffd >= 0 {
+		_ = unix.Close(h.uffd)
+		h.uffd = -1
+	}
+	if h.live != nil {
+		_ = unix.Munmap(h.live)
+		h.live = nil
+	}
+	if h.frozen != nil {
+		_ = unix.Munmap(h.frozen)
+		h.frozen = nil
+	}
+	if h.bm != nil {
+		_ = unix.Munmap(h.bm)
+		h.bm = nil
+	}
+	if h.stage != nil {
+		_ = unix.Munmap(h.stage)
+		h.stage = nil
+	}
+	_ = os.Remove(h.sockPath)
+	return nil
+}

--- a/internal/fork/childuffd_linux.go
+++ b/internal/fork/childuffd_linux.go
@@ -59,6 +59,17 @@ type childUFFDHandler struct {
 	regions []uffdMapping
 	closed  bool
 
+	// serveMu guards the source views + the child uffd against Close while a fault is
+	// in flight. serveFault holds it RLocked across the WHOLE compose + UFFDIO_COPY, so
+	// the mmap'd source slices (h.live/h.frozen/h.bm/h.stage) it dereferences and the
+	// uffd it copies into stay mapped for the duration of the copy. Close takes it
+	// LOCKED before it closes the uffd + munmaps, so it waits for any in-flight fault
+	// to finish and no serveFault ever touches a munmapped view or a closed uffd (a
+	// use-after-unmap would segfault; a UFFDIO_COPY with a freed Src is worse). It is a
+	// separate lock from mu (which is only ever held briefly) so a slow fault copy
+	// never blocks a lifecycle read.
+	serveMu sync.RWMutex
+
 	// uffdFile wraps the child uffd so Serve's read is driven by the Go runtime
 	// poller: a blocking read(2) on the raw uffd is not interrupted when Close closes
 	// it, but uffdFile.Close() unblocks a poller-driven Read cleanly. The raw uffd is
@@ -173,9 +184,18 @@ func (h *childUFFDHandler) Receive() error {
 	}
 	defer conn.Close()
 
+	// Only accept the expected peer: this socket is the child's MEMORY BACKEND, so a
+	// hostile local process that raced the real child Firecracker to connect could
+	// hand us its own uffd + region layout and drive UFFDIO_COPY into memory it
+	// controls. The child Firecracker the husk launched runs as THIS process's uid, so
+	// require the connecting peer's SO_PEERCRED uid to match; a mismatch fails closed.
+	if err := verifyPeerUID(conn, os.Getuid()); err != nil {
+		return fmt.Errorf("childuffd: reject connector: %w", err)
+	}
+
 	uffdFD, regions, err := recvUffdHandshake(conn)
 	if err != nil {
-		return err
+		return fmt.Errorf("childuffd: receive handshake: %w", err)
 	}
 
 	// Wrap the uffd in an *os.File so Serve's read runs on the Go runtime poller
@@ -229,15 +249,49 @@ func (h *childUFFDHandler) Serve() error {
 	}
 }
 
+// verifyPeerUID checks the connected peer's SO_PEERCRED uid equals wantUID, so only
+// the child Firecracker the husk launched (same uid) can supply this backend's uffd
+// + region layout. A hostile local connector with a different uid fails closed.
+func verifyPeerUID(conn *net.UnixConn, wantUID int) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("syscallconn: %w", err)
+	}
+	var ucred *unix.Ucred
+	var cerr error
+	if e := raw.Control(func(fd uintptr) {
+		ucred, cerr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); e != nil {
+		return fmt.Errorf("rawconn control: %w", e)
+	}
+	if cerr != nil {
+		return fmt.Errorf("getsockopt SO_PEERCRED: %w", cerr)
+	}
+	if ucred == nil || int(ucred.Uid) != wantUID {
+		return fmt.Errorf("peer uid mismatch (got %v, want %d): not the expected child Firecracker", ucred, wantUID)
+	}
+	return nil
+}
+
 // serveFault fills one faulting guest page at host address addr: it composes the
 // page's fork-time bytes into the stage page (FROZEN for a frozen page, the live
 // source memfd otherwise, with a fault-time re-check that closes the leak window)
-// and UFFDIO_COPYs the stage page into the guest.
+// and UFFDIO_COPYs the stage page into the guest. It holds serveMu RLocked across
+// the whole compose + copy so Close cannot munmap the source views or close the
+// uffd under it (no use-after-unmap).
 func (h *childUFFDHandler) serveFault(addr uint64) error {
+	h.serveMu.RLock()
+	defer h.serveMu.RUnlock()
 	h.mu.Lock()
 	regions := h.regions
 	uffd := h.uffd
+	closed := h.closed
 	h.mu.Unlock()
+	if closed {
+		// Close has begun (it is blocked on serveMu.Lock waiting for this RLock): do not
+		// touch the views it is about to munmap; let Serve unwind on the next read.
+		return nil
+	}
 	if uffd < 0 {
 		return fmt.Errorf("childuffd: serveFault before handshake")
 	}
@@ -303,44 +357,60 @@ func (h *childUFFDHandler) copyPage(dst, pageSize uint64) error {
 // working set). Safe to call concurrently.
 func (h *childUFFDHandler) FaultCount() int64 { return atomic.LoadInt64(&h.served) }
 
-// Close tears the handler down: it closes the child uffd (unblocking Serve's
-// poller-driven read), the socket, removes the socket path, and munmaps the source
-// views and the stage page. Idempotent.
+// Close tears the handler down: it stops new accepts, WAITS for any in-flight fault
+// to finish, then closes the child uffd (unblocking Serve's poller-driven read) and
+// munmaps the source views and the stage page. Idempotent. The ordering closes the
+// Close-vs-serveFault race: serveMu.Lock waits for the active serveFault's RLock, so
+// the uffd is not closed and the views are not munmapped while a fault dereferences
+// them (no use-after-unmap, no UFFDIO_COPY with a freed Src).
 func (h *childUFFDHandler) Close() error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	if h.closed {
+		h.mu.Unlock()
 		return nil
 	}
 	h.closed = true
-	if h.ln != nil {
-		_ = h.ln.Close()
+	ln := h.ln
+	h.mu.Unlock()
+
+	// Stop new accepts first so no fresh handshake races the teardown.
+	if ln != nil {
+		_ = ln.Close()
 	}
+
+	// Wait for any in-flight fault to drain (it holds serveMu RLocked across its whole
+	// compose + copy), then tear down the views + uffd under the write lock so no fault
+	// can start touching them again.
+	h.serveMu.Lock()
+	defer h.serveMu.Unlock()
+
+	h.mu.Lock()
+	uffdFile := h.uffdFile
+	uffd := h.uffd
+	h.uffdFile = nil
+	h.uffd = -1
+	live, frozen, bm, stage := h.live, h.frozen, h.bm, h.stage
+	h.live, h.frozen, h.bm, h.stage = nil, nil, nil, nil
+	h.mu.Unlock()
+
 	// Closing the file unblocks Serve's poller-driven Read and closes the uffd fd it
 	// owns. Clear the raw alias without a second unix.Close (double close).
-	if h.uffdFile != nil {
-		_ = h.uffdFile.Close()
-		h.uffdFile = nil
-		h.uffd = -1
-	} else if h.uffd >= 0 {
-		_ = unix.Close(h.uffd)
-		h.uffd = -1
+	if uffdFile != nil {
+		_ = uffdFile.Close()
+	} else if uffd >= 0 {
+		_ = unix.Close(uffd)
 	}
-	if h.live != nil {
-		_ = unix.Munmap(h.live)
-		h.live = nil
+	if live != nil {
+		_ = unix.Munmap(live)
 	}
-	if h.frozen != nil {
-		_ = unix.Munmap(h.frozen)
-		h.frozen = nil
+	if frozen != nil {
+		_ = unix.Munmap(frozen)
 	}
-	if h.bm != nil {
-		_ = unix.Munmap(h.bm)
-		h.bm = nil
+	if bm != nil {
+		_ = unix.Munmap(bm)
 	}
-	if h.stage != nil {
-		_ = unix.Munmap(h.stage)
-		h.stage = nil
+	if stage != nil {
+		_ = unix.Munmap(stage)
 	}
 	_ = os.Remove(h.sockPath)
 	return nil

--- a/internal/fork/childuffd_linux_test.go
+++ b/internal/fork/childuffd_linux_test.go
@@ -1,0 +1,221 @@
+//go:build linux
+
+package fork
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// This test drives the lazy child-side UFFD handler (childuffd_linux.go) end to end
+// over a REAL Linux userfaultfd in MISSING mode plus hand-built memfds, WITHOUT a
+// KVM guest, exactly as wpfork_kvm_test.go stands in for the patched Firecracker
+// PARENT side. It plays the role of the child Firecracker's stock Uffd restore
+// backend: create anonymous "guest RAM", register it MISSING with a userfaultfd,
+// hand the uffd + region layout to the handler over the backend socket, then fault
+// pages and assert the handler filled each faulting page from the composed source.
+// It proves the per-fault frozen composite (childuffd.go): a page whose frozen bit
+// is set is served from the FROZEN memfd at its fork-time value EVEN AFTER the live
+// source memfd is overwritten (the no-leak invariant), and a page whose bit is
+// clear is served from the live source memfd.
+//
+// It skips (never falsely fails) when userfaultfd is unavailable on the runner
+// (needs CAP_SYS_PTRACE or vm.unprivileged_userfaultfd=1), the same honest gating
+// createWPUffd uses. The firecracker-test job runs it for real without -race.
+
+// registerModeMissing is UFFDIO_REGISTER_MODE_MISSING: the stock Firecracker Uffd
+// backend registers guest RAM in MISSING mode so a first touch of an unfilled page
+// faults and the handler UFFDIO_COPYs it in.
+const registerModeMissing = 0x1
+
+// createMissingUffd creates a plain userfaultfd (no WP feature) as the stock
+// Firecracker Uffd restore backend does. It returns skip=true with a reason when
+// userfaultfd is unavailable on this runner.
+func createMissingUffd(t *testing.T) (int, bool, string) {
+	t.Helper()
+	fd, _, errno := unix.Syscall(unix.SYS_USERFAULTFD, uintptr(unix.O_CLOEXEC|unix.O_NONBLOCK|uffdUserModeOnly), 0, 0)
+	if errno != 0 {
+		return -1, true, fmt.Sprintf("userfaultfd() unavailable (errno %v); needs Linux and CAP_SYS_PTRACE or vm.unprivileged_userfaultfd=1", errno)
+	}
+	api := uffdioAPIArg{API: uffdAPIVersion}
+	if _, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(int(fd)), uintptr(uffdioAPICmd), uintptr(unsafe.Pointer(&api))); e != 0 {
+		_ = unix.Close(int(fd))
+		return -1, true, fmt.Sprintf("UFFDIO_API failed (errno %v): kernel too old for userfaultfd", e)
+	}
+	return int(fd), false, ""
+}
+
+// registerMissing registers [addr,addr+len) with the uffd in MISSING mode, as the
+// stock Firecracker Uffd backend does over each guest region.
+func registerMissing(t *testing.T, uffd int, addr, length uint64) bool {
+	t.Helper()
+	reg := uffdioRegisterArg{Start: addr, Len: length, Mode: registerModeMissing}
+	if _, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(uffd), uintptr(uffdioRegisterCmd), uintptr(unsafe.Pointer(&reg))); e != 0 {
+		t.Logf("UFFDIO_REGISTER MODE_MISSING failed (errno %v)", e)
+		return false
+	}
+	return true
+}
+
+// mkNamedMemfd creates a memfd with the given name sized to bytes, returns its fd
+// and its (ino, dev) identity. The caller owns the fd.
+func mkNamedMemfd(t *testing.T, name string, bytes uint64) (int, uint64, uint64) {
+	t.Helper()
+	fd, err := unix.MemfdCreate(name, unix.MFD_CLOEXEC)
+	if err != nil {
+		t.Fatalf("memfd_create %s: %v", name, err)
+	}
+	if err := unix.Ftruncate(fd, int64(bytes)); err != nil {
+		t.Fatalf("ftruncate %s: %v", name, err)
+	}
+	ino, dev, err := fdIdentity(fd)
+	if err != nil {
+		t.Fatalf("fdIdentity %s: %v", name, err)
+	}
+	return fd, ino, dev
+}
+
+func TestChildUFFDLazyImportComposesAndNoLeak(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("skipping child-uffd handshake test under -race (timing-sensitive; the firecracker-test job runs it without -race)")
+	}
+	const pageSize = 4096
+	const npages = 8
+	size := uint64(npages * pageSize)
+
+	// Page roles: page frozenPage is a page the parent overwrote after the fork (bit
+	// set, fork-time bytes preserved in FROZEN); page livePage is untouched (bit
+	// clear, served from the live source memfd). first byte per page carries a
+	// distinct tag so the composed source is unambiguous.
+	const frozenPage = 2
+	const livePage = 5
+	const forkTimeTag = byte('F')
+	const leakTag = byte('X') // the source's post-fork overwrite that must NOT leak
+	const liveTag = byte('N')
+
+	// --- Source (parent) shared memfd: the child faults its guest RAM from here. ---
+	parentFd, parentIno, parentDev := mkNamedMemfd(t, "mitos-guest-ram", size)
+	defer unix.Close(parentFd) //nolint:errcheck // test teardown
+	parent, err := unix.Mmap(parentFd, 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap parent: %v", err)
+	}
+	defer unix.Munmap(parent) //nolint:errcheck // test teardown
+	// Every page starts at its fork-time value.
+	parent[livePage*pageSize] = liveTag
+	parent[frozenPage*pageSize] = forkTimeTag
+
+	// --- FROZEN memfd + bitmap (the WP handler's per-fork epoch). frozenPage is
+	// marked frozen and its fork-time bytes preserved; then the LIVE source page is
+	// overwritten with the leak tag, simulating a resumed source's post-fork write. ---
+	frozenFd, frozenIno, frozenDev := mkNamedMemfd(t, frozenMemfdName, size)
+	defer unix.Close(frozenFd) //nolint:errcheck // test teardown
+	frozen, err := unix.Mmap(frozenFd, 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap frozen: %v", err)
+	}
+	defer unix.Munmap(frozen)                 //nolint:errcheck // test teardown
+	frozen[frozenPage*pageSize] = forkTimeTag // fork-time bytes preserved by the WP handler
+
+	bmBytes := frozenBitmapBytes(size, pageSize)
+	bmFd, bmIno, bmDev := mkNamedMemfd(t, frozenBitmapName, bmBytes)
+	defer unix.Close(bmFd) //nolint:errcheck // test teardown
+	bm, err := unix.Mmap(bmFd, 0, int(bmBytes), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap bitmap: %v", err)
+	}
+	defer unix.Munmap(bm) //nolint:errcheck // test teardown
+	setFrozenBit(bm, frozenPage)
+	// The resumed source overwrites the frozen page's LIVE bytes: a leak would serve
+	// this. The frozen bit is already set, so the handler must serve FROZEN instead.
+	parent[frozenPage*pageSize] = leakTag
+
+	imp := ChildMemfdImport{
+		ParentPID: os.Getpid(), ParentFD: parentFd, ParentIno: parentIno, ParentDev: parentDev,
+		Bytes:     size,
+		FrozenPID: os.Getpid(), FrozenFD: frozenFd, FrozenIno: frozenIno, FrozenDev: frozenDev,
+		BitmapPID: os.Getpid(), BitmapFD: bmFd, BitmapIno: bmIno, BitmapDev: bmDev,
+		PageSize: pageSize,
+	}
+
+	sockPath := filepath.Join(t.TempDir(), "cu.sock")
+	handleIface, err := StartChildUFFDHandler(sockPath, imp)
+	if err != nil {
+		t.Fatalf("StartChildUFFDHandler: %v", err)
+	}
+	h := handleIface.(*childUFFDHandler)
+	defer h.Close() //nolint:errcheck // test teardown
+
+	// --- Play the child Firecracker Uffd backend: anonymous guest RAM registered
+	// MISSING, uffd + region layout handed to the handler over the socket. ---
+	guest, err := unix.Mmap(-1, 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS)
+	if err != nil {
+		t.Fatalf("mmap guest: %v", err)
+	}
+	defer unix.Munmap(guest) //nolint:errcheck // test teardown
+	uffd, skip, reason := createMissingUffd(t)
+	if skip {
+		t.Skipf("userfaultfd precondition not met on this runner: %s", reason)
+	}
+	base := uint64(uintptr(unsafe.Pointer(&guest[0])))
+	if !registerMissing(t, uffd, base, size) {
+		t.Skipf("could not register the guest mapping MISSING with userfaultfd on this runner")
+	}
+
+	// Receive runs concurrently with the "child" connect+send (Firecracker connects
+	// during /snapshot/load).
+	recvErr := make(chan error, 1)
+	go func() { recvErr <- h.Receive() }()
+
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: sockPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("dial handler socket: %v", err)
+	}
+	regions := []uffdMapping{{BaseHostVirtAddr: base, Size: size, Offset: 0, PageSize: pageSize}}
+	body, err := json.Marshal(regions)
+	if err != nil {
+		t.Fatalf("marshal regions: %v", err)
+	}
+	sendUffd(t, conn, body, uffd)
+	_ = conn.Close()
+
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			t.Fatalf("handler Receive: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler Receive timed out")
+	}
+
+	go func() { _ = h.Serve() }()
+
+	// Fault the frozen page and the live page. Reading the first byte of each page
+	// triggers a MISSING fault the handler fills from the composed source.
+	readByte := func(page int) byte {
+		off := page * pageSize
+		// A volatile-ish read: copy out through a slice so the compiler cannot elide
+		// the load that triggers the fault.
+		var out [1]byte
+		copy(out[:], guest[off:off+1])
+		return out[0]
+	}
+
+	if got := readByte(frozenPage); got != forkTimeTag {
+		t.Fatalf("frozen page served %q, want fork-time %q (leak tag is %q): the per-fault frozen composite did not isolate the child", string(got), string(forkTimeTag), string(leakTag))
+	}
+	if got := readByte(livePage); got != liveTag {
+		t.Fatalf("live page served %q, want live source %q", string(got), string(liveTag))
+	}
+	if fc := h.FaultCount(); fc < 2 {
+		t.Errorf("handler served %d faults, want at least 2 (frozen + live pages)", fc)
+	}
+}

--- a/internal/fork/childuffd_linux_test.go
+++ b/internal/fork/childuffd_linux_test.go
@@ -196,17 +196,36 @@ func TestChildUFFDLazyImportComposesAndNoLeak(t *testing.T) {
 		t.Fatal("handler Receive timed out")
 	}
 
-	go func() { _ = h.Serve() }()
+	// Capture the Serve error: if Serve exits (e.g. a compose bug returns an error) a
+	// page read would fault forever with no one to fill it, hanging the test to the
+	// global timeout. readByte therefore RACES the page load against the Serve error
+	// and a short deadline, so a Serve failure or a stuck fill fails fast.
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- h.Serve() }()
 
-	// Fault the frozen page and the live page. Reading the first byte of each page
-	// triggers a MISSING fault the handler fills from the composed source.
+	// Fault a page and return its first byte. Reading it triggers a MISSING fault the
+	// handler fills from the composed source; the read runs in its own goroutine so the
+	// select can bail if Serve died or the fill wedges.
 	readByte := func(page int) byte {
+		t.Helper()
 		off := page * pageSize
-		// A volatile-ish read: copy out through a slice so the compiler cannot elide
-		// the load that triggers the fault.
-		var out [1]byte
-		copy(out[:], guest[off:off+1])
-		return out[0]
+		got := make(chan byte, 1)
+		go func() {
+			// A volatile-ish read: copy out through a slice so the compiler cannot elide
+			// the load that triggers the fault.
+			var out [1]byte
+			copy(out[:], guest[off:off+1])
+			got <- out[0]
+		}()
+		select {
+		case b := <-got:
+			return b
+		case err := <-serveErr:
+			t.Fatalf("handler Serve exited before page %d was filled: %v", page, err)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("page %d fault was not served within the deadline (Serve wedged)", page)
+		}
+		return 0 // unreachable (t.Fatalf exits)
 	}
 
 	if got := readByte(frozenPage); got != forkTimeTag {

--- a/internal/fork/childuffd_other.go
+++ b/internal/fork/childuffd_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package fork
+
+// StartChildUFFDHandler is unavailable off Linux: the lazy child-side UFFD import
+// needs userfaultfd + memfd + /proc fd re-open, all Linux-only. Callers must fall
+// back to the disk-snapshot restore (fail-closed). The signature matches the Linux
+// build so the husk wiring compiles on any host.
+func StartChildUFFDHandler(_ string, _ ChildMemfdImport) (ChildUFFDHandle, error) {
+	return nil, ErrChildUFFDUnsupported
+}

--- a/internal/husk/forksnapshot_livecow_kvm_test.go
+++ b/internal/husk/forksnapshot_livecow_kvm_test.go
@@ -422,37 +422,44 @@ func TestForkSnapshotLiveCowArmedFullFallbackColocatedChildKVM(t *testing.T) {
 		armed, fres.Stages["create_snapshot"])
 }
 
-// TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM is the m5
-// real-KVM gate that closes the loop: with --live-cow-fork AND child import ON, a
-// co-located fork child BOOTS ITS GUEST RAM BY IMPORTING THE SOURCE MEMFD (the
-// patched child restore reads FIRECRACKER_MITOS_CHILD_MEMFD, MAP_PRIVATEs the
-// source's shared memfd, overlays the frozen pages, and loads NO disk mem file), so
-// the create_snapshot mem write disappears end to end and the fork still completes.
+// TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM is the
+// real-KVM gate that closes the loop AND proves the fork latency actually drops:
+// with --live-cow-fork AND child import ON, a co-located fork child BOOTS ITS GUEST
+// RAM BY LAZILY FAULTING IT IN FROM THE SOURCE MEMFD. The child restores through
+// Firecracker's NATIVE Uffd backend pointed at a husk-side handler socket (NO disk
+// mem file, NO FIRECRACKER_MITOS_CHILD_MEMFD env): the handler serves each faulting
+// page from the source memfd + FROZEN overlay ON DEMAND, so the child copies only
+// its working set (a few MiB) instead of eagerly copying all 256MiB.
 //
 // This is the half TestForkSnapshotLiveCowArmedFullFallbackColocatedChildKVM
 // deliberately leaves off: that test proves the SAFE fallback (child import OFF ->
 // source writes the disk mem -> child restores from disk, no hang). Here child
 // import is ON, so the source writes NO mem file and the ONLY way the co-located
-// child can boot is by importing the source memfd. It asserts, end to end on KVM:
+// child can boot is by faulting its guest RAM from the source memfd. It asserts,
+// end to end on KVM:
 //   - (VMSTATE ONLY) the fork wrote NO `mem` file (the ~364ms guest-RAM write is
 //     gone) and create_snapshot is sub-15ms;
-//   - (CHILD IMPORTS, BOOTS, NO DISK MEM) a real co-located SpawnVM child restores
-//     from the fork snapshot that has NO mem file and still boots + execs within a
-//     bounded deadline: it can only have taken its guest RAM from the source memfd;
+//   - (CHILD LAZILY FAULTS, BOOTS, NO DISK MEM) a real co-located SpawnVM child
+//     restores from the fork snapshot that has NO mem file and still boots + execs
+//     within a bounded deadline: it can only have taken its guest RAM from the
+//     source memfd via the lazy UFFD handler;
+//   - (LATENCY DROPS) the child's vmstate_restore stage is SMALL (well below 100ms),
+//     NOT the ~391ms the EAGER 256MiB child copy cost: this is the whole point of the
+//     lazy import, that the vmstate-only source win is finally realized end to end;
 //   - (FORK COMPLETES) SpawnVM returns OK (no hang, the v1.32.2 prod failure mode);
 //   - (FORK-TIME MEMORY, NO LEAK) when the restored source can exec, a fork-time
 //     sentinel planted in guest tmpfs is read back by the child as its FORK-TIME
 //     value even after the resumed source overwrites it, so the source's post-fork
-//     write is write-protect-frozen and never leaks into the child (the m2
-//     invariant, observed through the real guest).
+//     write is write-protect-frozen and served from FROZEN at fault time, never
+//     leaking into the child (the m2 invariant, observed through the real guest).
 //
 // GATING: skips on no /dev/kvm, no assets, race detector, or a source that does not
 // arm the write-protect handshake (unpatched / uffd-less runner), exactly like the
-// sibling tests. The child-import boot additionally needs the m5 patched binary; a
-// child that cannot boot from the memfd SKIPS unless
-// MITOS_KVM_REQUIRE_LIVECOW_CHILD_IMPORT is set (the firecracker-test job sets it
-// once the re-pinned child-import binary is installed), so an old patched binary is
-// never a false pass and the shipped binary is never a false skip.
+// sibling tests. The child boots through Firecracker's STOCK Uffd backend (no child
+// patch), so a child that cannot boot lazily (e.g. a runner that blocks the child's
+// userfaultfd) SKIPS unless MITOS_KVM_REQUIRE_LIVECOW_CHILD_IMPORT is set (the
+// firecracker-test job sets it once the runner's userfaultfd is reachable), so a
+// gap is never a false pass and a capable runner is never a false skip.
 func TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM(t *testing.T) {
 	if raceDetectorEnabled {
 		t.Skip("skipping live-cow child-import KVM test under -race (WP handshake is timing-sensitive; firecracker-test runs it without -race)")
@@ -596,12 +603,12 @@ func TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM(t *testi
 		}
 	}
 
-	// (CHILD IMPORTS, BOOTS, NO DISK MEM) spawn a real co-located child from the
-	// mem-less fork snapshot. With child import ON and the source armed, SpawnVM sets
-	// FIRECRACKER_MITOS_CHILD_MEMFD on the child from the armed handle's ChildImport,
-	// so the patched child restore imports the source memfd instead of a disk mem file
-	// (there is none). On the v1.32.2 prod binary (no child-import patch) this HANGS;
-	// with the m5 binary it boots.
+	// (CHILD LAZILY FAULTS, BOOTS, NO DISK MEM) spawn a real co-located child from the
+	// mem-less fork snapshot. With child import ON and the source armed, SpawnVM
+	// restores the child through Firecracker's NATIVE Uffd backend pointed at a
+	// husk-side handler (from the armed handle's ChildImport), so the child faults its
+	// guest RAM from the source memfd + FROZEN overlay ON DEMAND instead of a disk mem
+	// file (there is none). No child Firecracker patch is needed (stock Uffd backend).
 	spawnCtx, spawnCancel := context.WithTimeout(ctx, 60*time.Second)
 	defer spawnCancel()
 	childRes := src.SpawnVM(spawnCtx, SpawnVMRequest{
@@ -610,9 +617,9 @@ func TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM(t *testi
 	})
 	if !childRes.OK {
 		if requireChildImport {
-			t.Fatalf("live-cow child-import e2e (strict, MITOS_KVM_REQUIRE_LIVECOW_CHILD_IMPORT set): co-located child must boot BY IMPORTING THE SOURCE MEMFD from the mem-less fork snapshot, got: %+v. The pinned Firecracker must honor FIRECRACKER_MITOS_CHILD_MEMFD (m5)", childRes)
+			t.Fatalf("live-cow child-import e2e (strict, MITOS_KVM_REQUIRE_LIVECOW_CHILD_IMPORT set): co-located child must boot BY LAZILY FAULTING THE SOURCE MEMFD from the mem-less fork snapshot, got: %+v. Firecracker's native Uffd restore backend + the husk lazy handler must serve the child's guest RAM", childRes)
 		}
-		t.Skipf("skipping live-cow child-import e2e: co-located child did not boot from the source memfd (runner Firecracker lacks the m5 child-import patch); the mem-less fork is only bootable by import: %+v", childRes)
+		t.Skipf("skipping live-cow child-import e2e: co-located child did not boot by lazy UFFD from the source memfd (runner Firecracker Uffd backend or child userfaultfd unavailable); the mem-less fork is only bootable by import: %+v", childRes)
 	}
 	// A child that boots from a mem-less fork snapshot proves it read NO disk mem file
 	// (there is none) and took its guest RAM from the imported source memfd.
@@ -630,6 +637,22 @@ func TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM(t *testi
 		t.Fatalf("co-located child imported the source memfd and restored but could not exec (a corrupt/incoherent RAM import would not boot a working guest): %v", err)
 	}
 
+	// (LATENCY DROPS) the whole point of the lazy import: the child's vmstate_restore
+	// must be SMALL, not the ~391ms the EAGER 256MiB child copy cost. The lazy UFFD
+	// load returns as soon as the device-restore faults are served (a few pages), and
+	// the guest faults the rest of its working set on demand after resume, so
+	// vmstate_restore drops back to the low-tens-of-ms it was before the eager copy.
+	// A stage at or above 100ms means the child still copied its whole guest RAM
+	// up front (the eager path), which would make the vmstate-only source win
+	// latency-neutral, the exact failure this change fixes.
+	childRestoreMs, ok := childRes.Stages["vmstate_restore"]
+	if !ok {
+		t.Fatalf("co-located child spawn result missing vmstate_restore stage; got %v", childRes.Stages)
+	}
+	if childRestoreMs >= 100 {
+		t.Fatalf("child vmstate_restore = %.3fms, want well below 100ms (lazy UFFD faults only the working set; >=100ms means the child eagerly copied all %dMiB, leaving the fork latency-neutral)", childRestoreMs, memMiB)
+	}
+
 	// (FORK-TIME MEMORY, NO LEAK) the child must read the sentinel at its FORK-TIME
 	// value, never the source's post-fork overwrite. Hard when the sentinel was
 	// planted; a corrupt import or a leaked source write would fail here.
@@ -645,8 +668,8 @@ func TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM(t *testi
 		}
 	}
 
-	t.Logf("m5 live-cow child-import PASS: vmstate-only fork wrote NO mem file; create_snapshot=%.3fms freeze=%.3fms (vs ~364ms Full mem write); co-located child BOOTED BY IMPORTING THE SOURCE MEMFD (%dMiB) and execed with no hang; sentinelPlanted=%v sourceOverwrote=%v (child read fork-time value, no leak)",
-		fres.Stages["create_snapshot"], fres.Stages["freeze"], memMiB, sentinelPlanted, sourceOverwrote)
+	t.Logf("live-cow lazy child-import PASS: vmstate-only fork wrote NO mem file; create_snapshot=%.3fms freeze=%.3fms (vs ~364ms Full mem write); co-located child LAZILY FAULTED its guest RAM from the source memfd (%dMiB) with child vmstate_restore=%.3fms (vs ~391ms eager copy) and execed with no hang; sentinelPlanted=%v sourceOverwrote=%v (child read fork-time value, no leak)",
+		fres.Stages["create_snapshot"], fres.Stages["freeze"], memMiB, childRestoreMs, sentinelPlanted, sourceOverwrote)
 }
 
 // fullPathRestoredSourceSurvivesFork stands up a SECOND source with live-cow OFF (the

--- a/internal/husk/livecow.go
+++ b/internal/husk/livecow.go
@@ -3,6 +3,7 @@ package husk
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"net"
 	"os"
@@ -105,6 +106,59 @@ func (s *Stub) liveCowChildImportEnv(req ActivateRequest) ([]string, error) {
 		return nil, fmt.Errorf("live-cow child import: write export %s: %w", exportPath, err)
 	}
 	return fork.ChildMemfdEnv(exportPath), nil
+}
+
+// liveCowChildUFFDPlan assembles the LAZY UFFD import plan a co-located fork child
+// Firecracker must be launched with so it faults its guest RAM in ON DEMAND from
+// the parent's live shared memfd (composed per page with the FROZEN overlay)
+// through Firecracker's NATIVE Uffd restore backend, instead of eagerly copying the
+// whole guest RAM (the shipped child-memfd-import path) or reading a disk mem file.
+// This is the fork-latency fix (childuffd.go): the child restore drops back to
+// milliseconds because it copies only the working set, not all 256MiB.
+//
+// It returns:
+//   - (plan, nil) when an armed live-cow parent published a child import: the child
+//     restores through the Uffd backend on plan.sockPath, and the husk-side handler
+//     serves faults from the source memfd + FROZEN overlay;
+//   - (nil, nil) when no live-cow parent is armed: the child restores from disk;
+//   - (nil, err) on a real failure assembling the import: SpawnVM logs and falls
+//     back to the disk restore, so the flag never breaks a fork (fail-closed).
+func (s *Stub) liveCowChildUFFDPlan(id vmID, req ActivateRequest) (*lazyChildUFFDPlan, error) {
+	// Read the armed parent under s.mu (see liveCowChildImportEnv): an interface value
+	// is two words, so an unsynchronized read of a concurrently armed parent tears.
+	s.mu.Lock()
+	parent := s.liveCowParent
+	s.mu.Unlock()
+	if parent == nil {
+		return nil, nil
+	}
+	if req.SnapshotDir == "" {
+		return nil, fmt.Errorf("live-cow child uffd: empty snapshot dir")
+	}
+	imp, err := parent.ChildImport(req.SnapshotDir)
+	if err != nil {
+		return nil, fmt.Errorf("live-cow child uffd: %w", err)
+	}
+	sockPath, err := s.childUFFDSockPath(id)
+	if err != nil {
+		return nil, fmt.Errorf("live-cow child uffd: %w", err)
+	}
+	return &lazyChildUFFDPlan{imp: imp, sockPath: sockPath}, nil
+}
+
+// childUFFDSockPath returns the backend unix socket path a co-located fork child's
+// lazy UFFD restore connects to. It lives in the POD workdir (not the child's
+// nested per-VM workdir) under a SHORT hashed name so the absolute path stays under
+// the ~108-byte AF_UNIX sun_path limit even for a long vmID and a long pod workdir.
+// An empty pod workdir (the unit path) has no place to bind, so it errors and the
+// child falls back to the disk restore.
+func (s *Stub) childUFFDSockPath(id vmID) (string, error) {
+	if s.cfg.WorkDir == "" {
+		return "", fmt.Errorf("no pod workdir to bind the child uffd socket")
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(id))
+	return filepath.Join(s.cfg.WorkDir, fmt.Sprintf("cu-%08x.sock", h.Sum32())), nil
 }
 
 // LiveCowForkEnabled reports whether this pod was started with the live-cow fork

--- a/internal/husk/livecow.go
+++ b/internal/husk/livecow.go
@@ -146,19 +146,33 @@ func (s *Stub) liveCowChildUFFDPlan(id vmID, req ActivateRequest) (*lazyChildUFF
 	return &lazyChildUFFDPlan{imp: imp, sockPath: sockPath}, nil
 }
 
+// sunPathMax is the AF_UNIX sun_path capacity (sizeof(sockaddr_un.sun_path)) on
+// Linux: a bind/connect to a longer absolute path is truncated/rejected, so the
+// child UFFD backend socket path MUST fit. 108 bytes INCLUDING the NUL terminator,
+// so the usable path is at most 107 bytes.
+const sunPathMax = 108
+
 // childUFFDSockPath returns the backend unix socket path a co-located fork child's
 // lazy UFFD restore connects to. It lives in the POD workdir (not the child's
-// nested per-VM workdir) under a SHORT hashed name so the absolute path stays under
-// the ~108-byte AF_UNIX sun_path limit even for a long vmID and a long pod workdir.
-// An empty pod workdir (the unit path) has no place to bind, so it errors and the
-// child falls back to the disk restore.
+// nested per-VM workdir) under a FIXED-LENGTH hashed name so the absolute path stays
+// as short as possible for a long vmID. The name uses a 64-bit vmID hash (16 hex
+// digits) so two co-located children in one pod do not collide on the same socket
+// (a 32-bit hash could, and a collision would let one child unlink or misroute a
+// sibling child's memory backend). It FAILS CLOSED when the pod workdir is empty (no
+// place to bind, the unit path) or when the resulting absolute path would exceed the
+// AF_UNIX sun_path limit, so a too-long workdir never silently binds a truncated
+// path the child cannot reach.
 func (s *Stub) childUFFDSockPath(id vmID) (string, error) {
 	if s.cfg.WorkDir == "" {
 		return "", fmt.Errorf("no pod workdir to bind the child uffd socket")
 	}
-	h := fnv.New32a()
+	h := fnv.New64a()
 	_, _ = h.Write([]byte(id))
-	return filepath.Join(s.cfg.WorkDir, fmt.Sprintf("cu-%08x.sock", h.Sum32())), nil
+	sock := filepath.Join(s.cfg.WorkDir, fmt.Sprintf("cu-%016x.sock", h.Sum64()))
+	if len(sock) >= sunPathMax {
+		return "", fmt.Errorf("child uffd socket path %d bytes exceeds the AF_UNIX sun_path limit %d (pod workdir too long)", len(sock), sunPathMax)
+	}
+	return sock, nil
 }
 
 // LiveCowForkEnabled reports whether this pod was started with the live-cow fork

--- a/internal/husk/livecow_test.go
+++ b/internal/husk/livecow_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"mitos.run/mitos/internal/firecracker"
@@ -248,7 +249,14 @@ func TestLiveCowChildUFFDPlanNoParent(t *testing.T) {
 // the ChildImport coordinates and a backend socket path under the pod workdir whose
 // absolute length stays under the AF_UNIX sun_path limit even for a long vmID.
 func TestLiveCowChildUFFDPlanArmed(t *testing.T) {
-	workDir := t.TempDir()
+	// A SHORT pod workdir under /tmp: the child uffd socket path must fit the AF_UNIX
+	// sun_path limit, and t.TempDir() on some hosts is already too long on its own.
+	// The production pod workdir is short (e.g. /run/husk).
+	workDir, err := os.MkdirTemp("/tmp", "cu")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(workDir) //nolint:errcheck // test teardown
 	prov := &fakeChildImportProvider{imp: fork.ChildMemfdImport{
 		ParentPID: 4242, ParentFD: 5, ParentIno: 111, ParentDev: 42, Bytes: 256 << 20,
 		FrozenPID: 4243, FrozenFD: 6, FrozenIno: 222, FrozenDev: 42,
@@ -280,7 +288,7 @@ func TestLiveCowChildUFFDPlanArmed(t *testing.T) {
 	// nested per-VM workdir). The absolute length then depends only on the pod
 	// workdir, which is short in production (e.g. /run/husk).
 	base := filepath.Base(plan.sockPath)
-	if len(base) > 20 {
+	if len(base) > 28 {
 		t.Errorf("socket basename %q is %d bytes, want a short fixed-length hashed name", base, len(base))
 	}
 	longer, err := s.liveCowChildUFFDPlan("this-is-a-much-much-longer-vm-identifier-than-before", ActivateRequest{SnapshotDir: dir})
@@ -314,5 +322,17 @@ func TestLiveCowChildUFFDPlanFailClosed(t *testing.T) {
 	}})
 	if _, err := noWD.liveCowChildUFFDPlan("child", ActivateRequest{SnapshotDir: t.TempDir()}); err == nil {
 		t.Fatal("empty pod workdir must be an error (no place to bind the child uffd socket)")
+	}
+
+	// A pod workdir so long the absolute socket path would exceed the AF_UNIX
+	// sun_path limit must fail closed rather than bind a truncated, unreachable path.
+	longWD := New(firecracker.VMConfig{WorkDir: "/" + strings.Repeat("d", 200)}, Options{MultiVM: true, LiveCowFork: true})
+	longWD.SetLiveCowParent(&fakeChildImportProvider{imp: fork.ChildMemfdImport{
+		ParentPID: 1, ParentFD: 2, ParentIno: 3, ParentDev: 4, Bytes: 4096,
+		FrozenPID: 1, FrozenFD: 3, FrozenIno: 5, FrozenDev: 4,
+		BitmapPID: 1, BitmapFD: 4, BitmapIno: 6, BitmapDev: 4, PageSize: 4096,
+	}})
+	if _, err := longWD.liveCowChildUFFDPlan("child", ActivateRequest{SnapshotDir: t.TempDir()}); err == nil {
+		t.Fatal("a too-long pod workdir must be an error (socket path over the sun_path limit)")
 	}
 }

--- a/internal/husk/livecow_test.go
+++ b/internal/husk/livecow_test.go
@@ -229,3 +229,90 @@ func TestLiveCowChildImportEnvFailClosed(t *testing.T) {
 		t.Fatal("empty snapshot dir must be an error")
 	}
 }
+
+// TestLiveCowChildUFFDPlanNoParent proves that with no armed live-cow parent the
+// lazy-UFFD import plan is (nil, nil), so SpawnVM restores the child from the disk
+// fork snapshot (fail-closed disk fallback).
+func TestLiveCowChildUFFDPlanNoParent(t *testing.T) {
+	s := New(firecracker.VMConfig{WorkDir: t.TempDir()}, Options{MultiVM: true, LiveCowFork: true})
+	plan, err := s.liveCowChildUFFDPlan("child", ActivateRequest{SnapshotDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("liveCowChildUFFDPlan (no parent) err = %v, want nil", err)
+	}
+	if plan != nil {
+		t.Fatalf("liveCowChildUFFDPlan (no parent) = %+v, want nil (disk fallback)", plan)
+	}
+}
+
+// TestLiveCowChildUFFDPlanArmed proves that with an armed parent the plan carries
+// the ChildImport coordinates and a backend socket path under the pod workdir whose
+// absolute length stays under the AF_UNIX sun_path limit even for a long vmID.
+func TestLiveCowChildUFFDPlanArmed(t *testing.T) {
+	workDir := t.TempDir()
+	prov := &fakeChildImportProvider{imp: fork.ChildMemfdImport{
+		ParentPID: 4242, ParentFD: 5, ParentIno: 111, ParentDev: 42, Bytes: 256 << 20,
+		FrozenPID: 4243, FrozenFD: 6, FrozenIno: 222, FrozenDev: 42,
+		BitmapPID: 4243, BitmapFD: 7, BitmapIno: 333, BitmapDev: 42, PageSize: 4096,
+	}}
+	s := New(firecracker.VMConfig{WorkDir: workDir}, Options{MultiVM: true, LiveCowFork: true})
+	s.SetLiveCowParent(prov)
+
+	dir := t.TempDir()
+	plan, err := s.liveCowChildUFFDPlan("livecow-childimp-colo-longish-vmid", ActivateRequest{SnapshotDir: dir})
+	if err != nil {
+		t.Fatalf("liveCowChildUFFDPlan (armed): %v", err)
+	}
+	if plan == nil {
+		t.Fatal("liveCowChildUFFDPlan (armed) = nil, want a plan")
+	}
+	if prov.gotDir != dir {
+		t.Errorf("ChildImport dir = %q, want %q", prov.gotDir, dir)
+	}
+	if plan.imp.ParentPID != 4242 || plan.imp.Bytes != 256<<20 || plan.imp.BitmapIno != 333 {
+		t.Errorf("plan lost import fields: %+v", plan.imp)
+	}
+	if filepath.Dir(plan.sockPath) != workDir {
+		t.Errorf("socket %q must live under the pod workdir %q", plan.sockPath, workDir)
+	}
+	// The socket basename must be SHORT and FIXED-LENGTH regardless of how long the
+	// vmID is: a long vmID must not push the absolute path over the AF_UNIX sun_path
+	// limit (the socket lives in the SHORT pod workdir under a hashed name, not the
+	// nested per-VM workdir). The absolute length then depends only on the pod
+	// workdir, which is short in production (e.g. /run/husk).
+	base := filepath.Base(plan.sockPath)
+	if len(base) > 20 {
+		t.Errorf("socket basename %q is %d bytes, want a short fixed-length hashed name", base, len(base))
+	}
+	longer, err := s.liveCowChildUFFDPlan("this-is-a-much-much-longer-vm-identifier-than-before", ActivateRequest{SnapshotDir: dir})
+	if err != nil {
+		t.Fatalf("liveCowChildUFFDPlan (long vmID): %v", err)
+	}
+	if got := len(filepath.Base(longer.sockPath)); got != len(base) {
+		t.Errorf("a longer vmID changed the socket basename length (%d -> %d); it must stay fixed", len(base), got)
+	}
+}
+
+// TestLiveCowChildUFFDPlanFailClosed proves a provider error, an empty snapshot
+// dir, and an empty pod workdir each surface as an error (no plan), so SpawnVM
+// falls back to the disk restore and the flag never breaks a fork.
+func TestLiveCowChildUFFDPlanFailClosed(t *testing.T) {
+	s := New(firecracker.VMConfig{WorkDir: t.TempDir()}, Options{MultiVM: true, LiveCowFork: true})
+	s.SetLiveCowParent(&fakeChildImportProvider{err: fmt.Errorf("handshake not complete")})
+	if plan, err := s.liveCowChildUFFDPlan("child", ActivateRequest{SnapshotDir: t.TempDir()}); err == nil || plan != nil {
+		t.Fatalf("provider error must yield (nil, err); got plan=%+v err=%v", plan, err)
+	}
+	if _, err := s.liveCowChildUFFDPlan("child", ActivateRequest{SnapshotDir: ""}); err == nil {
+		t.Fatal("empty snapshot dir must be an error")
+	}
+
+	// Empty pod workdir has nowhere to bind the socket: fail closed (disk fallback).
+	noWD := New(firecracker.VMConfig{}, Options{MultiVM: true, LiveCowFork: true})
+	noWD.SetLiveCowParent(&fakeChildImportProvider{imp: fork.ChildMemfdImport{
+		ParentPID: 1, ParentFD: 2, ParentIno: 3, ParentDev: 4, Bytes: 4096,
+		FrozenPID: 1, FrozenFD: 3, FrozenIno: 5, FrozenDev: 4,
+		BitmapPID: 1, BitmapFD: 4, BitmapIno: 6, BitmapDev: 4, PageSize: 4096,
+	}})
+	if _, err := noWD.liveCowChildUFFDPlan("child", ActivateRequest{SnapshotDir: t.TempDir()}); err == nil {
+		t.Fatal("empty pod workdir must be an error (no place to bind the child uffd socket)")
+	}
+}

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -455,8 +455,23 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 	mark = time.Now()
 
 	// Load PAUSED so the rootfs drive can be rebound before the guest runs, then
-	// resume explicitly, exactly as the single-VM path does.
-	if err := inst.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, false, overrides); err != nil {
+	// resume explicitly, exactly as the single-VM path does. A co-located live-cow
+	// fork child armed with a lazy-UFFD import (childUFFDPlan) restores through
+	// Firecracker's NATIVE Uffd backend so it faults its guest RAM in ON DEMAND
+	// (composed from the source memfd + FROZEN overlay) instead of reading a disk mem
+	// file; every other VM loads the disk mem. On the lazy path there is no disk mem
+	// (the fork went vmstate-only), so a UFFD load failure is fatal for this spawn
+	// (fail-closed, never serve a half-restored guest); the plan is only set when the
+	// parent armed, so it is never taken for a plain disk fork.
+	if plan := inst.childUFFDPlan; plan != nil {
+		inst.childUFFDPlan = nil
+		handler, err := s.loadSnapshotChildUFFD(inst.vm, plan, vmStateFile, overrides)
+		if err != nil {
+			werr := fmt.Errorf("husk: lazy-uffd load snapshot from %s for vm %q: %w", req.SnapshotDir, id, err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+		inst.childUFFD = handler
+	} else if err := inst.vm.LoadSnapshotWithOverrides(memFile, vmStateFile, false, overrides); err != nil {
 		werr := fmt.Errorf("husk: load snapshot from %s for vm %q: %w", req.SnapshotDir, id, err)
 		return ActivateResult{OK: false, Error: werr.Error()}, werr
 	}
@@ -526,6 +541,60 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 	}, nil
 }
 
+// armInstanceChildUFFD stores a co-located fork child's lazy-UFFD import plan on
+// its dormant instance so activateInstance takes the Uffd backend at its load step.
+// It takes the instance lock (SpawnVM calls it between prepareInstance and
+// activateInstance, both of which take the lock themselves); a missing instance is
+// a no-op (activate will then fail closed on the missing dormant VM).
+func (s *Stub) armInstanceChildUFFD(id vmID, plan *lazyChildUFFDPlan) {
+	inst := s.instanceFor(id, false)
+	if inst == nil {
+		return
+	}
+	inst.mu.Lock()
+	inst.childUFFDPlan = plan
+	inst.mu.Unlock()
+}
+
+// loadSnapshotChildUFFD restores a co-located fork child through Firecracker's
+// native userfaultfd backend and returns a handler already serving the child's
+// guest-memory faults from the composed source (the source memfd + FROZEN
+// overlay). It binds the backend socket handler, starts the handshake receiver,
+// points /snapshot/load at the socket (paused), waits for the handshake, then
+// starts the Serve loop so the load's own device-restore faults are filled. On any
+// error it Closes the handler and returns. The caller resumes the VM and retains
+// the handler on the instance so teardown Closes it. It mirrors the issue #167
+// UFFD restore orchestration (uffd_engine.go), minus the hot-page preload: the
+// live-cow child pays only the faults for its working set, on demand.
+func (s *Stub) loadSnapshotChildUFFD(vm vmm, plan *lazyChildUFFDPlan, vmStateFile string, overrides []firecracker.NetworkOverride) (fork.ChildUFFDHandle, error) {
+	h, err := fork.StartChildUFFDHandler(plan.sockPath, plan.imp)
+	if err != nil {
+		return nil, fmt.Errorf("start child uffd handler: %w", err)
+	}
+	// Firecracker connects to the socket during /snapshot/load and FAULTS guest
+	// memory DURING the load (device restore dereferences guest RAM), blocking in the
+	// kernel until the handler services those faults. So the receiver must be
+	// accepting before the load, and Serve must be running before the load can
+	// complete: start the receiver + the load PUT concurrently, and once the handshake
+	// delivers the uffd, start Serve so the load's faults are handled.
+	recvErr := make(chan error, 1)
+	go func() { recvErr <- h.Receive() }()
+	putErr := make(chan error, 1)
+	go func() { putErr <- vm.LoadSnapshotUFFD(vmStateFile, plan.sockPath, overrides) }()
+
+	if err := <-recvErr; err != nil {
+		_ = h.Close()
+		<-putErr // let the load unwind so the FC process is reaped by the caller
+		return nil, fmt.Errorf("child uffd handshake: %w", err)
+	}
+	go func() { _ = h.Serve() }()
+	if err := <-putErr; err != nil {
+		_ = h.Close()
+		return nil, fmt.Errorf("load snapshot (child uffd): %w", err)
+	}
+	return h, nil
+}
+
 // SpawnVM brings up an ADDITIONAL same-tenant VM (a new vmID) in a running husk
 // pod: it prepares a dormant per-VM Firecracker for req.VMID then activates it
 // from req.Activate, returning the activated guest's vsock path. It is the server
@@ -565,25 +634,27 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 	if req.Activate.ForkSnapshot && req.Activate.SnapshotDir != "" {
 		rootfsSrcOverride = filepath.Join(req.Activate.SnapshotDir, "rootfs.ext4")
 	}
-	// Milestone m5: when this pod has an armed parent-side live-cow WP handler
-	// (SetLiveCowParent) AND --live-cow-fork is on, the co-located child imports its
-	// guest RAM from the parent's LIVE shared memfd (MAP_PRIVATE + FROZEN overlay)
-	// instead of restoring the memory image from the disk fork snapshot: SpawnVM
-	// sets FIRECRACKER_MITOS_CHILD_MEMFD on the child Firecracker from the parent
-	// handle's ChildImport. The disk mem path is STILL passed to LoadSnapshot as the
-	// fallback, so a child Firecracker that does not honor the env (or a pod with no
-	// armed parent) restores from disk byte-for-byte. FAIL-CLOSED: any error
-	// assembling the import logs and falls back to the disk restore, so turning the
-	// flag on never breaks a fork.
-	var childMemfdEnv []string
+	// When this pod has an armed parent-side live-cow WP handler (SetLiveCowParent)
+	// AND --live-cow-fork is on, the co-located child imports its guest RAM from the
+	// parent's LIVE shared memfd (composed per page with the FROZEN overlay) instead
+	// of restoring the memory image from the disk fork snapshot. It does so LAZILY,
+	// through Firecracker's NATIVE Uffd restore backend: activateInstance points
+	// /snapshot/load at a husk-side handler socket, so the child faults only its
+	// working set in on demand rather than eagerly copying all 256MiB (the
+	// fork-latency fix, childuffd.go). No FIRECRACKER_MITOS_CHILD_MEMFD env and no
+	// disk mem file are needed on this path. FAIL-CLOSED: any error assembling the
+	// import logs and leaves childUFFDPlan nil, so activateInstance restores from disk
+	// (which is present unless the fork went vmstate-only); turning the flag on never
+	// breaks a fork.
+	var childPlan *lazyChildUFFDPlan
 	if s.liveCowForkApplies(req.Activate) && s.liveCowChildImport {
-		env, err := s.liveCowChildImportEnv(req.Activate)
+		plan, err := s.liveCowChildUFFDPlan(id, req.Activate)
 		switch {
 		case err != nil:
-			fmt.Fprintf(os.Stderr, "husk: live-cow child memfd import unavailable for vm %q (%v); restoring from disk fork snapshot this pass\n", req.VMID, err)
-		case env != nil:
-			childMemfdEnv = env
-			fmt.Fprintf(os.Stderr, "husk: live-cow child vm %q boots from the shared parent memfd (%s set); disk mem restore is the fallback\n", req.VMID, fork.EnvChildMemfd)
+			fmt.Fprintf(os.Stderr, "husk: live-cow child uffd import unavailable for vm %q (%v); restoring from disk fork snapshot this pass\n", req.VMID, err)
+		case plan != nil:
+			childPlan = plan
+			fmt.Fprintf(os.Stderr, "husk: live-cow child vm %q lazily faults its guest RAM from the shared parent memfd (uffd backend %s); no disk mem file needed\n", req.VMID, plan.sockPath)
 		default:
 			fmt.Fprintf(os.Stderr, "husk: live-cow fork enabled for co-located child vm %q but no armed live-cow parent; restoring from disk fork snapshot this pass\n", req.VMID)
 		}
@@ -593,7 +664,7 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 	// come from prepare, vmstate_restore / guest_ready / handshake from activate.
 	prepStart := time.Now()
 	prepStages := make(map[string]float64, 3)
-	if err := s.prepareInstance(ctx, id, rootfsSrcOverride, prepStages, childMemfdEnv...); err != nil {
+	if err := s.prepareInstance(ctx, id, rootfsSrcOverride, prepStages); err != nil {
 		return SpawnVMResult{
 			OK:    false,
 			VMID:  req.VMID,
@@ -601,6 +672,12 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 		}
 	}
 	prepStages["prepare_total"] = stageMs(prepStart)
+	// Arm the dormant instance with the lazy-UFFD import plan (if any) so
+	// activateInstance takes the Uffd backend at its load step. Set under the
+	// instance lock, before activate re-acquires it.
+	if childPlan != nil {
+		s.armInstanceChildUFFD(id, childPlan)
+	}
 	res, _ := s.activateInstance(ctx, id, req.Activate)
 	// Merge the prepare and activate stage maps into one breakdown for the spawn.
 	// prepare and activate use disjoint stage names, so neither overwrites the
@@ -667,6 +744,15 @@ func (s *Stub) closeInstanceBody(id vmID, inst *vmInstance) error {
 	if inst.vm != nil {
 		err = inst.vm.Close()
 		inst.vm = nil
+	}
+	// Tear down the lazy-UFFD child import handler AFTER the VMM is gone: closing the
+	// child Firecracker stops it faulting, so the handler's Serve loop then unblocks
+	// cleanly and its source-view munmaps race nothing. A no-op on the disk-restore
+	// path (nil handler). Also clear any unconsumed plan so a re-prepare starts clean.
+	inst.childUFFDPlan = nil
+	if inst.childUFFD != nil {
+		_ = inst.childUFFD.Close()
+		inst.childUFFD = nil
 	}
 	inst.state = StateNew
 	return err

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -545,14 +545,21 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 // its dormant instance so activateInstance takes the Uffd backend at its load step.
 // It takes the instance lock (SpawnVM calls it between prepareInstance and
 // activateInstance, both of which take the lock themselves); a missing instance is
-// a no-op (activate will then fail closed on the missing dormant VM).
+// a no-op (activate will then fail closed on the missing dormant VM). It arms ONLY
+// while the instance is STILL DORMANT: a concurrent Close between prepareInstance
+// and here resets it to StateNew (clearing any plan), so arming unconditionally
+// could leave a stale plan that a LATER prepare of the same vmID would wrongly
+// consume; a state mismatch skips the arm and the spawn takes the disk path (or
+// fails closed on a missing dormant VM at activate).
 func (s *Stub) armInstanceChildUFFD(id vmID, plan *lazyChildUFFDPlan) {
 	inst := s.instanceFor(id, false)
 	if inst == nil {
 		return
 	}
 	inst.mu.Lock()
-	inst.childUFFDPlan = plan
+	if inst.state == StateDormant {
+		inst.childUFFDPlan = plan
+	}
 	inst.mu.Unlock()
 }
 
@@ -577,22 +584,60 @@ func (s *Stub) loadSnapshotChildUFFD(vm vmm, plan *lazyChildUFFDPlan, vmStateFil
 	// accepting before the load, and Serve must be running before the load can
 	// complete: start the receiver + the load PUT concurrently, and once the handshake
 	// delivers the uffd, start Serve so the load's faults are handled.
+	//
+	// FAIL-CLOSED, NO HANG: every wait races the OTHER outcomes so no failure mode
+	// blocks forever. If the load fails BEFORE Firecracker connects, Receive's Accept
+	// would block indefinitely, so a load result that arrives before the handshake
+	// tears the handler down (which unblocks Accept). If Serve exits while the load is
+	// still faulting, the load is stuck on a page no one will fill, so a Serve result
+	// during the load also fails closed. All channels are buffered so a goroutine never
+	// blocks on send after we stop reading.
 	recvErr := make(chan error, 1)
 	go func() { recvErr <- h.Receive() }()
 	putErr := make(chan error, 1)
 	go func() { putErr <- vm.LoadSnapshotUFFD(vmStateFile, plan.sockPath, overrides) }()
 
-	if err := <-recvErr; err != nil {
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			_ = h.Close()
+			<-putErr // let the load unwind so the FC process is reaped by the caller
+			return nil, fmt.Errorf("child uffd handshake: %w", err)
+		}
+	case err := <-putErr:
+		// The load returned before the handshake. A SUCCESSFUL load blocks until Serve
+		// fills its restore faults, so reaching here means the load failed (or exited
+		// early); tear down so Receive's Accept unblocks, then fail closed.
 		_ = h.Close()
-		<-putErr // let the load unwind so the FC process is reaped by the caller
-		return nil, fmt.Errorf("child uffd handshake: %w", err)
+		<-recvErr
+		if err != nil {
+			return nil, fmt.Errorf("load snapshot (child uffd): %w", err)
+		}
+		return nil, fmt.Errorf("load snapshot (child uffd) returned before the uffd handshake")
 	}
-	go func() { _ = h.Serve() }()
-	if err := <-putErr; err != nil {
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- h.Serve() }()
+	select {
+	case err := <-putErr:
+		if err != nil {
+			_ = h.Close()
+			<-serveErr
+			return nil, fmt.Errorf("load snapshot (child uffd): %w", err)
+		}
+		// Load complete; Serve keeps running for the life of the child (its final error
+		// is drained via the buffered channel at teardown, never blocking).
+		return h, nil
+	case err := <-serveErr:
+		// Serve ended while the load was still faulting: the restore is wedged on a page
+		// the handler can no longer fill. Fail closed rather than hang.
 		_ = h.Close()
-		return nil, fmt.Errorf("load snapshot (child uffd): %w", err)
+		<-putErr
+		if err != nil {
+			return nil, fmt.Errorf("child uffd serve ended during restore: %w", err)
+		}
+		return nil, fmt.Errorf("child uffd serve ended before the restore completed")
 	}
-	return h, nil
 }
 
 // SpawnVM brings up an ADDITIONAL same-tenant VM (a new vmID) in a running husk

--- a/internal/husk/sandbox_api_test.go
+++ b/internal/husk/sandbox_api_test.go
@@ -206,6 +206,9 @@ type pathVMM struct {
 func (m *pathVMM) LoadSnapshotWithOverrides(_, _ string, _ bool, _ []firecracker.NetworkOverride) error {
 	return nil
 }
+func (m *pathVMM) LoadSnapshotUFFD(_, _ string, _ []firecracker.NetworkOverride) error {
+	return nil
+}
 func (m *pathVMM) VsockHostPath(string) string              { return m.vsockPath }
 func (m *pathVMM) PatchDrive(_, _ string) error             { return nil }
 func (m *pathVMM) Resume() error                            { return nil }

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -100,6 +100,29 @@ type vmInstance struct {
 	rootfsClonePath string
 	activeTap       string
 	dnsProxy        *dnsproxy.Server
+
+	// childUFFDPlan carries a co-located live-cow fork child's LAZY UFFD import
+	// intent from SpawnVM to activateInstance: the ChildMemfdImport coordinates (the
+	// source memfd + FROZEN overlay + live bitmap) and the backend socket path.
+	// activateInstance consumes it at the load step to restore through Firecracker's
+	// native Uffd backend (faulting the working set in on demand) instead of a disk
+	// mem file. Nil keeps the disk restore. Set + read under inst.mu.
+	childUFFDPlan *lazyChildUFFDPlan
+	// childUFFD is the live lazy-UFFD handler serving this instance's guest-memory
+	// faults for the life of the child, retained so teardown Closes it (which unblocks
+	// its Serve loop and munmaps the source views). Nil on the disk-restore path.
+	childUFFD fork.ChildUFFDHandle
+}
+
+// lazyChildUFFDPlan is the co-located live-cow fork child's lazy-UFFD import
+// intent. imp is the armed parent handle's ChildImport (the source shared memfd,
+// the FROZEN memfd, and the LIVE frozen bitmap memfd, each identity-verified);
+// sockPath is the backend unix socket the child Firecracker's Uffd restore backend
+// connects to. Built by SpawnVM on the armed child-import path and consumed once by
+// activateInstance.
+type lazyChildUFFDPlan struct {
+	imp      fork.ChildMemfdImport
+	sockPath string
 }
 
 // newVMInstance builds a fresh per-VM instance in StateNew. It is the
@@ -119,6 +142,16 @@ type vmm interface {
 	// (PatchDrive) while the VM is PAUSED, before the guest can write anything,
 	// then resumes explicitly via Resume.
 	LoadSnapshotWithOverrides(mem, snapshot string, resume bool, overrides []firecracker.NetworkOverride) error
+	// LoadSnapshotUFFD loads a snapshot through Firecracker's native userfaultfd
+	// memory backend: instead of a mem file it points /snapshot/load at
+	// uffdSocketPath, a unix socket an external handler is already listening on, so
+	// Firecracker creates the guest userfaultfd and hands it to the handler over the
+	// socket. Always loads PAUSED. The live-cow lazy child import uses it so a
+	// co-located fork child faults its guest RAM in on demand (composed from the
+	// source memfd + FROZEN overlay) instead of restoring a disk mem file. The
+	// vmstate-only fork writes no mem file, so this is the ONLY memory backend a
+	// child-import spawn can take.
+	LoadSnapshotUFFD(snapshot, uffdSocketPath string, overrides []firecracker.NetworkOverride) error
 	// VsockHostPath resolves a relative vsock uds_path to its host location.
 	VsockHostPath(rel string) string
 	// PatchDrive rebinds an existing baked drive (by drive id) to a host backing

--- a/internal/husk/stub_test.go
+++ b/internal/husk/stub_test.go
@@ -23,13 +23,14 @@ import (
 type fakeVMM struct {
 	loadErr error
 
-	mu        sync.Mutex
-	loadCalls int
-	gotMem    string
-	gotState  string
-	gotResume bool
-	gotOverr  []firecracker.NetworkOverride
-	closed    bool
+	mu          sync.Mutex
+	loadCalls   int
+	gotMem      string
+	gotState    string
+	gotResume   bool
+	gotOverr    []firecracker.NetworkOverride
+	gotUFFDSock string
+	closed      bool
 
 	patchCalls []struct {
 		driveID string
@@ -93,6 +94,18 @@ func (f *fakeVMM) LoadSnapshotWithOverrides(mem, snapshot string, resume bool, o
 	f.gotResume = resume
 	f.gotOverr = overrides
 	f.callOrder = append(f.callOrder, "load")
+	return f.loadErr
+}
+
+func (f *fakeVMM) LoadSnapshotUFFD(snapshot, uffdSocketPath string, overrides []firecracker.NetworkOverride) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.loadCalls++
+	f.gotState = snapshot
+	f.gotUFFDSock = uffdSocketPath
+	f.gotResume = false
+	f.gotOverr = overrides
+	f.callOrder = append(f.callOrder, "load_uffd")
 	return f.loadErr
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; the hosted fork latency is the thing users feel.
> - The live-cow fork (internal/husk + internal/fork) targets sub-100ms forks; the dominant fork stage measured on prod is create_snapshot=373ms (the source writing 256MiB of guest RAM to disk).
> - The armed vmstate-only fork already SKIPS that write (create_snapshot -> 59ms), but the shipped co-located child then EAGERLY copies the whole 256MiB from the source memfd into anonymous RAM at restore (child vmstate_restore ~20ms -> ~391ms), so the win is cancelled: the fork is latency-neutral, the cost just moved from source to child.
> - The eager copy exists to avoid a leak: a lazily file-backed MAP_PRIVATE of the RESUMED source's live memfd reads back pages the source rewrites after the fork (a torn kernel image).
> - It needs addressing now because it is the last gap between "vmstate-only fork" and an actual latency drop (the whole point of the live-cow work, ROADMAP hosted-fork latency).
> - This pull request imports the child's guest RAM LAZILY through Firecracker's native userfaultfd restore backend: a husk-side handler fills each faulting page on demand, composed per page from the source memfd (unfrozen) or the FROZEN memfd (frozen), checking the frozen bit AT FAULT time so a post-fork source write is served as its fork-time value and never leaks.
> - The benefit is the child copies only its working set (a few MiB), so its restore drops back to milliseconds and the source-side vmstate-only win is finally realized end to end, with the no-leak invariant preserved.

## Linked Issues or Issue Description

Related: #832 (live-cow vmstate-only fork). Problem: the vmstate-only fork removes the source mem-file write but the shipped child EAGER-copies the whole guest RAM at restore, so the fork is latency-neutral. This change makes the child fault its guest RAM in lazily instead, so the source-side win translates into a real fork-latency drop.

## What Changed

- `internal/fork/childuffd.go` / `childuffd_linux.go` / `childuffd_other.go`: new `ChildUFFDHandle` + `StartChildUFFDHandler`. The Linux handler reuses the identity-verified `/proc` reopen the eager import uses (`openProcFdVerified`), maps the source memfd read-only + the FROZEN memfd + the LIVE frozen bitmap, and serves Firecracker's native `GuestRegionUffdMapping` handshake: each faulting page is `UFFDIO_COPY`ed from a composed staging page (FROZEN if the bit is set, else the live source memfd, with a fault-time re-check that closes the leak window).
- `internal/husk`: `SpawnVM` builds a `lazyChildUFFDPlan` from the armed handle's `ChildImport` and stashes it on the instance; `activateInstance` restores via `LoadSnapshotUFFD` + `loadSnapshotChildUFFD` (bind, receive, serve, then wait the load) instead of the disk mem load; `closeInstanceBody` Closes the handler after the VMM is gone. The socket lives in the pod workdir under a short hashed name (AF_UNIX sun_path safe). Disk restore stays the fallback when child-import is off or unarmed.
- `vmm` interface + both fakes gain `LoadSnapshotUFFD`.
- Tests: `TestChildUFFDLazyImportComposesAndNoLeak` drives the handler over a REAL userfaultfd (no KVM) and proves the per-fault frozen composite + no-leak; the KVM gate `TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM` now asserts the child `vmstate_restore` is well below 100ms (not ~391ms) alongside boots-from-memfd + child-alive + fork-time-sentinel no-leak; plan-gate unit tests in `livecow_test.go`.
- `docs/threat-model.md` + `docs/fork-correctness.md`: the new lazy child-import surface and the per-fault frozen composite.

## Verification

- [x] `go build ./...` and `GOOS=linux go build ./...`
- [x] `go test ./internal/husk/... ./internal/fork/...` (darwin) and `-race`, green
- [x] `GOOS=linux go test -c` compiles the husk + fork test binaries (KVM/userfaultfd tests skip off a KVM runner)
- [x] `golangci-lint run` and `GOOS=linux golangci-lint run` clean for the changed packages (the pre-existing `uffd.go:42 pageSizeBytes` darwin-unused warning is unchanged by this PR)
- [ ] `firecracker-test` KVM job is the gate: it exercises the lazy child import end to end and enforces the sub-100ms child restore + no-leak. Not runnable locally (no /dev/kvm).

No public latency number is claimed in code or docs beyond the test threshold; the real measurement lands from the KVM job.

## Risks

Medium: this is a security-sensitive path (`internal/fork`, `internal/husk`) and needs a named reviewer. The lazy path is taken ONLY when the source armed AND `LiveCowChildImport` is on (default off), and fails closed (a UFFD handshake/start failure fails the spawn rather than serving a half-restored guest); off the armed path the child restores from disk byte-for-byte. The no-leak invariant is checked per fault and covered by both a userfaultfd unit test and the KVM gate. No prod flags flipped, no deploy.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), extended thinking. Agent-assisted, human-reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazy guest-memory restore path for co-located live copy-on-write forks, loading pages on demand via a child-side userfaultfd handler.

* **Bug Fixes**
  * Prevents post-fork memory leaks by re-checking the frozen state after live reads.
  * Fail-closed fallback when the lazy handler isn’t available or configuration is invalid.

* **Tests**
  * Added Linux end-to-end and unit tests validating lazy faults, composition, and no-leak guarantees, including real-KVM latency checks.

* **Documentation**
  * Updated threat-model and fork-correctness docs with the lazy import trust and correctness details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->