### PR TITLE
ci: pin setup-go to 1.26.5 so govuln scans the fixed crypto/tls stdlib

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - run: go build ./...
       - name: Install envtest assets (controller suite needs etcd/kube-apiserver)
         run: echo "KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use 1.31 -p path)" >> "$GITHUB_ENV"
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: golangci-lint
         run: |
           # Build golangci-lint from source with the job's go 1.26 toolchain.
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
@@ -480,7 +480,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: mitos-ci
@@ -756,7 +756,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: Check KVM availability on the runner
         # The kind-e2e runner class has /dev/kvm (proven by the device-plugin
         # e2e in the mock job and by kvm-test.yaml). Record it up front so a
@@ -1910,7 +1910,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: mitos-tenancy
@@ -1973,7 +1973,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: Check KVM availability on the runner
         run: |
           set -euo pipefail
@@ -2143,7 +2143,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: mitos-facade

--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Run unit tests
         run: go test ./internal/fork/... ./internal/volume/... -v


### PR DESCRIPTION
## Thinking Path
govuln is red on main and every open PR on GO-2026-5856 (crypto/tls@go1.26.4). The earlier go.mod `toolchain go1.26.5` bump did not fix it: ci.yaml's `setup-go` uses `go-version: "1.26"` which resolves to 1.26.4 (the failing run prints `GOVERSION='go1.26.4'`), and the toolchain directive is not honored by the govulncheck stdlib scan. So CI keeps building and scanning with the vulnerable 1.26.4 stdlib.

## Changes
- `.github/workflows/ci.yaml` + `kvm-test.yaml`: pin every `setup-go` `go-version` from "1.26" to "1.26.5" (the patched release), so build, test, and govulncheck all use the fixed crypto/tls stdlib. No code change.

## Verification
This PR's own govulncheck runs under 1.26.5 and resolves GO-2026-5856. Repo-wide unblock.

## Model Used
Claude Opus 4.8 (claude-opus-4-8), Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and integration test workflows to use Go 1.26.5 for all Go-based jobs.
  * Standardized the Go version across build, lint, vulnerability check, conformance, and end-to-end test pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->