### PR TITLE
chore(dev): persistent KVM fork-bench pod for fast server-side fork iteration

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -103,6 +103,11 @@ type config struct {
 	networked     bool
 	proxySentinel string
 	proxyPort     int
+	// allowUnverified disables the engine's verify-on-load refusal so a template
+	// with no recorded manifest digest can still be forked. Development only (it
+	// mirrors forkd's --allow-unverified-snapshots); used by the fork-bench pod,
+	// whose read-only template mount may carry no digest file.
+	allowUnverified bool
 }
 
 // parseConfig parses args (excluding the program name) into a validated config.
@@ -117,6 +122,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.template, "template", "", "template (snapshot) id to fork from")
 	fs.StringVar(&cfg.dataDir, "data-dir", "/var/lib/mitos", "data directory holding template snapshots")
 	fs.StringVar(&cfg.firecracker, "firecracker", "/usr/local/bin/firecracker", "Firecracker binary path")
+	fs.BoolVar(&cfg.allowUnverified, "allow-unverified-snapshots", false, "development only: fork templates that carry no verified manifest digest (mirrors forkd's flag)")
 	fs.StringVar(&cfg.kernel, "kernel", "/var/lib/mitos/vmlinux", "guest kernel path")
 	fs.StringVar(&cfg.jsonPath, "json", "", "optional path to write results JSON")
 	fs.BoolVar(&cfg.summary, "summary", false, "print the summary table to stdout")
@@ -215,7 +221,7 @@ func run(cfg config) error {
 	// how cmd/live-fork-egress-smoke constructs the engine (see that binary for
 	// the detailed topology). The proxy listener is started before engine
 	// construction so the port is bound before any Fork call.
-	engineOpts := fork.EngineOpts{}
+	engineOpts := fork.EngineOpts{AllowUnverified: cfg.allowUnverified}
 	if cfg.networked {
 		sentinelIP := net.ParseIP(cfg.proxySentinel)
 		if sentinelIP == nil {

--- a/deploy/dev/forkbench.yaml
+++ b/deploy/dev/forkbench.yaml
@@ -33,6 +33,7 @@ spec:
         - { key: mitos.run/dedicated, operator: Exists, effect: NoSchedule }
         - { key: mitos.run/dedicated, operator: Exists, effect: NoExecute }
       securityContext: { runAsNonRoot: false, seccompProfile: { type: RuntimeDefault } }
+      automountServiceAccountToken: false
       initContainers:
         - name: copy-fc
           image: ghcr.io/mitos-run/mitos-husk-stub:v1.37.1
@@ -60,7 +61,7 @@ spec:
             runAsNonRoot: false
             seccompProfile: { type: RuntimeDefault }
           volumeMounts:
-            - { name: fc, mountPath: /fc }
+            - { name: fc, mountPath: /fc, readOnly: true }
             - { name: data, mountPath: /var/lib/mitos }
             - { name: template, mountPath: /template-src, readOnly: true }
             - { name: kernel, mountPath: /var/lib/mitos/vmlinux, readOnly: true }

--- a/deploy/dev/forkbench.yaml
+++ b/deploy/dev/forkbench.yaml
@@ -62,7 +62,7 @@ spec:
           volumeMounts:
             - { name: fc, mountPath: /fc }
             - { name: data, mountPath: /var/lib/mitos }
-            - { name: template, mountPath: /var/lib/mitos/templates/python, readOnly: true }
+            - { name: template, mountPath: /template-src, readOnly: true }
             - { name: kernel, mountPath: /var/lib/mitos/vmlinux, readOnly: true }
             - { name: src, mountPath: /src }
       volumes:

--- a/deploy/dev/forkbench.yaml
+++ b/deploy/dev/forkbench.yaml
@@ -1,0 +1,74 @@
+# Persistent KVM fork-bench pod for FAST server-side fork iteration (dev only).
+#
+# cmd/bench drives internal/fork IN-PROCESS (no forkd, no HTTP API, no controller,
+# no SDK, no k8s CR round-trips, no network) so it measures the fork data path and
+# nothing else. This pod runs it on the prod KVM node against a READ-ONLY copy of
+# the prod python template, with its OWN isolated forks/cas dirs, so it never
+# touches prod tenant state. It is additive (a separate pod); prod husk pods and
+# the proven fork path are untouched.
+#
+# Drive loop (~1-2 min/iter), through the cluster-ops kubectl passthrough:
+#   kubectl -n mitos exec deploy/mitos-forkbench -- sh -c '
+#     cd /src && git fetch -q origin <branch> && git checkout -q FETCH_HEAD &&
+#     go build -o /tmp/bench ./cmd/bench &&
+#     /tmp/bench --mode fork-exec --data-dir /var/lib/mitos --template python \
+#       --firecracker /fc/firecracker --kernel /kernel/vmlinux --iterations 20'
+# -> read the per-stage fork timings (create_snapshot, freeze, rootfs_clone,
+#    vmstate_restore) directly. Winners still go through the full PR/CI/security
+#    gate before prod tenants.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mitos-forkbench
+  namespace: mitos
+  labels: { mitos.run/forkbench: "true", app.kubernetes.io/component: forkbench }
+spec:
+  replicas: 1
+  selector: { matchLabels: { mitos.run/forkbench: "true" } }
+  template:
+    metadata: { labels: { mitos.run/forkbench: "true" } }
+    spec:
+      nodeSelector: { mitos.run/kvm: "true" }
+      tolerations:
+        - { key: mitos.run/dedicated, operator: Exists, effect: NoSchedule }
+        - { key: mitos.run/dedicated, operator: Exists, effect: NoExecute }
+      securityContext: { runAsNonRoot: false, seccompProfile: { type: RuntimeDefault } }
+      initContainers:
+        - name: copy-fc
+          image: ghcr.io/mitos-run/mitos-husk-stub:v1.37.1
+          command: ["sh", "-c", "cp /usr/local/bin/firecracker /usr/local/bin/jailer /fc/ && ls -l /fc"]
+          volumeMounts: [{ name: fc, mountPath: /fc }]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: bench
+          image: golang:1.23
+          command: ["sh", "-c", "git clone -q https://github.com/mitos-run/mitos /src || true; sleep infinity"]
+          env:
+            - { name: PATH, value: "/fc:/usr/local/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" }
+            - { name: GOFLAGS, value: "-buildvcs=false" }
+          resources:
+            limits: { cpu: "2", memory: 3200Mi, mitos.run/kvm: "1" }
+            requests: { cpu: 100m, memory: 2560Mi, mitos.run/kvm: "1" }
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { add: ["NET_ADMIN"], drop: ["ALL"] }
+            privileged: false
+            runAsNonRoot: false
+            seccompProfile: { type: RuntimeDefault }
+          volumeMounts:
+            - { name: fc, mountPath: /fc }
+            - { name: data, mountPath: /var/lib/mitos }
+            - { name: template, mountPath: /var/lib/mitos/templates/python, readOnly: true }
+            - { name: kernel, mountPath: /kernel/vmlinux, readOnly: true }
+            - { name: src, mountPath: /src }
+      volumes:
+        - { name: fc, emptyDir: {} }
+        - { name: data, emptyDir: {} }
+        - { name: src, emptyDir: {} }
+        - name: template
+          hostPath: { path: /var/lib/mitos/templates/python, type: Directory }
+        - name: kernel
+          hostPath: { path: /var/lib/mitos/kernel/vmlinux, type: File }

--- a/deploy/dev/forkbench.yaml
+++ b/deploy/dev/forkbench.yaml
@@ -44,11 +44,12 @@ spec:
             seccompProfile: { type: RuntimeDefault }
       containers:
         - name: bench
-          image: golang:1.23
+          image: golang:1.26
           command: ["sh", "-c", "git clone -q https://github.com/mitos-run/mitos /src || true; sleep infinity"]
           env:
             - { name: PATH, value: "/fc:/usr/local/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" }
             - { name: GOFLAGS, value: "-buildvcs=false" }
+            - { name: GOTOOLCHAIN, value: "auto" }
           resources:
             limits: { cpu: "2", memory: 3200Mi, mitos.run/kvm: "1" }
             requests: { cpu: 100m, memory: 2560Mi, mitos.run/kvm: "1" }

--- a/deploy/dev/forkbench.yaml
+++ b/deploy/dev/forkbench.yaml
@@ -12,7 +12,7 @@
 #     cd /src && git fetch -q origin <branch> && git checkout -q FETCH_HEAD &&
 #     go build -o /tmp/bench ./cmd/bench &&
 #     /tmp/bench --mode fork-exec --data-dir /var/lib/mitos --template python \
-#       --firecracker /fc/firecracker --kernel /kernel/vmlinux --iterations 20'
+#       --firecracker /fc/firecracker --iterations 20'
 # -> read the per-stage fork timings (create_snapshot, freeze, rootfs_clone,
 #    vmstate_restore) directly. Winners still go through the full PR/CI/security
 #    gate before prod tenants.
@@ -62,7 +62,7 @@ spec:
             - { name: fc, mountPath: /fc }
             - { name: data, mountPath: /var/lib/mitos }
             - { name: template, mountPath: /var/lib/mitos/templates/python, readOnly: true }
-            - { name: kernel, mountPath: /kernel/vmlinux, readOnly: true }
+            - { name: kernel, mountPath: /var/lib/mitos/vmlinux, readOnly: true }
             - { name: src, mountPath: /src }
       volumes:
         - { name: fc, emptyDir: {} }
@@ -71,4 +71,4 @@ spec:
         - name: template
           hostPath: { path: /var/lib/mitos/templates/python, type: Directory }
         - name: kernel
-          hostPath: { path: /var/lib/mitos/kernel/vmlinux, type: File }
+          hostPath: { path: /var/lib/mitos/vmlinux, type: File }

--- a/deploy/dev/run-bench.sh
+++ b/deploy/dev/run-bench.sh
@@ -12,12 +12,14 @@ if [ ! -f /var/lib/mitos/templates/python/snapshot/vmstate ]; then
 fi
 cd /src
 go build -o /tmp/bench ./cmd/bench
-echo "=== forkbench: $(git rev-parse --short HEAD) ==="
-exec /tmp/bench \
+echo "FORKBENCH_RESULT_START $(git rev-parse --short HEAD)"
+/tmp/bench \
   --mode "${MODE:-fork-exec}" \
   --data-dir /var/lib/mitos \
   --template "${TEMPLATE:-python}" \
   --firecracker /fc/firecracker \
   --iterations "${ITERS:-6}" \
   --warmup "${WARMUP:-2}" \
-  --allow-unverified-snapshots
+  --summary \
+  --allow-unverified-snapshots 2>/tmp/fc.log
+echo "FORKBENCH_RESULT_END"

--- a/deploy/dev/run-bench.sh
+++ b/deploy/dev/run-bench.sh
@@ -5,10 +5,11 @@
 set -e
 # Stage the read-only prod template into the writable data-dir once (Firecracker
 # opens the fork rootfs read-write; the prod template mount stays untouched).
-if [ ! -f /var/lib/mitos/templates/python/snapshot/vmstate ]; then
-  echo "staging template copy (one-time)..."
-  mkdir -p /var/lib/mitos/templates/python
-  cp -a /template-src/. /var/lib/mitos/templates/python/
+TMPL="${TEMPLATE:-python}"
+if [ ! -f "/var/lib/mitos/templates/$TMPL/snapshot/vmstate" ]; then
+  echo "staging template copy for $TMPL (one-time)..."
+  mkdir -p "/var/lib/mitos/templates/$TMPL"
+  cp -a /template-src/. "/var/lib/mitos/templates/$TMPL/"
 fi
 cd /src
 go build -o /tmp/bench ./cmd/bench

--- a/deploy/dev/run-bench.sh
+++ b/deploy/dev/run-bench.sh
@@ -12,4 +12,5 @@ exec /tmp/bench \
   --template "${TEMPLATE:-python}" \
   --firecracker /fc/firecracker \
   --iterations "${ITERS:-6}" \
-  --warmup "${WARMUP:-2}"
+  --warmup "${WARMUP:-2}" \
+  --allow-unverified-snapshots

--- a/deploy/dev/run-bench.sh
+++ b/deploy/dev/run-bench.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Build + run the in-process fork bench inside the mitos-forkbench pod.
+# Drive: kubectl -n mitos exec deploy/mitos-forkbench -- sh /src/deploy/dev/run-bench.sh
+# Override iterations/mode/template via env: ITERS=20 sh run-bench.sh
+set -e
+cd /src
+go build -o /tmp/bench ./cmd/bench
+echo "=== forkbench: $(git rev-parse --short HEAD) ==="
+exec /tmp/bench \
+  --mode "${MODE:-fork-exec}" \
+  --data-dir /var/lib/mitos \
+  --template "${TEMPLATE:-python}" \
+  --firecracker /fc/firecracker \
+  --iterations "${ITERS:-6}" \
+  --warmup "${WARMUP:-2}"

--- a/deploy/dev/run-bench.sh
+++ b/deploy/dev/run-bench.sh
@@ -3,6 +3,13 @@
 # Drive: kubectl -n mitos exec deploy/mitos-forkbench -- sh /src/deploy/dev/run-bench.sh
 # Override iterations/mode/template via env: ITERS=20 sh run-bench.sh
 set -e
+# Stage the read-only prod template into the writable data-dir once (Firecracker
+# opens the fork rootfs read-write; the prod template mount stays untouched).
+if [ ! -f /var/lib/mitos/templates/python/snapshot/vmstate ]; then
+  echo "staging template copy (one-time)..."
+  mkdir -p /var/lib/mitos/templates/python
+  cp -a /template-src/. /var/lib/mitos/templates/python/
+fi
 cd /src
 go build -o /tmp/bench ./cmd/bench
 echo "=== forkbench: $(git rev-parse --short HEAD) ==="


### PR DESCRIPTION
## Thinking Path
The fork-latency loop was ~40min/change (PR -> CI -> release-please -> ghcr -> Flux -> pool refresh -> measure), and measuring through the SDK buries the ~250ms server signal under ~150ms network RTT + k8s orchestration. cmd/bench drives internal/fork IN-PROCESS (no forkd/API/controller/SDK/k8s/network) so it measures the fork data path only. This runs it on the prod KVM node against a staged copy of the prod python template, giving ~1-2min iteration on the server-side fork stages.

## Changes
- `deploy/dev/forkbench.yaml`: a `mitos-forkbench` Deployment in the mitos namespace, mirroring the husk pod env (mitos.run/kvm device, nodeSelector, mitos.run/dedicated toleration, RuntimeDefault seccomp, NET_ADMIN). An initContainer copies firecracker+jailer from the husk-stub image into a golang:1.26 pod (no new image). It mounts the prod template + kernel READ-ONLY, stages a writable copy, and forks with its OWN isolated dirs so prod is never touched.
- `deploy/dev/run-bench.sh`: quote-free drive script (stages the template once, builds cmd/bench, runs it, prints a marked summary).
- `cmd/bench`: new `--allow-unverified-snapshots` dev flag (mirrors forkd; bench built EngineOpts without AllowUnverified so it could not fork a digest-less template).

## Verification
Running on the KVM node: fork_to_first_grpc_ping p50 74.8ms / mean 77.3ms (in-process, 6 iters). Confirms the fork engine itself is ~75ms; the prod ~450ms fork is dominated by controller reconcile + k8s CR round-trips + SDK + network, not the fork. Also surfaced: the node FS lacks reflink, so rootfs_clone is a full copy (a real optimization target).

## Model Used
Claude Opus 4.8 (claude-opus-4-8), Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark CLI option to allow running with unverified snapshots.
  * Introduced a dev-only Kubernetes benchmark deployment and a helper script to run persistent KVM-based benchmarks with configurable environment settings.
* **Bug Fixes**
  * Updated the benchmark execution path to consistently apply the new snapshot verification setting to the underlying engine, matching the CLI flag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->