### PR TITLE
fix(guest): reseed the run_code kernel PRNGs after a fork

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,10 @@ jobs:
           python-version: "3.12"
       - run: pip install -e ".[dev]"
       - run: pytest tests/ -v
+      # The in-guest run_code kernel driver ships in the guest rootfs, not in the SDK,
+      # and its fork-reseed tests stub jupyter_client so they need no kernel deps. They
+      # ran nowhere before this step; the PRNG-sharing bug they gate is a real one.
+      - run: pytest ../../guest/rootfs/kernel_driver_test.py -v
 
   typescript-sdk:
     runs-on: ubuntu-latest

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -423,7 +423,9 @@ clone of the sandbox that captured it; it gets the same per-restore reseed an
 engine fork or a husk fork child gets (sections 1 and 2). The Python-level PRNG
 caveat in section 1 applies to a resumed sandbox identically (a long-lived
 interpreter that seeded its PRNG before the checkpoint keeps that PRNG state
-across the resume; reseed in-process after wake if it matters).
+across the resume; reseed in-process after wake if it matters). The run_code
+kernel reseeds itself on the post-fork SIGUSR2, so it is covered; any other
+long-lived interpreter is not.
 
 Disk/memory consistency: the resume pairs the memory image with the SAME
 workspace filesystem state it was captured against (the revision's
@@ -525,7 +527,7 @@ in this phase and run on every KVM CI run (the `firecracker-test` job), so they
 are observed on KVM, not only unit-asserted. The N=8 variant remains a
 follow-up.
 
-**run_code kernel caveat.** A forked VM inherits the LIVE run_code kernel
+**run_code kernel.** A forked VM inherits the LIVE run_code kernel
 (`/opt/mitos/kernel_driver.py`) and its entire Python namespace, because the
 kernel process is part of the snapshot. Two ways the kernel gets into the
 snapshot: by default it starts lazily on the first `run_code` (so a template
@@ -534,23 +536,46 @@ snapshotted before any `run_code` has NO kernel and every fork cold-starts it,
 (CreateTemplateRequest.warm_kernel), the template build runs one trivial cell
 (`pass`) through `Sandbox.RunCodeStream` right before the snapshot, so the
 kernel is captured ALREADY RUNNING and forks answer their first `run_code`
-warm. The warmup cell deliberately draws no randomness and imports nothing:
-CPython seeds its Mersenne Twister lazily from `os.urandom` on first use, so
-an untouched `random` (and numpy) stays UNSEEDED in the snapshot and each fork
-seeds it fresh, after the per-fork CRNG reseed, on its own first draw
-(pinned by `TestWarmKernelCode_NeverDrawsRandomness`).
+warm. The hosted `python` pool sets it.
 
-The post-fork `NotifyForked` reseed handles the kernel CRNG (`/dev/urandom`)
-and signals userspace, but a Python-level PRNG that was already seeded INSIDE
-the kernel before the fork (`random.seed(...)`, `numpy.random.seed(...)`, or
-the implicit module-global `random` state once drawn from, e.g. by user code
-run against the template or a pre-fork sandbox) is captured in the snapshot
-and is therefore IDENTICAL across all forks until reseeded. This is the same
-class as item 1 for any already-started runtime; it is not a host boundary,
-and the warm_kernel warmup neither causes nor fixes it. Remediation: callers
-who need per-fork randomness in the kernel should reseed after a fork
-(`random.seed()`, `np.random.seed()` with no argument reseeds from fresh OS
-entropy), or avoid seeding the PRNG before the fork point.
+**This document previously claimed that the inert warmup cell was sufficient,
+on the grounds that CPython seeds its Mersenne Twister lazily on first use. That
+is FALSE.** `random.Random` seeds itself from `os.urandom` in its CONSTRUCTOR,
+and the `random` module builds its shared instance at IMPORT. ipykernel's own
+import chain imports `random` (and `numpy`), so the Mersenne state is already
+fixed by the time the warmup cell runs, and it is captured in the snapshot.
+Measured against production with `warmKernel: true`, three INDEPENDENT sandboxes
+each returned:
+
+```
+random.random() == 0.993005259705148
+```
+
+while `os.urandom()` and `numpy.random.random()` diverged correctly (the kernel
+CRNG is credibly reseeded per fork; numpy's global RandomState seeds lazily from
+it). `TestWarmKernelCode_NeverDrawsRandomness` pinned the warmup CELL, not the
+invariant, so it never caught this.
+
+**Mitigation (in the guest, not the host).** `kernel_driver.py` installs a
+SIGUSR2 handler, opting in to the agent's post-fork broadcast, which the agent
+sends AFTER the credited CRNG reseed and ONLY to processes that installed a
+handler (an unhandled SIGUSR2 terminates a process, which is why the handler
+lives in the driver and not in the ipykernel subprocess). The handler only sets a
+flag; before the next cell runs, the driver executes a silent, history-free cell
+that reseeds `random` from `os.urandom(32)` and, when numpy is already imported,
+`numpy.random` as well. A cell already executing when the fork lands keeps its
+pre-fork PRNG state; the next one does not. Pinned by
+`guest/rootfs/kernel_driver_test.py` (`ForkReseedTest`).
+
+Keeping the warmup cell inert still matters: it keeps the snapshot free of
+randomness the driver does not know how to reseed.
+
+**Still NOT covered.** `PYTHONHASHSEED` is fixed at interpreter start, so sibling
+forks of a warm kernel share hash randomization. Any library that seeded its own
+PRNG into its own state before the snapshot (other than `random` and `numpy`) is
+not reseeded; a caller who explicitly ran `random.seed(1234)` before the fork
+point has asked for a deterministic stream and gets one. Remediation for those:
+reseed after the fork, or avoid seeding before the fork point.
 
 ## 2. Clock correctness
 

--- a/docs/fork-correctness.md
+++ b/docs/fork-correctness.md
@@ -547,7 +547,7 @@ fixed by the time the warmup cell runs, and it is captured in the snapshot.
 Measured against production with `warmKernel: true`, three INDEPENDENT sandboxes
 each returned:
 
-```
+```text
 random.random() == 0.993005259705148
 ```
 

--- a/guest/rootfs/kernel_driver.py
+++ b/guest/rootfs/kernel_driver.py
@@ -29,6 +29,7 @@ single threaded regardless).
 """
 import base64
 import json
+import signal
 import sys
 import time
 
@@ -37,6 +38,82 @@ from jupyter_client.manager import start_new_kernel
 # MIME types whose payload ipykernel delivers already base64-encoded as bytes
 # we keep as-is (image/png, image/jpeg). Everything else is text we pass through.
 _BINARY_MIMES = {"image/png", "image/jpeg"}
+
+# --- fork correctness -------------------------------------------------------------
+#
+# The kernel is started EAGERLY, before the template snapshot is taken, so a restored
+# sandbox does not pay ~70 ms of interpreter startup on its first run_code. That means
+# every fork of that snapshot inherits ONE already-imported interpreter, and therefore
+# the same seeded state in random.Random: without this, two children of the same
+# snapshot would emit identical random.random() sequences.
+#
+# The guest agent broadcasts SIGUSR2 to userspace processes after a fork, AFTER it has
+# credibly reseeded the kernel CRNG (RNDADDENTROPY), so os.urandom() below already
+# returns per-fork divergent bytes. The broadcast is gated on a process having
+# installed a SIGUSR2 handler (SIGUSR2 terminates a process that has not), which is why
+# this handler exists here in the DRIVER: the ipykernel subprocess installs none, so it
+# is never signalled and never killed.
+#
+# The handler only sets a flag. The reseed runs as a silent cell before the next
+# execution, because a signal handler cannot safely drive jupyter_client while a cell
+# is mid-flight. A cell already running when the fork happens keeps its pre-fork RNG
+# state; the next one does not.
+#
+# NOT covered: PYTHONHASHSEED (fixed at interpreter start, so sibling forks share hash
+# randomization) and any PRNG a library seeded into its own state before the snapshot
+# other than numpy. See docs/fork-correctness.md.
+_reseed_pending = False
+
+_RESEED_SRC = """
+def __mitos_reseed():
+    import os, random, sys
+    random.seed(os.urandom(32))
+    numpy = sys.modules.get("numpy")
+    if numpy is not None:
+        numpy.random.seed(int.from_bytes(os.urandom(4), "little"))
+__mitos_reseed()
+del __mitos_reseed
+"""
+
+
+def _on_sigusr2(_signum, _frame):
+    """Record that this VM was forked. Reseeding happens before the next cell."""
+    global _reseed_pending
+    _reseed_pending = True
+
+
+def _install_fork_handler():
+    """Opt in to the agent's post-fork SIGUSR2 broadcast.
+
+    The agent only signals processes that installed a handler, so this call is what
+    makes the broadcast reach us at all. It must run in the driver, never in the
+    ipykernel subprocess: an unhandled SIGUSR2 terminates a process.
+    """
+    signal.signal(signal.SIGUSR2, _on_sigusr2)
+
+
+def _maybe_reseed(km, client):
+    """Reseed the kernel once per fork, before the next cell. Returns whether it ran."""
+    global _reseed_pending
+    if not _reseed_pending:
+        return False
+    _reseed_pending = False
+    _reseed_kernel(km, client)
+    return True
+
+
+def _reseed_kernel(km, client):
+    """Reseed the kernel's PRNGs from the (already fork-reseeded) CRNG.
+
+    Runs silently: no history, no output frames. A failure here must not fail the
+    caller's cell, but it MUST be visible, because a silently unseeded fork emits
+    predictable, duplicated randomness.
+    """
+    try:
+        msg_id = client.execute(_RESEED_SRC, store_history=False, silent=True)
+        _drain_to_idle(km, client, msg_id)
+    except Exception as exc:  # noqa: BLE001 - never fail the user's cell over this
+        print("mitos: kernel PRNG reseed after fork failed: %r" % (exc,), file=sys.stderr)
 
 # Wall-clock budget applied to a single run when the request omits a positive
 # timeout. Bounds a runaway cell (e.g. while True: pass) so it cannot wedge the
@@ -175,6 +252,7 @@ def main():
     # start_new_kernel returns (KernelManager, BlockingKernelClient) with the
     # client already connected and channels started.
     km, client = start_new_kernel(kernel_name="python3")
+    _install_fork_handler()
     # Route matplotlib to the inline backend so figures become image/png
     # display_data instead of trying to open a GUI window.
     client.execute(
@@ -189,6 +267,7 @@ def main():
             if not line:
                 continue
             req = json.loads(line)
+            _maybe_reseed(km, client)
             _run_one(km, client, req.get("id", ""), req.get("code", ""), req.get("timeout", 0))
     finally:
         client.stop_channels()

--- a/guest/rootfs/kernel_driver_test.py
+++ b/guest/rootfs/kernel_driver_test.py
@@ -1,12 +1,16 @@
 """Drives kernel_driver.py over its stdin/stdout JSON protocol.
 
-Skips entirely if ipykernel/jupyter_client are not importable, so it does not
-fail on a machine without the kernel deps; the real-VM proof is Task 11.
+The protocol tests skip entirely if ipykernel/jupyter_client are not importable, so
+they do not fail on a machine without the kernel deps; the real-VM proof is Task 11.
+
+The fork-reseed tests below stub jupyter_client, so they always run.
 """
 import json
 import os
+import signal
 import subprocess
 import sys
+import types
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -91,6 +95,141 @@ class KernelDriverTest(unittest.TestCase):
             any(e["kind"] == "error" and e.get("name") == "KernelDied"
                 for e in events if e["id"] == "a")
         )
+
+
+def _import_driver():
+    """Import kernel_driver with jupyter_client stubbed, so no kernel deps are needed."""
+    if "kernel_driver" in sys.modules:
+        return sys.modules["kernel_driver"]
+    if "jupyter_client.manager" not in sys.modules:
+        stub = types.ModuleType("jupyter_client")
+        manager = types.ModuleType("jupyter_client.manager")
+        manager.start_new_kernel = lambda **_kw: (None, None)
+        stub.manager = manager
+        sys.modules.setdefault("jupyter_client", stub)
+        sys.modules["jupyter_client.manager"] = manager
+    sys.path.insert(0, HERE)
+    import kernel_driver
+    return kernel_driver
+
+
+class _FakeClient:
+    def __init__(self):
+        self.executed = []
+
+    def execute(self, code, store_history=True, silent=False):
+        self.executed.append({"code": code, "store_history": store_history, "silent": silent})
+        return "msg-1"
+
+
+class ForkReseedTest(unittest.TestCase):
+    """Fork correctness for the run_code kernel.
+
+    The hosted python pool sets warmKernel: true, so the template build starts the
+    ipykernel BEFORE the snapshot and every sandbox restores a live interpreter.
+    ipykernel's own import chain imports `random`, so random.Random's Mersenne state is
+    fixed in the snapshot and inherited identically by every restore. Measured against
+    prod before this fix, three INDEPENDENT sandboxes each returned
+
+        random.random() == 0.993005259705148
+
+    while os.urandom() and numpy.random diverged correctly (the kernel CRNG is credibly
+    reseeded per fork, and numpy seeds lazily from it).
+
+    The agent broadcasts SIGUSR2 after a fork, AFTER reseeding the CRNG, and only to
+    processes that installed a SIGUSR2 handler. The driver installs one and reseeds the
+    kernel's Python PRNGs before the next cell runs.
+    """
+
+    def setUp(self):
+        self.kd = _import_driver()
+        self.kd._reseed_pending = False
+        self._drained = []
+        self._real_drain = self.kd._drain_to_idle
+        self.kd._drain_to_idle = lambda km, client, msg_id, budget=10.0: self._drained.append(msg_id)
+
+    def tearDown(self):
+        self.kd._drain_to_idle = self._real_drain
+        self.kd._reseed_pending = False
+
+    def test_sigusr2_handler_only_sets_a_flag(self):
+        """A signal handler must not drive jupyter_client: a cell may be mid-flight."""
+        self.assertFalse(self.kd._reseed_pending)
+        self.kd._on_sigusr2(signal.SIGUSR2, None)
+        self.assertTrue(self.kd._reseed_pending)
+
+    def test_the_driver_installs_a_sigusr2_handler(self):
+        """The agent signals only processes that installed a handler, so without this
+        the post-fork broadcast never reaches the driver at all."""
+        previous = signal.getsignal(signal.SIGUSR2)
+        try:
+            self.kd._install_fork_handler()
+            self.assertIs(signal.getsignal(signal.SIGUSR2), self.kd._on_sigusr2)
+        finally:
+            signal.signal(signal.SIGUSR2, previous)
+
+    def test_reseed_runs_once_before_the_next_cell_and_not_again(self):
+        client = _FakeClient()
+        self.kd._on_sigusr2(signal.SIGUSR2, None)
+
+        self.assertTrue(self.kd._maybe_reseed(None, client), "a forked kernel must reseed")
+        self.assertEqual(len(client.executed), 1)
+        self.assertEqual(self._drained, ["msg-1"])
+
+        # A later cell in the same (unforked) sandbox must not pay for another reseed.
+        self.assertFalse(self.kd._maybe_reseed(None, client))
+        self.assertEqual(len(client.executed), 1)
+
+    def test_reseed_is_silent_and_leaves_no_history(self):
+        """The reseed is ours, not the tenant's: it must not appear in In[]/Out[] or
+        emit output frames that would corrupt the caller's stream."""
+        client = _FakeClient()
+        self.kd._on_sigusr2(signal.SIGUSR2, None)
+        self.kd._maybe_reseed(None, client)
+        sent = client.executed[0]
+        self.assertTrue(sent["silent"])
+        self.assertFalse(sent["store_history"])
+
+    def test_a_failing_reseed_never_fails_the_callers_cell(self):
+        class _Boom:
+            def execute(self, *_a, **_kw):
+                raise RuntimeError("kernel is wedged")
+
+        self.kd._on_sigusr2(signal.SIGUSR2, None)
+        self.kd._maybe_reseed(None, _Boom())  # must not raise
+        self.assertFalse(self.kd._reseed_pending)
+
+    def test_the_reseed_source_actually_reseeds_python_random(self):
+        """Execute the exact source the driver sends, here, and prove it moves
+        random.Random off the state it had. Two reseeds must not agree either."""
+        import random
+
+        random.seed(1234)
+        before = random.random()
+
+        random.seed(1234)
+        exec(self.kd._RESEED_SRC, {})
+        after_first = random.random()
+
+        random.seed(1234)
+        exec(self.kd._RESEED_SRC, {})
+        after_second = random.random()
+
+        self.assertNotEqual(before, after_first, "the reseed did not move random's state")
+        self.assertNotEqual(after_first, after_second, "two reseeds produced the same stream")
+
+    def test_the_reseed_source_leaves_no_names_behind(self):
+        """It runs in the tenant's namespace, so it must not litter it."""
+        ns = {}
+        exec(self.kd._RESEED_SRC, ns)
+        leaked = [k for k in ns if not k.startswith("__")]
+        self.assertEqual(leaked, [], "reseed leaked names into the user namespace: %r" % leaked)
+
+    def test_the_reseed_source_does_not_import_numpy_when_absent(self):
+        """Importing numpy just to reseed it would cost real time on every fork of an
+        image that never uses it."""
+        self.assertNotIn("import numpy", self.kd._RESEED_SRC)
+        self.assertIn('sys.modules.get("numpy")', self.kd._RESEED_SRC)
 
 
 if __name__ == "__main__":

--- a/internal/firecracker/template.go
+++ b/internal/firecracker/template.go
@@ -197,12 +197,22 @@ func (tm *TemplateManager) startWorkloadGRPC(vsockPath string, w *WorkloadSpec) 
 // start, so every fork wakes with a warm kernel instead of paying the ~5s lazy
 // start on its first run_code.
 //
-// FORK-CORRECTNESS INVARIANT: this cell must NOT touch random, numpy, uuid, or
-// anything else that draws randomness. CPython seeds its Mersenne Twister
-// lazily from os.urandom on first use; keeping the PRNGs unseeded at snapshot
-// time means each fork seeds fresh after the per-fork CRNG reseed instead of
-// inheriting one shared PRNG state (docs/fork-correctness.md, run_code kernel
-// caveat). Pinned by TestWarmKernelCode_NeverDrawsRandomness.
+// FORK-CORRECTNESS: this cell must NOT touch random, numpy, uuid, or anything else
+// that draws randomness. That is hygiene, and it is NOT sufficient on its own.
+//
+// The comment here used to claim that CPython seeds its Mersenne Twister lazily on
+// first use, so a warmup cell that drew no randomness left the kernel's PRNGs unseeded
+// in the snapshot. That is FALSE. random.Random seeds itself from os.urandom in its
+// CONSTRUCTOR, and the random module builds its shared instance at IMPORT. ipykernel's
+// own import chain imports random, so the Mersenne state is already fixed by the time
+// this cell runs. Measured against prod with warmKernel on, three INDEPENDENT sandboxes
+// each returned random.random() == 0.993005259705148.
+//
+// The actual mitigation lives in the guest: /opt/mitos/kernel_driver.py installs a
+// SIGUSR2 handler and reseeds the kernel's Python PRNGs before the next cell, after the
+// agent has credibly reseeded the CRNG (docs/fork-correctness.md, run_code kernel).
+// Keeping this cell inert still matters: it keeps the snapshot free of any randomness
+// the driver does not know how to reseed. Pinned by TestWarmKernelCode_NeverDrawsRandomness.
 const warmKernelCode = "pass"
 
 // warmKernelTimeoutSecs bounds the warmup cell. The ipykernel boot is ~5s on a

--- a/internal/firecracker/warm_kernel_test.go
+++ b/internal/firecracker/warm_kernel_test.go
@@ -158,7 +158,7 @@ func TestWarmKernelGRPC_DrainsToExitZero(t *testing.T) {
 func TestWarmKernelCode_NeverDrawsRandomness(t *testing.T) {
 	for _, banned := range []string{"random", "numpy", "np.", "import", "uuid", "secrets"} {
 		if strings.Contains(warmKernelCode, banned) {
-			t.Errorf("warmKernelCode %q must not contain %q: the warmup cell must keep the kernel's Python PRNGs unseeded at snapshot time", warmKernelCode, banned)
+			t.Errorf("warmKernelCode %q must not contain %q: the warmup cell must draw no randomness, so the snapshot holds no PRNG state the guest-side post-fork reseed does not know how to reseed. It does NOT keep the kernel's PRNGs unseeded: ipykernel's own imports seed random before this cell runs", warmKernelCode, banned)
 		}
 	}
 }

--- a/internal/firecracker/warm_kernel_test.go
+++ b/internal/firecracker/warm_kernel_test.go
@@ -147,11 +147,14 @@ func TestWarmKernelGRPC_DrainsToExitZero(t *testing.T) {
 	}
 }
 
-// TestWarmKernelCode_NeverDrawsRandomness pins the fork-correctness invariant:
-// the warmup cell must NOT touch random or numpy (or import anything at all).
-// CPython seeds its Mersenne Twister lazily from os.urandom on first use;
-// keeping it unseeded at snapshot time means each fork seeds fresh after the
-// per-fork CRNG reseed instead of inheriting one shared PRNG state.
+// TestWarmKernelCode_NeverDrawsRandomness pins that the warmup cell draws no
+// randomness. That is hygiene, NOT the fork-correctness guarantee it was once
+// documented to be: random.Random seeds itself in its constructor and the random module
+// builds its shared instance at import, so ipykernel's own imports already fix the
+// Mersenne state before this cell runs. The guarantee lives in the guest, where
+// kernel_driver.py reseeds the kernel's PRNGs on the post-fork SIGUSR2 (see
+// guest/rootfs/kernel_driver_test.py). Keeping this cell inert keeps the snapshot free
+// of randomness the driver does not know how to reseed.
 func TestWarmKernelCode_NeverDrawsRandomness(t *testing.T) {
 	for _, banned := range []string{"random", "numpy", "np.", "import", "uuid", "secrets"} {
 		if strings.Contains(warmKernelCode, banned) {


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots. Restoring a snapshot means every child starts from one captured memory image, so any state seeded before the snapshot is shared by every child. `docs/fork-correctness.md` exists to enumerate exactly that hazard class.
> - The `run_code` path is served by a long-lived ipykernel behind `/opt/mitos/kernel_driver.py`. The hosted `python` pool sets `warmKernel: true`, so the template build starts that kernel BEFORE the snapshot, and every sandbox restores a live interpreter.
> - `template.go` asserted this was safe because "CPython seeds its Mersenne Twister lazily from `os.urandom` on first use", so an inert warmup cell (`pass`) left the PRNGs unseeded in the snapshot.
> - That premise is false. `random.Random` seeds itself in its CONSTRUCTOR, and the `random` module builds its shared instance at IMPORT. ipykernel's own import chain imports `random`, so the Mersenne state is fixed before the warmup cell ever runs.
> - Measured against production: three INDEPENDENT sandboxes each returned `random.random() == 0.993005259705148`. `TestWarmKernelCode_NeverDrawsRandomness` pinned the warmup CELL, not the invariant, so it never had a chance to catch this.
> - This pull request reseeds the kernel's Python PRNGs in the guest on the post-fork SIGUSR2, corrects the false claim in the code and the doc, and wires the driver tests into CI, where they previously ran nowhere.
> - The benefit is that two sandboxes stop being random-number clones of each other, and the mechanism is pinned by tests that fail on the unfixed driver.

## Linked Issues or Issue Description

No issue existed. Found while attributing hosted time-to-interactive.

**Observed on production**, hosted `python` pool, three independent sandboxes created one after another:

```
sandbox 1 sb-c2ce0bb8 -> 0.993005259705148 0.867169317206659 2100173373
sandbox 2 sb-9ddab381 -> 0.993005259705148 0.2858248864852364 505350320
sandbox 3 sb-ac522163 -> 0.993005259705148 0.33238588040106276 615764463

random.random() identical across independent sandboxes: True
numpy.random.random() identical: False
os.urandom() identical (must be False): False
```

The kernel CRNG reseed works (`os.urandom` diverges) and numpy seeds lazily from it (diverges). Python's `random` module does not: its state is captured in the snapshot.

**Expected:** independent sandboxes draw independent `random` streams.
**Actual:** every sandbox from the pool template replays one stream.

`random` is not a cryptographic PRNG and never was, so this is not a key-recovery bug. But a tenant that shuffles, samples, picks jitter, or generates an id with it gets the identical sequence in every sandbox, which is exactly the hazard class `docs/fork-correctness.md` exists to close.

## What Changed

- `guest/rootfs/kernel_driver.py`: installs a SIGUSR2 handler (which is what opts the driver into the agent's post-fork broadcast: the agent signals only processes that installed one, because an unhandled SIGUSR2 terminates a process, and that is also why the handler belongs in the driver rather than the ipykernel subprocess). The handler only sets a flag, since a signal handler cannot safely drive `jupyter_client` while a cell is mid-flight. Before the next cell, the driver runs a silent, history-free reseed of `random`, and of `numpy.random` when numpy is already imported. It never imports numpy just to reseed it.
- `guest/rootfs/kernel_driver_test.py`: a `ForkReseedTest` class that stubs `jupyter_client`, so it needs neither ipykernel nor a VM.
- `.github/workflows/ci.yaml`: `python-test` now runs the driver tests. It only ran `sdk/python` before, so these tests ran NOWHERE.
- `internal/firecracker/template.go`: the false claim is replaced with what is actually true, and points at the guest-side mitigation.
- `internal/firecracker/warm_kernel_test.go`: `TestWarmKernelCode_NeverDrawsRandomness` keeps its assertion (an inert warmup cell is still good hygiene: it keeps the snapshot free of randomness the driver does not know how to reseed) but its rationale no longer claims to be the fork-correctness guarantee.
- `docs/fork-correctness.md`: the run_code kernel section now records the measurement, the mitigation, and what is STILL not covered.

Ordering that makes this correct: the agent reseeds the kernel CRNG (`RNDADDENTROPY`) as step 1 of `handle_notify_forked_inner` and broadcasts SIGUSR2 as step 6, so `os.urandom(32)` in the reseed cell already returns per-fork divergent bytes.

## Verification

- [x] `pytest guest/rootfs/kernel_driver_test.py` passes (8 passed, 5 skipped; the skips are the protocol tests that need real ipykernel)
- [x] Those tests FAIL on the unfixed driver: replacing the reseed source with `pass` fails `test_the_reseed_source_actually_reseeds_python_random`
- [x] `go test ./internal/firecracker/ -count=1` passes
- [x] `golangci-lint run --timeout=5m ./internal/firecracker/...` clean, and again with `GOOS=linux`
- [x] The premise correction is itself verified: `random.Random()` self-seeds at construction, so two `Random()` instances in one process already differ

Reproduce the production observation with three sequential `mitos.create("python")` calls running `import random; print(random.random())`.

## Risks

The reseed runs in the tenant's kernel namespace. It is silent and history-free, leaves no names behind (asserted), and a failure is logged to the driver's stderr and never fails the caller's cell, because a wedged reseed must not turn into a wedged sandbox.

A cell already executing when the fork lands keeps its pre-fork PRNG state. Reseeding from a signal handler mid-cell would mean driving `jupyter_client` re-entrantly, which is worse.

`PYTHONHASHSEED` remains fixed at interpreter start, so sibling forks of a warm kernel still share hash randomization. A library that seeded its own PRNG into its own state before the snapshot (anything other than `random` and `numpy`) is still not reseeded, and a caller who explicitly ran `random.seed(1234)` before the fork point has asked for a deterministic stream and still gets one. All three are now written down rather than implied.

**This does not fix production by merging.** The driver ships in the guest rootfs, so a python base image rebuild and a pool template rebuild are required; the running prod template still carries the old driver.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved
- [x] Benchmark run (bench/) included if the hot path was touched
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fork-restore behavior by installing signal-driven reseeding for Python (and NumPy when available) before resumed code runs.

* **Bug Fixes**
  * Reduced repeated or identical random outputs after snapshot restores.
  * Reseed failures no longer interrupt the next code request; reseeding is silent and not added to execution history.

* **Documentation**
  * Updated fork-correctness guidance, including restore edge cases and PRNG seeding details.

* **Tests**
  * Added automated coverage for reseed signaling and behavior; extended CI to run guest driver tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->