### PR TITLE
feat(husk): pre-warm a dormant child VMM to cut the fork spawn latency

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -2662,7 +2662,11 @@ jobs:
         run: |
           set -e
           sudo chmod 666 /dev/kvm || true
-          go test ./internal/husk/ -run 'TestColocatedForkInheritsSourceStateKVM|TestMultiVMForkSnapshotDefaultVMKVM' -count=1 -v
+          # TestPrewarmedColocatedForkSkipsBootKVM proves the pre-warm on the SAME
+          # disk-restore co-located fork: a pre-warmed dormant child is ADOPTED
+          # (fc_boot ~0, boot pre-paid off the hot path) and still inherits the
+          # source disk + memory, alive, with a fresh child re-warmed after.
+          go test ./internal/husk/ -run 'TestColocatedForkInheritsSourceStateKVM|TestMultiVMForkSnapshotDefaultVMKVM|TestPrewarmedColocatedForkSkipsBootKVM' -count=1 -v
 
       # Live-cow fork engages on a RESTORED source (issue #832). A warm husk SOURCE VM
       # is RESTORED from the pool template snapshot, so the live-cow fork engages only
@@ -2733,7 +2737,13 @@ jobs:
           else
             echo "uffd not reachable on this runner: the child-import boot will skip cleanly"
           fi
-          go test ./internal/husk/ -run 'TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM|TestForkSnapshotLiveCowArmedFullFallbackColocatedChildKVM' -count=1 -v
+          # TestPrewarmedLiveCowChildImportNoLeakKVM proves the pre-warm does NOT
+          # regress the mem-less lazy-UFFD import: a pre-warmed generic child is
+          # ADOPTED (fc_boot ~0) and STILL lazily faults its guest RAM from the
+          # source memfd through the husk fault handler, alive, with the fork-time
+          # sentinel intact (NO LEAK). Same require-arm/import env as the on-demand
+          # child-import proof.
+          go test ./internal/husk/ -run 'TestForkSnapshotLiveCowChildImportColocatedBootsFromSourceMemfdKVM|TestForkSnapshotLiveCowArmedFullFallbackColocatedChildKVM|TestPrewarmedLiveCowChildImportNoLeakKVM' -count=1 -v
 
       # Husk activate-correctness proof (#18). The fork-correctness phase above
       # proves the GUEST mechanism (distinct RNG + clock resync) when the host

--- a/internal/husk/forksnapshot_livecow_kvm_test.go
+++ b/internal/husk/forksnapshot_livecow_kvm_test.go
@@ -822,10 +822,13 @@ func TestPrewarmedLiveCowChildImportNoLeakKVM(t *testing.T) {
 	sentinelPlanted := false
 	plantCtx, plantCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer plantCancel()
-	if _, err := kvmExecOKCtx(plantCtx, srcAgent, "printf %s > "+sentinelPath+"; /bin/busybox sync || sync || true"); err == nil {
+	// VERIFY the write landed so sentinelPlanted reflects reality: on a runner with
+	// no /dev/shm (or #838 restore-resume vsock) the write fails and the content
+	// no-leak assertion is scoped out, exactly like the sibling child-import test.
+	if _, err := kvmExecOKCtx(plantCtx, srcAgent, "printf %s "+forkVal+" > "+sentinelPath+" && [ \"$(cat "+sentinelPath+")\" = "+forkVal+" ]"); err == nil {
 		sentinelPlanted = true
 	} else {
-		t.Logf("could not plant fork-time sentinel (#838 restore-resume vsock; content no-leak assertion scoped out): %v", err)
+		t.Logf("could not plant+verify fork-time sentinel (no /dev/shm or #838 restore-resume vsock; content no-leak assertion scoped out, still proven in the sibling child-import test): %v", err)
 	}
 
 	// EAGERLY pre-warm the dormant child BEFORE the fork, so the fork adopts it.
@@ -853,7 +856,7 @@ func TestPrewarmedLiveCowChildImportNoLeakKVM(t *testing.T) {
 	if sentinelPlanted {
 		owCtx, owCancel := context.WithTimeout(ctx, 30*time.Second)
 		defer owCancel()
-		if _, err := kvmExecOKCtx(owCtx, srcAgent, "printf %s > "+sentinelPath+"; /bin/busybox sync || sync || true"); err == nil {
+		if _, err := kvmExecOKCtx(owCtx, srcAgent, "printf %s "+leakVal+" > "+sentinelPath+" && [ \"$(cat "+sentinelPath+")\" = "+leakVal+" ]"); err == nil {
 			sourceOverwrote = true
 		} else {
 			t.Logf("resumed source could not overwrite the sentinel (#838); child must still read fork-time value: %v", err)

--- a/internal/husk/forksnapshot_livecow_kvm_test.go
+++ b/internal/husk/forksnapshot_livecow_kvm_test.go
@@ -731,3 +731,187 @@ func fullPathRestoredSourceSurvivesFork(ctx context.Context, t *testing.T, snapD
 	t.Logf("#838 control: FULL-path restored source SURVIVES its fork and execs (so the live-cow freeze, not #838, would be the cause)")
 	return true
 }
+
+// TestPrewarmedLiveCowChildImportNoLeakKVM is the gate that the pre-warm does NOT
+// regress the live-cow lazy-UFFD no-leak path (STRICT NO-REGRESSION gate #5): a
+// pod that keeps a dormant child pre-warmed lets a co-located fork ADOPT that
+// already-booted GENERIC Firecracker (fc_boot ~0, boot pre-paid off the hot path)
+// and STILL restore the mem-less fork by LAZILY FAULTING the source memfd through
+// the husk UFFD fault handler, alive, execing, and reading the fork-time sentinel
+// (NO LEAK of the source's post-fork write). It is the child-import boots-from-
+// memfd scenario with PrewarmChild ON, proving the pre-warmed child arms and
+// restores through LoadSnapshotUFFD + the husk handler identically to the
+// on-demand child. Self-skips where the runner Firecracker lacks the Uffd restore
+// backend; strict under MITOS_KVM_REQUIRE_LIVECOW_CHILD_IMPORT.
+func TestPrewarmedLiveCowChildImportNoLeakKVM(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("skipping pre-warm live-cow child-import KVM test under -race (WP handshake is timing-sensitive)")
+	}
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		t.Skip("skipping pre-warm live-cow child-import e2e: /dev/kvm not available (needs a KVM runner)")
+	}
+	snapDir := os.Getenv("MITOS_KVM_HUSK_SNAPSHOT_DIR")
+	if snapDir == "" {
+		t.Skip("skipping pre-warm live-cow child-import e2e: set MITOS_KVM_HUSK_SNAPSHOT_DIR (the KVM CI sets it)")
+	}
+	for _, name := range []string{"mem", "vmstate"} {
+		if _, err := os.Stat(filepath.Join(snapDir, name)); err != nil {
+			t.Skipf("skipping pre-warm live-cow child-import e2e: snapshot file %s not present: %v", name, err)
+		}
+	}
+	templateRootfs := filepath.Join(filepath.Dir(snapDir), "rootfs.ext4")
+	if _, err := os.Stat(templateRootfs); err != nil {
+		t.Skipf("skipping pre-warm live-cow child-import e2e: template rootfs %s not present: %v", templateRootfs, err)
+	}
+	fcBin := os.Getenv("MITOS_KVM_FIRECRACKER")
+	if fcBin == "" {
+		fcBin = "/usr/local/bin/firecracker"
+	}
+	requireArm := os.Getenv("MITOS_KVM_REQUIRE_LIVECOW_RESTORE_ARM") != ""
+	requireChildImport := os.Getenv("MITOS_KVM_REQUIRE_LIVECOW_CHILD_IMPORT") != ""
+
+	const memMiB = 256
+	src := New(firecracker.VMConfig{
+		ID:             "husk-prewarm-childimp-src",
+		FirecrackerBin: fcBin,
+		WorkDir:        t.TempDir(),
+		VcpuCount:      1,
+		MemSizeMib:     memMiB,
+	}, Options{
+		AllowUnverified:    true,
+		ReadyTimeout:       30 * time.Second,
+		MultiVM:            true,
+		LiveCowFork:        true,
+		LiveCowChildImport: true,
+		PrewarmChild:       true,
+		RootfsTemplatePath: templateRootfs,
+		RootfsCoWDir:       t.TempDir(),
+	})
+	defer func() { _ = src.Close() }()
+
+	ctx := context.Background()
+	if err := src.Prepare(ctx); err != nil {
+		t.Fatalf("source Prepare: %v", err)
+	}
+	sres, err := src.Activate(ctx, ActivateRequest{SnapshotDir: snapDir})
+	if err != nil || !sres.OK {
+		t.Fatalf("source Activate: err=%v res=%+v", err, sres)
+	}
+	srcAgent, err := kvmConnectAgent(sres.VsockPath)
+	if err != nil {
+		t.Fatalf("connect source agent: %v", err)
+	}
+	defer srcAgent.Close() //nolint:errcheck // best-effort teardown
+
+	deadline := time.Now().Add(20 * time.Second)
+	for src.liveCowSnapshotFreezer() == nil {
+		if time.Now().After(deadline) {
+			const msg = "the RESTORED source Firecracker did not offer the live-cow write-protect handshake; the vmstate-only path is unreachable"
+			if requireArm {
+				t.Fatalf("pre-warm live-cow child-import e2e (strict, MITOS_KVM_REQUIRE_LIVECOW_RESTORE_ARM set): %s", msg)
+			}
+			t.Skipf("skipping pre-warm live-cow child-import e2e: %s (unpatched or restore-path memfd share unsupported)", msg)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Plant a fork-time sentinel in the source guest RAM (tmpfs) BEFORE the fork.
+	const sentinelPath = "/dev/shm/mitos-prewarm-childimp-sentinel"
+	const forkVal = "forktime-c0ffee"
+	const leakVal = "postfork-LEAK-dead"
+	sentinelPlanted := false
+	plantCtx, plantCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer plantCancel()
+	if _, err := kvmExecOKCtx(plantCtx, srcAgent, "printf %s > "+sentinelPath+"; /bin/busybox sync || sync || true"); err == nil {
+		sentinelPlanted = true
+	} else {
+		t.Logf("could not plant fork-time sentinel (#838 restore-resume vsock; content no-leak assertion scoped out): %v", err)
+	}
+
+	// EAGERLY pre-warm the dormant child BEFORE the fork, so the fork adopts it.
+	if err := src.PrewarmChild(ctx); err != nil {
+		t.Fatalf("PrewarmChild must boot a dormant child: %v", err)
+	}
+	if got := src.instances[prewarmSlotVMID].state; got != StateDormant {
+		t.Fatalf("pre-warmed slot state = %s, want dormant before the fork", got)
+	}
+
+	// Fork down the vmstate-only path (freeze + vmstate, NO mem file).
+	forkDir := filepath.Join(t.TempDir(), "fork-snap")
+	fres, err := src.ForkSnapshot(ctx, ForkSnapshotRequest{ForkID: "prewarm-childimp", SnapshotDir: forkDir})
+	if err != nil || !fres.OK {
+		t.Fatalf("source ForkSnapshot (armed live-cow child-import) must succeed on KVM: err=%v res=%+v", err, fres)
+	}
+	memPath := filepath.Join(forkDir, "mem")
+	if _, err := os.Stat(memPath); err == nil {
+		t.Fatalf("child-import fork must write NO mem file, but %s exists", memPath)
+	}
+
+	// After the fork, if the source can still exec, overwrite the sentinel so a
+	// leaked page would be observable in the child.
+	sourceOverwrote := false
+	if sentinelPlanted {
+		owCtx, owCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer owCancel()
+		if _, err := kvmExecOKCtx(owCtx, srcAgent, "printf %s > "+sentinelPath+"; /bin/busybox sync || sync || true"); err == nil {
+			sourceOverwrote = true
+		} else {
+			t.Logf("resumed source could not overwrite the sentinel (#838); child must still read fork-time value: %v", err)
+		}
+	}
+
+	// The co-located child ADOPTS the pre-warmed generic Firecracker and restores the
+	// mem-less fork by lazy UFFD import through the husk handler.
+	spawnCtx, spawnCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer spawnCancel()
+	childRes := src.SpawnVM(spawnCtx, SpawnVMRequest{
+		VMID:     "prewarm-childimp-colo",
+		Activate: ActivateRequest{SnapshotDir: forkDir, ForkSnapshot: true},
+	})
+	if !childRes.OK {
+		if requireChildImport {
+			t.Fatalf("pre-warm live-cow child-import e2e (strict): pre-warmed co-located child must boot by LAZILY FAULTING the source memfd from the mem-less fork: %+v", childRes)
+		}
+		t.Skipf("skipping pre-warm live-cow child-import e2e: pre-warmed child did not boot by lazy UFFD (runner Firecracker Uffd backend unavailable): %+v", childRes)
+	}
+
+	// (ON-FORK-PATH BOOT ~0) the adopted child recorded fc_boot=0: the boot was
+	// pre-paid off the fork hot path, even on the live-cow import path.
+	if fc, ok := childRes.Stages["fc_boot"]; !ok || fc != 0 {
+		t.Fatalf("adopted pre-warmed child fc_boot = %v (ok=%v), want 0; stages=%v", fc, ok, childRes.Stages)
+	}
+	// The mem-less fork stays mem-less: the child imported the memfd, read no disk mem.
+	if _, err := os.Stat(memPath); err == nil {
+		t.Errorf("no mem file must exist in the fork snapshot at any point, but %s appeared", memPath)
+	}
+
+	childAgent, err := kvmConnectAgent(childRes.VsockPath)
+	if err != nil {
+		t.Fatalf("connect adopted pre-warmed child agent: %v", err)
+	}
+	defer childAgent.Close() //nolint:errcheck // best-effort teardown
+	execCtx, execCancel := context.WithTimeout(ctx, 45*time.Second)
+	defer execCancel()
+	if _, err := kvmExecOKCtx(execCtx, childAgent, "printf prewarm-childimp-alive"); err != nil {
+		t.Fatalf("adopted pre-warmed child imported the memfd and restored but could not exec: %v", err)
+	}
+	if childRestoreMs, ok := childRes.Stages["vmstate_restore"]; ok && childRestoreMs >= 100 {
+		t.Fatalf("child vmstate_restore = %.3fms, want well below 100ms (lazy UFFD faults only the working set)", childRestoreMs)
+	}
+
+	// (FORK-TIME MEMORY, NO LEAK) the child reads the sentinel at its FORK-TIME
+	// value, never the source's post-fork overwrite.
+	if sentinelPlanted {
+		readCtx, readCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer readCancel()
+		got, err := kvmExecOKCtx(readCtx, childAgent, "cat "+sentinelPath)
+		if err != nil {
+			t.Fatalf("adopted child could not read the imported fork-time sentinel: %v", err)
+		}
+		if got != forkVal {
+			t.Fatalf("child sentinel = %q, want fork-time %q (leaked source post-fork write=%v, sourceOverwrote=%v): the pre-warmed child's lazy import did not isolate it", got, forkVal, got == leakVal, sourceOverwrote)
+		}
+	}
+
+	t.Logf("pre-warm live-cow child-import PASS: pre-warmed child ADOPTED (fc_boot=0, boot pre-paid) and LAZILY FAULTED its guest RAM from the source memfd on the mem-less fork with no hang; sentinelPlanted=%v sourceOverwrote=%v (child read fork-time value, no leak)", sentinelPlanted, sourceOverwrote)
+}

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -739,6 +739,18 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 	if err := checkVMID(id); err != nil {
 		return SpawnVMResult{OK: false, VMID: req.VMID, Error: err.Error()}
 	}
+	// Refuse the RESERVED pre-warm slot id: checkVMID only enforces the character
+	// allowlist, so a caller could otherwise pass the internal slot id and collide
+	// with the pod's pre-warmed dormant child (adopting or tearing down the slot's
+	// Firecracker out from under the pool). The reserved id is engine-internal and
+	// is never a tenant fork, so it is rejected up front.
+	if id == prewarmSlotVMID {
+		return SpawnVMResult{
+			OK:    false,
+			VMID:  req.VMID,
+			Error: fmt.Sprintf("husk: spawn-vm refused: vm id %q is reserved for the pre-warm slot", req.VMID),
+		}
+	}
 	// A CO-LOCATED fork child clones its rootfs from the FROZEN source rootfs the
 	// fork snapshot carries at SnapshotDir/rootfs.ext4 (inherit the parent's DISK),
 	// NOT the pool template rootfs. Empty otherwise, so a non-fork spawn keeps the

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -217,6 +217,50 @@ func recordStage(stages map[string]float64, name string, since time.Time) {
 // no allocation. It is written under the instance lock, so a caller reads it only
 // after prepareInstance returns. Timing/observability only.
 func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride string, stages map[string]float64, extraEnv ...string) error {
+	return s.prepareInstanceOpt(ctx, id, prepareOpts{
+		rootfsSrcOverride: rootfsSrcOverride,
+		stages:            stages,
+		extraEnv:          extraEnv,
+	})
+}
+
+// prepareOpts carries the optional inputs prepareInstanceOpt varies over. The
+// zero value (what prepareInstance forwards) is a plain fresh prepare: start a
+// dormant VMM, verify the template snapshot when configured, clone the
+// per-activation rootfs.
+type prepareOpts struct {
+	// rootfsSrcOverride selects the file the per-activation rootfs CoW clone is
+	// made FROM. Empty clones from the pool template rootfs (s.rootfsTemplatePath);
+	// a co-located fork child passes the frozen source rootfs the fork snapshot
+	// carries (SnapshotDir/rootfs.ext4).
+	rootfsSrcOverride string
+	// skipRootfsClone leaves the instance WITHOUT a per-activation rootfs clone,
+	// used by the pre-warm boot to keep a GENERIC dormant child. The child's
+	// fork-time rootfs is cloned later, at consume, from the fork snapshot it
+	// actually carries, so the reflink stays at fork time (never on the pre-warm).
+	skipRootfsClone bool
+	// reuseVM, when non-nil, ADOPTS an already-booted dormant VMM (the pre-warmed
+	// child) into this instance instead of starting a fresh Firecracker. The
+	// process boot (fc_boot) and the template snapshot verify were paid during the
+	// pre-warm, off the hot path, so both are skipped here and fc_boot is recorded
+	// as 0. extraEnv is ignored (the VMM is already launched).
+	reuseVM vmm
+	// stages, when non-nil, is filled with this prepare's per-stage timing.
+	stages map[string]float64
+	// extraEnv is appended to the child Firecracker process environment at launch
+	// (the m5 child memfd-import env). It never applies to an adopted VMM.
+	extraEnv []string
+}
+
+// prepareInstanceOpt is prepareInstance's core, parameterized by prepareOpts so
+// ONE fail-closed, per-instance-locked state machine backs three callers: a plain
+// fresh prepare (SpawnVM on-demand, the single-VM Prepare), the pre-warm BOOT
+// (skipRootfsClone: a generic dormant child, no rootfs clone), and the pre-warm
+// CONSUME (reuseVM: adopt the pre-warmed VMM, skipping fc_boot + the template
+// verify, still cloning THIS fork's rootfs). Fail closed: any error tears the
+// (started or adopted) VMM down and leaves the instance out of StateDormant. It
+// never reads or mutates a sibling instance.
+func (s *Stub) prepareInstanceOpt(ctx context.Context, id vmID, opts prepareOpts) error {
 	if err := checkVMID(id); err != nil {
 		return err
 	}
@@ -243,8 +287,8 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride s
 	cfg := s.deriveVMConfig(id)
 	// Append any per-spawn environment (m5: the child memfd-import env) onto a COPY
 	// of the base env so one spawn's env never mutates the shared s.cfg slice.
-	if len(extraEnv) > 0 {
-		cfg.Env = append(append([]string(nil), cfg.Env...), extraEnv...)
+	if len(opts.extraEnv) > 0 {
+		cfg.Env = append(append([]string(nil), cfg.Env...), opts.extraEnv...)
 	}
 	// Arm the PARENT side of the live-cow fork for the SOURCE (default) VM (milestone
 	// m6b): bind the write-protect handshake socket and launch THIS Firecracker with
@@ -268,72 +312,97 @@ func (s *Stub) prepareInstance(ctx context.Context, id vmID, rootfsSrcOverride s
 			return fmt.Errorf("husk: create per-VM workdir for vm %q: %w", id, err)
 		}
 	}
-	fcBootStart := time.Now()
-	vm, err := s.start(cfg)
-	if err != nil {
-		return fmt.Errorf("husk: prepare dormant VMM for vm %q: %w", id, err)
-	}
-	recordStage(stages, "fc_boot", fcBootStart)
-	inst.vm = vm
+	if opts.reuseVM != nil {
+		// ADOPT the pre-warmed dormant VMM. Its process boot AND the template
+		// snapshot verify were paid during the pre-warm, off the hot path, so the
+		// fork path skips both here. fc_boot is recorded as 0 to make the "boot was
+		// pre-paid" fact legible in the merged stage breakdown. The adopted VMM was
+		// booted with a GENERIC config (no fork-specific env), so it only serves a
+		// fork that needs no launch env (the live-cow child-import fork, which needs
+		// FIRECRACKER_MITOS_CHILD_MEMFD at exec, is never routed here).
+		inst.vm = opts.reuseVM
+		if opts.stages != nil {
+			opts.stages["fc_boot"] = 0
+		}
+	} else {
+		fcBootStart := time.Now()
+		vm, err := s.start(cfg)
+		if err != nil {
+			return fmt.Errorf("husk: prepare dormant VMM for vm %q: %w", id, err)
+		}
+		recordStage(opts.stages, "fc_boot", fcBootStart)
+		inst.vm = vm
 
-	// Snapshot verify at prepare time (pre-paid, dormant), the same fail-closed
-	// gate the single-VM Prepare runs, when the pod was started with the snapshot
-	// dir + expected digest. The snapshot is read-only and content-addressed, so
-	// verifying once here is equivalent to verifying at activate.
-	if s.prepareSnapshotDir != "" && s.prepareExpectedDigest != "" {
-		verifyStart := time.Now()
-		for _, name := range []string{"mem", "vmstate"} {
-			f := filepath.Join(s.prepareSnapshotDir, name)
-			if err := waitForFile(ctx, f, rootfsTemplateWait); err != nil {
+		// Snapshot verify at prepare time (pre-paid, dormant), the same fail-closed
+		// gate the single-VM Prepare runs, when the pod was started with the snapshot
+		// dir + expected digest. The snapshot is read-only and content-addressed, so
+		// verifying once here is equivalent to verifying at activate.
+		if s.prepareSnapshotDir != "" && s.prepareExpectedDigest != "" {
+			verifyStart := time.Now()
+			for _, name := range []string{"mem", "vmstate"} {
+				f := filepath.Join(s.prepareSnapshotDir, name)
+				if err := waitForFile(ctx, f, rootfsTemplateWait); err != nil {
+					_ = inst.vm.Close()
+					inst.vm = nil
+					return fmt.Errorf("husk: snapshot file %s not ready for vm %q: %w", f, id, err)
+				}
+			}
+			if err := s.verify(ActivateRequest{
+				SnapshotDir:    s.prepareSnapshotDir,
+				ExpectedDigest: s.prepareExpectedDigest,
+			}); err != nil {
 				_ = inst.vm.Close()
 				inst.vm = nil
-				return fmt.Errorf("husk: snapshot file %s not ready for vm %q: %w", f, id, err)
+				return fmt.Errorf("husk: prepare-time snapshot verification failed for vm %q: %w", id, err)
 			}
+			recordStage(opts.stages, "verify_prepare", verifyStart)
+			inst.prepareVerified = true
 		}
-		if err := s.verify(ActivateRequest{
-			SnapshotDir:    s.prepareSnapshotDir,
-			ExpectedDigest: s.prepareExpectedDigest,
-		}); err != nil {
-			_ = inst.vm.Close()
-			inst.vm = nil
-			return fmt.Errorf("husk: prepare-time snapshot verification failed for vm %q: %w", id, err)
-		}
-		recordStage(stages, "verify_prepare", verifyStart)
-		inst.prepareVerified = true
 	}
 
 	// Per-activation rootfs CoW clone, scoped to this VM's derived id so two VMs in
-	// the pod never share or overwrite a rootfs clone. Same primitive and dormant
-	// pre-paid timing as the single-VM Prepare. The clone SOURCE is the pool template
-	// rootfs by default; a CO-LOCATED fork child overrides it with the frozen source
-	// rootfs the fork snapshot carries so the child inherits the parent's DISK.
+	// the pod never share or overwrite a clone. Skipped for the pre-warm boot: a
+	// generic dormant child clones its fork-time rootfs at consume, not here.
+	if !opts.skipRootfsClone {
+		if err := s.cloneRootfsForInstance(ctx, id, cfg, inst, opts.rootfsSrcOverride, opts.stages); err != nil {
+			_ = inst.vm.Close()
+			inst.vm = nil
+			return err
+		}
+	}
+
+	inst.state = StateDormant
+	return nil
+}
+
+// cloneRootfsForInstance makes THIS VM's per-activation rootfs CoW clone and
+// records it on the instance so activate rebinds the drive to it and Close removes
+// it. The clone SOURCE is the pool template rootfs by default; a co-located fork
+// child overrides it with the frozen source rootfs the fork snapshot carries so
+// the child inherits the parent's DISK. A no-op (nil) when no template rootfs or
+// CoW dir is configured (the mock/unit path). It NEVER tears the VMM down on
+// error; the caller owns that so the fail-closed teardown stays in one place.
+func (s *Stub) cloneRootfsForInstance(ctx context.Context, id vmID, cfg firecracker.VMConfig, inst *vmInstance, rootfsSrcOverride string, stages map[string]float64) error {
 	rootfsSrc := s.rootfsTemplatePath
 	if rootfsSrcOverride != "" {
 		rootfsSrc = rootfsSrcOverride
 	}
-	if rootfsSrc != "" && s.rootfsCoWDir != "" {
-		clonePath := filepath.Join(s.rootfsCoWDir, cfg.ID, "rootfs.ext4")
-		if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
-			_ = inst.vm.Close()
-			inst.vm = nil
-			return fmt.Errorf("husk: create per-activation rootfs dir for vm %q: %w", id, err)
-		}
-		if err := waitForFile(ctx, rootfsSrc, rootfsTemplateWait); err != nil {
-			_ = inst.vm.Close()
-			inst.vm = nil
-			return fmt.Errorf("husk: per-activation rootfs source %s not ready for vm %q: %w", rootfsSrc, id, err)
-		}
-		cloneStart := time.Now()
-		if err := s.reflink(rootfsSrc, clonePath); err != nil {
-			_ = inst.vm.Close()
-			inst.vm = nil
-			return fmt.Errorf("husk: clone per-activation rootfs for vm %q: %w", id, err)
-		}
-		recordStage(stages, "rootfs_clone", cloneStart)
-		inst.rootfsClonePath = clonePath
+	if rootfsSrc == "" || s.rootfsCoWDir == "" {
+		return nil
 	}
-
-	inst.state = StateDormant
+	clonePath := filepath.Join(s.rootfsCoWDir, cfg.ID, "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
+		return fmt.Errorf("husk: create per-activation rootfs dir for vm %q: %w", id, err)
+	}
+	if err := waitForFile(ctx, rootfsSrc, rootfsTemplateWait); err != nil {
+		return fmt.Errorf("husk: per-activation rootfs source %s not ready for vm %q: %w", rootfsSrc, id, err)
+	}
+	cloneStart := time.Now()
+	if err := s.reflink(rootfsSrc, clonePath); err != nil {
+		return fmt.Errorf("husk: clone per-activation rootfs for vm %q: %w", id, err)
+	}
+	recordStage(stages, "rootfs_clone", cloneStart)
+	inst.rootfsClonePath = clonePath
 	return nil
 }
 
@@ -709,11 +778,39 @@ func (s *Stub) SpawnVM(ctx context.Context, req SpawnVMRequest) SpawnVMResult {
 	// come from prepare, vmstate_restore / guest_ready / handshake from activate.
 	prepStart := time.Now()
 	prepStages := make(map[string]float64, 3)
-	if err := s.prepareInstance(ctx, id, rootfsSrcOverride, prepStages); err != nil {
+	// Consume a pre-warmed dormant child when one is ready: ADOPT its already-booted
+	// generic Firecracker into this fork's instance so the process boot (fc_boot) and
+	// the template snapshot verify are OFF the fork hot path (paid ahead), leaving
+	// only this fork's rootfs clone to run here. A miss (pre-warm off, or the slot not
+	// yet warm) falls back to the on-demand prepare, byte-for-byte the prior behavior.
+	// The pre-warmed child is GENERIC (no fork-specific launch env): the live-cow
+	// lazy-UFFD import (childPlan) is armed on the dormant instance AFTER prepare and
+	// BEFORE activate below, exactly as on the on-demand path, so the pre-warm never
+	// changes HOW the child restores (disk mem, or the husk UFFD fault handler when
+	// armed). The pre-warmed child counts against the pod's per-VM memory budget, so
+	// at most one is kept.
+	var prepErr error
+	if prewarmed := s.consumePrewarmedChild(); prewarmed != nil {
+		if err := s.prepareInstanceOpt(ctx, id, prepareOpts{
+			rootfsSrcOverride: rootfsSrcOverride,
+			reuseVM:           prewarmed,
+			stages:            prepStages,
+		}); err != nil {
+			prepErr = fmt.Errorf("adopt pre-warmed child: %w", err)
+		}
+	} else {
+		prepErr = s.prepareInstance(ctx, id, rootfsSrcOverride, prepStages)
+	}
+	// Replenish the pool for the NEXT fork, OFF this fork's hot path, whether we hit
+	// or missed the slot (a miss warms it so a later fork skips the boot). A no-op
+	// when pre-warm is off or a re-warm is already in flight, so the fork never waits
+	// on it and the pod never keeps more than one dormant child.
+	s.rewarmPrewarmChildAsync()
+	if prepErr != nil {
 		return SpawnVMResult{
 			OK:    false,
 			VMID:  req.VMID,
-			Error: fmt.Errorf("husk: spawn-vm prepare vm %q: %w", req.VMID, err).Error(),
+			Error: fmt.Errorf("husk: spawn-vm prepare vm %q: %w", req.VMID, prepErr).Error(),
 		}
 	}
 	prepStages["prepare_total"] = stageMs(prepStart)

--- a/internal/husk/multivm_kvm_test.go
+++ b/internal/husk/multivm_kvm_test.go
@@ -420,6 +420,153 @@ func TestColocatedForkInheritsSourceStateKVM(t *testing.T) {
 	}
 }
 
+// TestPrewarmedColocatedForkSkipsBootKVM proves the pre-warm on real KVM: a
+// pod that keeps ONE dormant child pre-warmed lets a co-located fork ADOPT the
+// already-booted Firecracker (fc_boot ~0, the process boot pre-paid off the fork
+// hot path) while STILL producing a correct child, alive and inheriting the
+// source's disk AND memory, identical to the on-demand co-located fork. It also
+// proves a fresh dormant child is re-warmed for the next fork. This is the
+// no-regression gate for the pre-warm: same correctness, boot moved off the hot
+// path. It uses the disk-restore co-located fork (no m5 child-import binary
+// needed), so it runs on every KVM CI runner that has a husk snapshot.
+func TestPrewarmedColocatedForkSkipsBootKVM(t *testing.T) {
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		t.Skip("skipping pre-warm co-located-fork proof: /dev/kvm not available (needs a KVM runner)")
+	}
+	snapDir := os.Getenv("MITOS_KVM_HUSK_SNAPSHOT_DIR")
+	if snapDir == "" {
+		t.Skip("skipping pre-warm co-located-fork proof: set MITOS_KVM_HUSK_SNAPSHOT_DIR (the KVM CI sets it)")
+	}
+	for _, name := range []string{"mem", "vmstate"} {
+		if _, err := os.Stat(filepath.Join(snapDir, name)); err != nil {
+			t.Skipf("skipping pre-warm co-located-fork proof: snapshot file %s not present: %v", name, err)
+		}
+	}
+	templateRootfs := filepath.Join(filepath.Dir(snapDir), "rootfs.ext4")
+	if _, err := os.Stat(templateRootfs); err != nil {
+		t.Skipf("skipping pre-warm co-located-fork proof: template rootfs %s not present: %v", templateRootfs, err)
+	}
+	fcBin := os.Getenv("MITOS_KVM_FIRECRACKER")
+	if fcBin == "" {
+		fcBin = "/usr/local/bin/firecracker"
+	}
+
+	ctx := context.Background()
+
+	// A --multi-vm source pod with the pre-warm slot ON.
+	src := New(firecracker.VMConfig{
+		ID:             "husk-prewarm-src",
+		FirecrackerBin: fcBin,
+		WorkDir:        t.TempDir(),
+		VcpuCount:      1,
+		MemSizeMib:     256,
+	}, Options{
+		AllowUnverified:    true,
+		ReadyTimeout:       30 * time.Second,
+		MultiVM:            true,
+		PrewarmChild:       true,
+		RootfsTemplatePath: templateRootfs,
+		RootfsCoWDir:       t.TempDir(),
+	})
+	defer func() { _ = src.Close() }()
+
+	if err := src.Prepare(ctx); err != nil {
+		t.Fatalf("source Prepare: %v", err)
+	}
+	sres, err := src.Activate(ctx, ActivateRequest{SnapshotDir: snapDir})
+	if err != nil || !sres.OK {
+		t.Fatalf("source Activate: err=%v res=%+v", err, sres)
+	}
+	srcAgent, err := kvmConnectAgent(sres.VsockPath)
+	if err != nil {
+		t.Fatalf("connect source agent: %v", err)
+	}
+	defer srcAgent.Close() //nolint:errcheck // best-effort teardown
+
+	// Source writes a unique DISK marker and advances its guest clock so the fork
+	// carries a distinct disk + memory state (the same signals the on-demand
+	// co-located inheritance test uses).
+	const markerPath = "/mitos-prewarm-marker.txt"
+	marker := fmt.Sprintf("prewarm-inherit-%d", time.Now().UnixNano())
+	if _, err := kvmExecOK(srcAgent, fmt.Sprintf("printf %s > %s && /bin/busybox sync", marker, markerPath)); err != nil {
+		t.Fatalf("write+sync marker in source: %v", err)
+	}
+	time.Sleep(9 * time.Second)
+
+	// EAGERLY pre-warm the dormant child BEFORE the fork, so the fork adopts it.
+	if err := src.PrewarmChild(ctx); err != nil {
+		t.Fatalf("PrewarmChild must boot a dormant child: %v", err)
+	}
+
+	forkDir := filepath.Join(t.TempDir(), "fork-snap")
+	fres, err := src.ForkSnapshot(ctx, ForkSnapshotRequest{ForkID: "prewarm-child", SnapshotDir: forkDir})
+	if err != nil || !fres.OK {
+		t.Fatalf("source ForkSnapshot must succeed on KVM: err=%v res=%+v", err, fres)
+	}
+	for _, name := range []string{"mem", "vmstate", "rootfs.ext4"} {
+		if _, err := os.Stat(filepath.Join(forkDir, name)); err != nil {
+			t.Fatalf("fork snapshot did not write %s: %v", name, err)
+		}
+	}
+
+	// The co-located fork ADOPTS the pre-warmed child.
+	fixRes := src.SpawnVM(ctx, SpawnVMRequest{
+		VMID:     "prewarm-fix",
+		Activate: ActivateRequest{SnapshotDir: forkDir, ForkSnapshot: true},
+	})
+	if !fixRes.OK {
+		t.Fatalf("pre-warmed co-located spawn must succeed: %+v", fixRes)
+	}
+
+	// (ON-FORK-PATH BOOT ~0) the adopted child recorded fc_boot=0: the process boot
+	// was pre-paid off the fork hot path, and the template verify did not re-run.
+	if fc, ok := fixRes.Stages["fc_boot"]; !ok || fc != 0 {
+		t.Fatalf("adopted pre-warmed fork fc_boot = %v (ok=%v), want 0 (boot pre-paid off the hot path); stages=%v", fc, ok, fixRes.Stages)
+	}
+	if _, ran := fixRes.Stages["verify_prepare"]; ran {
+		t.Fatalf("adopted pre-warmed fork must not re-run the snapshot verify on the hot path; stages=%v", fixRes.Stages)
+	}
+
+	// (CHILD ALIVE + INHERIT) the adopted child boots, execs, and inherits the
+	// source's disk (marker) AND memory (uptime well past the template's baked one).
+	fixAgent, err := kvmConnectAgent(fixRes.VsockPath)
+	if err != nil {
+		t.Fatalf("connect pre-warmed child agent (adopted child booted): %v", err)
+	}
+	defer fixAgent.Close() //nolint:errcheck // best-effort teardown
+	if _, err := kvmExecOK(fixAgent, "printf prewarm-alive"); err != nil {
+		t.Fatalf("adopted pre-warmed child must exec (a broken adoption would not run a working guest): %v", err)
+	}
+	got, _ := kvmExecOK(fixAgent, fmt.Sprintf("cat %s 2>/dev/null || true", markerPath))
+	if strings.TrimSpace(got) != marker {
+		t.Fatalf("DISK inheritance FAILED via the pre-warmed child: read %q, want %q", strings.TrimSpace(got), marker)
+	}
+	if up := kvmReadUptime(t, fixAgent); up < 8 {
+		t.Fatalf("MEMORY inheritance FAILED via the pre-warmed child: uptime %.2fs must reflect the source's advanced clock (fork memory not restored)", up)
+	}
+
+	// (RE-WARMED) a fresh dormant child is warmed for the NEXT fork, off the hot path.
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		src.mu.Lock()
+		inst := src.instances[prewarmSlotVMID]
+		src.mu.Unlock()
+		warm := false
+		if inst != nil {
+			inst.mu.Lock()
+			warm = inst.state == StateDormant && inst.vm != nil
+			inst.mu.Unlock()
+		}
+		if warm {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("pre-warm slot was not re-warmed after the fork consumed it")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 // kvmReadUptime reads the guest's /proc/uptime and returns the first field (seconds
 // since the guest booted) as a float. It fails the test on a transport or parse
 // error so a broken read is never silently treated as zero uptime.

--- a/internal/husk/prewarm.go
+++ b/internal/husk/prewarm.go
@@ -1,0 +1,145 @@
+package husk
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// Pre-warmed co-located child slot (perf: cut the fork spawn latency).
+//
+// A co-located fork pays a per-fork process boot (fc_boot) plus the dormant
+// prepare overhead on the fork HOT PATH because the child Firecracker is prepared
+// ON DEMAND at fork time (prepareInstance -> boot -> activate). This file keeps
+// ONE dormant, GENERIC child Firecracker pre-prepared (booted, and template-
+// snapshot-verified when a template is configured) in a multi-VM pod, so a fork
+// ADOPTS the ready child (SpawnVM -> prepareInstanceOpt{reuseVM} -> activate)
+// instead of booting one, moving fc_boot and the verify off the fork hot path.
+//
+// SAFE FOR THE LIVE-COW LAZY-UFFD PATH: the child Firecracker is booted GENERIC
+// (no fork-specific launch env). The fork-specific part, the live-cow lazy-UFFD
+// import, is armed on the dormant instance AFTER prepare and BEFORE activate
+// (armInstanceChildUFFD in SpawnVM), reading the source's FROZEN composite through
+// the husk fault handler at LoadSnapshotUFFD time. The pre-warmed child reaches
+// activate in the SAME StateDormant, so it arms and restores through the husk
+// UFFD fault handler identically; the pre-warm only changes WHEN the process was
+// booted, never HOW the child restores or inherits, so the no-leak invariant is
+// untouched. The per-fork rootfs clone stays at fork time (the child needs the
+// source's fork-time rootfs the fork snapshot carries), so the pre-warmed slot is
+// a generic boot only.
+//
+// It is gated behind Options.PrewarmChild (default OFF) and needs MultiVM. At
+// most ONE dormant child is kept (single-flight re-warm), so the pre-warm never
+// over-admits the pod's per-VM memory budget: a dormant child counts as one extra
+// VM against co-location capacity, exactly as an on-demand child would once
+// spawned, just paid a fork earlier.
+
+// prewarmSlotVMID is the reserved instances-map key the pre-warmed dormant child
+// is prepared under. It satisfies validVMID (leading alphanumeric) and is namesp
+// aced so a controller-assigned fork vmID does not collide with it. It is NEVER
+// the vmID a fork activates under: SpawnVM ADOPTS the slot's booted Firecracker
+// into the fork's OWN vmID instance, so the slot is a boot reservation, not a
+// tenant VM (a dormant slot is not metered, meteringMulti counts StateActive
+// only).
+const prewarmSlotVMID vmID = "huskprewarmchild0"
+
+// PrewarmChild eagerly prepares the pod's dormant child slot so the FIRST
+// co-located fork already skips the process boot, instead of warming lazily after
+// the first fork. A pod lifecycle can call it once the source (default) VM is
+// active. It is a no-op (nil) when pre-warm is off or the slot is already warm,
+// and returns the prepare error (fail-closed) when the boot itself fails, so a
+// caller can log it without the fork path ever depending on it. Safe to call
+// repeatedly.
+func (s *Stub) PrewarmChild(ctx context.Context) error {
+	return s.warmPrewarmChild(ctx)
+}
+
+// consumePrewarmedChild pops the pre-warmed dormant child's booted Firecracker for
+// adoption into a fork's instance, returning nil on a miss (pre-warm off, no slot,
+// or the slot not dormant). It scopes s.mu to the map lookup, then takes ONLY the
+// slot instance's own lock to detach the VMM and reset the slot to StateNew so a
+// re-warm can refill it. The caller adopts the returned VMM via
+// prepareInstanceOpt{reuseVM}; on a miss the caller boots on demand. It never
+// touches a sibling instance.
+func (s *Stub) consumePrewarmedChild() vmm {
+	if !s.prewarmChild {
+		return nil
+	}
+	inst := s.instanceFor(prewarmSlotVMID, false)
+	if inst == nil {
+		return nil
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if inst.state != StateDormant || inst.vm == nil {
+		return nil
+	}
+	vm := inst.vm
+	inst.vm = nil
+	// A generic pre-warmed boot never armed a per-fork import or per-activation
+	// artifact, but reset defensively so the freed slot re-warms from a clean state.
+	inst.childUFFDPlan = nil
+	inst.rootfsClonePath = ""
+	inst.prepareVerified = false
+	inst.state = StateNew
+	return vm
+}
+
+// warmPrewarmChild prepares (boots, and verifies the template snapshot when
+// configured) ONE dormant, GENERIC child Firecracker under the reserved slot, if
+// pre-warm is on and no re-warm is already running. It is single-flight (s.prewarming)
+// so the pod never keeps more than one dormant child. It skips the per-fork rootfs
+// clone (skipRootfsClone): the fork clones its own rootfs from the fork snapshot at
+// consume. Fail-closed: on any error the slot is left out of StateDormant (a later
+// fork simply boots on demand). It never blocks a fork; SpawnVM runs it in the
+// background via rewarmPrewarmChildAsync.
+func (s *Stub) warmPrewarmChild(ctx context.Context) error {
+	if !s.prewarmChild {
+		return nil
+	}
+	// Single-flight + closing guard under s.mu: claim the re-warm, or bail if one is
+	// already running, the pod is closing, or the slot is already dormant.
+	s.mu.Lock()
+	if s.closing || s.prewarming {
+		s.mu.Unlock()
+		return nil
+	}
+	if inst := s.instances[prewarmSlotVMID]; inst != nil {
+		inst.mu.Lock()
+		warm := inst.state == StateDormant
+		inst.mu.Unlock()
+		if warm {
+			s.mu.Unlock()
+			return nil
+		}
+	}
+	s.prewarming = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.prewarming = false
+		s.mu.Unlock()
+	}()
+
+	if err := s.prepareInstanceOpt(ctx, prewarmSlotVMID, prepareOpts{skipRootfsClone: true}); err != nil {
+		return fmt.Errorf("husk: pre-warm dormant child: %w", err)
+	}
+	return nil
+}
+
+// rewarmPrewarmChildAsync replenishes the pre-warmed slot for the NEXT fork off
+// the current fork's hot path. It is a no-op when pre-warm is off; otherwise it
+// runs warmPrewarmChild on a background context (the fork's ctx may be cancelled
+// once SpawnVM returns) and logs, never returns, the re-warm error so a fork never
+// waits on or fails from the pool refill. single-flight in warmPrewarmChild keeps
+// concurrent calls to one dormant child.
+func (s *Stub) rewarmPrewarmChildAsync() {
+	if !s.prewarmChild {
+		return
+	}
+	go func() {
+		if err := s.warmPrewarmChild(context.Background()); err != nil {
+			fmt.Fprintf(os.Stderr, "husk: re-warm pre-warmed child failed (next fork boots on demand): %v\n", err)
+		}
+	}()
+}

--- a/internal/husk/prewarm.go
+++ b/internal/husk/prewarm.go
@@ -51,6 +51,12 @@ const prewarmSlotVMID vmID = "huskprewarmchild0"
 // caller can log it without the fork path ever depending on it. Safe to call
 // repeatedly.
 func (s *Stub) PrewarmChild(ctx context.Context) error {
+	// FAIL CLOSED on the flag, exactly like SpawnVM: a single-VM pod owns exactly
+	// one VM and has a nil instances map, so pre-warming a second dormant child
+	// there is refused with a clear error rather than touching the nil map.
+	if !s.multiVM {
+		return fmt.Errorf("husk: pre-warm child refused: this pod is not running in multi-VM mode")
+	}
 	return s.warmPrewarmChild(ctx)
 }
 
@@ -62,7 +68,7 @@ func (s *Stub) PrewarmChild(ctx context.Context) error {
 // prepareInstanceOpt{reuseVM}; on a miss the caller boots on demand. It never
 // touches a sibling instance.
 func (s *Stub) consumePrewarmedChild() vmm {
-	if !s.prewarmChild {
+	if !s.multiVM || !s.prewarmChild {
 		return nil
 	}
 	inst := s.instanceFor(prewarmSlotVMID, false)
@@ -94,7 +100,9 @@ func (s *Stub) consumePrewarmedChild() vmm {
 // fork simply boots on demand). It never blocks a fork; SpawnVM runs it in the
 // background via rewarmPrewarmChildAsync.
 func (s *Stub) warmPrewarmChild(ctx context.Context) error {
-	if !s.prewarmChild {
+	// Guard on multiVM too: the instances map is nil on a single-VM stub, so
+	// prepareInstanceOpt (which inserts into it) must never run there.
+	if !s.multiVM || !s.prewarmChild {
 		return nil
 	}
 	// Single-flight + closing guard under s.mu: claim the re-warm, or bail if one is
@@ -134,7 +142,7 @@ func (s *Stub) warmPrewarmChild(ctx context.Context) error {
 // waits on or fails from the pool refill. single-flight in warmPrewarmChild keeps
 // concurrent calls to one dormant child.
 func (s *Stub) rewarmPrewarmChildAsync() {
-	if !s.prewarmChild {
+	if !s.multiVM || !s.prewarmChild {
 		return
 	}
 	go func() {

--- a/internal/husk/prewarm_test.go
+++ b/internal/husk/prewarm_test.go
@@ -1,0 +1,238 @@
+package husk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/firecracker"
+)
+
+// vmRegistry is a concurrency-safe map of derived-config-ID -> started fake VMM.
+// The pre-warm re-warms the slot on a BACKGROUND goroutine (off the fork hot
+// path), so its start callback writes this map concurrently with a test's reads;
+// a plain map would data-race even across distinct keys. Every access takes mu.
+type vmRegistry struct {
+	mu sync.Mutex
+	m  map[string]*fakeVMM
+}
+
+func newVMRegistry() *vmRegistry { return &vmRegistry{m: map[string]*fakeVMM{}} }
+
+func (r *vmRegistry) put(id string, vm *fakeVMM) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[id] = vm
+}
+
+func (r *vmRegistry) get(id string) *fakeVMM {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.m[id]
+}
+
+// newPrewarmTestStub builds a multi-VM stub with the pre-warm slot ON, using a
+// keyed starter so a test can look up the per-VM fake by its derived VMConfig ID
+// and prove which Firecracker a fork ran on.
+func newPrewarmTestStub(t *testing.T, vms *vmRegistry) *Stub {
+	t.Helper()
+	start := func(cfg firecracker.VMConfig) (vmm, error) {
+		vm := &fakeVMM{}
+		vms.put(cfg.ID, vm)
+		return vm, nil
+	}
+	return New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:        start,
+		Ready:        readyOK,
+		Notify:       (&fakeNotifier{}).notify,
+		Verify:       verifyOK,
+		MultiVM:      true,
+		PrewarmChild: true,
+	})
+}
+
+const prewarmSlotCfgID = "husk-test-" + string(prewarmSlotVMID)
+
+// instVM reads one instance's VMM handle under the same locks the engine uses, so
+// a test assertion never races the background re-warm goroutine's map/instance
+// writes. Returns nil when the instance does not exist.
+func instVM(s *Stub, id vmID) vmm {
+	s.mu.Lock()
+	inst := s.instances[id]
+	s.mu.Unlock()
+	if inst == nil {
+		return nil
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	return inst.vm
+}
+
+// instState reads one instance's lifecycle State under locks. Returns StateNew for
+// a missing instance.
+func instState(s *Stub, id vmID) State {
+	s.mu.Lock()
+	inst := s.instances[id]
+	s.mu.Unlock()
+	if inst == nil {
+		return StateNew
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	return inst.state
+}
+
+// waitForPrewarmSlot polls until the reserved slot holds a DORMANT VMM (the
+// re-warm goroutine runs off the fork hot path), returning that VMM handle. It
+// fails the test if the slot is not re-warmed within the deadline.
+func waitForPrewarmSlot(t *testing.T, s *Stub) vmm {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if instState(s, prewarmSlotVMID) == StateDormant {
+			if vm := instVM(s, prewarmSlotVMID); vm != nil {
+				return vm
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("pre-warm slot was not re-warmed to StateDormant in time")
+	return nil
+}
+
+// TestPrewarmedChildIsConsumedAndReWarmed proves the core of the pre-warm: an
+// eagerly pre-warmed dormant child is ADOPTED by a fork (so the fork skips the
+// on-demand process boot, fc_boot ~0, and reaches StateActive on the SAME
+// Firecracker that was pre-booted), and a FRESH dormant child is re-warmed for the
+// next fork, off the fork hot path.
+func TestPrewarmedChildIsConsumedAndReWarmed(t *testing.T) {
+	vms := newVMRegistry()
+	s := newPrewarmTestStub(t, vms)
+
+	// Bring up the source (default) VM, then eagerly warm the child slot.
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+		t.Fatalf("activateInstance(default): %v", err)
+	}
+	if err := s.PrewarmChild(context.Background()); err != nil {
+		t.Fatalf("PrewarmChild: %v", err)
+	}
+	warmed := vms.get(prewarmSlotCfgID)
+	if warmed == nil {
+		t.Fatalf("pre-warm must boot a dormant child under %q", prewarmSlotCfgID)
+	}
+	if got := instState(s, prewarmSlotVMID); got != StateDormant {
+		t.Fatalf("pre-warmed slot state = %s, want dormant", got)
+	}
+
+	// A fork ADOPTS the pre-warmed child: no on-demand boot for the fork's own vmID.
+	res := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     "fork-1",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if !res.OK {
+		t.Fatalf("SpawnVM adopting the pre-warmed child must succeed: %+v", res)
+	}
+	// The fork ran on the SAME Firecracker that was pre-booted (adoption), and no
+	// fresh process was started under the fork's own derived id.
+	if instVM(s, "fork-1") != warmed {
+		t.Fatal("fork must ADOPT the pre-warmed child's Firecracker, not boot its own")
+	}
+	if booted := vms.get("husk-test-fork-1"); booted != nil {
+		t.Fatal("adopting a pre-warmed child must NOT boot a Firecracker under the fork's derived id")
+	}
+	if got := instState(s, "fork-1"); got != StateActive {
+		t.Fatalf("adopted fork state = %s, want active", got)
+	}
+	// The on-fork-path boot is pre-paid: fc_boot is recorded as 0, and no
+	// verify_prepare ran on the hot path (both happened during the pre-warm).
+	if fc, ok := res.Stages["fc_boot"]; !ok || fc != 0 {
+		t.Fatalf("adopted fork fc_boot stage = %v (ok=%v), want 0 (boot pre-paid off the hot path)", fc, ok)
+	}
+	if _, ran := res.Stages["verify_prepare"]; ran {
+		t.Fatalf("adopted fork must not re-run the snapshot verify on the hot path, got stages %v", res.Stages)
+	}
+
+	// A fresh dormant child is re-warmed for the NEXT fork, and it is a DISTINCT
+	// Firecracker from the one just consumed.
+	next := waitForPrewarmSlot(t, s)
+	if next == warmed {
+		t.Fatal("re-warm must boot a FRESH dormant child, not re-use the consumed one")
+	}
+	if rewarmed := vms.get(prewarmSlotCfgID); rewarmed == warmed {
+		t.Fatal("re-warm must start a new Firecracker under the reserved slot id")
+	}
+}
+
+// TestPrewarmMissBootsOnDemandThenWarms proves the fallback: with the slot not yet
+// warm, the FIRST fork boots on demand (fc_boot recorded, byte-for-byte the prior
+// behavior) and the slot is warmed for a LATER fork, off the hot path.
+func TestPrewarmMissBootsOnDemandThenWarms(t *testing.T) {
+	vms := newVMRegistry()
+	s := newPrewarmTestStub(t, vms)
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+
+	// No eager warm: the first fork misses and boots its OWN Firecracker on demand.
+	res := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     "fork-1",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if !res.OK {
+		t.Fatalf("SpawnVM on a pre-warm miss must still succeed on demand: %+v", res)
+	}
+	if booted := vms.get("husk-test-fork-1"); booted == nil {
+		t.Fatal("a pre-warm miss must boot the fork's own Firecracker on demand")
+	}
+	if _, ok := res.Stages["fc_boot"]; !ok {
+		t.Fatalf("an on-demand fork must record a real fc_boot stage, got %v", res.Stages)
+	}
+
+	// The miss kicked a re-warm so a LATER fork can skip the boot.
+	warmed := waitForPrewarmSlot(t, s)
+	res2 := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     "fork-2",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if !res2.OK {
+		t.Fatalf("second SpawnVM must adopt the warmed child: %+v", res2)
+	}
+	if instVM(s, "fork-2") != warmed {
+		t.Fatal("the second fork must ADOPT the warmed child booted after the first fork")
+	}
+	if fc := res2.Stages["fc_boot"]; fc != 0 {
+		t.Fatalf("the second (adopting) fork fc_boot = %v, want 0", fc)
+	}
+}
+
+// TestPrewarmOffKeepsOnDemandBoot proves pre-warm OFF (the default) is
+// byte-for-byte the on-demand path: no reserved slot is ever created and every
+// fork boots its own Firecracker. It uses the plain-map stub (no re-warm
+// goroutine runs when pre-warm is off, so no concurrency-safe registry is needed).
+func TestPrewarmOffKeepsOnDemandBoot(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms) // PrewarmChild defaults off
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	if vm := s.consumePrewarmedChild(); vm != nil {
+		t.Fatal("consumePrewarmedChild must return nil when pre-warm is off")
+	}
+	res := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     "fork-1",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if !res.OK {
+		t.Fatalf("SpawnVM: %+v", res)
+	}
+	if _, booted := vms["husk-test-fork-1"]; !booted {
+		t.Fatal("with pre-warm off a fork must boot its own Firecracker")
+	}
+	if _, warmed := s.instances[prewarmSlotVMID]; warmed {
+		t.Fatal("with pre-warm off no reserved slot may be created")
+	}
+}

--- a/internal/husk/prewarm_test.go
+++ b/internal/husk/prewarm_test.go
@@ -209,6 +209,59 @@ func TestPrewarmMissBootsOnDemandThenWarms(t *testing.T) {
 	}
 }
 
+// TestPrewarmChildOnSingleVMStubIsSafe proves a single-VM stub (nil instances
+// map) with PrewarmChild set never touches that map: PrewarmChild refuses with a
+// clear error instead of panicking, and no reserved slot is created.
+func TestPrewarmChildOnSingleVMStubIsSafe(t *testing.T) {
+	// PrewarmChild ON but MultiVM OFF: the instances map is nil, so pre-warming
+	// must be refused, not panic.
+	s := New(firecracker.VMConfig{ID: "husk-test"}, Options{
+		Start:        func(cfg firecracker.VMConfig) (vmm, error) { return &fakeVMM{}, nil },
+		Ready:        readyOK,
+		Notify:       (&fakeNotifier{}).notify,
+		Verify:       verifyOK,
+		PrewarmChild: true, // MultiVM deliberately left off
+	})
+	if err := s.PrewarmChild(context.Background()); err == nil {
+		t.Fatal("PrewarmChild on a single-VM stub must refuse with an error, not succeed")
+	}
+	if s.instances != nil {
+		t.Fatal("a single-VM stub must not allocate the instances map")
+	}
+	// The internal helpers are also safe no-ops (they never touch the nil map).
+	if vm := s.consumePrewarmedChild(); vm != nil {
+		t.Fatal("consumePrewarmedChild on a single-VM stub must return nil")
+	}
+	if err := s.warmPrewarmChild(context.Background()); err != nil {
+		t.Fatalf("warmPrewarmChild on a single-VM stub must be a safe no-op, got %v", err)
+	}
+	s.rewarmPrewarmChildAsync() // must not panic
+}
+
+// TestSpawnVMRejectsReservedPrewarmSlotID proves a caller cannot drive SpawnVM at
+// the engine-internal pre-warm slot id and collide with the pod's dormant child.
+func TestSpawnVMRejectsReservedPrewarmSlotID(t *testing.T) {
+	vms := newVMRegistry()
+	s := newPrewarmTestStub(t, vms)
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	res := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     string(prewarmSlotVMID),
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if res.OK {
+		t.Fatal("SpawnVM must refuse the reserved pre-warm slot id")
+	}
+	if res.Error == "" {
+		t.Fatal("a refused reserved-id spawn must carry an error")
+	}
+	// The reserved slot must not have been activated as a tenant VM.
+	if got := instState(s, prewarmSlotVMID); got == StateActive {
+		t.Fatalf("the reserved slot must never be driven Active by SpawnVM, got %s", got)
+	}
+}
+
 // TestPrewarmOffKeepsOnDemandBoot proves pre-warm OFF (the default) is
 // byte-for-byte the on-demand path: no reserved slot is ever created and every
 // fork boots its own Firecracker. It uses the plain-map stub (no re-warm

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -567,6 +567,21 @@ type Options struct {
 	// Independent of LiveCowFork so the source can be armed (freezer live) without
 	// yet skipping the disk mem.
 	LiveCowChildImport bool
+	// PrewarmChild opts into keeping ONE dormant, generic co-located child
+	// Firecracker pre-prepared (booted, and snapshot-verified when a template
+	// snapshot is configured) in a multi-VM pod, so a co-located fork that does
+	// NOT need a fork-specific launch env can ACTIVATE the pre-warmed child (rootfs
+	// clone at fork time + LoadSnapshot + resume) instead of paying the on-demand
+	// process boot on the fork hot path. SpawnVM consumes the pre-warmed slot and
+	// asynchronously re-warms a fresh one for the NEXT fork, OFF the hot path. It
+	// DEFAULTS false and is a no-op unless MultiVM is also on. It is deliberately
+	// bypassed for the live-cow child-import fork (FIRECRACKER_MITOS_CHILD_MEMFD):
+	// that child MUST be exec'd with per-fork frozen-epoch coordinates that only
+	// exist after the fork's Freeze, so it keeps the on-demand launch byte-for-byte
+	// (the disk-restore co-located fork and template spawn are what the pre-warm
+	// accelerates). At most ONE dormant child is kept, so the pre-warm never
+	// over-admits the pod's per-VM memory budget (it counts as one extra VM).
+	PrewarmChild bool
 }
 
 // DefaultReadyTimeout bounds how long Activate waits for the guest agent to
@@ -675,6 +690,15 @@ type Stub struct {
 	// restores from the disk fork snapshot until a child-side memfd-import
 	// Firecracker patch ships) is always restorable and the fork never hangs.
 	liveCowChildImport bool
+	// prewarmChild keeps ONE dormant, generic co-located child Firecracker
+	// pre-prepared (Options.PrewarmChild) so a co-located fork that needs no
+	// fork-specific launch env activates it instead of paying the process boot on
+	// the hot path. prewarming is the single-flight guard so at most one re-warm
+	// runs at a time and the pod never keeps more than one pre-warmed child (never
+	// over-admitting the per-VM memory budget). Both guarded by mu; only meaningful
+	// on the multi-VM path.
+	prewarmChild bool
+	prewarming   bool
 	// liveCowParent is the armed parent-side live-cow WP handler for this pod's
 	// running source VM (milestone m5). When non-nil AND liveCowFork is on, a
 	// co-located fork child spawn imports its guest RAM from the parent's live
@@ -743,6 +767,7 @@ func New(cfg firecracker.VMConfig, opts Options) *Stub {
 		multiVM:            opts.MultiVM,
 		liveCowFork:        opts.LiveCowFork,
 		liveCowChildImport: opts.LiveCowChildImport,
+		prewarmChild:       opts.PrewarmChild,
 	}
 	// Multi-VM scaffold (#764), default off: allocate the per-fork instance map
 	// ONLY when a caller opts in. No production caller sets MultiVM in increment


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The husk stub (internal/husk) is the in-pod VMM lifecycle engine; in multi-vm mode (#764) one pod hosts many same-tenant forks, and SpawnVM is the co-located fork server side.
> - Today the co-located child Firecracker is prepared ON DEMAND at fork time: prepareInstance boots a fresh VMM then activateInstance restores it, so the process boot (fc_boot) and the dormant prepare overhead sit on the fork hot path (measured prod: prepare_total + fc_boot cost ~50ms per fork).
> - With the server-side fork now correct and fast (lazy-UFFD child import, vmstate-only capture), the process boot is the next hot-path cost to move off the critical path, toward sub-100ms.
> - The DEFAULT source VM is already warm-prepared to a dormant VMM; the same dormant-prepare can keep a co-located CHILD slot ready and waiting.
> - This pull request keeps one dormant, generic child Firecracker pre-prepared per multi-vm pod so a fork ADOPTS the ready child instead of booting one, and re-warms a fresh slot asynchronously off the hot path.
> - The benefit is fc_boot and the template verify move off the fork hot path (recorded fc_boot ~0 on an adopting fork) with zero change to how the child restores or inherits, so the fork approaches sub-100ms server-side without touching the no-leak path.

## Linked Issues or Issue Description

Related: #764 (multi-vm-per-pod density). No user-visible behavior changes while `PrewarmChild` is off (the default); the controller is not wired to it. Problem: the co-located fork boots the child Firecracker on the fork hot path (fc_boot + dormant prepare overhead), which the server-side latency work needs to eliminate.

## What Changed

- Add `Options.PrewarmChild` (default off, needs `MultiVM`): keep ONE dormant, generic child Firecracker pre-prepared (booted, and template-snapshot-verified when configured) under a reserved slot.
- `SpawnVM` consumes the pre-warmed slot by ADOPTING its booted VMM into the fork's own vmID instance (skips fc_boot + the template verify, records `fc_boot=0`), pays only this fork's rootfs clone, then re-warms a fresh slot asynchronously off the hot path. A miss falls back to the on-demand prepare byte-for-byte.
- Refactor `prepareInstance` into `prepareInstanceOpt` (+ a `cloneRootfsForInstance` helper) so ONE fail-closed, per-instance-locked state machine backs the plain prepare, the pre-warm boot (`skipRootfsClone`), and the consume (`reuseVM`). `prepareInstance`'s signature and every existing caller/test are unchanged.
- New `internal/husk/prewarm.go`: reserved slot id, `consumePrewarmedChild`, single-flight `warmPrewarmChild`, `rewarmPrewarmChildAsync`, and exported `PrewarmChild(ctx)` for eager warming after the source is up.
- Tests: unit (`prewarm_test.go`) proving the slot is consumed + re-warmed and an adopting fork skips the boot (`fc_boot=0`, no `verify_prepare`), the miss-then-warm fallback, and pre-warm-off keeping the on-demand path. KVM: `TestPrewarmedColocatedForkSkipsBootKVM` (disk-restore, runs on every KVM runner) and `TestPrewarmedLiveCowChildImportNoLeakKVM` (mem-less lazy-UFFD import) proving child alive + disk/memory inheritance + fork-time sentinel (NO LEAK) + `fc_boot=0` with a pre-warmed slot.

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/husk/... ./internal/fork/...`
- [x] `go test -race ./internal/husk/... ./internal/fork/...`
- [x] `~/go/bin/golangci-lint run` and `GOOS=linux ~/go/bin/golangci-lint run` (clean for internal/husk; only pre-existing unused-func note in untouched internal/fork/uffd.go)
- [ ] firecracker-test KVM job (the gate): operator runs it to observe the prepare_total/fc_boot drop and the pre-warm no-leak KVM tests on real KVM.

## Risks

Low risk with the flag off (default): the single-VM path and the on-demand fork path are byte-for-byte unchanged, no production caller sets `PrewarmChild`. With the flag on, the pre-warmed child is generic and adoption reaches activate in the same StateDormant, so correctness/isolation/no-leak run identically; at most one dormant child is kept (single-flight), so it never over-admits the per-VM memory budget. The security-sensitive live-cow lazy-UFFD restore path is unchanged (the import is still armed after prepare, before activate). The firecracker-test KVM job is the correctness gate the operator runs before flipping the flag.

## Model Used

Claude Opus (claude-opus-4-8), extended thinking mode. Assisted the design, implementation, and tests; reviewed by the author.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [ ] Docs updated in the same PR (behavior is flag-off default; docs/fork-correctness.md unchanged since the restore path is unchanged)
- [x] Threat-model delta: none, the security surface is unchanged (generic boot; restore path armed identically)
- [ ] Benchmark run: deferred to the operator's KVM firecracker-test job (no local /dev/kvm)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to pre-warm and reserve a single co-located child VM to reduce fork startup latency.
  * Forks can reuse the already-booted child (skipping the usual boot path), while the next pre-warm slot is refreshed in the background.
* **Bug Fixes**
  * Improved multi-VM preparation/activation behavior to preserve expected guest state and avoid redundant work.
  * Added safeguards for KVM live-cow modes to prevent mem/leak regressions.
* **Tests**
  * Added new KVM-gated acceptance and unit tests for pre-warm consumption, re-warming, and safety constraints (including reserved-slot rejection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->