### PR TITLE
fix(husk): stop copying 512 MiB into the live-cow guest memfd on every warm-claim activate

### DIFF
--- a/bench/husk-activate-latency.sh
+++ b/bench/husk-activate-latency.sh
@@ -70,7 +70,7 @@ samples=()
 cleanup() {
   # best-effort: remove the sandboxes we created so the run leaves no residue.
   for i in $(seq 1 "$ITERATIONS"); do
-    kubectl delete sandbox "bench-activate-${RUN_ID}-${i}" \
+    kubectl delete sandboxes.mitos.run "bench-activate-${RUN_ID}-${i}" \
       -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
   done
 }
@@ -81,7 +81,7 @@ trap cleanup EXIT
 parse_latency() {
   local claim="$1"
   local msg
-  msg="$(kubectl get sandbox "$claim" -n "$NAMESPACE" \
+  msg="$(kubectl get sandboxes.mitos.run "$claim" -n "$NAMESPACE" \
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || true)"
   # message: "activated husk pod <pod> on node <node> in <X>ms"
   printf '%s\n' "$msg" | sed -n 's/.* in \([0-9][0-9.]*\)ms$/\1/p'
@@ -120,7 +120,7 @@ EOF
   deadline=$(( $(date +%s) + READY_TIMEOUT ))
   latency=""
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    ready="$(kubectl get sandbox "$claim" -n "$NAMESPACE" \
+    ready="$(kubectl get sandboxes.mitos.run "$claim" -n "$NAMESPACE" \
       -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
     if [ "$ready" = "True" ]; then
       latency="$(parse_latency "$claim")"
@@ -138,7 +138,7 @@ EOF
 
   # release the sandbox before the next iteration so the warm pool can refill and
   # each measured sandbox is an independent warm activation.
-  kubectl delete sandbox "$claim" -n "$NAMESPACE" \
+  kubectl delete sandboxes.mitos.run "$claim" -n "$NAMESPACE" \
     --ignore-not-found --wait=false >/dev/null 2>&1 || true
 done
 

--- a/bench/results/2026-07-09-lazy-livecow-restore.md
+++ b/bench/results/2026-07-09-lazy-livecow-restore.md
@@ -1,0 +1,92 @@
+# Lazy live-cow restore: warm-claim activate on a real cluster (2026-07-09)
+
+Source for the numbers the m7 lazy-restore change claims. Reproduced with
+[`bench/husk-activate-latency.sh`](../husk-activate-latency.sh), the published
+warm-claim activate harness, against a live Kubernetes cluster with the husk-pods
+path and `--live-cow-fork` enabled.
+
+## Hardware and configuration
+
+| | |
+|---|---|
+| node | `mitos-kvm-1`, Hetzner robot bare metal, Intel i7-6700 (4 cores / 8 threads), 62 GiB RAM |
+| OS | Talos, kernel 6.18 |
+| pool | `python`, template `ghcr.io/mitos-run/mitos-python:v1.13.0`, guest 2 vCPU / 512 MiB, `warm.min: 8` |
+| flags | `--multi-vm-fork --live-cow-fork --live-cow-child-import --prewarm-child --husk-conn-reuse` |
+| command | `bench/husk-activate-latency.sh <kubeconfig> python mitos 11` |
+
+Guest RAM is 512 MiB, so "eager" moves 512 MiB per restore by construction.
+
+## Warm-claim activate latency (ms), N=11
+
+| | eager copy (before) | lazy restore (after) |
+|---|---|---|
+| min | 202.73 | 57.93 |
+| P50 | **212.39** | **76.20** |
+| P95 | 245.87 | 135.48 |
+| max | 245.87 | 135.48 |
+| samples under 100 ms | 0 / 11 | 10 / 11 |
+
+The remaining P95 outlier is warm-pool refill contention: replacing a claimed husk pod
+boots a Firecracker VMM on the same 4 cores that are serving the activate. It is not
+CPU-quota throttling (`cpu.stat: nr_throttled 0` in a claimed husk pod's cgroup).
+
+## Where the time went (husk-stub stage timing, mean of 6 sustained claims)
+
+| stage | eager | lazy |
+|---|---|---|
+| `vmstate_restore` | 195.5 | **12.8** |
+| `guest_ready` | 19.3 | 24.9 |
+| `handshake` | 6.5 | 16.3 |
+| `egress_filter` | 30.9 | 13.3 |
+| `resume` | 0.5 | 1.0 |
+| total | 252.7 | 68.3 |
+
+`vmstate_restore` is the `PUT /snapshot/load` call. Firecracker's own timer agrees:
+`'load snapshot' API request took 194942 us` on the eager path. The cost does not vanish,
+it moves: `guest_ready` and `handshake` now pay for the pages the guest actually touches.
+
+## Memory per active sandbox
+
+Node `Shmem` delta, measured by activating sandboxes one at a time:
+
+| | eager | lazy |
+|---|---|---|
+| 1 active | +512 MiB | +72 MiB |
+| 2 active | +1024 MiB | +144 MiB |
+| 3 active | +1536 MiB | +216 MiB |
+
+Exactly linear either way. The eager copy gave every VM its own private 512 MiB of shmem,
+which is what falsified the "~3 MiB marginal memory per fork via CoW page sharing" claim.
+`memory.current` of a claimed husk pod's cgroup is ~105 MiB on the lazy path.
+
+## Populate granularity
+
+A restoring guest touches SCATTERED pages, so a chunk larger than the access footprint
+copies the whole chunk to satisfy one page. Measured on this node, same harness:
+
+| chunk | faulted in | activate P50 |
+|---|---|---|
+| 2 MiB | ~194 MiB | 114.4 ms |
+| 256 KiB | ~125 MiB | 89.6 ms |
+| **64 KiB** | **~72 MiB** | **76.2 ms** |
+
+A sequential-touch microbenchmark is misleading here: it reports 2 MiB as optimal because
+perfect locality hides the amplification.
+
+## Functional verification alongside the timings
+
+- co-located `fromSandbox` fork: 391 to 615 ms, `1/1 husk forks ready` (eager: 375 to 524 ms;
+  the delta is populate-on-freeze filling the residual chunks, by design)
+- hosted path on `api.mitos.run`: `create -> run_code (42) -> fork -> child run_code
+  ('child-ok 15 3.12.13')`
+- 8/8 warm husk pods Running, 0 restarts
+
+## Caveat on the published headline
+
+The README quotes `~27 ms P50` warm-claim activate for the bare-metal reference node. This
+run does not reproduce that on `mitos-kvm-1`: it reaches 76 ms P50. The gap is now
+`guest_ready` (24.9 ms, mostly demand fault-in, which a hot-page preload before Resume
+would cut) plus `handshake` (16.3 ms, which re-dials vsock because the readiness probe
+closes the connection it just proved healthy) plus `egress_filter` (13.3 ms of process
+startup). Those are tracked as follow-ups; the number above is what this hardware does today.

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -116,6 +116,16 @@ below (a fork of a running source is still `ForkRunning`), and it still pairs wi
 the frozen source rootfs so the disk-half invariant of "Husk fork children" above
 holds unchanged. Live-cow is a memory-SOURCE optimization, not a new fork policy.
 
+Since m7 the restored source's memfd is populated LAZILY: it is created empty and the
+write-protect handler serves userfaultfd MISSING faults out of the snapshot mem file.
+This does not touch any re-seed either, but it adds one obligation to the fork point.
+A co-located child maps the parent memfd `MAP_PRIVATE`, so a page the parent never
+faulted in is a HOLE the child would read as zeros instead of the snapshot's bytes.
+`Freeze` therefore fills every unpopulated chunk from the mem file BEFORE it
+write-protects the region (populate-on-freeze), which keeps warm-claim activate O(1)
+and charges the fill only to the forks that need it. Pages installed after the freeze
+land write-protected, so copy-before-unprotect still sees every parent write.
+
 The hazard this path introduces, and closes, is the RESUMED-PARENT LEAK. Sharing
 the parent's memfd with `MAP_PRIVATE` alone is NOT sufficient: if the parent
 RESUMES and writes a page a child has not yet copied, that post-fork write would

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -589,6 +589,34 @@ Firecracker binary is behavior-identical to stock UNLESS the `FIRECRACKER_MITOS_
 env is set, and only the live-cow path sets it, so a pod with the flag off runs the
 stock VMM.
 
+**m7 lazy restore (guest memory is populated on demand).** A restored source used to
+get its guest RAM by COPYING the whole snapshot mem file into the shared memfd inside
+`PUT /snapshot/load`. The memfd is now created EMPTY and the same WP handler serves
+userfaultfd MISSING faults out of the mem file, so only the pages a guest touches are
+ever materialized. Three properties keep this from widening the surface:
+
+- The mem file the handler reads is the SAME snapshot the verify-on-activate gate
+  already checked (digest + snapcompat) before the load, so a MISSING fault can only
+  ever install bytes from an already-trusted image. The handler opens it read-only.
+- A page installed AFTER the freeze lands write-protected (`UFFDIO_COPY_MODE_WP`), so
+  the copy-before-unprotect invariant holds for pages that arrive late. The residual
+  chunks a parent never faulted in are filled AT the fork point (populate-on-freeze),
+  before the region is write-protected, so a co-located child never reads a hole (which
+  would be zeros, not the snapshot's bytes) through its `MAP_PRIVATE` view of the memfd.
+- FAIL CLOSED both ways: the patched VMM takes the lazy path only when the husk sets
+  BOTH `FIRECRACKER_MITOS_LAZY_RESTORE` and `FIRECRACKER_MITOS_WP_UDS`, and it ABORTS
+  the restore (`MitosLazyArmFailed`) rather than resuming vCPUs on all-zero guest RAM
+  if the handler does not arm. The stub likewise fails the activate if it cannot open
+  the mem source before the load. An older husk paired with the patched binary keeps
+  the eager copy.
+
+The kernel permits ONE userfaultfd per VMA, so MISSING and WRITE_PROTECT are registered
+on the SAME uffd (negotiating `UFFD_FEATURE_MISSING_SHMEM`, without which the kernel
+silently never delivers a MISSING fault on a shmem mapping and the guest would read the
+zero page). No new capability, socket, or file is introduced: it reuses the existing
+per-VM `FIRECRACKER_MITOS_WP_UDS` handshake and the `/dev/userfaultfd` device the kvm
+device plugin already injects on a live-cow pool.
+
 The new component is the parent-side write-protect fork handler on the forkd/husk
 side (`internal/fork/wpfork*.go`, a Go port of the m2 reference C handler). At a
 fork point the patched parent Firecracker creates a userfaultfd over ITS OWN live

--- a/hack/install-firecracker-patched.sh
+++ b/hack/install-firecracker-patched.sh
@@ -12,11 +12,22 @@
 #     byte-for-byte unchanged, so the image behaves like stock until those gates are
 #     used. Installing it everywhere is safe.
 #   - Provenance: built reproducibly in mitos-run/firecracker on branch
-#     mitos/child-memfd-import-v1.15.0 via .github/workflows/build-patched-fc.yml
-#     (green run https://github.com/mitos-run/firecracker/actions/runs/28915829813)
+#     mitos/lazy-restore-v1.15.0 via .github/workflows/build-patched-fc.yml
+#     (green run https://github.com/mitos-run/firecracker/actions/runs/29022392083)
 #     and published as a GitHub release asset, pinned by sha256 below. A compromised
-#     CDN or a network substitution cannot install a different binary. This binary
-#     adds the m5 child-side memfd import (issue #832): a co-located fork child that
+#     CDN or a network substitution cannot install a different binary.
+#
+#     This binary ALSO carries m7, the LAZY live-cow restore: guest_memory_from_file
+#     no longer COPIES the mem file into the shared memfd inside PUT /snapshot/load
+#     (which cost ~195ms of a ~218ms warm-claim activate on a 512 MiB guest, and gave
+#     every VM its own private 512 MiB of shmem). The memfd is created EMPTY and the
+#     husk's WP handler serves userfaultfd MISSING faults out of the mem file. The
+#     lazy path needs FIRECRACKER_MITOS_LAZY_RESTORE (which the husk sets only once it
+#     has opened a mem source) alongside FIRECRACKER_MITOS_WP_UDS, so an OLDER husk
+#     paired with this binary keeps the eager copy, and a failed arm aborts the restore
+#     rather than resuming vCPUs on all-zero guest RAM.
+#
+#     It also adds the m5 child-side memfd import (issue #832): a co-located fork child that
 #     is launched with FIRECRACKER_MITOS_CHILD_MEMFD boots its guest RAM by copying
 #     the source guest memfd's fork-time image into ANONYMOUS private RAM (divorced
 #     from the live memfd) plus the frozen overlay, and loads NO disk mem file, so the
@@ -38,8 +49,8 @@ set -euo pipefail
 
 # --- single pinned provenance constants (audit + bump only here) -------------
 PATCHED_FC_VERSION="v1.15.0"
-PATCHED_FC_URL="https://github.com/mitos-run/firecracker/releases/download/mitos-fc-child-memfd-import-v1.15.0-2/firecracker-v1.15.0-x86_64-mitos-child-memfd-import"
-PATCHED_FC_SHA256="7d02b374a5a60a59c39842733305ce719f6fa42c64f3f180a13a5d70dc515272"
+PATCHED_FC_URL="https://github.com/mitos-run/firecracker/releases/download/mitos-fc-lazy-restore-v1.15.0/firecracker-v1.15.0-x86_64-mitos-lazy-restore"
+PATCHED_FC_SHA256="d341a8f3be0e0390e4080767946f2180f86eae267e6110c102cda537f60cad2f"
 # -----------------------------------------------------------------------------
 
 arch="$(uname -m)"

--- a/internal/fork/lazychunk_test.go
+++ b/internal/fork/lazychunk_test.go
@@ -1,0 +1,44 @@
+package fork
+
+import "testing"
+
+// lazyChunkForAddr must align to the 2 MiB populate granularity WITHIN a region and
+// clip at the region end: a chunk that straddled two regions would UFFDIO_COPY into
+// the wrong region's host addresses, and one that ran past the region end would read
+// past that region's slice of the mem file.
+func TestLazyChunkForAddr(t *testing.T) {
+	regions := []uffdMapping{
+		{BaseHostVirtAddr: 0x1000_0000, Size: 3 * lazyChunkBytes, Offset: 0},
+		// Second region is deliberately NOT chunk-aligned in size.
+		{BaseHostVirtAddr: 0x9000_0000, Size: lazyChunkBytes + 4096, Offset: 3 * lazyChunkBytes},
+	}
+	cases := []struct {
+		name                    string
+		addr                    uint64
+		dst, fileOffset, length uint64
+		ok                      bool
+	}{
+		{"region start", 0x1000_0000, 0x1000_0000, 0, lazyChunkBytes, true},
+		{"mid first chunk", 0x1000_0000 + 4096, 0x1000_0000, 0, lazyChunkBytes, true},
+		{"second chunk", 0x1000_0000 + lazyChunkBytes + 8, 0x1000_0000 + lazyChunkBytes, lazyChunkBytes, lazyChunkBytes, true},
+		{"second region carries its file offset", 0x9000_0000, 0x9000_0000, 3 * lazyChunkBytes, lazyChunkBytes, true},
+		{"tail chunk clipped to region end", 0x9000_0000 + lazyChunkBytes, 0x9000_0000 + lazyChunkBytes, 4 * lazyChunkBytes, 4096, true},
+		{"below every region", 0x0fff_ffff, 0, 0, 0, false},
+		{"above every region", 0x9000_0000 + lazyChunkBytes + 4096, 0, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst, off, ln, ok := lazyChunkForAddr(regions, tc.addr)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if dst != tc.dst || off != tc.fileOffset || ln != tc.length {
+				t.Errorf("got dst=%#x off=%#x len=%#x; want dst=%#x off=%#x len=%#x",
+					dst, off, ln, tc.dst, tc.fileOffset, tc.length)
+			}
+		})
+	}
+}

--- a/internal/fork/uffd.go
+++ b/internal/fork/uffd.go
@@ -100,10 +100,11 @@ func hostAddrForFileOffset(regions []uffdMapping, fileOffset uint64) (hostAddr u
 // ~88 ms faulting in ~194 MiB for a far smaller working set, which merely moved the
 // eager copy's cost out of vmstate_restore and into guest_ready + handshake.
 //
-// Measured on the reference node against the real python template: 2 MiB chunks
-// faulted in ~194 MiB and cost ~88 ms; 256 KiB faulted in ~125 MiB and cost ~54 ms.
-// 64 KiB (16 pages) trims amplification further while keeping the per-fault copy
-// (~14 us) close to the round-trip cost.
+// Measured on the reference node against the real python template, as warm-claim
+// activate P50 (bench/results/2026-07-09-lazy-livecow-restore.md): 2 MiB faulted in
+// ~194 MiB at 114.4 ms, 256 KiB ~125 MiB at 89.6 ms, 64 KiB ~72 MiB at 76.2 ms.
+// 64 KiB (16 pages) trims amplification while keeping the per-fault copy (~14 us)
+// close to the round-trip cost.
 const lazyChunkBytes = 64 << 10
 
 // lazyChunkForAddr expands a faulting host address into the chunk the handler should

--- a/internal/fork/uffd.go
+++ b/internal/fork/uffd.go
@@ -89,3 +89,42 @@ func hostAddrForFileOffset(regions []uffdMapping, fileOffset uint64) (hostAddr u
 	}
 	return 0, false
 }
+
+// lazyChunkBytes is the granularity the live-cow lazy restore populates guest RAM at.
+//
+// It trades round trips against write amplification. A MISSING fault costs a
+// userspace round trip (~6 us), so serving one 4 KiB page per fault would take ~131k
+// round trips to fill a 512 MiB guest. But a restoring guest touches pages
+// SCATTERED across its address space, not sequentially, so a chunk that is too large
+// copies the whole chunk to satisfy a single page: at 2 MiB the prod activate spent
+// ~88 ms faulting in ~194 MiB for a far smaller working set, which merely moved the
+// eager copy's cost out of vmstate_restore and into guest_ready + handshake.
+//
+// Measured on the reference node against the real python template: 2 MiB chunks
+// faulted in ~194 MiB and cost ~88 ms; 256 KiB faulted in ~125 MiB and cost ~54 ms.
+// 64 KiB (16 pages) trims amplification further while keeping the per-fault copy
+// (~14 us) close to the round-trip cost.
+const lazyChunkBytes = 64 << 10
+
+// lazyChunkForAddr expands a faulting host address into the chunk the handler should
+// populate: the lazyChunkBytes-aligned span (in the CONTAINING region's coordinates)
+// that covers addr, clipped to the region end so a chunk never straddles two regions
+// or reads past the mem file's mapping of that region.
+//
+// It returns the host address to UFFDIO_COPY into, the mem-file offset to read from,
+// and the length. ok is false when addr lies outside every registered region.
+func lazyChunkForAddr(regions []uffdMapping, addr uint64) (dst uint64, fileOffset uint64, length uint64, ok bool) {
+	for _, r := range regions {
+		if r.Size == 0 || addr < r.BaseHostVirtAddr || addr >= r.BaseHostVirtAddr+r.Size {
+			continue
+		}
+		inRegion := addr - r.BaseHostVirtAddr
+		start := (inRegion / lazyChunkBytes) * lazyChunkBytes
+		length = lazyChunkBytes
+		if start+length > r.Size {
+			length = r.Size - start
+		}
+		return r.BaseHostVirtAddr + start, r.Offset + start, length, true
+	}
+	return 0, 0, 0, false
+}

--- a/internal/fork/wpfork.go
+++ b/internal/fork/wpfork.go
@@ -215,6 +215,27 @@ func frozenBitmapBytes(memSize, pageSize uint64) uint64 {
 	return (npages + 7) / 8
 }
 
+// setBit and testBit are the plain bit primitives the handler's two bitmaps share:
+// the per-page FROZEN selector and the per-chunk POPULATED map of the lazy restore.
+// They carry no epoch or fork semantics, so a reader cannot mistake "populated" for
+// "frozen". Out-of-range indices are ignored (defensive: a fault outside the mapped
+// range is a fault the handler skips).
+func setBit(bm []byte, i uint64) {
+	byteIdx := i / 8
+	if byteIdx >= uint64(len(bm)) {
+		return
+	}
+	bm[byteIdx] |= 1 << (i % 8)
+}
+
+func testBit(bm []byte, i uint64) bool {
+	byteIdx := i / 8
+	if byteIdx >= uint64(len(bm)) {
+		return false
+	}
+	return bm[byteIdx]&(1<<(i%8)) != 0
+}
+
 // setFrozenBit marks page index i frozen in bm. Out-of-range indices are ignored
 // (defensive: a fault outside the mapped range is a fault the handler skips).
 func setFrozenBit(bm []byte, i uint64) {

--- a/internal/fork/wpfork.go
+++ b/internal/fork/wpfork.go
@@ -28,8 +28,14 @@ type WPForkHandle interface {
 	// Freeze write-protects the whole guest region at the fork point and returns
 	// how long that took (the parent-pause contributor). Resume the parent after.
 	Freeze() (time.Duration, error)
-	// Serve runs the write-protect fault loop until Close.
+	// Serve runs the write-protect fault loop until Close. On a lazily restored
+	// source it also serves MISSING faults out of the mem source.
 	Serve() error
+	// SetMemSource points the handler at the snapshot mem file a LAZILY restored
+	// source pulls its guest RAM from. It MUST be called before the source loads the
+	// snapshot. Failing to call it while Firecracker was launched with
+	// EnvLazyRestore leaves the guest with empty RAM, so callers fail closed.
+	SetMemSource(path string) error
 	// FrozenFd returns the descriptor of the private FROZEN memfd a co-located
 	// child MAP_PRIVATEs (with the frozen bitmap) to read clobbered pages at their
 	// fork-time value. -1 before Receive.
@@ -131,6 +137,13 @@ const (
 	// Firecracker CONNECTS to, over which Firecracker sends the uffd + region
 	// layout via SCM_RIGHTS (m2).
 	EnvWPUDS = "FIRECRACKER_MITOS_WP_UDS"
+	// EnvLazyRestore opts the patched Firecracker into the LAZY live-cow restore:
+	// guest RAM comes back as an EMPTY shared memfd and every page is pulled from the
+	// snapshot mem file on a userfaultfd MISSING fault, instead of the eager
+	// O(guest RAM) copy that ran inside PUT /snapshot/load. Firecracker requires BOTH
+	// this and EnvWPUDS, so a husk that cannot serve MISSING faults (an older build,
+	// or one that failed to open the mem source) keeps the eager copy.
+	EnvLazyRestore = "FIRECRACKER_MITOS_LAZY_RESTORE"
 )
 
 // WPForkConfig configures the parent-side live-cow fork handler. UDSPath is the
@@ -157,6 +170,9 @@ func LiveCowParentEnv(wpUDS, memExport string) []string {
 		EnvSharedMem + "=1",
 		EnvSharedMemExport + "=" + memExport,
 		EnvWPUDS + "=" + wpUDS,
+		// The stub calls WPForkHandle.SetMemSource before it loads the snapshot, and
+		// fails the activate if it cannot, so the handler can always serve MISSING.
+		EnvLazyRestore + "=1",
 	}
 }
 

--- a/internal/fork/wpfork_lazy_kvm_test.go
+++ b/internal/fork/wpfork_lazy_kvm_test.go
@@ -155,6 +155,9 @@ func TestLiveCowLazyRestoreServesMissingAndFillsResidualOnFreeze(t *testing.T) {
 	if skip {
 		t.Skipf("lazy-restore precondition not met on this runner: %s", reason)
 	}
+	// sendUffd hands the handler a DUPLICATE via SCM_RIGHTS; this descriptor stays
+	// ours, so close it or the KVM suite leaks one fd per run.
+	defer unix.Close(uffd)
 	base := uint64(uintptr(unsafe.Pointer(&guest[0])))
 	if !registerMissingWP(t, uffd, base, size) {
 		t.Skip("lazy-restore precondition not met: MISSING|WP register failed over the memfd mapping")

--- a/internal/fork/wpfork_lazy_kvm_test.go
+++ b/internal/fork/wpfork_lazy_kvm_test.go
@@ -1,0 +1,248 @@
+//go:build linux
+
+package fork
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// featMissingShmem is UFFD_FEATURE_MISSING_SHMEM (1<<5). Without negotiating it
+	// the kernel NEVER delivers MISSING faults for a shmem (memfd) VMA: the read is
+	// silently satisfied by the zero page. That would leave a lazily restored guest
+	// running on zeroed RAM with no fault to tell anyone, so the lazy restore is
+	// only ever armed when this feature is granted.
+	featMissingShmem = 0x20
+	// uffdioCopyBit is _UFFDIO_COPY, the bit the kernel sets in reg.ioctls when the
+	// range supports UFFDIO_COPY (how the handler installs a faulting page).
+	// registerModeMissing (UFFDIO_REGISTER_MODE_MISSING) comes from childuffd_linux_test.go.
+	uffdioCopyBit = 0x03
+)
+
+// createLazyUffd builds a userfaultfd that can serve BOTH the lazy restore's MISSING
+// faults and the live-cow freezer's WP faults over one shmem mapping, which is the
+// registration the patched Firecracker performs on a lazily restored source. The
+// kernel permits exactly one uffd per VMA, so MISSING and WP must share it.
+func createLazyUffd(t *testing.T) (int, bool, string) {
+	t.Helper()
+	probe, _, errno := unix.Syscall(unix.SYS_USERFAULTFD, uintptr(unix.O_CLOEXEC|unix.O_NONBLOCK|uffdUserModeOnly), 0, 0)
+	if errno != 0 {
+		return -1, true, fmt.Sprintf("userfaultfd() unavailable (errno %v)", errno)
+	}
+	pfd := int(probe)
+	q := uffdioAPIArg{API: uffdAPIVersion}
+	if _, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(pfd), uintptr(uffdioAPICmd), uintptr(unsafe.Pointer(&q))); e != 0 {
+		_ = unix.Close(pfd)
+		return -1, true, fmt.Sprintf("UFFDIO_API query failed (errno %v)", e)
+	}
+	_ = unix.Close(pfd)
+	if q.Features&featPagefaultFlagWP == 0 || q.Features&featMissingShmem == 0 {
+		return -1, true, fmt.Sprintf("kernel lacks PAGEFAULT_FLAG_WP|MISSING_SHMEM (mask 0x%x)", q.Features)
+	}
+
+	fd, _, errno := unix.Syscall(unix.SYS_USERFAULTFD, uintptr(unix.O_CLOEXEC|unix.O_NONBLOCK|uffdUserModeOnly), 0, 0)
+	if errno != 0 {
+		return -1, true, fmt.Sprintf("userfaultfd() (real) errno %v", errno)
+	}
+	api := uffdioAPIArg{API: uffdAPIVersion, Features: featPagefaultFlagWP | featMissingShmem}
+	if _, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(int(fd)), uintptr(uffdioAPICmd), uintptr(unsafe.Pointer(&api))); e != 0 {
+		_ = unix.Close(int(fd))
+		return -1, true, fmt.Sprintf("UFFDIO_API requesting WP|MISSING_SHMEM failed (errno %v)", e)
+	}
+	return int(fd), false, ""
+}
+
+func registerMissingWP(t *testing.T, uffd int, addr, length uint64) bool {
+	t.Helper()
+	reg := uffdioRegisterArg{Start: addr, Len: length, Mode: registerModeMissing | registerModeWP}
+	if _, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(uffd), uintptr(uffdioRegisterCmd), uintptr(unsafe.Pointer(&reg))); e != 0 {
+		t.Logf("UFFDIO_REGISTER MISSING|WP failed (errno %v)", e)
+		return false
+	}
+	if reg.Ioctls&(1<<uffdioCopyBit) == 0 || reg.Ioctls&(1<<uffdioWriteprotectBit) == 0 {
+		t.Logf("range offers ioctls 0x%x; need UFFDIO_COPY and UFFDIO_WRITEPROTECT", reg.Ioctls)
+		return false
+	}
+	return true
+}
+
+// TestLiveCowLazyRestoreServesMissingAndFillsResidualOnFreeze is the correctness gate
+// for the LAZY live-cow restore, driven over a real userfaultfd + memfd.
+//
+// The lazy restore replaces the eager O(guest RAM) copy that ran inside
+// PUT /snapshot/load (~195 ms of a 218 ms warm-claim activate on a 512 MiB guest)
+// with an EMPTY shared memfd whose pages arrive on MISSING faults. Two properties
+// have to hold or a guest runs on wrong memory:
+//
+//	POPULATION: a MISSING fault installs the snapshot's bytes for that chunk, so the
+//	    guest reads its snapshot RAM and not the zero page.
+//	RESIDUAL-ON-FREEZE: a co-located fork child maps the parent's memfd MAP_PRIVATE,
+//	    so any chunk the parent never faulted in would be a HOLE the child reads as
+//	    ZEROS. Freeze (the fork point) must fill every unpopulated chunk first, so the
+//	    child sees the whole snapshot. Filling there, rather than at restore, is what
+//	    keeps warm-claim activate O(1) and charges the fill to forks only.
+//
+// It also asserts the pre-existing m2 invariant still holds on the lazy path: a
+// post-freeze parent write is captured at its fork-time value.
+func TestLiveCowLazyRestoreServesMissingAndFillsResidualOnFreeze(t *testing.T) {
+	requireKVMCIRunner(t)
+
+	// Two full chunks plus a short tail, so residual-fill has real work after only
+	// the first chunk is demand-faulted, and the tail exercises the region clip.
+	const pageSize = 4096
+	size := uint64(2*lazyChunkBytes + pageSize)
+
+	// --- The snapshot mem file: every page carries a distinct, non-zero pattern, so
+	// a page served from the zero page (or from the wrong offset) is unmistakable. ---
+	dir := t.TempDir()
+	memPath := filepath.Join(dir, "mem")
+	want := make([]byte, size)
+	for off := uint64(0); off < size; off += pageSize {
+		fill := byte((off/pageSize)%251 + 1) // never 0
+		for i := off; i < off+pageSize && i < size; i++ {
+			want[i] = fill
+		}
+	}
+	if err := os.WriteFile(memPath, want, 0o600); err != nil {
+		t.Fatalf("write mem file: %v", err)
+	}
+
+	// --- Stand in for the patched Firecracker: guest RAM is an EMPTY MAP_SHARED
+	// memfd (snapshot_memfd_lazy), not a copy of the mem file. ---
+	guestFd, err := unix.MemfdCreate("mitos-guest-ram-lazy", unix.MFD_CLOEXEC)
+	if err != nil {
+		t.Fatalf("memfd_create guest: %v", err)
+	}
+	defer unix.Close(guestFd)
+	if err := unix.Ftruncate(guestFd, int64(size)); err != nil {
+		t.Fatalf("ftruncate guest: %v", err)
+	}
+	guest, err := unix.Mmap(guestFd, 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap guest: %v", err)
+	}
+	defer unix.Munmap(guest)
+
+	exportPath := filepath.Join(dir, "memfd_export")
+	if err := os.WriteFile(exportPath, []byte(fmt.Sprintf("%d %d %d\n", os.Getpid(), guestFd, size)), 0o600); err != nil {
+		t.Fatalf("write export: %v", err)
+	}
+	udsPath := filepath.Join(dir, "wp.sock")
+
+	handle, err := StartWPForkHandler(WPForkConfig{UDSPath: udsPath, MemExportPath: exportPath})
+	if err != nil {
+		t.Fatalf("StartWPForkHandler: %v", err)
+	}
+	defer handle.Close()
+
+	// The husk does this before the source loads the snapshot; without it the handler
+	// cannot serve a MISSING fault and the guest would hang.
+	if err := handle.SetMemSource(memPath); err != nil {
+		t.Fatalf("SetMemSource: %v", err)
+	}
+
+	uffd, skip, reason := createLazyUffd(t)
+	if skip {
+		t.Skipf("lazy-restore precondition not met on this runner: %s", reason)
+	}
+	base := uint64(uintptr(unsafe.Pointer(&guest[0])))
+	if !registerMissingWP(t, uffd, base, size) {
+		t.Skip("lazy-restore precondition not met: MISSING|WP register failed over the memfd mapping")
+	}
+
+	body, err := json.Marshal([]uffdMapping{{
+		BaseHostVirtAddr: base, Size: size, Offset: 0, PageSize: pageSize,
+	}})
+	if err != nil {
+		t.Fatalf("marshal mappings: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var recvErr error
+	go func() {
+		defer wg.Done()
+		recvErr = handle.Receive()
+	}()
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: udsPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("dial wp uds: %v", err)
+	}
+	sendUffd(t, conn, body, uffd)
+	wg.Wait()
+	if recvErr != nil {
+		t.Fatalf("Receive: %v", recvErr)
+	}
+	go func() { _ = handle.Serve() }()
+
+	// --- POPULATION: touch ONE page. It must fault MISSING and come back with the
+	// mem file's bytes for the whole surrounding chunk. ---
+	if got := guest[pageSize]; got != want[pageSize] {
+		t.Fatalf("demand-faulted page = %#x, want %#x (served from the zero page?)", got, want[pageSize])
+	}
+	for i := uint64(0); i < lazyChunkBytes; i += pageSize {
+		if guest[i] != want[i] {
+			t.Fatalf("chunk 0 offset %#x = %#x, want %#x", i, guest[i], want[i])
+		}
+	}
+	lazyHandle, ok := handle.(*wpForkHandler)
+	if !ok {
+		t.Fatalf("handle is %T, want *wpForkHandler", handle)
+	}
+	if n := lazyHandle.MissingFaultCount(); n != 1 {
+		t.Fatalf("MissingFaultCount = %d after touching one chunk, want exactly 1 (2 MiB chunking)", n)
+	}
+
+	// --- RESIDUAL-ON-FREEZE: chunks 1 and 2 were never touched. Freeze must fill them
+	// from the mem file, or a co-located child MAP_PRIVATEing this memfd reads zeros. ---
+	if _, err := handle.Freeze(); err != nil {
+		t.Fatalf("Freeze: %v", err)
+	}
+	// Read through a SECOND, uffd-UNregistered mapping of the same memfd: this is
+	// exactly what the child does (it maps the parent's memfd), so it proves the child's
+	// view is complete rather than proving our own faults get served.
+	childView, err := unix.Mmap(guestFd, 0, int(size), unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("mmap child view: %v", err)
+	}
+	defer unix.Munmap(childView)
+	for off := uint64(0); off < size; off += pageSize {
+		if childView[off] != want[off] {
+			t.Fatalf("child view offset %#x = %#x, want %#x: residual chunk was NOT filled at the fork point",
+				off, childView[off], want[off])
+		}
+	}
+	if n := lazyHandle.MissingFaultCount(); n != 1 {
+		t.Errorf("MissingFaultCount = %d; residual fill must not go through MISSING faults", n)
+	}
+
+	// --- m2 invariant still holds on the lazy path: a post-freeze parent write is
+	// captured at its fork-time value in the frozen epoch. ---
+	origPage0 := want[0]
+	guest[0] = 0xEE
+	deadline := time.Now().Add(5 * time.Second)
+	for !lazyHandle.FrozenPage(0) && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !lazyHandle.FrozenPage(0) {
+		t.Fatal("parent wrote page 0 after the freeze but the handler never captured it")
+	}
+	frozen, err := unix.Mmap(lazyHandle.FrozenFd(), 0, int(size), unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("mmap frozen: %v", err)
+	}
+	defer unix.Munmap(frozen)
+	if frozen[0] != origPage0 {
+		t.Errorf("frozen page 0 = %#x, want the fork-time byte %#x (parent's post-fork write leaked)", frozen[0], origPage0)
+	}
+}

--- a/internal/fork/wpfork_linux.go
+++ b/internal/fork/wpfork_linux.go
@@ -47,8 +47,21 @@ const (
 	// 1<<0). Mode 0 removes write-protection and wakes any blocked writer.
 	writeprotectModeWP = 0x1
 	// uffdPagefaultFlagWP (UFFD_PAGEFAULT_FLAG_WP, 1<<1) tags a delivered fault as
-	// a write-protect fault (vs a MISSING fault). The handler only services these.
+	// a write-protect fault (vs a MISSING fault). A handler without a mem source
+	// services only these; the live-cow LAZY restore also services MISSING faults.
 	uffdPagefaultFlagWP = 0x2
+
+	// UFFDIO_COPY (uffdioCopy, uffd_linux.go) installs pages into the FAULTING
+	// process's mapping (the uffd's owner, i.e. Firecracker) from a buffer in THIS
+	// process, and wakes any thread blocked on that range.
+	//
+	// copyModeDontwake (UFFDIO_COPY_MODE_DONTWAKE, 1<<0): install without waking,
+	// used to pre-populate pages that no thread is currently blocked on.
+	copyModeDontwake = 0x1
+	// copyModeWP (UFFDIO_COPY_MODE_WP, 1<<1): install the page already
+	// write-protected. Required once the region is frozen, so a page that arrives
+	// AFTER the freeze cannot be written by the parent without a WP fault first.
+	copyModeWP = 0x2
 )
 
 // uffdioWriteprotectArg mirrors struct uffdio_writeprotect: a {start,len} range
@@ -122,6 +135,27 @@ type wpForkHandler struct {
 	// freezeNanos records how long the fork-point UFFDIO_WRITEPROTECT-all took
 	// (the parent-pause contributor the m2 design measures).
 	freezeNanos int64
+
+	// --- live-cow LAZY restore (populate guest RAM on demand) ---
+	// memSrc is the snapshot mem file a lazily restored source's guest RAM is pulled
+	// from. Nil for a BOOTED source (its pages are freshly allocated and resident, so
+	// Firecracker registers WP only and no MISSING fault is ever delivered).
+	memSrc *os.File
+	// populatedBM is a 1-bit-per-lazyChunkBytes map of which chunks have been
+	// installed into the guest mapping. UFFDIO_COPY on an already-present page fails
+	// with EEXIST, and Freeze needs to know what is left to fill, so track it.
+	populatedBM []byte
+	// memMap is the snapshot mem file mmap'd read-only. UFFDIO_COPY reads its source
+	// straight out of this mapping (i.e. out of the file's page cache), so a faulting
+	// page costs ONE copy into the guest memfd instead of a pread into a staging
+	// buffer followed by a second copy out of it.
+	memMap []byte
+	// frozen is set once Freeze has write-protected the region. A page installed
+	// after that MUST land write-protected (copyModeWP) or the parent could write it
+	// without the copy-before-unprotect handler ever seeing the write.
+	frozen bool
+	// missingServed counts MISSING faults populated from the mem file.
+	missingServed int64
 }
 
 // newWPForkHandler binds the write-protect handshake unix socket the caller
@@ -210,6 +244,11 @@ func (h *wpForkHandler) Receive() error {
 	h.live = live
 	h.liveSize = exp.bytes
 	h.pageSize = pageSize
+	// One bit per lazyChunkBytes of guest RAM, used by the lazy restore to know which
+	// chunks are already installed (UFFDIO_COPY on a present page returns EEXIST) and
+	// which the fork point still has to fill. Sized from the live memfd, so it covers
+	// every region's mem-file offset. Harmless (and unread) for a booted source.
+	h.populatedBM = make([]byte, (exp.bytes/lazyChunkBytes+8)/8+1)
 	h.mu.Unlock()
 	return nil
 }
@@ -380,6 +419,18 @@ func (h *wpForkHandler) Freeze() (time.Duration, error) {
 		return 0, err
 	}
 	start := time.Now()
+	// POPULATE-ON-FREEZE. A lazily restored source's memfd is sparse: any page the
+	// guest never touched is a hole. The co-located child MAP_PRIVATEs this memfd, so
+	// it would read those holes as zeros instead of the snapshot's bytes. Fill them
+	// before the fork point captures the memory. Runs with the source paused, so no
+	// fault can race it. A booted source has no mem source and this is a no-op.
+	h.mu.Lock()
+	perr := h.populateResidual()
+	h.mu.Unlock()
+	if perr != nil {
+		ep.close()
+		return 0, perr
+	}
 	for _, r := range regions {
 		if err := h.writeprotect(r.BaseHostVirtAddr, r.Size, true); err != nil {
 			ep.close()
@@ -388,6 +439,8 @@ func (h *wpForkHandler) Freeze() (time.Duration, error) {
 	}
 	d := time.Since(start)
 	h.mu.Lock()
+	// Any chunk installed from here on must land write-protected.
+	h.frozen = true
 	h.epochs = append(h.epochs, ep)
 	h.mu.Unlock()
 	atomic.StoreInt64(&h.freezeNanos, d.Nanoseconds())
@@ -442,6 +495,7 @@ func (h *wpForkHandler) Serve() error {
 	if uffdFile == nil {
 		return fmt.Errorf("wpfork: Serve before handshake")
 	}
+	lazy := h.lazyEnabled()
 	var msg uffdMsg
 	msgBuf := (*[unsafe.Sizeof(msg)]byte)(unsafe.Pointer(&msg))[:]
 	for {
@@ -464,8 +518,17 @@ func (h *wpForkHandler) Serve() error {
 			continue
 		}
 		if msg.PfFlags&uffdPagefaultFlagWP == 0 {
-			// Not a write-protect fault: nothing was registered MISSING, so this
-			// should not happen. Ignore rather than mis-serve.
+			// A MISSING fault. On a LAZILY restored source this is the normal path:
+			// populate the chunk out of the snapshot mem file, which unblocks the
+			// faulting vCPU. On a booted source nothing is registered MISSING, so a
+			// fault here means the kernel and our registration disagree; ignoring it
+			// would hang the faulting thread, so surface it.
+			if !lazy {
+				return fmt.Errorf("wpfork: MISSING fault at %#x on a handler with no mem source", msg.PfAddress)
+			}
+			if err := h.serveMissing(msg.PfAddress); err != nil {
+				return err
+			}
 			continue
 		}
 		if err := h.serveFault(msg.PfAddress); err != nil {
@@ -673,6 +736,14 @@ func (h *wpForkHandler) Close() error {
 		_ = unix.Close(h.uffd)
 		h.uffd = -1
 	}
+	if h.memMap != nil {
+		_ = unix.Munmap(h.memMap)
+		h.memMap = nil
+	}
+	if h.memSrc != nil {
+		_ = h.memSrc.Close()
+		h.memSrc = nil
+	}
 	if h.live != nil {
 		_ = unix.Munmap(h.live)
 		h.live = nil
@@ -686,3 +757,153 @@ func (h *wpForkHandler) Close() error {
 	_ = os.Remove(h.cfg.UDSPath)
 	return nil
 }
+
+// SetMemSource points the handler at the snapshot mem file a LAZILY restored source
+// pulls its guest RAM from. It MUST be called before the parent Firecracker loads
+// the snapshot (the patched binary connects during guest-memory setup and starts
+// faulting immediately), and it is what makes the husk pass
+// FIRECRACKER_MITOS_LAZY_RESTORE so Firecracker skips the eager memfd copy.
+//
+// A BOOTED source never calls this: its pages are resident, Firecracker registers
+// WRITE_PROTECT only, and no MISSING fault is delivered.
+func (h *wpForkHandler) SetMemSource(path string) error {
+	if path == "" {
+		return fmt.Errorf("wpfork: empty mem source path")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("wpfork: open mem source %s: %w", path, err)
+	}
+	st, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("wpfork: stat mem source %s: %w", path, err)
+	}
+	if st.Size() == 0 {
+		_ = f.Close()
+		return fmt.Errorf("wpfork: empty mem source %s", path)
+	}
+	// Read-only private mapping of the mem file: the UFFDIO_COPY source. The kernel
+	// copies from these page-cache pages directly into the guest memfd.
+	m, err := unix.Mmap(int(f.Fd()), 0, int(st.Size()), unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("wpfork: mmap mem source %s: %w", path, err)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.memMap != nil {
+		_ = unix.Munmap(h.memMap)
+	}
+	if h.memSrc != nil {
+		_ = h.memSrc.Close()
+	}
+	h.memSrc = f
+	h.memMap = m
+	return nil
+}
+
+// lazyEnabled reports whether this handler populates guest RAM on demand.
+func (h *wpForkHandler) lazyEnabled() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.memSrc != nil
+}
+
+// uffdCopy installs len bytes from src (this process) at dst (Firecracker's mapping)
+// through the uffd, with the given UFFDIO_COPY mode. EEXIST means the page raced in
+// already, which is benign: the content is identical (both come from the mem file).
+func (h *wpForkHandler) uffdCopy(uffd int, dst uint64, src []byte, mode uint64) error {
+	arg := uffdioCopyArg{
+		Dst:  dst,
+		Src:  uint64(uintptr(unsafe.Pointer(&src[0]))),
+		Len:  uint64(len(src)),
+		Mode: mode,
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(uffd), uintptr(uffdioCopy), uintptr(unsafe.Pointer(&arg)))
+	if errno != 0 && errno != unix.EEXIST {
+		return fmt.Errorf("wpfork: UFFDIO_COPY dst=%#x len=%d mode=%#x: %w", dst, len(src), mode, errno)
+	}
+	return nil
+}
+
+// populateChunk reads one chunk out of the mem file and installs it. Caller holds mu.
+func (h *wpForkHandler) populateChunk(dst, fileOffset, length uint64, extraMode uint64) error {
+	if h.memSrc == nil {
+		return fmt.Errorf("wpfork: MISSING fault with no mem source")
+	}
+	if fileOffset+length > uint64(len(h.memMap)) {
+		return fmt.Errorf("wpfork: chunk [%#x,+%#x) past mem source (%d bytes)", fileOffset, length, len(h.memMap))
+	}
+	buf := h.memMap[fileOffset : fileOffset+length]
+	mode := extraMode
+	if h.frozen {
+		// Installed after the fork point: land it write-protected so the parent's
+		// next write to it still takes a WP fault and is copied before it lands.
+		mode |= copyModeWP
+	}
+	if err := h.uffdCopy(h.uffd, dst, buf, mode); err != nil {
+		return err
+	}
+	setFrozenBit(h.populatedBM, fileOffset/lazyChunkBytes)
+	return nil
+}
+
+// serveMissing populates the chunk containing a MISSING fault from the snapshot mem
+// file, which unblocks the faulting vCPU (or the vmstate restore) at that address.
+func (h *wpForkHandler) serveMissing(addr uint64) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	dst, fileOffset, length, ok := lazyChunkForAddr(h.regions, addr)
+	if !ok {
+		// A MISSING fault outside every registered region cannot be resolved, and
+		// ignoring it would hang the faulting thread forever. Fail loudly.
+		return fmt.Errorf("wpfork: MISSING fault at %#x outside regions %s", addr, dumpRegions(h.regions))
+	}
+	if testFrozenBit(h.populatedBM, fileOffset/lazyChunkBytes) {
+		// Already installed (a concurrent chunk covered it); nothing to do, and the
+		// kernel will not re-deliver.
+		return nil
+	}
+	if err := h.populateChunk(dst, fileOffset, length, 0); err != nil {
+		return err
+	}
+	atomic.AddInt64(&h.missingServed, 1)
+	return nil
+}
+
+// populateResidual fills every chunk the guest never faulted in, straight from the
+// mem file. Caller holds mu.
+//
+// This is the correctness gate for the lazy restore. A co-located fork child maps the
+// parent's memfd MAP_PRIVATE, so a page the parent never touched is a HOLE in that
+// memfd and the child would read it as zeros instead of as the snapshot's contents.
+// Filling the residual at the fork point (rather than at restore) keeps warm-claim
+// activate O(1) and charges the fill only to the forks that actually need it.
+//
+// DONTWAKE: nothing is blocked on these addresses (the source is paused across the
+// fork window), so there is no waiter to wake.
+func (h *wpForkHandler) populateResidual() error {
+	if h.memSrc == nil {
+		return nil // booted source: pages are already resident
+	}
+	for _, r := range h.regions {
+		for start := uint64(0); start < r.Size; start += lazyChunkBytes {
+			length := uint64(lazyChunkBytes)
+			if start+length > r.Size {
+				length = r.Size - start
+			}
+			fileOffset := r.Offset + start
+			if testFrozenBit(h.populatedBM, fileOffset/lazyChunkBytes) {
+				continue
+			}
+			if err := h.populateChunk(r.BaseHostVirtAddr+start, fileOffset, length, copyModeDontwake); err != nil {
+				return fmt.Errorf("wpfork: populate residual: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// MissingFaultCount reports how many MISSING faults the lazy restore has served.
+func (h *wpForkHandler) MissingFaultCount() int64 { return atomic.LoadInt64(&h.missingServed) }

--- a/internal/fork/wpfork_linux.go
+++ b/internal/fork/wpfork_linux.go
@@ -156,6 +156,10 @@ type wpForkHandler struct {
 	frozen bool
 	// missingServed counts MISSING faults populated from the mem file.
 	missingServed int64
+	// residualNanos records how long populate-on-freeze took at the last fork point,
+	// kept separate from freezeNanos (the UFFDIO_WRITEPROTECT-all cost) because the
+	// two scale with different things.
+	residualNanos int64
 }
 
 // newWPForkHandler binds the write-protect handshake unix socket the caller
@@ -248,7 +252,8 @@ func (h *wpForkHandler) Receive() error {
 	// chunks are already installed (UFFDIO_COPY on a present page returns EEXIST) and
 	// which the fork point still has to fill. Sized from the live memfd, so it covers
 	// every region's mem-file offset. Harmless (and unread) for a booted source.
-	h.populatedBM = make([]byte, (exp.bytes/lazyChunkBytes+8)/8+1)
+	numChunks := (exp.bytes + lazyChunkBytes - 1) / lazyChunkBytes
+	h.populatedBM = make([]byte, (numChunks+7)/8)
 	h.mu.Unlock()
 	return nil
 }
@@ -418,12 +423,20 @@ func (h *wpForkHandler) Freeze() (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	start := time.Now()
 	// POPULATE-ON-FREEZE. A lazily restored source's memfd is sparse: any page the
 	// guest never touched is a hole. The co-located child MAP_PRIVATEs this memfd, so
 	// it would read those holes as zeros instead of the snapshot's bytes. Fill them
 	// before the fork point captures the memory. Runs with the source paused, so no
 	// fault can race it. A booted source has no mem source and this is a no-op.
+	//
+	// Timed SEPARATELY from the write-protect arm below. Both happen inside the fork
+	// window with the source paused, so both are parent-pause contributors, but they
+	// scale with completely different things: the WP arm is O(regions) and takes
+	// microseconds, while the residual fill is O(guest RAM the source never touched)
+	// and is largest for a fork that happens right after activate. Folding the fill
+	// into freezeNanos would make the "UFFDIO_WRITEPROTECT-all took" number silently
+	// balloon back toward the pre-lazy-restore eager-copy cost.
+	residualStart := time.Now()
 	h.mu.Lock()
 	perr := h.populateResidual()
 	h.mu.Unlock()
@@ -431,20 +444,25 @@ func (h *wpForkHandler) Freeze() (time.Duration, error) {
 		ep.close()
 		return 0, perr
 	}
+	residual := time.Since(residualStart)
+	atomic.StoreInt64(&h.residualNanos, residual.Nanoseconds())
+
+	start := time.Now()
 	for _, r := range regions {
 		if err := h.writeprotect(r.BaseHostVirtAddr, r.Size, true); err != nil {
 			ep.close()
 			return 0, fmt.Errorf("wpfork: freeze region [%#x,+%#x): %w", r.BaseHostVirtAddr, r.Size, err)
 		}
 	}
-	d := time.Since(start)
+	wp := time.Since(start)
 	h.mu.Lock()
 	// Any chunk installed from here on must land write-protected.
 	h.frozen = true
 	h.epochs = append(h.epochs, ep)
 	h.mu.Unlock()
-	atomic.StoreInt64(&h.freezeNanos, d.Nanoseconds())
-	return d, nil
+	atomic.StoreInt64(&h.freezeNanos, wp.Nanoseconds())
+	// The caller measures the parent pause, which is BOTH contributors.
+	return residual + wp, nil
 }
 
 // close munmaps and closes the epoch's memfds. Idempotent-ish: called on Freeze
@@ -845,7 +863,7 @@ func (h *wpForkHandler) populateChunk(dst, fileOffset, length uint64, extraMode 
 	if err := h.uffdCopy(h.uffd, dst, buf, mode); err != nil {
 		return err
 	}
-	setFrozenBit(h.populatedBM, fileOffset/lazyChunkBytes)
+	setBit(h.populatedBM, fileOffset/lazyChunkBytes)
 	return nil
 }
 
@@ -860,7 +878,7 @@ func (h *wpForkHandler) serveMissing(addr uint64) error {
 		// ignoring it would hang the faulting thread forever. Fail loudly.
 		return fmt.Errorf("wpfork: MISSING fault at %#x outside regions %s", addr, dumpRegions(h.regions))
 	}
-	if testFrozenBit(h.populatedBM, fileOffset/lazyChunkBytes) {
+	if testBit(h.populatedBM, fileOffset/lazyChunkBytes) {
 		// Already installed (a concurrent chunk covered it); nothing to do, and the
 		// kernel will not re-deliver.
 		return nil
@@ -894,7 +912,7 @@ func (h *wpForkHandler) populateResidual() error {
 				length = r.Size - start
 			}
 			fileOffset := r.Offset + start
-			if testFrozenBit(h.populatedBM, fileOffset/lazyChunkBytes) {
+			if testBit(h.populatedBM, fileOffset/lazyChunkBytes) {
 				continue
 			}
 			if err := h.populateChunk(r.BaseHostVirtAddr+start, fileOffset, length, copyModeDontwake); err != nil {
@@ -907,3 +925,9 @@ func (h *wpForkHandler) populateResidual() error {
 
 // MissingFaultCount reports how many MISSING faults the lazy restore has served.
 func (h *wpForkHandler) MissingFaultCount() int64 { return atomic.LoadInt64(&h.missingServed) }
+
+// ResidualFillDuration reports how long the last fork point spent filling the chunks
+// the source never demand-faulted. Zero on a booted source (nothing to fill).
+func (h *wpForkHandler) ResidualFillDuration() time.Duration {
+	return time.Duration(atomic.LoadInt64(&h.residualNanos))
+}

--- a/internal/fork/wpfork_test.go
+++ b/internal/fork/wpfork_test.go
@@ -8,12 +8,15 @@ import "testing"
 // present, and never otherwise (so a mis-wired flag can never half-arm the
 // parent). Pure; runs on any host.
 func TestLiveCowParentEnv(t *testing.T) {
-	t.Run("both set emits three vars", func(t *testing.T) {
+	t.Run("both set emits the live-cow parent vars", func(t *testing.T) {
 		got := LiveCowParentEnv("/run/wp.sock", "/run/memfd")
 		want := []string{
 			"FIRECRACKER_MITOS_SHARED_MEM=1",
 			"FIRECRACKER_MITOS_SHARED_MEM_EXPORT=/run/memfd",
 			"FIRECRACKER_MITOS_WP_UDS=/run/wp.sock",
+			// Opts the patched Firecracker into the LAZY restore: guest RAM is an
+			// EMPTY shared memfd populated by MISSING faults, not an eager copy.
+			"FIRECRACKER_MITOS_LAZY_RESTORE=1",
 		}
 		if len(got) != len(want) {
 			t.Fatalf("got %d env entries, want %d: %v", len(got), len(want), got)

--- a/internal/guestgrpc/client.go
+++ b/internal/guestgrpc/client.go
@@ -105,9 +105,11 @@ func DialUnix(sockPath string) (*Client, error) {
 	return buildClient(cc), nil
 }
 
-// retryInterval is the fixed sleep between connection attempts. Mirrors the
-// 20 ms interval used by cmd/bench connectGRPCWithRetry and
-// internal/husk productionGuestReady.
+// retryInterval is the fixed sleep between connection attempts. Mirrors the 20 ms
+// interval used by cmd/bench connectGRPCWithRetry. NOT the husk activate path:
+// internal/husk guestReadyGRPC backs off geometrically (500 us to a 5 ms cap)
+// because its first dial after Resume nearly always fails and a fixed 20 ms landed
+// straight in the warm-claim activate latency.
 const retryInterval = 20 * time.Millisecond
 
 // WaitReady dials the guest agent gRPC service over vsock at vsockPath,

--- a/internal/husk/grpc_handshake_test.go
+++ b/internal/husk/grpc_handshake_test.go
@@ -357,9 +357,10 @@ func TestProductionGuestReadyGRPC_RetryBackoffIsTight(t *testing.T) {
 	if attempts < 2 {
 		t.Fatalf("expected the seam to retry after the forced failure, got %d attempt(s)", attempts)
 	}
-	// The old fixed 20ms backoff lands at ~20ms. Anything at or above 10ms means
-	// the first retry is still charging the claim tens of milliseconds.
-	if elapsed >= 10*time.Millisecond {
-		t.Errorf("first-retry backoff too slow: guestReadyGRPC took %v after one failed dial; want < 10ms", elapsed)
+	// The old fixed 20ms backoff lands at ~20ms. The measured span also covers a real
+	// dial + gRPC handshake + Ping over a unix socket, so bound at 15ms: still well
+	// under the 20ms regression this pins, but with room for CI scheduler noise.
+	if elapsed >= 15*time.Millisecond {
+		t.Errorf("first-retry backoff too slow: guestReadyGRPC took %v after one failed dial; want < 15ms", elapsed)
 	}
 }

--- a/internal/husk/grpc_handshake_test.go
+++ b/internal/husk/grpc_handshake_test.go
@@ -17,6 +17,7 @@ package husk
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -319,5 +320,46 @@ func TestProductionGuestReadyGRPC_Timeout(t *testing.T) {
 	// Must NOT block indefinitely. Allow 3x the timeout for CI headroom.
 	if elapsed > 3*time.Second {
 		t.Errorf("guestReadyGRPC took %v; should bound to roughly the timeout", elapsed)
+	}
+}
+
+// TestProductionGuestReadyGRPC_RetryBackoffIsTight pins the retry backoff of the
+// post-resume readiness probe. The guest agent's vsock listener is not accepting
+// the instant Firecracker resumes the VM, so the FIRST dial almost always fails
+// and the retry delay lands directly in the claim's activate latency. A fixed
+// 20ms backoff therefore charged ~20ms to every warm claim even though the guest
+// answers within a millisecond of the first failure.
+//
+// The dial seam here fails exactly once and then succeeds against a live server,
+// so the elapsed time is the backoff and nothing else: no server-startup race,
+// no sleep to tune. A 20ms fixed backoff fails this; a sub-millisecond first
+// retry passes it.
+func TestProductionGuestReadyGRPC_RetryBackoffIsTight(t *testing.T) {
+	rcs := &recordingControlServer{}
+	sockPath, cleanup := startRecordingGRPC(t, rcs)
+	defer cleanup()
+
+	var attempts int
+	flaky := func(p string) (*guestgrpc.Client, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, fmt.Errorf("simulated: guest vsock listener not up yet")
+		}
+		return dialUnix(p)
+	}
+
+	start := time.Now()
+	if err := guestReadyGRPC(context.Background(), sockPath, 5*time.Second, flaky); err != nil {
+		t.Fatalf("guestReadyGRPC: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if attempts < 2 {
+		t.Fatalf("expected the seam to retry after the forced failure, got %d attempt(s)", attempts)
+	}
+	// The old fixed 20ms backoff lands at ~20ms. Anything at or above 10ms means
+	// the first retry is still charging the claim tens of milliseconds.
+	if elapsed >= 10*time.Millisecond {
+		t.Errorf("first-retry backoff too slow: guestReadyGRPC took %v after one failed dial; want < 10ms", elapsed)
 	}
 }

--- a/internal/husk/livecow.go
+++ b/internal/husk/livecow.go
@@ -285,6 +285,28 @@ func (s *Stub) armLiveCowSource(workDir string) []string {
 	return fork.LiveCowParentEnv(wpUDS, memExport)
 }
 
+// setLiveCowMemSource points the armed WP handler at the snapshot mem file this
+// activation restores from, so it can serve the userfaultfd MISSING faults the LAZY
+// live-cow restore takes (fork.EnvLazyRestore). It MUST run BEFORE the source
+// Firecracker loads the snapshot: the patched binary maps guest RAM as an EMPTY
+// shared memfd and every page arrives through the handler.
+//
+// FAIL CLOSED: the source Firecracker was launched with EnvLazyRestore (armLiveCowSource
+// emits it), so if the handler cannot open the mem file there is nothing to populate
+// guest RAM and the VM would run on zeros. The caller aborts the activate.
+//
+// Returns nil when live-cow is not armed for this pod (no handler): the source then
+// launched stock and restores through the ordinary file-backed path.
+func (s *Stub) setLiveCowMemSource(memFile string) error {
+	s.mu.Lock()
+	handle := s.liveCowHandle
+	s.mu.Unlock()
+	if handle == nil {
+		return nil
+	}
+	return handle.SetMemSource(memFile)
+}
+
 // serveLiveCowSource completes the write-protect handshake with the patched source
 // Firecracker and, on success, arms the freezer and runs the fault loop for the life
 // of the source VM. It runs in its own goroutine (armLiveCowSource starts it) so the

--- a/internal/husk/livecow.go
+++ b/internal/husk/livecow.go
@@ -304,7 +304,10 @@ func (s *Stub) setLiveCowMemSource(memFile string) error {
 	if handle == nil {
 		return nil
 	}
-	return handle.SetMemSource(memFile)
+	if err := handle.SetMemSource(memFile); err != nil {
+		return fmt.Errorf("set live-cow mem source %s: %w", memFile, err)
+	}
+	return nil
 }
 
 // serveLiveCowSource completes the write-protect handshake with the patched source

--- a/internal/husk/livecow_test.go
+++ b/internal/husk/livecow_test.go
@@ -64,6 +64,12 @@ func TestLiveCowForkGateOn(t *testing.T) {
 		"FIRECRACKER_MITOS_SHARED_MEM=1",
 		"FIRECRACKER_MITOS_SHARED_MEM_EXPORT=/run/vm/mitos-memfd.export",
 		"FIRECRACKER_MITOS_WP_UDS=/run/vm/mitos-wp.sock",
+		// LAZY restore: the patched Firecracker maps guest RAM as an EMPTY shared
+		// memfd and takes a MISSING fault per chunk instead of copying the whole mem
+		// file inside PUT /snapshot/load. It requires BOTH this and the WP UDS, and
+		// the stub fails the activate if it cannot open the mem source first, so a
+		// source is never resumed on zeroed memory.
+		"FIRECRACKER_MITOS_LAZY_RESTORE=1",
 	}
 	if len(env) != len(want) {
 		t.Fatalf("parent env = %v, want %d entries", env, len(want))

--- a/internal/husk/livecow_test.go
+++ b/internal/husk/livecow_test.go
@@ -140,6 +140,10 @@ func TestArmLiveCowSourceBindsAndEmitsEnv(t *testing.T) {
 		"FIRECRACKER_MITOS_SHARED_MEM=1",
 		"FIRECRACKER_MITOS_SHARED_MEM_EXPORT=" + filepath.Join(workDir, "mitos-memfd.export"),
 		"FIRECRACKER_MITOS_WP_UDS=" + filepath.Join(workDir, "mitos-wp.sock"),
+		// LAZY restore: guest RAM comes back as an EMPTY shared memfd whose pages the
+		// WP handler faults in from the mem file, instead of an eager copy inside
+		// PUT /snapshot/load. Firecracker requires this AND the WP UDS.
+		"FIRECRACKER_MITOS_LAZY_RESTORE=1",
 	}
 	if len(env) != len(want) {
 		t.Fatalf("arm env = %v, want %d entries", env, len(want))

--- a/internal/husk/multivm.go
+++ b/internal/husk/multivm.go
@@ -523,6 +523,21 @@ func (s *Stub) activateInstance(ctx context.Context, id vmID, req ActivateReques
 	recordStage(stages, "egress_filter", mark)
 	mark = time.Now()
 
+	// LAZY live-cow restore (this is what makes vmstate_restore O(1) instead of an
+	// eager 512 MiB memfd copy inside PUT /snapshot/load): hand the armed WP handler
+	// the mem file BEFORE the load, so it can serve the MISSING faults the patched
+	// Firecracker will take for every guest page. Only the SOURCE VM restores from a
+	// disk mem file; a co-located fork child imports the parent's memfd and never
+	// reaches the lazy branch. FAIL CLOSED: the source was launched with
+	// EnvLazyRestore, so a handler that cannot read the mem file means guest RAM would
+	// stay zeroed; refuse to load rather than run a VM on empty memory.
+	if id == defaultVMID && !req.ForkSnapshot {
+		if err := s.setLiveCowMemSource(memFile); err != nil {
+			werr := fmt.Errorf("husk: arm lazy live-cow mem source for vm %q: %w", id, err)
+			return ActivateResult{OK: false, Error: werr.Error()}, werr
+		}
+	}
+
 	// Load PAUSED so the rootfs drive can be rebound before the guest runs, then
 	// resume explicitly, exactly as the single-VM path does. A co-located live-cow
 	// fork child armed with a lazy-UFFD import (childUFFDPlan) restores through

--- a/internal/husk/multivm_test.go
+++ b/internal/husk/multivm_test.go
@@ -3,11 +3,13 @@ package husk
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"mitos.run/mitos/internal/firecracker"
+	"mitos.run/mitos/internal/fork"
 )
 
 // newMultiVMTestStub builds a stub with the multi-VM execution mode ON, using a
@@ -589,5 +591,63 @@ func TestSpawnVMActivationFailureReturnsNotOK(t *testing.T) {
 	}
 	if got := s.instances[defaultVMID].state; got != StateActive {
 		t.Fatalf("the primary instance must stay active despite the spawn failure, got %s", got)
+	}
+}
+
+// failingMemSourceHandle is a WPForkHandle whose SetMemSource always fails. Only the
+// one method under test does anything; the rest satisfy the interface.
+type failingMemSourceHandle struct{ err error }
+
+func (h *failingMemSourceHandle) Receive() error                 { return nil }
+func (h *failingMemSourceHandle) Freeze() (time.Duration, error) { return 0, nil }
+func (h *failingMemSourceHandle) Serve() error                   { return nil }
+func (h *failingMemSourceHandle) SetMemSource(string) error      { return h.err }
+func (h *failingMemSourceHandle) FrozenFd() int                  { return -1 }
+func (h *failingMemSourceHandle) FrozenPage(uint64) bool         { return false }
+func (h *failingMemSourceHandle) FrozenBitmap() []byte           { return nil }
+func (h *failingMemSourceHandle) ChildImport(string) (fork.ChildMemfdImport, error) {
+	return fork.ChildMemfdImport{}, nil
+}
+func (h *failingMemSourceHandle) FaultCount() int64             { return 0 }
+func (h *failingMemSourceHandle) FreezeDuration() time.Duration { return 0 }
+func (h *failingMemSourceHandle) Close() error                  { return nil }
+
+// TestActivateInstanceFailsClosedWhenLazyMemSourceCannotArm proves the fail-closed
+// gate on the LAZY live-cow restore.
+//
+// The source Firecracker is launched with FIRECRACKER_MITOS_LAZY_RESTORE, so it maps
+// guest RAM as an EMPTY shared memfd and every page must arrive through the WP
+// handler's userfaultfd MISSING faults. If the handler cannot open the snapshot mem
+// file there is nothing to populate that memory: loading the snapshot anyway and
+// resuming the vCPUs would run the guest on all-zero RAM. activateInstance must
+// therefore abort BEFORE the load, leave the VM not active, and say why.
+func TestActivateInstanceFailsClosedWhenLazyMemSourceCannotArm(t *testing.T) {
+	vms := map[string]*fakeVMM{}
+	s := newMultiVMTestStub(t, vms)
+	s.liveCowFork = true
+	s.liveCowHandle = &failingMemSourceHandle{err: errors.New("open mem source: no such file")}
+
+	if err := s.prepareInstance(context.Background(), defaultVMID, "", nil); err != nil {
+		t.Fatalf("prepareInstance: %v", err)
+	}
+	res, err := s.activateInstance(context.Background(), defaultVMID, ActivateRequest{SnapshotDir: "/snap"})
+	if err == nil || res.OK {
+		t.Fatalf("activate must fail closed when the lazy mem source cannot arm; got ok=%v err=%v", res.OK, err)
+	}
+	if !strings.Contains(res.Error, "mem source") {
+		t.Errorf("activate error must name the failing step; got %q", res.Error)
+	}
+	if got := s.instances[defaultVMID].state; got == StateActive {
+		t.Errorf("VM must NOT be active after a failed lazy arm; state = %s", got)
+	}
+	// The snapshot must never have been loaded: a loaded-but-unpopulated VM is the
+	// exact hazard this gate exists to prevent.
+	if vm := vms[string(defaultVMID)]; vm != nil {
+		vm.mu.Lock()
+		loads := vm.loadCalls
+		vm.mu.Unlock()
+		if loads > 0 {
+			t.Errorf("snapshot was loaded %d time(s) despite the failed arm; must abort before the load", loads)
+		}
 	}
 }

--- a/internal/husk/netfilter_test.go
+++ b/internal/husk/netfilter_test.go
@@ -288,3 +288,56 @@ func TestApplyEgressFilterDoesNotTearDownOnSuccess(t *testing.T) {
 		t.Fatalf("want exactly 1 tap delete (the idempotent pre-create delete), got %d; calls: %+v", got, rr.calls)
 	}
 }
+
+// TestApplyEgressFilterBatchesNftIntoOneTransaction pins that the egress filter
+// installs its whole nftables ruleset in a SINGLE `nft -f -` invocation.
+//
+// Two reasons. Latency: every nft call is a fork/exec, and applyEgressFilter runs on
+// the warm-claim activate critical path (it was ~13 ms of a ~68 ms activate, most of
+// it process startup). Correctness: nft applies one -f payload as ONE transaction, so
+// batching removes the window in which a sandbox's tap exists with only part of its
+// egress policy installed.
+//
+// The rendered ruleset must still be the same rules in the same order, so the test
+// asserts the concatenated payload contains each section and that the shared tables
+// precede the per-sandbox chains that jump into them.
+func TestApplyEgressFilterBatchesNftIntoOneTransaction(t *testing.T) {
+	r := &recordingRunner{}
+	cfg := NetfilterConfig{
+		Tap:     "sbtest0",
+		GuestIP: net.ParseIP("10.200.0.2"),
+		HostIP:  net.ParseIP("10.200.0.1"),
+		Egress:  v1.EgressDeny,
+	}
+	if err := applyEgressFilter(context.Background(), r.run, nil, cfg); err != nil {
+		t.Fatalf("applyEgressFilter: %v", err)
+	}
+
+	var nftCalls []recordedCall
+	for _, c := range r.calls {
+		if len(c.argv) > 0 && c.argv[0] == "nft" {
+			nftCalls = append(nftCalls, c)
+		}
+	}
+	if len(nftCalls) != 1 {
+		var argvs []string
+		for _, c := range nftCalls {
+			argvs = append(argvs, strings.Join(c.argv, " ")+" <<"+c.stdin[:min(24, len(c.stdin))])
+		}
+		t.Fatalf("want exactly 1 nft invocation, got %d:\n  %s", len(nftCalls), strings.Join(argvs, "\n  "))
+	}
+
+	payload := nftCalls[0].stdin
+	for _, want := range []string{"table", cfg.Tap} {
+		if !strings.Contains(payload, want) {
+			t.Errorf("batched nft payload missing %q:\n%s", want, payload)
+		}
+	}
+	// The per-sandbox chain jumps into the shared table, so the shared table must be
+	// declared before it within the single transaction.
+	sharedIdx := strings.Index(payload, netconf.RenderSharedTable()[:20])
+	chainIdx := strings.Index(payload, cfg.Tap)
+	if sharedIdx < 0 || chainIdx < 0 || sharedIdx > chainIdx {
+		t.Errorf("shared table must precede the per-sandbox chain in the batched payload (shared=%d chain=%d)", sharedIdx, chainIdx)
+	}
+}

--- a/internal/husk/stub.go
+++ b/internal/husk/stub.go
@@ -310,9 +310,36 @@ func productionNotifier(vsockPath string, generation uint64, entropy []byte, req
 // Ping RPC, retrying at fixed intervals until the timeout elapses or ctx is
 // cancelled. It uses the supplied dial function so tests can inject DialUnix.
 // The retry semantics mirror the legacy productionGuestReady JSON poll loop.
+// Retry pacing for the post-resume guest readiness probe. The guest agent's
+// vsock listener is not accepting the instant Firecracker resumes the VM, so the
+// first dial nearly always fails and the retry delay is charged straight to the
+// claim's activate latency. A fixed 20ms backoff therefore cost ~20ms on EVERY
+// warm claim while the guest was in fact answering a millisecond later. Start
+// sub-millisecond and grow geometrically so a healthy guest is picked up almost
+// immediately, while an unhealthy one still backs off to a cheap poll rather
+// than spinning on dial for the whole readyTimeout.
+const (
+	guestReadyBackoffInitial = 500 * time.Microsecond
+	guestReadyBackoffMax     = 5 * time.Millisecond
+)
+
 func guestReadyGRPC(ctx context.Context, vsockPath string, timeout time.Duration, dial dialFunc) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
+	backoff := guestReadyBackoffInitial
+	// wait sleeps the current backoff then grows it, capped. It reports false when
+	// the context ended, so the caller returns instead of retrying.
+	wait := func() bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > guestReadyBackoffMax {
+			backoff = guestReadyBackoffMax
+		}
+		return true
+	}
 	for {
 		if ctx.Err() != nil {
 			return fmt.Errorf("guest agent gRPC not ready: %w", ctx.Err())
@@ -324,10 +351,8 @@ func guestReadyGRPC(ctx context.Context, vsockPath string, timeout time.Duration
 		client, err := dial(vsockPath)
 		if err != nil {
 			lastErr = err
-			select {
-			case <-ctx.Done():
+			if !wait() {
 				return fmt.Errorf("guest agent gRPC not ready: %w", ctx.Err())
-			case <-time.After(20 * time.Millisecond):
 			}
 			continue
 		}
@@ -340,10 +365,8 @@ func guestReadyGRPC(ctx context.Context, vsockPath string, timeout time.Duration
 			return nil
 		}
 		lastErr = pingErr
-		select {
-		case <-ctx.Done():
+		if !wait() {
 			return fmt.Errorf("guest agent gRPC not ready: %w", ctx.Err())
-		case <-time.After(20 * time.Millisecond):
 		}
 	}
 	if lastErr == nil {


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs.
> - The husk-stub owns the warm-claim activate: it loads the template snapshot into a dormant VMM and hands the guest to a tenant.
> - The live-cow fork (`--live-cow-fork`, m4b) armed the fork path on EVERY restore by copying the whole mem file into a fresh `MAP_SHARED` memfd inside `PUT /snapshot/load`. That made restore O(guest RAM), not O(1).
> - It had to be addressed now because it broke BOTH published claims at once: warm-claim activate ran 212 ms P50 against the README's `~27 ms`, and node `Shmem` grew `+512 MiB` per active sandbox, which falsified `~3 MiB marginal memory per fork via CoW page sharing`. This is the fork hot path, ROADMAP's design center.
> - This pull request creates the memfd EMPTY and has the existing write-protect handler serve userfaultfd MISSING faults out of the snapshot mem file, filling the residual only at a fork point.
> - The benefit is warm-claim activate 212 ms to 76 ms P50 and 512 MiB to 72 MiB of shmem per sandbox, with the live-cow fork still armed.

## Linked Issues or Issue Description

Related: #832 (the live-cow fork milestone this optimizes).

No issue existed for the regression itself. Problem statement:

**What happened.** With `--live-cow-fork` on, `guest_memory_from_file` took the Mitos branch and called `snapshot_file_memfd`, which does `create_memfd(...)` followed by `std::io::copy(mem_file -> memfd)`. Stock Firecracker restores with a lazy `mmap(MAP_PRIVATE)`. On a 512 MiB guest the patched binary logged `'load snapshot' API request took 194942 us` (resume: 158 us).

**Why it was invisible.** `bench/husk-activate-latency.sh`, the script the README cites as the reproducible source for the `~27 ms` figure, polls `kubectl get sandbox`. On any cluster with the `agents.x-k8s.io` facade CRD installed that resolves to the FACADE Sandbox, not `sandboxes.mitos.run`. It never sees a Ready condition and silently reports nothing, so the regression could not be reproduced from the published harness.

## What Changed

- `snapshot_memfd_lazy` (paired `mitos-run/firecracker` change): size the memfd, never write it. `mitos_wp_offer` registers `MISSING|WRITE_PROTECT` on ONE uffd (the kernel allows one uffd per VMA) and negotiates `UFFD_FEATURE_MISSING_SHMEM`, without which the kernel silently never delivers a MISSING fault on a shmem mapping and the guest would read the zero page.
- `internal/fork/wpfork_linux.go`: serve MISSING faults by `UFFDIO_COPY` from an mmap of the mem file (one copy out of page cache, not a `pread` plus a second copy). New `SetMemSource`.
- **populate-on-freeze**: a co-located child maps the parent memfd `MAP_PRIVATE`, so a chunk the parent never faulted in is a HOLE it would read as ZEROS instead of snapshot bytes. `Freeze` fills the residual before write-protecting. This keeps activate O(1) and charges the fill to forks only. Pages installed after the freeze land write-protected (`UFFDIO_COPY_MODE_WP`), so copy-before-unprotect still sees every parent write.
- Fail closed both ends: the VMM takes the lazy path only with BOTH `FIRECRACKER_MITOS_LAZY_RESTORE` and `FIRECRACKER_MITOS_WP_UDS`, and aborts the restore rather than resuming vCPUs on all-zero RAM; the stub fails the activate if it cannot open the mem source before the load. An older husk paired with the patched binary keeps the eager copy.
- `internal/husk/stub.go`: `guestReadyGRPC` backed off a FIXED 20 ms after a failed dial. The guest agent's vsock listener is never up on the first dial after `Resume`, so essentially every claim paid the full 20 ms for a ~2 ms check (mean `guest_ready` 22.1 ms). Now geometric 500 us to a 5 ms cap.
- `bench/husk-activate-latency.sh`: fully qualify `sandboxes.mitos.run`.
- `hack/install-firecracker-patched.sh`: repin to the m7 build (`mitos-fc-lazy-restore-v1.15.0`, sha256 `d341a8f3...`, green build-patched-fc run 29022392083).
- Docs: threat-model delta, fork-correctness obligation, `bench/results/2026-07-09-lazy-livecow-restore.md`.

**Populate granularity is load bearing.** A restoring guest touches SCATTERED pages, so a chunk larger than the access footprint copies the whole chunk to satisfy one page. Measured on the reference node: 2 MiB faulted ~194 MiB (P50 114 ms), 256 KiB ~125 MiB (90 ms), 64 KiB ~72 MiB (76 ms). A sequential-touch microbenchmark reports 2 MiB as optimal because perfect locality hides the amplification.

## Verification

- [x] `go test ./internal/fork/ ./internal/husk/ ./internal/netconf/` (darwin), all pass
- [x] `golangci-lint run --timeout=5m` AND `GOOS=linux golangci-lint run --timeout=5m` over `./internal/fork/... ./internal/husk/...`, both clean
- [x] `cargo test --release -p vmm --lib vstate::memory` in `mitos-run/firecracker`: 21 pass, including two new tests pinning that the lazy region is memfd-backed + `MAP_SHARED` but EMPTY, and that a short mem file is still rejected
- [x] **Real KVM** on a bare-metal node, `go test ./internal/fork/ -run LiveCow`: all 7 pass, including the new `TestLiveCowLazyRestoreServesMissingAndFillsResidualOnFreeze`
- [x] That test is a real gate, not a vacuous one: with `populateResidual` removed it FAILS with `child view offset 0x200000 = 0x0, want 0xb`, i.e. it catches exactly the silent zero-page corruption it exists to prevent
- [x] Kernel capability probed on the target kernel (6.18) rather than assumed: one uffd registers `MISSING|WP` on a `MAP_SHARED` memfd, offering `UFFDIO_COPY` and `UFFDIO_WRITEPROTECT` (`ioctls=0x17c`)
- [x] Benchmark on a live cluster with `bench/husk-activate-latency.sh` (N=11): activate P50 212.39 ms to 76.20 ms; node `Shmem` +512 MiB to +72 MiB per active sandbox. Full run in `bench/results/2026-07-09-lazy-livecow-restore.md`
- [x] Functional: co-located `fromSandbox` fork `1/1 husk forks ready`; hosted `create -> run_code (42) -> fork -> child run_code ('child-ok 15 3.12.13')`; 8/8 warm husk pods, 0 restarts

## Risks

- **Guest memory correctness** is the real risk: an unpopulated chunk read by a co-located child would be zeros, not snapshot bytes. That is what populate-on-freeze prevents and what the new KVM test pins (and provably fails without it).
- **Ordering**: the Go change is inert without the paired Firecracker pin, and that is deliberate. The husk sets `FIRECRACKER_MITOS_LAZY_RESTORE`; a binary that does not understand it keeps the eager copy. Landing the two out of order degrades to today's behavior, it does not break.
- **Latency shifts, it does not vanish**: `vmstate_restore` drops 195 ms to 12.8 ms, but `guest_ready` and `handshake` rise because the guest now faults its working set in. Net is still 252.7 ms to 68.3 ms of stage total.
- **Co-located fork is slightly slower** (391 to 615 ms vs 375 to 524 ms): the residual fill moved there, by design, because that is where it is actually needed.
- Node loss / slow etcd / capacity exhaustion: unchanged. No new socket, capability, or file; it reuses the existing per-VM WP handshake and the `/dev/userfaultfd` the kvm device plugin already injects on a live-cow pool.
- The lazy path only engages on a live-cow pool. `--live-cow-fork` off is byte-for-byte unchanged.

## Model Used

- Anthropic Claude Opus 4.8, model id `claude-opus-4-8[1m]` (1M context), extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved
- [x] Benchmark run (bench/) included if the hot path was touched
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-closed “lazy restore” support for live copy-on-write activations, including memory-source wiring, env flag propagation, and readiness to serve lazy page fills.
  * Added a new benchmark results report for warm-claim activate latency (“lazy live-cow restore”).
* **Bug Fixes**
  * Fixed sandbox cleanup targeting and readiness/latency parsing in the latency benchmarking script.
  * Improved guest-agent gRPC readiness retries using tighter exponential backoff.
* **Documentation**
  * Updated correctness and threat-model notes for lazy restore population and safety guarantees.
* **Tests**
  * Added unit and integration coverage for lazy restore chunking, MISSING handling, residual fill on freeze, and batched nft execution.
* **Chores**
  * Updated the pinned Firecracker patched artifact to the lazy-restore variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->