### PR TITLE
fix(husk): await dormant slot in the prewarm KVM test (eager warm races it)

### DIFF
--- a/internal/husk/forksnapshot_livecow_kvm_test.go
+++ b/internal/husk/forksnapshot_livecow_kvm_test.go
@@ -832,11 +832,27 @@ func TestPrewarmedLiveCowChildImportNoLeakKVM(t *testing.T) {
 	}
 
 	// EAGERLY pre-warm the dormant child BEFORE the fork, so the fork adopts it.
+	// The source activation above ALSO kicks an eager warm (eagerPrewarmChildAsync),
+	// and warmPrewarmChild is single-flight, so this explicit PrewarmChild can return
+	// while that in-flight warm is still finishing (the slot momentarily reads new).
+	// A racing fork just misses and boots on demand in prod; here we need the adopt
+	// path, so wait for the slot to actually reach dormant before forking.
 	if err := src.PrewarmChild(ctx); err != nil {
 		t.Fatalf("PrewarmChild must boot a dormant child: %v", err)
 	}
-	if got := src.instances[prewarmSlotVMID].state; got != StateDormant {
-		t.Fatalf("pre-warmed slot state = %s, want dormant before the fork", got)
+	var slotState State
+	warmDeadline := time.Now().Add(20 * time.Second)
+	for {
+		if inst := src.instances[prewarmSlotVMID]; inst != nil {
+			slotState = inst.state
+		}
+		if slotState == StateDormant || time.Now().After(warmDeadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if slotState != StateDormant {
+		t.Fatalf("pre-warmed slot state = %s, want dormant before the fork", slotState)
 	}
 
 	// Fork down the vmstate-only path (freeze + vmstate, NO mem file).

--- a/internal/husk/forksnapshot_livecow_kvm_test.go
+++ b/internal/husk/forksnapshot_livecow_kvm_test.go
@@ -843,8 +843,13 @@ func TestPrewarmedLiveCowChildImportNoLeakKVM(t *testing.T) {
 	var slotState State
 	warmDeadline := time.Now().Add(20 * time.Second)
 	for {
-		if inst := src.instances[prewarmSlotVMID]; inst != nil {
+		// Read the slot under the same locks the eager warm goroutine uses
+		// (s.mu for the map lookup via instanceFor, then the instance's own mu),
+		// so the poll never races prepareInstanceOpt's concurrent map/state writes.
+		if inst := src.instanceFor(prewarmSlotVMID, false); inst != nil {
+			inst.mu.Lock()
 			slotState = inst.state
+			inst.mu.Unlock()
 		}
 		if slotState == StateDormant || time.Now().After(warmDeadline) {
 			break


### PR DESCRIPTION
## Thinking Path
firecracker-test has been RED on main since #855 (eager prewarm), deterministically failing `TestPrewarmedLiveCowChildImportNoLeakKVM` with `pre-warmed slot state = new, want dormant before the fork` (forksnapshot_livecow_kvm_test.go:838). Root cause: #855 made source activation kick `eagerPrewarmChildAsync`, and `warmPrewarmChild` is single-flight, so the test's explicit `PrewarmChild(ctx)` returns as a no-op while that in-flight async warm is still finishing, and the slot momentarily reads `new`. This blocks every PR's required firecracker-test check.

## Changes
- `internal/husk/forksnapshot_livecow_kvm_test.go`: after `PrewarmChild`, wait (bounded, 20s) for the slot to reach `StateDormant` before forking, instead of asserting immediately. A fork racing the warm just misses and boots on demand in prod (by design); the test needs the adopt path, so it waits for the warm to settle. Test-only, no production behavior change.

## Verification
`GOOS=linux go test -c ./internal/husk/` compiles; both `golangci-lint` invocations clean. The KVM assertion now tolerates the eager async warm's timing (the firecracker-test job proves it on real KVM).

## Model Used
Claude Opus 4.8 (claude-opus-4-8), Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for live import workflows by waiting for the prewarmed instance to fully settle before continuing, reducing race-related failures.
* **Tests**
  * Updated automated coverage to verify the prewarmed adoption path by waiting until the prewarmed instance reaches the expected dormant state, preventing timing-related flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->