### PR TITLE
fix(husk): eagerly prewarm the child slot at startup so the first fork adopts it

### DIFF
--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -602,6 +602,18 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 	// names and durations only; no secret, token, or entropy value is logged.
 	fmt.Fprintf(os.Stderr, "husk: activate vm %q stage timing ms: %s total=%.2f\n", id, formatStages(stages), float64(latency.Microseconds())/1000.0)
 	inst.state = StateActive
+	// A claimed pod is now a live tenant VM whose next request may be a co-located
+	// fork. Eagerly boot the pod's ONE dormant child slot so that FIRST fork adopts
+	// it (fc_boot=0) instead of paying the boot on its hot path; without this the
+	// slot is created only AFTER a fork, so a fresh pod's first fork always misses.
+	// Gated on the SOURCE (default) VM: a fork child's own activation must not warm
+	// a slot (SpawnVM's post-fork rewarm already replenishes). Off the hot path (a
+	// goroutine) and fail-closed, so it never delays activate and never over-admits
+	// the per-VM budget (the adopted slot is the same extra VM an on-demand fork
+	// would boot). A no-op when pre-warm is off or the pod is single-VM.
+	if id == defaultVMID {
+		s.eagerPrewarmChildAsync()
+	}
 	return ActivateResult{
 		OK:        true,
 		VsockPath: vsockPath,

--- a/internal/husk/prewarm.go
+++ b/internal/husk/prewarm.go
@@ -151,3 +151,30 @@ func (s *Stub) rewarmPrewarmChildAsync() {
 		}
 	}()
 }
+
+// eagerPrewarmChildAsync boots the pod's dormant child slot as soon as the SOURCE
+// (default) VM has activated, so a pod's FIRST co-located fork already finds a warm
+// slot to ADOPT (fc_boot=0) instead of paying the process boot on its hot path.
+// Without this the slot is created ONLY by the post-fork rewarmPrewarmChildAsync,
+// so the FIRST fork of a freshly claimed pod always misses the slot (in prod most
+// forks are a fresh pod's first fork). activateInstance calls it once the default
+// VM reaches StateActive; it is a no-op when pre-warm is off or the pod is
+// single-VM. It runs OFF the activate path (its own goroutine + a background
+// context, since the activate ctx may be cancelled once Activate returns) so it
+// never delays the activation or the first request. warmPrewarmChild is
+// single-flight and fail-closed, so an eager warm racing the first fork is safe: a
+// miss just falls back to the on-demand prepare, and the pod never keeps more than
+// one dormant child. It fires ONLY on the source activation (a CLAIMED pod), so an
+// unclaimed warm-pool pod never boots a dormant child it may never fork, and the
+// warm slot the fork adopts is the SAME extra VM the on-demand fork would have
+// booted, so eager warming never over-admits the pod's per-VM memory budget.
+func (s *Stub) eagerPrewarmChildAsync() {
+	if !s.multiVM || !s.prewarmChild {
+		return
+	}
+	go func() {
+		if err := s.warmPrewarmChild(context.Background()); err != nil {
+			fmt.Fprintf(os.Stderr, "husk: eager pre-warm child at source activation failed (first fork boots on demand): %v\n", err)
+		}
+	}()
+}

--- a/internal/husk/prewarm.go
+++ b/internal/husk/prewarm.go
@@ -142,14 +142,7 @@ func (s *Stub) warmPrewarmChild(ctx context.Context) error {
 // waits on or fails from the pool refill. single-flight in warmPrewarmChild keeps
 // concurrent calls to one dormant child.
 func (s *Stub) rewarmPrewarmChildAsync() {
-	if !s.multiVM || !s.prewarmChild {
-		return
-	}
-	go func() {
-		if err := s.warmPrewarmChild(context.Background()); err != nil {
-			fmt.Fprintf(os.Stderr, "husk: re-warm pre-warmed child failed (next fork boots on demand): %v\n", err)
-		}
-	}()
+	s.warmPrewarmChildAsync("re-warm pre-warmed child failed (next fork boots on demand)")
 }
 
 // eagerPrewarmChildAsync boots the pod's dormant child slot as soon as the SOURCE
@@ -169,12 +162,21 @@ func (s *Stub) rewarmPrewarmChildAsync() {
 // warm slot the fork adopts is the SAME extra VM the on-demand fork would have
 // booted, so eager warming never over-admits the pod's per-VM memory budget.
 func (s *Stub) eagerPrewarmChildAsync() {
+	s.warmPrewarmChildAsync("eager pre-warm child at source activation failed (first fork boots on demand)")
+}
+
+// warmPrewarmChildAsync is the shared body of the eager (source-activation) and
+// re-warm (post-fork) paths: a no-op when pre-warm is off or the pod is single-VM,
+// else it runs the single-flight, fail-closed warmPrewarmChild on its own goroutine
+// and a background context (the caller's ctx may be cancelled once it returns),
+// logging failCtx on error so neither path ever blocks or fails on the pool refill.
+func (s *Stub) warmPrewarmChildAsync(failCtx string) {
 	if !s.multiVM || !s.prewarmChild {
 		return
 	}
 	go func() {
 		if err := s.warmPrewarmChild(context.Background()); err != nil {
-			fmt.Fprintf(os.Stderr, "husk: eager pre-warm child at source activation failed (first fork boots on demand): %v\n", err)
+			fmt.Fprintf(os.Stderr, "husk: %s: %v\n", failCtx, err)
 		}
 	}()
 }

--- a/internal/husk/prewarm_test.go
+++ b/internal/husk/prewarm_test.go
@@ -167,6 +167,77 @@ func TestPrewarmedChildIsConsumedAndReWarmed(t *testing.T) {
 	}
 }
 
+// TestSourceActivationEagerlyWarmsSlotSoFirstForkAdopts proves the STARTUP wiring:
+// activating the SOURCE (default) VM eagerly warms the child slot on its own, so a
+// pod's FIRST co-located fork adopts it (fc_boot=0) WITHOUT any caller ever calling
+// PrewarmChild by hand. This is the exact gap the manual-PrewarmChild tests missed:
+// in prod the slot must exist before the first fork, and only the source activation
+// (not a prior fork) can create it for that first fork.
+func TestSourceActivationEagerlyWarmsSlotSoFirstForkAdopts(t *testing.T) {
+	vms := newVMRegistry()
+	s := newPrewarmTestStub(t, vms)
+
+	// Bring up + activate the source VM ONLY. Deliberately do NOT call PrewarmChild:
+	// the activation itself must trigger the eager warm.
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+		t.Fatalf("activateInstance(default): %v", err)
+	}
+
+	// The source activation alone must have booted a dormant child slot (off the
+	// activate path), so the first fork has something to adopt.
+	warmed := waitForPrewarmSlot(t, s)
+	if got := vms.get(prewarmSlotCfgID); got != warmed {
+		t.Fatalf("source activation must eagerly boot the dormant child under %q", prewarmSlotCfgID)
+	}
+
+	// The pod's FIRST fork (no prior fork, no manual PrewarmChild) ADOPTS the eagerly
+	// warmed child: no on-demand boot under its own derived id, and fc_boot=0.
+	res := s.SpawnVM(context.Background(), SpawnVMRequest{
+		VMID:     "fork-1",
+		Activate: ActivateRequest{SnapshotDir: "/snap"},
+	})
+	if !res.OK {
+		t.Fatalf("first SpawnVM must adopt the eagerly warmed child: %+v", res)
+	}
+	if instVM(s, "fork-1") != warmed {
+		t.Fatal("the FIRST fork must ADOPT the eagerly warmed child, not boot its own")
+	}
+	if booted := vms.get("husk-test-fork-1"); booted != nil {
+		t.Fatal("adopting the eager slot must NOT boot a Firecracker under the fork's derived id")
+	}
+	if fc, ok := res.Stages["fc_boot"]; !ok || fc != 0 {
+		t.Fatalf("first fork fc_boot = %v (ok=%v), want 0 (boot pre-paid by eager warm at source activation)", fc, ok)
+	}
+}
+
+// TestSourceActivationDoesNotWarmWhenPrewarmOff proves the eager warm is gated: with
+// pre-warm OFF (the default), activating the source VM creates NO reserved slot, so
+// the wiring is byte-for-byte the prior on-demand path when the flag is off.
+func TestSourceActivationDoesNotWarmWhenPrewarmOff(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms) // PrewarmChild defaults off
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance(default): %v", err)
+	}
+	if _, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"}); err != nil {
+		t.Fatalf("activateInstance(default): %v", err)
+	}
+	// eagerPrewarmChildAsync returns before spawning any goroutine when the flag is
+	// off, so this is deterministic: no reserved slot exists.
+	s.mu.Lock()
+	_, slotExists := s.instances[prewarmSlotVMID]
+	s.mu.Unlock()
+	if slotExists {
+		t.Fatal("with pre-warm off, source activation must not create the reserved slot")
+	}
+	if vm := s.consumePrewarmedChild(); vm != nil {
+		t.Fatal("with pre-warm off, no eager slot may be consumable after activation")
+	}
+}
+
 // TestPrewarmMissBootsOnDemandThenWarms proves the fallback: with the slot not yet
 // warm, the FIRST fork boots on demand (fc_boot recorded, byte-for-byte the prior
 // behavior) and the slot is warmed for a LATER fork, off the hot path.


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The husk stub (internal/husk) runs the per-pod VM lifecycle; in multi-VM mode (#764) it multiplexes co-located same-tenant forks over a per-VM instance map, and #851 added a pre-warmed dormant child slot (Options.PrewarmChild) so a fork ADOPTS an already-booted generic Firecracker (fc_boot=0) instead of booting one on its hot path.
> - The eager entrypoint `Stub.PrewarmChild` was never called at startup: only the post-fork `rewarmPrewarmChildAsync` created a slot, so a freshly claimed pod's FIRST fork always missed the slot and paid the full boot + dormant prepare. On prod fc_boot stayed ~11ms + prepare_total ~50ms on every fork with no husk prewarm activity, because in prod most forks are a fresh pod's first fork.
> - This needs addressing now to make the shipped #851 slot actually cut fork latency on the hosted live-fork hot path; the KVM test passed only because it called `PrewarmChild` by hand.
> - This pull request wires the eager warm to the SOURCE (default) VM activation: `activateInstance` kicks off `eagerPrewarmChildAsync` once the default VM reaches StateActive, so the dormant child slot exists BEFORE the first fork.
> - The benefit is a pod's first (and every) co-located fork adopts the warm slot at fc_boot=0, off the hot path, without touching the adopt/consume/no-leak logic.

## Linked Issues or Issue Description

Related: #851

The #851 pre-warm slot is inert in production: `Stub.PrewarmChild` (the eager entrypoint that "eagerly prepares the pod's dormant child slot so the FIRST fork can adopt it") is never called at startup. Only `rewarmPrewarmChildAsync` (post-fork) creates a slot, so a fresh pod's first fork always misses and boots on demand.

## What Changed

- Added `Stub.eagerPrewarmChildAsync` (internal/husk/prewarm.go): fires the existing single-flight, fail-closed `warmPrewarmChild` on its own goroutine + background context. No-op when pre-warm is off or the pod is single-VM.
- `activateInstance` (internal/husk/multivm.go) calls it after the SOURCE (default) VM reaches StateActive, gated on `id == defaultVMID` so a fork child's own activation never warms a slot (the post-fork rewarm already replenishes).
- Added `TestSourceActivationEagerlyWarmsSlotSoFirstForkAdopts`: source activation alone warms the slot so a pod's FIRST fork (no prior fork, no manual `PrewarmChild`) adopts it at fc_boot=0.
- Added `TestSourceActivationDoesNotWarmWhenPrewarmOff`: with pre-warm off, activation creates no reserved slot.

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/husk/...` and `go test -race ./internal/husk/...` (all green, including the #851 KVM gates TestPrewarmedColocatedForkSkipsBootKVM / TestPrewarmedLiveCowChildImportNoLeakKVM which still pass; the manual PrewarmChild after activation is a single-flight no-op)
- [x] `golangci-lint run ./internal/husk/...` and `GOOS=linux golangci-lint run ./internal/husk/...` clean
- [ ] firecracker-test KVM job is the gate (runs in CI)

Note: `internal/controller/...` envtest needs local etcd/kube-apiserver binaries not installed in this sandbox and is untouched by this change; a pre-existing `internal/fork/uffd.go` host-only unused finding is outside this diff (GOOS=linux clean).

## Risks

Low risk. The eager warm is behind the existing `Options.PrewarmChild` flag (default OFF; a no-op when off or single-VM), runs off the activate path, and reuses the unchanged single-flight fail-closed warm/consume/rewarm machinery. Memory headroom: the eagerly warmed slot is the SAME extra VM an on-demand fork would boot (a dormant slot is not metered; at most one is kept), and the fork ADOPTS it rather than adding to it, so peak memory is source + active fork + one dormant child, identical to the existing post-fork steady state; a fork racing an in-progress warm just misses and boots on demand, so the eager slot never starves a real fork. Firing only on the source (claimed) activation means unclaimed warm-pool pods hold no dormant child.

## Model Used

Claude Opus (claude-opus-4-8), extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit (TDD)
- [ ] Docs updated in the same PR (no user-facing docs; internal flag behavior only)
- [x] Threat-model delta: none, the security surface (adopt/consume/no-leak) is unchanged
- [ ] Benchmark: hot path touched, but no new bench numbers claimed; the KVM gate measures fc_boot=0
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source VM activation now triggers a background eager pre-warm of a dormant child slot when pre-warming is enabled.
  * The first co-located fork can adopt a ready child, improving startup responsiveness.

* **Bug Fixes**
  * Co-located forks are more likely to start from a pre-warmed slot instead of creating it on demand.
  * Pre-warming behavior remains correctly disabled when turned off.

* **Tests**
  * Added integration coverage for eager slot warming during source activation and for the “pre-warm off” scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->