### PR TITLE
chore: bump Go toolchain to 1.26.5 (GO-2026-5856 crypto/tls fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module mitos.run/mitos
 
 go 1.26.2
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	connectrpc.com/connect v1.20.0


### PR DESCRIPTION
## Thinking Path
govulncheck started failing repo-wide (every open PR) on GO-2026-5856, a newly-published Go stdlib vulnerability in crypto/tls@go1.26.4 reachable through the husk control-plane TLS handshake (internal/husk, internal/sniproxy, internal/controller/huskclient). Fixed in crypto/tls@go1.26.5. main's last passing govuln run predates the CVE.

## Changes
- `go.mod`: `toolchain go1.26.4` -> `go1.26.5` so the build links the fixed stdlib crypto/tls. No dependency or code change.

## Verification
`GOTOOLCHAIN=go1.26.5 go build ./...` clean; govulncheck resolves GO-2026-5856 (fixed in 1.26.5). CI runs the full suite.

## Model Used
Claude Opus 4.8 (claude-opus-4-8), Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to a newer patch version for builds and development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->