### PR TITLE
feat(controller): reuse the husk control-plane connection across RPCs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -339,7 +339,9 @@ func main() {
 
 	if huskConnReuse && !enableHuskPods {
 		logger.Info("WARNING: --husk-conn-reuse is on but --enable-husk-pods is off; connection reuse targets husk control RPCs, which only exist on the husk-pods path, so the flag is a no-op on the raw-forkd path")
-	} else if !huskConnReuse {
+	} else if huskConnReuse {
+		logger.Info("husk control connection reuse: ENABLED; the controller reuses one authenticated mTLS connection per husk pod across control RPCs instead of dialing fresh per RPC, cutting per-RPC handshake overhead on the fork hot path")
+	} else {
 		logger.Info("husk control connection reuse: disabled (default); each husk control RPC dials a fresh mTLS connection. Pass --husk-conn-reuse to reuse one connection per husk pod and cut per-RPC handshake overhead")
 	}
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -60,6 +60,7 @@ func main() {
 	var enableRawForkd bool
 	var multiVMFork bool
 	var liveCowFork bool
+	var huskConnReuse bool
 	var liveCowChildImport bool
 	var prewarmChild bool
 	var huskStubImage string
@@ -95,6 +96,7 @@ func main() {
 	flag.BoolVar(&liveCowFork, "live-cow-fork", false, "EXPERIMENTAL, DEFAULT OFF: start warm husk pods with --live-cow-fork so a CO-LOCATED fork child shares the PARENT's resident guest memory (patched Firecracker memfd + userfaultfd write-protect) instead of restoring from the disk fork snapshot (milestone m4b), driving the hosted fork toward sub-100ms. SEPARATE from --multi-vm-fork so it can be deployed off and canaried independently. OFF is byte-for-byte the current disk co-location. The co-located child still falls back to the disk restore where the child-side memfd import is not yet complete, so turning it on never breaks a fork; it is a no-op off Linux (userfaultfd write-protect is Linux-only). Only meaningful with --enable-husk-pods.")
 	flag.BoolVar(&liveCowChildImport, "live-cow-child-import", false, "EXPERIMENTAL, DEFAULT OFF: with --live-cow-fork on, opt warm husk pods onto the VMSTATE-ONLY fork capture (skip the ~364ms disk mem write) so a co-located child boots its guest RAM from the source shared memfd instead of the disk fork snapshot. REQUIRES a child-side-import patched Firecracker; off keeps the armed source writing the disk mem so every child restores from disk and no fork hangs. Only meaningful with --live-cow-fork and --enable-husk-pods.")
 	flag.BoolVar(&prewarmChild, "prewarm-child", false, "EXPERIMENTAL, DEFAULT OFF: keep one dormant generic co-located child Firecracker pre-prepared per multi-vm husk pod so a fork adopts the ready child (fc_boot=0, prepare off the hot path) instead of booting one at fork time. Requires --multi-vm-fork and --enable-husk-pods; a fresh slot re-warms async, a miss falls back to on-demand prepare byte-for-byte.")
+	flag.BoolVar(&huskConnReuse, "husk-conn-reuse", false, "EXPERIMENTAL, DEFAULT OFF: reuse ONE authenticated mTLS husk control connection per husk pod across control-plane RPCs (activate, fork-snapshot, spawn-vm, remove-fork-snapshot) instead of opening a fresh TCP+TLS handshake per RPC. A co-located fork does fork-snapshot then spawn-vm to the SAME source pod, so reuse saves the second full handshake and cuts the per-RPC connection-setup overhead toward zero, driving the hosted fork toward sub-100ms. OFF is byte-for-byte the current one-shot dial-per-RPC path. The husk server always supports both (a one-shot client that closes after one request and a reused connection that sends several), so this flag only changes the CONTROLLER side and can be canaried + rolled back independently. mTLS identity is verified on every dial and one request is in flight per connection, so a reused connection is neither less authenticated nor frame-interleaved (see docs/threat-model.md). Only meaningful with --enable-husk-pods.")
 	flag.StringVar(&huskStubImage, "husk-stub-image", "mitos-husk-stub:latest", "Container image that runs the dormant-VMM stub in a husk pod. Only used with --enable-husk-pods.")
 	flag.StringVar(&huskDNSUpstream, "husk-dns-upstream", "", "Comma-separated DNS resolver list (host:port) the husk-stub per-pod DNS proxy forwards allowlisted name queries to, tried in failover order (recommended: 1.1.1.1:53,8.8.8.8:53). Empty leaves name-based egress off (IP:port allowlists still enforced). Use a public resolver, not cluster DNS, so untrusted sandboxes cannot resolve internal service names.")
 	flag.IntVar(&huskControlPort, "husk-control-port", controller.HuskControlPort, "TCP port the husk stub serves the mTLS network control on; the controller dials podIP:port to activate a dormant husk pod. Only used with --enable-husk-pods.")
@@ -254,6 +256,17 @@ func main() {
 	// husk fields. Its HuskTLS (the controller client mTLS config used to dial a
 	// husk stub's network control) is the SAME config EnsurePKI returns for forkd
 	// dialing; it is assigned below after bootstrap, exactly like nodeRegistry.TLS.
+	// husk control-plane connection reuse (--husk-conn-reuse): when set, hand the
+	// reconciler a connection pool so the activate/fork-snapshot/spawn-vm seams
+	// reuse one authenticated mTLS connection per husk pod instead of dialing a
+	// fresh handshake per RPC. Nil (the default) keeps the byte-for-byte one-shot
+	// dial-per-RPC path.
+	var huskConnPool *controller.HuskConnPool
+	if huskConnReuse {
+		huskConnPool = controller.NewHuskConnPool()
+		logger.Info("husk control connection reuse: ENABLED; the controller reuses one authenticated mTLS control connection per husk pod across RPCs (a co-located fork's fork-snapshot + spawn-vm share one handshake). mTLS identity is verified on every dial")
+	}
+
 	sandboxReconciler := &controller.SandboxReconciler{
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
@@ -263,6 +276,7 @@ func main() {
 		EnableHuskPods:     enableHuskPods,
 		MultiVMFork:        multiVMFork,
 		LiveCowFork:        liveCowFork,
+		HuskConns:          huskConnPool,
 		LiveCowChildImport: liveCowChildImport,
 		PrewarmChild:       prewarmChild,
 		HuskControlPort:    huskControlPort,
@@ -321,6 +335,12 @@ func main() {
 		logger.Info("live-cow fork: ENABLED (experimental); warm husk pods run --live-cow-fork so a co-located fork child shares the parent's resident guest memory instead of restoring from the disk fork snapshot, failing closed to the disk restore where the child-side memfd import is not yet complete. Separate from --multi-vm-fork; canary it independently")
 	} else {
 		logger.Info("live-cow fork: disabled (default); co-located fork children restore from the disk fork snapshot. Pass --live-cow-fork to canary parent-memory sharing")
+	}
+
+	if huskConnReuse && !enableHuskPods {
+		logger.Info("WARNING: --husk-conn-reuse is on but --enable-husk-pods is off; connection reuse targets husk control RPCs, which only exist on the husk-pods path, so the flag is a no-op on the raw-forkd path")
+	} else if !huskConnReuse {
+		logger.Info("husk control connection reuse: disabled (default); each husk control RPC dials a fresh mTLS connection. Pass --husk-conn-reuse to reuse one connection per husk pod and cut per-RPC handshake overhead")
 	}
 
 	if enableHuskPods {

--- a/deploy/charts/mitos/templates/controller-deployment.yaml
+++ b/deploy/charts/mitos/templates/controller-deployment.yaml
@@ -4,6 +4,9 @@
 {{- if and .Values.controller.liveCowFork (not .Values.controller.enableHuskPods) }}
 {{- fail "controller.liveCowFork requires controller.enableHuskPods: live-cow fork rides the warm husk pod spec, which only exists on the husk-pods path. Set enableHuskPods: true or liveCowFork: false." }}
 {{- end }}
+{{- if and .Values.controller.huskConnReuse (not .Values.controller.enableHuskPods) }}
+{{- fail "controller.huskConnReuse requires controller.enableHuskPods: connection reuse targets husk control RPCs, which only exist on the husk-pods path. Set enableHuskPods: true or huskConnReuse: false." }}
+{{- end }}
 {{- if and .Values.controller.liveCowChildImport (not .Values.controller.liveCowFork) }}
 {{- fail "controller.liveCowChildImport requires controller.liveCowFork: the child-side memfd import only applies to an armed live-cow fork. Set liveCowFork: true or liveCowChildImport: false." }}
 {{- end }}
@@ -53,6 +56,9 @@ spec:
             {{- end }}
             {{- if .Values.controller.liveCowFork }}
             - --live-cow-fork
+            {{- end }}
+            {{- if .Values.controller.huskConnReuse }}
+            - --husk-conn-reuse
             {{- end }}
             {{- if .Values.controller.liveCowChildImport }}
             - --live-cow-child-import

--- a/deploy/charts/mitos/values.schema.json
+++ b/deploy/charts/mitos/values.schema.json
@@ -184,6 +184,10 @@
           "description": "EXPERIMENTAL, default off. Render --live-cow-fork so warm husk pods share the parent's resident guest memory with a co-located fork child (patched Firecracker memfd + userfaultfd write-protect) instead of restoring from the disk fork snapshot. SEPARATE from multiVMFork so it canaries independently; off is byte-for-byte the disk co-location and on fails closed to the disk restore where the child-side import is not yet complete. Only meaningful with enableHuskPods.",
           "type": "boolean"
         },
+        "huskConnReuse": {
+          "description": "EXPERIMENTAL, default off. Render --husk-conn-reuse so the controller reuses one authenticated mTLS husk control connection per husk pod across RPCs (activate, fork-snapshot, spawn-vm, remove-fork-snapshot) instead of a fresh handshake per RPC. A co-located fork's fork-snapshot + spawn-vm to the same source pod then share one handshake, cutting per-RPC connection-setup overhead. Off is byte-for-byte the one-shot dial-per-RPC path; the husk server accepts both, so this changes only the controller and canaries independently. mTLS identity is verified on every dial and one request is in flight per connection. Only meaningful with enableHuskPods.",
+          "type": "boolean"
+        },
         "liveCowChildImport": {
           "description": "EXPERIMENTAL, default off. With liveCowFork on, render --live-cow-child-import so an armed live-cow fork takes the vmstate-only capture (skip the ~364ms disk mem write) and the co-located child boots its guest RAM from the source shared memfd. Requires a child-side-import patched Firecracker; off keeps the armed source writing the disk mem.",
           "type": "boolean"

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -70,6 +70,19 @@ controller:
   # fork. Only meaningful with enableHuskPods.
   liveCowFork: false
 
+  # EXPERIMENTAL, default off. When true, render --husk-conn-reuse: the controller
+  # reuses ONE authenticated mTLS husk control connection per husk pod across RPCs
+  # (activate, fork-snapshot, spawn-vm, remove-fork-snapshot) instead of a fresh
+  # TCP+TLS handshake per RPC. A co-located fork does fork-snapshot then spawn-vm
+  # to the SAME source pod, so reuse saves the second handshake and cuts per-RPC
+  # connection-setup overhead toward zero (hosted fork toward sub-100ms). Off is
+  # byte-for-byte the current one-shot dial-per-RPC path. The husk server always
+  # accepts both a one-shot and a reused connection, so this only changes the
+  # controller and canaries + rolls back independently. mTLS identity is verified
+  # on every dial and one request is in flight per connection. Only meaningful
+  # with enableHuskPods.
+  huskConnReuse: false
+
   # EXPERIMENTAL, default off. When true (and liveCowFork on), render
   # --live-cow-child-import so an armed live-cow fork takes the vmstate-only capture
   # (skip the ~364ms disk mem write) and the co-located child boots its guest RAM

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -327,6 +327,32 @@ controller is the trust anchor here, the same anchor as in the raw-forkd model
 and the encryption key custody (section 5); this is not a regression, it is the
 same boundary.
 
+*Persistent (reused) control connection.* `serveControlConn` serves MORE than one
+request per accepted connection: the mTLS handshake and the
+`AuthorizeControllerIdentity` check run ONCE, then the connection loops read-op /
+dispatch / write-result until the peer closes it, it sits idle past
+`controlIdleTimeout` (90s), or a framing error desyncs the stream. This exists so
+the controller can REUSE one authenticated connection per husk pod across RPCs
+(`internal/controller.HuskConnPool`, behind the DEFAULT-OFF `--husk-conn-reuse`
+flag), removing a TCP+TLS handshake per op on the hot fork path (a co-located
+fork's fork-snapshot + spawn-vm go to the SAME source pod). Reuse changes only
+WHEN the verified handshake happens, never WHETHER it is verified: the peer
+identity is bound to the mTLS session at handshake and does not change under a
+persistent connection, so every request on it comes from the same verified
+`pki.ControllerName` peer; there is no per-request re-auth to weaken because the
+session is unchanged. The pool serializes RPCs to a given pod behind a per-address
+mutex, so exactly one request/response is in flight per connection and concurrent
+forks never interleave frames on one stream; a read/write error, an idle
+connection past the pool's shorter retirement window (`huskConnIdle`, 30s), or a
+husk restart drops the connection and the pool re-dials a fresh authenticated one.
+The one-shot path (dial, one request, close) stays byte-for-byte the default and
+is what runs with the flag off. No secret VALUE is logged on this surface: a
+per-connection error names only the operation and the transport error, never the
+request payload. This is a NET-NEW long-lived-socket surface (a husk pod now holds
+an authenticated controller connection open between ops), bounded by the idle
+timeout and the one-in-flight-request-per-connection invariant; it does not widen
+who may drive the channel (still the controller identity only).
+
 **Surface 3: the READ-ONLY SNAPSHOT HOSTPATH.** The node template snapshot is
 mounted READ-ONLY into the husk pod (`huskpod.go`: the snapshot hostPath and the
 kernel file are both `ReadOnly: true`). The husk stub RE-VERIFIES the snapshot ON

--- a/internal/controller/huskconnpool.go
+++ b/internal/controller/huskconnpool.go
@@ -1,0 +1,260 @@
+package controller
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"mitos.run/mitos/internal/husk"
+)
+
+// huskConnIdle is how long the controller keeps an authenticated husk control
+// connection in the pool before it re-dials rather than reuse a possibly stale
+// one. It is deliberately SHORTER than the husk server's inter-request idle
+// timeout (husk.controlIdleTimeout, 90s) so the controller retires a connection
+// before the server would idle-close it, so it never writes a request onto a
+// socket the server already closed.
+const huskConnIdle = 30 * time.Second
+
+// huskConn is a single authenticated mTLS control connection to one husk pod,
+// paired with the persistent bufio.Reader its results are decoded through. It is
+// NOT safe for concurrent use; the pool serializes access with a per-address
+// mutex so at most one request/response is ever in flight on it, which is what
+// keeps two concurrent forks from interleaving frames on one stream.
+type huskConn struct {
+	conn net.Conn
+	br   *bufio.Reader
+}
+
+// huskConnEntry is the pool's per-address slot: a mutex that serializes all RPCs
+// to that husk (one in-flight frame at a time), the live connection (nil until
+// first dialed and after any drop), and the time it was last used successfully
+// for idle retirement.
+type huskConnEntry struct {
+	mu       sync.Mutex
+	conn     *huskConn
+	lastUsed time.Time
+}
+
+// close tears down the entry's connection and marks the slot empty so the next
+// use re-dials. The caller must hold e.mu.
+func (e *huskConnEntry) close() {
+	if e.conn != nil {
+		_ = e.conn.conn.Close()
+		e.conn = nil
+	}
+}
+
+// HuskConnPool reuses one authenticated mTLS control connection per husk pod
+// across control-plane RPCs, so a co-located fork (fork-snapshot then spawn-vm,
+// both to the SAME source pod) pays ONE TCP+TLS handshake instead of one per
+// RPC. The default one-shot huskclient.go functions (dial, one request, close)
+// remain the byte-for-byte fallback; a pool is wired into the reconciler only
+// behind the --husk-conn-reuse flag so it can be canaried and rolled back.
+//
+// SECURITY: reuse changes only WHEN the handshake happens, never WHETHER it is
+// verified. Every dial goes through tlsConf, which pins the husk server identity
+// and presents the controller client leaf the husk server authorizes
+// (AuthorizeControllerIdentity), so a reused connection is the SAME authenticated
+// peer the husk verified at dial time; the mTLS session does not change under it.
+// A nil tlsConf is refused by each seam method before any dial, so the control
+// channel is never driven unauthenticated. One request/response is in flight per
+// connection (the per-address mutex), so concurrent forks never interleave
+// frames. Secret VALUES are never logged: errors carry only the operation, the
+// address, and the transport error, never the request payload.
+//
+// The pool holds at most one connection per distinct husk address. A dead or
+// restarted husk's connection is dropped on the next use (re-dial on error) or
+// when it exceeds huskConnIdle; a slot whose pod is gone keeps only a tiny
+// nil-connection struct, reclaimed if the process restarts.
+type HuskConnPool struct {
+	entries sync.Map // addr string -> *huskConnEntry
+}
+
+// NewHuskConnPool returns an empty pool ready to serve the husk control seams.
+func NewHuskConnPool() *HuskConnPool {
+	return &HuskConnPool{}
+}
+
+// dialHuskConn opens a fresh authenticated mTLS control connection to addr. The
+// returned huskConn carries a persistent reader so a reused stream decodes
+// cleanly across results.
+func dialHuskConn(ctx context.Context, addr string, tlsConf *tls.Config) (*huskConn, error) {
+	dialer := &tls.Dialer{Config: tlsConf}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("dial husk control %s: %w", addr, err)
+	}
+	return &huskConn{conn: conn, br: bufio.NewReader(conn)}, nil
+}
+
+// do runs one control exchange (fn) against the pooled connection to addr under
+// the per-address lock, so concurrent RPCs to the SAME husk never interleave
+// frames on one stream. It dials on first use, reuses the authenticated
+// connection afterwards, and transparently RE-DIALS once if a REUSED connection
+// fails (a husk restart or a server idle-close between uses): the request still
+// succeeds on the fresh connection. A FRESHLY dialed connection that fails
+// returns the error, because that is a real transport or protocol failure, not
+// staleness. Any failure drops the connection so a desynced stream is never
+// reused.
+func (p *HuskConnPool) do(ctx context.Context, addr string, tlsConf *tls.Config, fn func(*huskConn) error) error {
+	ei, _ := p.entries.LoadOrStore(addr, &huskConnEntry{})
+	e := ei.(*huskConnEntry)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Retire an idle connection before use so we never write onto a socket the
+	// husk server may already have idle-closed on its own timeout.
+	if e.conn != nil && time.Since(e.lastUsed) > huskConnIdle {
+		e.close()
+	}
+
+	reused := e.conn != nil
+	if !reused {
+		c, err := dialHuskConn(ctx, addr, tlsConf)
+		if err != nil {
+			return err
+		}
+		e.conn = c
+	}
+
+	if err := p.run(ctx, e.conn, fn); err == nil {
+		e.lastUsed = time.Now()
+		return nil
+	} else if !reused {
+		// A fresh connection failed: a real transport/protocol error. Drop it and
+		// report; do not mask it behind a retry.
+		e.close()
+		return err
+	} else {
+		// A reused connection failed: the husk may have restarted or idle-closed
+		// between uses. Drop it, re-dial ONCE, and retry so transient staleness
+		// does not fail the RPC.
+		e.close()
+		c, derr := dialHuskConn(ctx, addr, tlsConf)
+		if derr != nil {
+			return fmt.Errorf("re-dial husk control %s after reuse error (%v): %w", addr, err, derr)
+		}
+		e.conn = c
+		if rerr := p.run(ctx, e.conn, fn); rerr != nil {
+			e.close()
+			return rerr
+		}
+		e.lastUsed = time.Now()
+		return nil
+	}
+}
+
+// run bounds the exchange by the caller's context deadline (so a wedged husk
+// cannot block the reconcile) and invokes fn on the connection.
+func (p *HuskConnPool) run(ctx context.Context, hc *huskConn, fn func(*huskConn) error) error {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = hc.conn.SetDeadline(deadline)
+	}
+	return fn(hc)
+}
+
+// ActivateHuskPod runs the Activate exchange over the pooled connection. Its
+// signature matches the one-shot ActivateHuskPod so it satisfies the reconciler
+// huskActivator seam. req carries tenant SECRETS, so a nil tlsConf is refused.
+func (p *HuskConnPool) ActivateHuskPod(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ActivateRequest) (husk.ActivateResult, error) {
+	if tlsConf == nil {
+		return husk.ActivateResult{}, fmt.Errorf("activate husk pod %s: refusing to send activation secrets over an unauthenticated channel", addr)
+	}
+	var res husk.ActivateResult
+	err := p.do(ctx, addr, tlsConf, func(hc *huskConn) error {
+		if err := husk.WriteControlOp(hc.conn, husk.OpActivate); err != nil {
+			return fmt.Errorf("send activate op to %s: %w", addr, err)
+		}
+		if err := husk.WriteRequest(hc.conn, req); err != nil {
+			return fmt.Errorf("send activate request to %s: %w", addr, err)
+		}
+		r, err := husk.ReadResultReader(hc.br)
+		if err != nil {
+			return fmt.Errorf("read activate result from %s: %w", addr, err)
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}
+
+// ForkSnapshotOnHusk runs the fork-snapshot exchange over the pooled connection.
+// Its signature matches the one-shot ForkSnapshotOnHusk (the huskForkSnapshotter
+// seam). req carries no secrets; a nil tlsConf is still refused because the same
+// control surface delivers secrets on activate.
+func (p *HuskConnPool) ForkSnapshotOnHusk(ctx context.Context, addr string, tlsConf *tls.Config, req husk.ForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+	if tlsConf == nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("fork-snapshot on husk %s: refusing to drive the control channel unauthenticated", addr)
+	}
+	var res husk.ForkSnapshotResult
+	err := p.do(ctx, addr, tlsConf, func(hc *huskConn) error {
+		if err := husk.WriteControlOp(hc.conn, husk.OpForkSnapshot); err != nil {
+			return fmt.Errorf("send fork-snapshot op to %s: %w", addr, err)
+		}
+		if err := husk.WriteForkSnapshotRequest(hc.conn, req); err != nil {
+			return fmt.Errorf("send fork-snapshot request to %s: %w", addr, err)
+		}
+		r, err := husk.ReadForkSnapshotResultReader(hc.br)
+		if err != nil {
+			return fmt.Errorf("read fork-snapshot result from %s: %w", addr, err)
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}
+
+// SpawnVMOnHusk runs the spawn-vm exchange over the pooled connection. Its
+// signature matches the one-shot SpawnVMOnHusk (the huskVMSpawner seam).
+// req.Activate carries tenant SECRETS, so a nil tlsConf is refused.
+func (p *HuskConnPool) SpawnVMOnHusk(ctx context.Context, addr string, tlsConf *tls.Config, req husk.SpawnVMRequest) (husk.SpawnVMResult, error) {
+	if tlsConf == nil {
+		return husk.SpawnVMResult{}, fmt.Errorf("spawn-vm on husk %s: refusing to drive the control channel unauthenticated", addr)
+	}
+	var res husk.SpawnVMResult
+	err := p.do(ctx, addr, tlsConf, func(hc *huskConn) error {
+		if err := husk.WriteControlOp(hc.conn, husk.OpSpawnVM); err != nil {
+			return fmt.Errorf("send spawn-vm op to %s: %w", addr, err)
+		}
+		if err := husk.WriteSpawnVMRequest(hc.conn, req); err != nil {
+			return fmt.Errorf("send spawn-vm request to %s: %w", addr, err)
+		}
+		r, err := husk.ReadSpawnVMResultReader(hc.br)
+		if err != nil {
+			return fmt.Errorf("read spawn-vm result from %s: %w", addr, err)
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}
+
+// RemoveForkSnapshotOnHusk runs the remove-fork-snapshot exchange over the pooled
+// connection. Its signature matches the one-shot RemoveForkSnapshotOnHusk (the
+// huskForkSnapshotRemover seam). A nil tlsConf is refused.
+func (p *HuskConnPool) RemoveForkSnapshotOnHusk(ctx context.Context, addr string, tlsConf *tls.Config, req husk.RemoveForkSnapshotRequest) (husk.ForkSnapshotResult, error) {
+	if tlsConf == nil {
+		return husk.ForkSnapshotResult{}, fmt.Errorf("remove fork-snapshot on husk %s: refusing to drive the control channel unauthenticated", addr)
+	}
+	var res husk.ForkSnapshotResult
+	err := p.do(ctx, addr, tlsConf, func(hc *huskConn) error {
+		if err := husk.WriteControlOp(hc.conn, husk.OpRemoveForkSnapshot); err != nil {
+			return fmt.Errorf("send remove-fork-snapshot op to %s: %w", addr, err)
+		}
+		if err := husk.WriteRemoveForkSnapshotRequest(hc.conn, req); err != nil {
+			return fmt.Errorf("send remove-fork-snapshot request to %s: %w", addr, err)
+		}
+		r, err := husk.ReadForkSnapshotResultReader(hc.br)
+		if err != nil {
+			return fmt.Errorf("read remove-fork-snapshot result from %s: %w", addr, err)
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}

--- a/internal/controller/huskconnpool_test.go
+++ b/internal/controller/huskconnpool_test.go
@@ -1,0 +1,385 @@
+package controller
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"mitos.run/mitos/internal/husk"
+	"mitos.run/mitos/internal/pki"
+)
+
+// loopHuskServer is an mTLS husk control server that speaks the real husk wire
+// codec and serves MULTIPLE requests per accepted connection (mirroring
+// husk.ServeTLS's keep-alive loop), so the controller HuskConnPool's reuse is
+// exercised end to end over the genuine protocol. accepts counts TCP
+// connections (a reused connection counts once), so a pool that reuses shows
+// accepts=1 for many RPCs. closeAfter, when > 0, closes a connection after
+// serving that many requests to simulate a husk restart / server idle-close and
+// force the pool to re-dial.
+type loopHuskServer struct {
+	addr       string
+	stop       func()
+	closeAfter int
+
+	accepts   int64
+	forkReqs  int64
+	spawnReqs int64
+	actReqs   int64
+
+	mu      sync.Mutex
+	secrets []string // captured to prove secret-bearing reuse works; never logged
+}
+
+func newLoopHuskServer(t *testing.T, p *huskClientPKI, closeAfter int) *loopHuskServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tlsLn := tls.NewListener(ln, p.serverConf)
+	s := &loopHuskServer{addr: ln.Addr().String(), closeAfter: closeAfter}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, aerr := tlsLn.Accept()
+			if aerr != nil {
+				return
+			}
+			atomic.AddInt64(&s.accepts, 1)
+			go s.serve(conn)
+		}
+	}()
+	s.stop = func() {
+		_ = tlsLn.Close()
+		<-done
+	}
+	return s
+}
+
+func (s *loopHuskServer) serve(conn net.Conn) {
+	defer conn.Close()
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return
+	}
+	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
+		return
+	}
+	state := tlsConn.ConnectionState()
+	// The reused connection is authorized ONCE with the same controller-identity
+	// gate the real server uses; an unauthorized peer never reaches a request.
+	if err := husk.AuthorizeControllerIdentity(&state); err != nil {
+		return
+	}
+	br := bufio.NewReader(conn)
+	served := 0
+	for {
+		op, err := husk.ReadControlOp(br)
+		if err != nil {
+			return
+		}
+		switch op {
+		case husk.OpForkSnapshot:
+			req, rerr := husk.ReadForkSnapshotRequestReader(br)
+			if rerr != nil {
+				return
+			}
+			atomic.AddInt64(&s.forkReqs, 1)
+			// Echo the request's SnapshotDir so a caller can prove the response is
+			// ITS OWN (no frame interleaving under concurrency).
+			_ = husk.WriteForkSnapshotResult(conn, husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir})
+		case husk.OpSpawnVM:
+			req, rerr := husk.ReadSpawnVMRequestReader(br)
+			if rerr != nil {
+				return
+			}
+			atomic.AddInt64(&s.spawnReqs, 1)
+			s.mu.Lock()
+			s.secrets = append(s.secrets, req.Activate.Secrets["API_KEY"])
+			s.mu.Unlock()
+			_ = husk.WriteSpawnVMResult(conn, husk.SpawnVMResult{OK: true, VMID: req.VMID, VsockPath: "/run/husk/" + req.VMID + "/vsock.sock"})
+		case husk.OpActivate:
+			req, rerr := husk.ReadActivateRequestReader(br)
+			if rerr != nil {
+				return
+			}
+			atomic.AddInt64(&s.actReqs, 1)
+			s.mu.Lock()
+			s.secrets = append(s.secrets, req.Secrets["API_KEY"])
+			s.mu.Unlock()
+			_ = husk.WriteResult(conn, husk.ActivateResult{OK: true, VsockPath: "/run/husk/vsock.sock"})
+		case husk.OpRemoveForkSnapshot:
+			req, rerr := husk.ReadForkSnapshotRequestReader(br) // remove shares the fork-snapshot request shape
+			if rerr != nil {
+				return
+			}
+			_ = husk.WriteForkSnapshotResult(conn, husk.ForkSnapshotResult{OK: true, SnapshotDir: req.SnapshotDir})
+		default:
+			return
+		}
+		served++
+		if s.closeAfter > 0 && served >= s.closeAfter {
+			return
+		}
+	}
+}
+
+// TestHuskConnPoolReusesConnection proves the pool reuses ONE authenticated mTLS
+// connection across two RPCs to the SAME husk address: a fork-snapshot then a
+// spawn-vm (the co-located fork's two RPCs, both to the source pod) are served
+// on a single accepted connection, so the second RPC pays no TCP+TLS handshake.
+func TestHuskConnPoolReusesConnection(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newLoopHuskServer(t, p, 0)
+	defer s.stop()
+
+	pool := NewHuskConnPool()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	fres, err := pool.ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{ForkID: "f1", SnapshotDir: "/snap/f1"})
+	if err != nil || !fres.OK {
+		t.Fatalf("fork-snapshot over pool: res=%+v err=%v", fres, err)
+	}
+	sres, err := pool.SpawnVMOnHusk(ctx, s.addr, p.clientConf, husk.SpawnVMRequest{
+		VMID:     "vm-1",
+		Activate: husk.ActivateRequest{SnapshotDir: "/snap/f1", Secrets: map[string]string{"API_KEY": "s3cr3t"}},
+	})
+	if err != nil || !sres.OK {
+		t.Fatalf("spawn-vm over pool: res=%+v err=%v", sres, err)
+	}
+
+	if got := atomic.LoadInt64(&s.accepts); got != 1 {
+		t.Fatalf("pool must reuse ONE connection for both RPCs, got %d accepts", got)
+	}
+	if f := atomic.LoadInt64(&s.forkReqs); f != 1 {
+		t.Fatalf("server saw %d fork-snapshot requests, want 1", f)
+	}
+	if sp := atomic.LoadInt64(&s.spawnReqs); sp != 1 {
+		t.Fatalf("server saw %d spawn-vm requests, want 1", sp)
+	}
+	// The secret rode the REUSED connection intact.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.secrets) != 1 || s.secrets[0] != "s3cr3t" {
+		t.Fatalf("secret did not survive connection reuse: %v", s.secrets)
+	}
+}
+
+// TestHuskConnPoolRedialsAfterServerClose proves the pool re-dials when a REUSED
+// connection is dead: the server closes each connection after one request
+// (simulating a husk restart / idle-close), so the pool's cached connection is
+// stale on the second RPC. The pool must transparently re-dial and the RPC must
+// still succeed. accepts=2 proves the re-dial happened.
+func TestHuskConnPoolRedialsAfterServerClose(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newLoopHuskServer(t, p, 1) // close after every single request
+	defer s.stop()
+
+	pool := NewHuskConnPool()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if fres, err := pool.ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{ForkID: "f1", SnapshotDir: "/snap/f1"}); err != nil || !fres.OK {
+		t.Fatalf("first fork-snapshot: res=%+v err=%v", fres, err)
+	}
+	// The server closed that connection; the pool still holds it. This second RPC
+	// must detect the dead reused connection and re-dial.
+	if fres, err := pool.ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{ForkID: "f2", SnapshotDir: "/snap/f2"}); err != nil || !fres.OK {
+		t.Fatalf("second fork-snapshot (after server close) must re-dial and succeed: res=%+v err=%v", fres, err)
+	}
+	if got := atomic.LoadInt64(&s.accepts); got != 2 {
+		t.Fatalf("pool must re-dial after a dead reused connection, got %d accepts (want 2)", got)
+	}
+}
+
+// TestHuskConnPoolConcurrent proves concurrent RPCs to the SAME husk never
+// interleave frames on the shared connection: N goroutines each run a
+// fork-snapshot carrying a UNIQUE SnapshotDir, and each must get ITS OWN dir
+// echoed back. A frame interleave would hand a goroutine another's response.
+// Run with -race to catch data races on the pooled connection.
+func TestHuskConnPoolConcurrent(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newLoopHuskServer(t, p, 0)
+	defer s.stop()
+
+	pool := NewHuskConnPool()
+	const n = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			dir := fmt.Sprintf("/snap/f%d", i)
+			res, err := pool.ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{ForkID: fmt.Sprintf("f%d", i), SnapshotDir: dir})
+			if err != nil {
+				errs <- fmt.Errorf("rpc %d: %w", i, err)
+				return
+			}
+			if !res.OK || res.SnapshotDir != dir {
+				errs <- fmt.Errorf("rpc %d got wrong response (interleave?): %+v want dir %q", i, res, dir)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt64(&s.forkReqs); got != n {
+		t.Fatalf("server saw %d fork-snapshot requests, want %d", got, n)
+	}
+}
+
+// TestHuskConnPoolEnforcesMTLSIdentity proves every pooled dial is mTLS
+// authenticated: a client leaf from a DIFFERENT CA (so the husk server's
+// ClientCAs reject it) fails the handshake, and no request is served. Reuse
+// never weakens the identity gate; it only changes WHEN the verified handshake
+// happens.
+func TestHuskConnPoolEnforcesMTLSIdentity(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newLoopHuskServer(t, p, 0)
+	defer s.stop()
+
+	// A rogue client cert from an untrusted CA, but trusting the real server CA so
+	// the CLIENT accepts the server; the SERVER must reject the rogue client.
+	rogueCA, err := pki.NewCA("attacker")
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+	rogueLeaf, err := rogueCA.Issue(pki.ControllerName)
+	if err != nil {
+		t.Fatalf("issue rogue leaf: %v", err)
+	}
+	rogueCert, err := tls.X509KeyPair(rogueLeaf.CertPEM, rogueLeaf.KeyPEM)
+	if err != nil {
+		t.Fatalf("rogue keypair: %v", err)
+	}
+	rogueConf := &tls.Config{
+		Certificates: []tls.Certificate{rogueCert},
+		RootCAs:      huskCertPool(t, p.caPEM),
+		ServerName:   pki.ServerName,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	pool := NewHuskConnPool()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = pool.ForkSnapshotOnHusk(ctx, s.addr, rogueConf, husk.ForkSnapshotRequest{ForkID: "f1", SnapshotDir: "/snap/f1"})
+	if err == nil {
+		t.Fatalf("pool must reject a wrong-CA client cert at the handshake")
+	}
+	if got := atomic.LoadInt64(&s.forkReqs); got != 0 {
+		t.Fatalf("an unauthenticated peer must never have a request served, got %d", got)
+	}
+}
+
+// TestHuskConnPoolRefusesNilTLS proves each seam refuses a nil TLS config so the
+// control channel is never driven unauthenticated, matching the one-shot
+// huskclient.go functions.
+func TestHuskConnPoolRefusesNilTLS(t *testing.T) {
+	pool := NewHuskConnPool()
+	ctx := context.Background()
+	if _, err := pool.ActivateHuskPod(ctx, "10.0.0.1:9443", nil, husk.ActivateRequest{Secrets: map[string]string{"API_KEY": "x"}}); err == nil {
+		t.Fatal("ActivateHuskPod must refuse a nil TLS config")
+	}
+	if _, err := pool.ForkSnapshotOnHusk(ctx, "10.0.0.1:9443", nil, husk.ForkSnapshotRequest{}); err == nil {
+		t.Fatal("ForkSnapshotOnHusk must refuse a nil TLS config")
+	}
+	if _, err := pool.SpawnVMOnHusk(ctx, "10.0.0.1:9443", nil, husk.SpawnVMRequest{}); err == nil {
+		t.Fatal("SpawnVMOnHusk must refuse a nil TLS config")
+	}
+	if _, err := pool.RemoveForkSnapshotOnHusk(ctx, "10.0.0.1:9443", nil, husk.RemoveForkSnapshotRequest{}); err == nil {
+		t.Fatal("RemoveForkSnapshotOnHusk must refuse a nil TLS config")
+	}
+}
+
+// TestHuskConnPoolErrorHidesSecret proves an RPC error never carries the request
+// payload: when the server drops the connection after the handshake, the
+// activate result read fails, and the returned error names only the operation
+// and address, never the secret.
+func TestHuskConnPoolErrorHidesSecret(t *testing.T) {
+	p := newHuskClientPKI(t)
+	// A server that accepts the mTLS connection then closes WITHOUT replying, so
+	// the pool's result read fails.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tlsLn := tls.NewListener(ln, p.serverConf)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, aerr := tlsLn.Accept()
+			if aerr != nil {
+				return
+			}
+			if tc, ok := conn.(*tls.Conn); ok {
+				_ = tc.HandshakeContext(context.Background())
+			}
+			_ = conn.Close() // drop without answering
+		}
+	}()
+	defer func() { _ = tlsLn.Close(); <-done }()
+
+	pool := NewHuskConnPool()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	const secret = "TOPSECRET-do-not-leak"
+	_, err = pool.ActivateHuskPod(ctx, ln.Addr().String(), p.clientConf, husk.ActivateRequest{
+		SnapshotDir: "/snap",
+		Secrets:     map[string]string{"API_KEY": secret},
+	})
+	if err == nil {
+		t.Fatal("activate against a dropping server must fail")
+	}
+	if got := err.Error(); strings.Contains(got, secret) {
+		t.Fatalf("error leaked the secret: %q", got)
+	}
+}
+
+// TestHuskConnPoolRetiresIdleConnection proves an idle connection past
+// huskConnIdle is retired and re-dialed rather than reused, so the controller
+// never writes onto a socket the husk server may have idle-closed.
+func TestHuskConnPoolRetiresIdleConnection(t *testing.T) {
+	p := newHuskClientPKI(t)
+	s := newLoopHuskServer(t, p, 0)
+	defer s.stop()
+
+	pool := NewHuskConnPool()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if fres, err := pool.ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{ForkID: "f1", SnapshotDir: "/snap/f1"}); err != nil || !fres.OK {
+		t.Fatalf("first fork-snapshot: res=%+v err=%v", fres, err)
+	}
+	// Force the pooled entry to look idle by backdating its lastUsed.
+	ei, ok := pool.entries.Load(s.addr)
+	if !ok {
+		t.Fatal("pool did not cache a connection entry")
+	}
+	e := ei.(*huskConnEntry)
+	e.mu.Lock()
+	e.lastUsed = time.Now().Add(-2 * huskConnIdle)
+	e.mu.Unlock()
+
+	if fres, err := pool.ForkSnapshotOnHusk(ctx, s.addr, p.clientConf, husk.ForkSnapshotRequest{ForkID: "f2", SnapshotDir: "/snap/f2"}); err != nil || !fres.OK {
+		t.Fatalf("second fork-snapshot after idle retire: res=%+v err=%v", fres, err)
+	}
+	if got := atomic.LoadInt64(&s.accepts); got != 2 {
+		t.Fatalf("an idle-retired connection must be re-dialed, got %d accepts (want 2)", got)
+	}
+}

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -152,6 +152,20 @@ type SandboxReconciler struct {
 	// Nil defaults to SpawnVMOnHusk; tests inject a fake.
 	spawnVM huskVMSpawner
 
+	// HuskConns, when non-nil, is the husk control-plane CONNECTION POOL: the
+	// activate, fork-snapshot, spawn-vm, and remove-fork-snapshot seams REUSE one
+	// authenticated mTLS connection per husk pod across RPCs instead of dialing a
+	// fresh TCP+TLS handshake per call, so a co-located fork (fork-snapshot then
+	// spawn-vm to the SAME source pod) pays one handshake instead of two. It is
+	// used ONLY when the explicitly-injected seam (forkSnapshot/spawnVM/Activate/
+	// removeForkSnapshot, set by tests) is nil, so a test fake still wins and the
+	// nil-pool default stays byte-for-byte the one-shot huskclient.go path.
+	// EXPERIMENTAL, DEFAULT OFF (wired only behind --husk-conn-reuse) so it can be
+	// canaried and rolled back. The reused connection is the SAME authenticated
+	// peer the husk verified at dial time (mTLS identity is enforced on every
+	// dial); see internal/controller/huskconnpool.go and docs/threat-model.md.
+	HuskConns *HuskConnPool
+
 	// multiVMForkGate, when non-nil, overrides MultiVMFork so a test can toggle the
 	// routing race-safely on the shared reconciler (the field itself is never
 	// mutated after setup). Nil (the production default) reads MultiVMFork. Tests only.
@@ -833,6 +847,9 @@ func (r *SandboxReconciler) reconcileHuskClaim(ctx context.Context, claim *v1.Sa
 	activate := r.Activate
 	if activate == nil {
 		activate = ActivateHuskPod
+		if r.HuskConns != nil {
+			activate = r.HuskConns.ActivateHuskPod
+		}
 	}
 
 	// Claim the dormant pod BEFORE activating it: stamp the mitos.run/claim

--- a/internal/controller/sandboxfork_controller.go
+++ b/internal/controller/sandboxfork_controller.go
@@ -678,17 +678,31 @@ func (r *SandboxReconciler) reconcileHuskFork(ctx context.Context, fork *v1.Sand
 	if sandboxPort == 0 {
 		sandboxPort = huskSandboxPort
 	}
+	// The husk control seams default to the one-shot huskclient.go dialers, or,
+	// when the connection pool is wired (--husk-conn-reuse), to the pool's reusing
+	// variants so the co-located fork's fork-snapshot and spawn-vm to the SAME
+	// source pod share one authenticated mTLS connection. An explicitly-injected
+	// test fake still wins (the nil check).
 	forkSnap := r.forkSnapshot
 	if forkSnap == nil {
 		forkSnap = ForkSnapshotOnHusk
+		if r.HuskConns != nil {
+			forkSnap = r.HuskConns.ForkSnapshotOnHusk
+		}
 	}
 	activate := r.Activate
 	if activate == nil {
 		activate = ActivateHuskPod
+		if r.HuskConns != nil {
+			activate = r.HuskConns.ActivateHuskPod
+		}
 	}
 	spawnVM := r.spawnVM
 	if spawnVM == nil {
 		spawnVM = SpawnVMOnHusk
+		if r.HuskConns != nil {
+			spawnVM = r.HuskConns.SpawnVMOnHusk
+		}
 	}
 
 	// MultiVMFork routing decision, computed ONCE for the whole fan-out. The
@@ -1366,6 +1380,9 @@ func (r *SandboxReconciler) finalizeHuskFork(ctx context.Context, fork *v1.Sandb
 	remove := r.removeForkSnapshot
 	if remove == nil {
 		remove = RemoveForkSnapshotOnHusk
+		if r.HuskConns != nil {
+			remove = r.HuskConns.RemoveForkSnapshotOnHusk
+		}
 	}
 
 	// Resolve the source pod to dial; if it is gone the snapshot went with it.

--- a/internal/husk/control.go
+++ b/internal/husk/control.go
@@ -163,6 +163,52 @@ func ReadResult(r io.Reader) (ActivateResult, error) {
 	return res, err
 }
 
+// The Read*ResultReader variants below decode exactly one newline-delimited
+// result from a SHARED, persistent *bufio.Reader (via readLineReader, which
+// stops at the first '\n' and leaves any surplus buffered on the reader). The
+// io.Reader forms above wrap the stream in a per-call bufio.Scanner that MAY
+// read past the newline and DISCARD the surplus, which corrupts the next read on
+// a REUSED connection. A one-shot connection (dial, one request, close) sees no
+// next read, so the io.Reader forms stay correct there; a controller connection
+// pool that reuses one authenticated stream across RPCs MUST use these reader
+// forms so consecutive results decode cleanly. The decoded value is byte-for-
+// byte identical either way; only the stream-position bookkeeping differs.
+
+// ReadResultReader reads one ActivateResult from a shared reader.
+func ReadResultReader(r *bufio.Reader) (ActivateResult, error) {
+	var res ActivateResult
+	err := readLineReader(r, &res)
+	return res, err
+}
+
+// ReadForkSnapshotResultReader reads one ForkSnapshotResult from a shared reader.
+func ReadForkSnapshotResultReader(r *bufio.Reader) (ForkSnapshotResult, error) {
+	var res ForkSnapshotResult
+	err := readLineReader(r, &res)
+	return res, err
+}
+
+// ReadSpawnVMResultReader reads one SpawnVMResult from a shared reader.
+func ReadSpawnVMResultReader(r *bufio.Reader) (SpawnVMResult, error) {
+	var res SpawnVMResult
+	err := readLineReader(r, &res)
+	return res, err
+}
+
+// ReadDehydrateWorkspaceResultReader reads one DehydrateWorkspaceResult from a shared reader.
+func ReadDehydrateWorkspaceResultReader(r *bufio.Reader) (DehydrateWorkspaceResult, error) {
+	var res DehydrateWorkspaceResult
+	err := readLineReader(r, &res)
+	return res, err
+}
+
+// ReadHydrateWorkspaceResultReader reads one HydrateWorkspaceResult from a shared reader.
+func ReadHydrateWorkspaceResultReader(r *bufio.Reader) (HydrateWorkspaceResult, error) {
+	var res HydrateWorkspaceResult
+	err := readLineReader(r, &res)
+	return res, err
+}
+
 // ControlOp discriminates the control message that follows it on the wire, so
 // one mTLS control channel can serve activate, fork-snapshot, and
 // remove-fork-snapshot. The op line is written BEFORE the request line. The

--- a/internal/husk/netcontrol.go
+++ b/internal/husk/netcontrol.go
@@ -26,6 +26,13 @@ import (
 // socket the server already idle-closed.
 const controlIdleTimeout = 90 * time.Second
 
+// controlOpTimeout bounds a single in-flight control op (request-body read +
+// operation + result write) so a peer that half-sends a request or stops reading
+// the reply cannot pin the serving goroutine forever. It is a finite socket
+// backstop (unlike clearing the deadline); generous enough for the slowest
+// activate/fork/workspace op the client itself would wait on.
+const controlOpTimeout = 120 * time.Second
+
 // AuthorizeControllerIdentity is the authorize hook for ServeTLS that mirrors
 // forkd's RequireControllerIdentity interceptor: a control connection is
 // accepted only when its VERIFIED mTLS peer presents the controller leaf's DNS
@@ -172,9 +179,11 @@ func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize 
 			fmt.Fprintf(os.Stderr, "husk control: read control op: %v\n", err)
 			return
 		}
-		// The op arrived: clear the idle deadline so the operation itself is
-		// bounded by ctx (a slow activate/fork), not the inter-request window.
-		_ = conn.SetReadDeadline(time.Time{})
+		// The op arrived: re-arm a finite per-op deadline (both read + write) so a
+		// slow activate/fork is allowed but a peer that half-sends the request body
+		// or stops reading the reply cannot pin this goroutine forever. ctx bounds
+		// the operation logic; this bounds the raw socket I/O ctx cannot unblock.
+		_ = conn.SetDeadline(time.Now().Add(controlOpTimeout))
 		if !dispatchControlOp(ctx, conn, br, op, stub) {
 			// A request-read or result-write error left the stream in an unknown
 			// framing state; close instead of reading the next op off a desynced

--- a/internal/husk/netcontrol.go
+++ b/internal/husk/netcontrol.go
@@ -6,11 +6,25 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
+	"time"
 
 	"mitos.run/mitos/internal/pki"
 )
+
+// controlIdleTimeout bounds how long an authenticated control connection may sit
+// idle BETWEEN requests before the server reaps it. It exists only so a reused
+// connection (the controller's connection pool keeps one authenticated stream
+// open across RPCs) does not leak a wedged or forgotten socket; a one-shot
+// client closes right after its single request and never reaches the timeout.
+// It bounds the inter-request WAIT only, not the op itself: once a request is
+// read, the deadline is cleared so a slow activate/fork is bounded by the
+// caller's context deadline, not this idle window. The controller retires its
+// pooled connection well before this (huskConnIdle) so it never writes onto a
+// socket the server already idle-closed.
+const controlIdleTimeout = 90 * time.Second
 
 // AuthorizeControllerIdentity is the authorize hook for ServeTLS that mirrors
 // forkd's RequireControllerIdentity interceptor: a control connection is
@@ -45,7 +59,9 @@ func AuthorizeControllerIdentity(state *tls.ConnectionState) error {
 
 // ServeTLS serves the line-delimited JSON control protocol (control.go's
 // ReadRequest / WriteResult) over an mTLS net.Listener, dispatching each
-// accepted connection to stub.Activate.
+// accepted connection to serveControlConn, which authorizes the verified peer
+// once and then serves one or more requests (activate/fork/spawn/workspace) on
+// that connection until the peer closes it or it sits idle.
 //
 // SECURITY: this is the network control channel that activates a dormant VM
 // with tenant secrets. tlsConf MUST require and verify client certificates
@@ -96,12 +112,25 @@ func ServeTLS(ctx context.Context, ln net.Listener, stub *Stub, tlsConf *tls.Con
 	}
 }
 
-// serveControlConn completes the mTLS handshake, authorizes the verified peer,
-// then reads one ActivateRequest, runs Activate, and writes the result. Any
-// handshake or authorization failure closes the connection without reading the
-// request, so a secret-bearing request is never accepted from an
-// unauthenticated or unauthorized peer. Errors are logged by operation only;
-// the request payload (env/secrets/entropy) is never logged.
+// serveControlConn completes the mTLS handshake ONCE, authorizes the verified
+// peer ONCE, then serves requests on the connection in a loop: read op, dispatch,
+// write result, repeat until the peer closes it (EOF), it sits idle past
+// controlIdleTimeout, or a framing/transport error desyncs the stream. Any
+// handshake or authorization failure closes the connection without reading a
+// request, so a secret-bearing request is never accepted from an unauthenticated
+// or unauthorized peer.
+//
+// The loop makes the connection REUSABLE for the controller's connection pool
+// (one authenticated stream carries many RPCs, saving a TCP+TLS handshake per
+// op) while staying byte-for-byte backward compatible with a one-shot client: a
+// client that writes a single request and closes drives exactly one iteration,
+// then the next ReadControlOp sees EOF and the connection closes, identical in
+// effect to the previous one-request-per-connection behavior. The identity is
+// verified once and remains the verified peer for the connection's whole life;
+// there is no per-request re-auth because the mTLS session does not change.
+//
+// Errors are logged by operation only; the request payload (env/secrets/entropy)
+// is never logged.
 func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize func(*tls.ConnectionState) error) {
 	defer conn.Close()
 
@@ -123,38 +152,75 @@ func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize 
 		return
 	}
 
+	// One persistent reader for the connection's whole life so a reused stream
+	// decodes cleanly across requests (bufio keeps any buffered surplus between
+	// reads; a fresh reader per request would drop it).
 	br := bufio.NewReader(conn)
-	op, err := ReadControlOp(br)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "husk control: read control op: %v\n", err)
-		return
+	for {
+		// Bound only the WAIT for the next request so an idle or wedged reused
+		// connection is reaped. A one-shot client's close surfaces here as EOF.
+		_ = conn.SetReadDeadline(time.Now().Add(controlIdleTimeout))
+		op, err := ReadControlOp(br)
+		if err != nil {
+			// EOF (peer closed / one-shot), idle timeout, or a cancelled server:
+			// close quietly. A genuine framing/decode error is logged (never the
+			// payload) so a desync is visible.
+			var nerr net.Error
+			if errors.Is(err, io.EOF) || (errors.As(err, &nerr) && nerr.Timeout()) || ctx.Err() != nil {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "husk control: read control op: %v\n", err)
+			return
+		}
+		// The op arrived: clear the idle deadline so the operation itself is
+		// bounded by ctx (a slow activate/fork), not the inter-request window.
+		_ = conn.SetReadDeadline(time.Time{})
+		if !dispatchControlOp(ctx, conn, br, op, stub) {
+			// A request-read or result-write error left the stream in an unknown
+			// framing state; close instead of reading the next op off a desynced
+			// stream.
+			return
+		}
 	}
+}
+
+// dispatchControlOp reads the request for op off the shared reader, runs the
+// stub operation, and writes the result to conn. It returns true when the
+// request-response frame completed cleanly (the connection may serve the next
+// op) and false when a request read or result write failed, which desyncs the
+// stream and requires closing the connection. Errors are logged by operation
+// only; the request payload (env/secrets/entropy) is never logged.
+func dispatchControlOp(ctx context.Context, conn net.Conn, br *bufio.Reader, op string, stub *Stub) bool {
 	switch op {
 	case OpActivate:
 		req, rerr := readActivateRequest(br)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: read activate request: %v\n", rerr)
-			return
+			return false
 		}
 		res, _ := stub.Activate(ctx, req)
 		if werr := WriteResult(conn, res); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write activate result: %v\n", werr)
+			return false
 		}
+		return true
 	case OpForkSnapshot:
 		req, rerr := readForkSnapshotRequest(br)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: read fork-snapshot request: %v\n", rerr)
-			return
+			return false
 		}
 		res, _ := stub.ForkSnapshot(ctx, req)
 		if werr := WriteForkSnapshotResult(conn, res); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write fork-snapshot result: %v\n", werr)
+			return false
 		}
+		return true
 	case OpRemoveForkSnapshot:
 		req, rerr := readRemoveForkSnapshotRequest(br)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: read remove-fork-snapshot request: %v\n", rerr)
-			return
+			return false
 		}
 		rmErr := stub.RemoveForkSnapshot(ForkSnapshotRequest{ForkID: req.ForkID, SnapshotDir: req.SnapshotDir})
 		out := ForkSnapshotResult{OK: rmErr == nil, SnapshotDir: req.SnapshotDir}
@@ -163,32 +229,38 @@ func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize 
 		}
 		if werr := WriteForkSnapshotResult(conn, out); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write remove-fork-snapshot result: %v\n", werr)
+			return false
 		}
+		return true
 	case OpDehydrateWorkspace:
 		req, rerr := readDehydrateWorkspaceRequest(br)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: read dehydrate-workspace request: %v\n", rerr)
-			return
+			return false
 		}
 		res, _ := stub.DehydrateWorkspace(ctx, req)
 		if werr := WriteDehydrateWorkspaceResult(conn, res); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write dehydrate-workspace result: %v\n", werr)
+			return false
 		}
+		return true
 	case OpHydrateWorkspace:
 		req, rerr := readHydrateWorkspaceRequest(br)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: read hydrate-workspace request: %v\n", rerr)
-			return
+			return false
 		}
 		res, _ := stub.HydrateWorkspace(ctx, req)
 		if werr := WriteHydrateWorkspaceResult(conn, res); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write hydrate-workspace result: %v\n", werr)
+			return false
 		}
+		return true
 	case OpSpawnVM:
 		req, rerr := readSpawnVMRequest(br)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: read spawn-vm request: %v\n", rerr)
-			return
+			return false
 		}
 		// SpawnVM fails closed on a non-multi-vm stub and validates req.VMID with
 		// checkVMID before deriving any path from it, so a single-VM pod never
@@ -197,8 +269,13 @@ func serveControlConn(ctx context.Context, conn net.Conn, stub *Stub, authorize 
 		res := stub.SpawnVM(ctx, req)
 		if werr := WriteSpawnVMResult(conn, res); werr != nil {
 			fmt.Fprintf(os.Stderr, "husk control: write spawn-vm result: %v\n", werr)
+			return false
 		}
+		return true
 	default:
+		// An unknown op on a shared stream cannot be safely skipped (its request
+		// framing is unknown), so the connection is closed.
 		fmt.Fprintf(os.Stderr, "husk control: unknown control op %q\n", op)
+		return false
 	}
 }

--- a/internal/husk/netcontrol_test.go
+++ b/internal/husk/netcontrol_test.go
@@ -1,6 +1,7 @@
 package husk
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -389,6 +390,99 @@ func TestServeTLSDispatchesDehydrateAndHydrateWorkspace(t *testing.T) {
 	}
 	if agent.untarPath != workspace.WorkspacePath {
 		t.Fatalf("hydrate did not untar into the guest workspace, got %q", agent.untarPath)
+	}
+}
+
+// TestServeTLSKeepAliveMultipleRequests proves the control server serves MORE
+// than one request on a SINGLE authenticated connection: the mTLS handshake and
+// the controller-identity authorization happen ONCE, then two fork-snapshot ops
+// are pipelined request-response on the same conn and BOTH succeed. This is the
+// server half of the controller connection pool: one handshake, many RPCs. It
+// also proves no frame desync across requests, because each result decodes
+// cleanly after the previous one on the shared stream.
+func TestServeTLSKeepAliveMultipleRequests(t *testing.T) {
+	p := newNetTestPKI(t)
+	f := &fakeVMM{}
+	stub := &Stub{state: StateActive, vm: f}
+
+	addr, stop := startServer(t, stub, p)
+	defer stop()
+
+	dialer := &tls.Dialer{Config: p.clientConf(t, p.ctrlCert)}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// A persistent reader for the reused stream: results must decode one line at a
+	// time without over-reading into the next response.
+	br := bufio.NewReader(conn)
+	for i := 0; i < 3; i++ {
+		dir := t.TempDir()
+		if err := WriteControlOp(conn, OpForkSnapshot); err != nil {
+			t.Fatalf("req %d WriteControlOp: %v", i, err)
+		}
+		if err := WriteForkSnapshotRequest(conn, ForkSnapshotRequest{ForkID: "fork", SnapshotDir: dir}); err != nil {
+			t.Fatalf("req %d WriteForkSnapshotRequest: %v", i, err)
+		}
+		res, err := ReadForkSnapshotResultReader(br)
+		if err != nil {
+			t.Fatalf("req %d ReadForkSnapshotResultReader: %v", i, err)
+		}
+		if !res.OK {
+			t.Fatalf("req %d fork-snapshot not OK: %+v", i, res)
+		}
+		// The echoed dir proves this response belongs to THIS request (no desync).
+		if res.SnapshotDir != dir {
+			t.Fatalf("req %d result dir = %q, want %q (frame desync)", i, res.SnapshotDir, dir)
+		}
+	}
+}
+
+// TestServeTLSKeepAliveClosesOnPeerEOF proves a one-shot client stays byte-for-
+// byte compatible: a client that sends a single request and closes drives one
+// iteration, and the server loop then sees EOF and closes without error. The
+// server goroutine must not wedge or panic on the closed connection.
+func TestServeTLSKeepAliveClosesOnPeerEOF(t *testing.T) {
+	p := newNetTestPKI(t)
+	stub := &Stub{state: StateActive, vm: &fakeVMM{}}
+	addr, stop := startServer(t, stub, p)
+	defer stop()
+
+	logged := captureStderr(t, func() {
+		dir := t.TempDir()
+		res, err := func() (ForkSnapshotResult, error) {
+			dialer := &tls.Dialer{Config: p.clientConf(t, p.ctrlCert)}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			conn, derr := dialer.DialContext(ctx, "tcp", addr)
+			if derr != nil {
+				return ForkSnapshotResult{}, derr
+			}
+			defer conn.Close()
+			if werr := WriteControlOp(conn, OpForkSnapshot); werr != nil {
+				return ForkSnapshotResult{}, werr
+			}
+			if werr := WriteForkSnapshotRequest(conn, ForkSnapshotRequest{ForkID: "fork", SnapshotDir: dir}); werr != nil {
+				return ForkSnapshotResult{}, werr
+			}
+			return ReadForkSnapshotResult(conn)
+		}()
+		if err != nil {
+			t.Fatalf("one-shot fork-snapshot: %v", err)
+		}
+		if !res.OK {
+			t.Fatalf("one-shot fork-snapshot not OK: %+v", res)
+		}
+		// Let the server loop observe the peer close and exit its iteration.
+		time.Sleep(50 * time.Millisecond)
+	})
+	// A clean peer close is NOT an error and must not be logged as one.
+	if strings.Contains(logged, "read control op") {
+		t.Fatalf("clean one-shot close logged a read error:\n%s", logged)
 	}
 }
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The husk CONTROL PLANE (controller -> husk pod) carries every husk op: activate, fork-snapshot, spawn-vm, and the workspace hydrate/dehydrate ops, over line-delimited JSON on an mTLS socket.
> - Today `internal/controller/huskclient.go` opens a FRESH mTLS connection PER RPC (full TCP+TLS handshake, one request-response, `defer conn.Close()`), and the husk server (`serveControlConn`) handles exactly ONE request per accepted connection then closes.
> - On prod the co-located fork's two husk RPCs (fork-snapshot then spawn-vm, both to the SAME source pod) each pay their own handshake; the rpcMs-minus-huskLatency GAP is ~82ms of pure connection + framing overhead, the #1 clean lever to cut the ~450ms fork toward sub-100ms (ROADMAP hosted-fork latency).
> - This pull request makes the husk control server serve MANY requests per connection (always on, backward compatible) and adds a controller-side connection POOL that reuses one authenticated connection per husk pod across RPCs, behind a default-off `--husk-conn-reuse` flag so it canaries and rolls back like the other fork flags.
> - The benefit is the co-located fork pays ONE handshake instead of two (and successive activates to a pod reuse the warm connection), removing the ~82ms per-RPC setup overhead from the hot fork path with no change to the auth boundary.

## Linked Issues or Issue Description

No tracking issue. Problem: the husk control channel dials a fresh mTLS connection per RPC, so a single co-located fork pays two full TCP+TLS handshakes to the same source husk pod (a measured ~82ms of the prod fork's rpcMs-minus-huskLatency gap). Connection reuse removes that per-RPC setup overhead.

## What Changed

- **husk server keep-alive (always on, backward compatible):** `serveControlConn` (`internal/husk/netcontrol.go`) now handshakes + authorizes ONCE, then loops read-op / dispatch / write-result on the same connection until the peer closes it, it sits idle past `controlIdleTimeout` (90s), or a framing error desyncs the stream. Dispatch was extracted to `dispatchControlOp` returning whether the frame completed cleanly. A one-shot client is byte-for-byte unchanged (one iteration, then EOF closes).
- **reused-stream decode fix:** added `Read*ResultReader` variants in `internal/husk/control.go` that decode via `readLineReader` (stop at the first newline, keep surplus buffered). The existing `Read*Result` io.Reader forms wrap a per-call `bufio.Scanner` that over-reads and discards surplus, which would corrupt the next read on a reused connection; they stay the one-shot path.
- **controller connection pool (behind `--husk-conn-reuse`, default off):** new `internal/controller/huskconnpool.go` `HuskConnPool` keys a `sync.Map` by husk addr, guards each slot with a per-address mutex (one in-flight request per connection = no frame interleaving), dials once and reuses the authenticated connection, retires it past `huskConnIdle` (30s, shorter than the server's), and re-dials once on any error or husk restart. Its `ActivateHuskPod` / `ForkSnapshotOnHusk` / `SpawnVMOnHusk` / `RemoveForkSnapshotOnHusk` methods match the reconciler seam signatures.
- **wiring:** `SandboxReconciler` gains an exported `HuskConns *HuskConnPool`; the fork/activate/spawn/remove default-injection sites use the pool when it is set (a test fake still wins, nil pool = byte-for-byte one-shot). `cmd/controller/main.go` adds the `--husk-conn-reuse` flag + guard, and Helm gains `controller.huskConnReuse` (values.yaml, schema, deployment arg, enableHuskPods guard) mirroring `liveCowFork`.
- **docs:** `docs/threat-model.md` documents the persistent control-connection surface.

## Verification

- [x] `go build ./...`
- [x] `go test ./internal/husk/... -race -count=1` (incl. the new keep-alive + one-shot-EOF tests)
- [x] `go test ./internal/controller/... -count=1` full envtest suite green (239s); pool tests also run with `-race`
- [x] `golangci-lint run` (darwin) and `GOOS=linux golangci-lint run` both clean on husk, controller, cmd/controller

New tests prove: server handles 2+ requests on one connection and closes cleanly on a one-shot peer EOF without logging an error; the pool reuses one connection for fork-snapshot + spawn-vm (accepts=1), re-dials after a server close and after idle retirement (accepts=2), is concurrent-safe under -race with no frame interleave, enforces mTLS identity (wrong-CA client rejected, no request served), refuses a nil TLS config, and never leaks a secret into an error.

## Risks

Low with the flag off (byte-for-byte the current one-shot dial-per-RPC path; the server keep-alive is backward compatible with one-shot clients). With `--husk-conn-reuse` on, the new surface is a long-lived authenticated controller<->husk socket held between ops, bounded by the idle timeout and the one-in-flight-request-per-connection mutex; a stale/half-closed connection re-dials transparently. mTLS identity is verified on every dial and unchanged for the connection's life, so the auth boundary does not move. Deliberately scoped OUT: the workspace hydrate/dehydrate ops (called deeper in `workspace_binding.go`, not the measured hot path) stay on the one-shot path.

## Model Used

Claude Opus (claude-opus-4-8), extended thinking.

## Checklist

- [x] PR title is a conventional commit
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in
- [x] Tests added for behavior changes, in the same commit
- [x] Docs updated in the same PR (threat-model)
- [x] Threat-model delta included (persistent control-connection surface)
- [ ] Benchmark run: the operator canaries + measures the rpcMs-minus-huskLatency drop and the end-to-end fork on prod (not a local bench)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references
- [x] Every commit carries a Signed-off-by trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental controller option and CLI flag to reuse authenticated mTLS control connections for husk operations (per husk pod), improving efficiency on supported deployments.
  * Helm now exposes the setting, includes schema validation, and errors if enabled without husk pods.

* **Bug Fixes**
  * Improved stability and reliability for repeated husk requests by supporting multi-request control-channel reuse and safer handling of idle/EOF scenarios.

* **Documentation**
  * Updated the threat model to reflect the revised control-connection lifecycle and verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->