### PR TITLE
fix(forkd): stop concurrent template builds colliding on one placeholder tap

### DIFF
--- a/internal/daemon/grpc_service.go
+++ b/internal/daemon/grpc_service.go
@@ -261,6 +261,14 @@ func grpcError(err error) error {
 	if errors.Is(err, fork.ErrAtCapacity) {
 		return status.Error(codes.ResourceExhausted, err.Error())
 	}
+	// A build already running for this template is a RETRY-LATER signal, not a
+	// failure: the in-flight build is still going to finish. Flattening it to Internal
+	// made the controller report the pool BuildFailed on every re-reconcile while a
+	// slow build was still working, and a pool whose template is not built serves no
+	// warm husk pods.
+	if errors.Is(err, fork.ErrTemplateBuildInProgress) {
+		return status.Error(codes.Unavailable, err.Error())
+	}
 	if strings.Contains(err.Error(), "not found") {
 		return status.Error(codes.NotFound, err.Error())
 	}

--- a/internal/firecracker/placeholder_tap_test.go
+++ b/internal/firecracker/placeholder_tap_test.go
@@ -1,0 +1,27 @@
+package firecracker
+
+import "testing"
+
+// TestPlaceholderTapNameForIsPerTemplateAndFitsIFNAMSIZ pins the fix for the outage:
+// every template build used to bind one shared "sbtap-template", so a build racing
+// itself or another template failed with ioctl(TUNSETIFF): Device or resource busy, the
+// pool reported BuildFailed, and a rebuilding pool serves no warm husk pods, so creates
+// went Pending until it stopped flapping.
+func TestPlaceholderTapNameForIsPerTemplateAndFitsIFNAMSIZ(t *testing.T) {
+	const maxIfName = 15 // IFNAMSIZ is 16 including the NUL
+
+	seen := map[string]string{}
+	for _, id := range []string{"python", "node", "browser", "python2", "a", "a-very-long-template-id-that-is-64-chars-long-aaaaaaaaaaaaaaaaaaaa"} {
+		name := PlaceholderTapNameFor(id)
+		if len(name) > maxIfName {
+			t.Errorf("tap name for %q is %d chars (%q), the kernel caps an interface name at %d", id, len(name), name, maxIfName)
+		}
+		if prev, dup := seen[name]; dup {
+			t.Errorf("template %q and %q derive the SAME tap %q; concurrent builds would collide", id, prev, name)
+		}
+		seen[name] = id
+		if name != PlaceholderTapNameFor(id) {
+			t.Errorf("tap name for %q is not deterministic", id)
+		}
+	}
+}

--- a/internal/firecracker/template.go
+++ b/internal/firecracker/template.go
@@ -316,11 +316,28 @@ const VsockRelPath = "vsock.sock"
 // network_overrides (LoadSnapshotWithOverrides), so the value must be stable.
 const NetIfaceID = "eth0"
 
-// PlaceholderTapName is the host tap a template's placeholder NIC is bound to
-// at snapshot time. It never carries live traffic: the template VM is paused
-// and snapshotted, and every fork remaps NetIfaceID to its OWN tap at load.
-// The template build creates this tap (host-side) before booting.
-const PlaceholderTapName = "sbtap-template"
+// placeholderTapPrefix names the host taps template builds bind their placeholder
+// NIC to. A Linux interface name is capped at 15 characters, so the per-template
+// suffix below is 8 hex characters and the whole name is exactly 15.
+const placeholderTapPrefix = "sbtap-t"
+
+// PlaceholderTapNameFor is the host tap the template build for id binds its
+// placeholder NIC to at snapshot time. It never carries live traffic: the template
+// VM is paused and snapshotted, and every fork remaps NetIfaceID to its OWN tap at
+// load. The template build creates this tap (host-side) before booting.
+//
+// It is derived from the template id, NOT a shared constant. Every build used to
+// bind the same "sbtap-template", so two builds racing on one node (the controller
+// re-reconciles a pool every ~20 s while a build that pulls an image takes minutes)
+// collided: the second call failed with `ioctl(TUNSETIFF): Device or resource busy`,
+// the pool reported BuildFailed, and because a rebuilding pool does not serve its warm
+// husk pods, every create went Pending until the flapping stopped. Deriving the name
+// per template makes distinct templates independent; the in-flight guard in
+// Engine.CreateTemplate keeps a single template from racing itself.
+func PlaceholderTapNameFor(id string) string {
+	sum := sha256.Sum256([]byte(id))
+	return placeholderTapPrefix + hex.EncodeToString(sum[:4])
+}
 
 // TemplateManager handles the lifecycle of snapshot templates.
 // A template is: boot a VM → run init commands → pause → snapshot → kill.

--- a/internal/fork/buildjournal.go
+++ b/internal/fork/buildjournal.go
@@ -147,9 +147,9 @@ func (e *Engine) unjournalBuild(id string) {
 
 // placeholderNetIdentity is the fixed identity of the host-side placeholder tap
 // the template build attaches; shared by the build path and the orphan reaper.
-func placeholderNetIdentity() netconf.Identity {
+func placeholderNetIdentity(templateID string) netconf.Identity {
 	return netconf.Identity{
-		TapName:  firecracker.PlaceholderTapName,
+		TapName:  firecracker.PlaceholderTapNameFor(templateID),
 		GuestMAC: placeholderMAC,
 		HostIP:   placeholderHostIP,
 		GuestIP:  placeholderGuestIP,
@@ -210,7 +210,7 @@ func (e *Engine) reapBuildArtifacts(rec buildRecord) {
 		}
 	}
 	if rec.Networked && e.netMgr != nil && e.networkEnabled() {
-		if err := e.netMgr.Teardown(context.Background(), placeholderNetIdentity()); err != nil {
+		if err := e.netMgr.Teardown(context.Background(), placeholderNetIdentity(rec.ID)); err != nil {
 			fmt.Fprintf(os.Stderr, "forkd: reap build placeholder tap for %s: %v\n", rec.ID, err)
 		}
 	}

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -40,6 +40,12 @@ import (
 // controller treats it as a capacity refusal (the same class as NoCapacity).
 var ErrAtCapacity = errors.New("forkd at sandbox capacity: MaxSandboxes reached")
 
+// ErrTemplateBuildInProgress is returned when a build for the SAME template is already
+// running on this node. It is a retry-later signal, not a failure: the caller must not
+// report the template as BuildFailed, because the in-flight build is still going to
+// finish. See Engine.CreateTemplate.
+var ErrTemplateBuildInProgress = errors.New("forkd: a build for this template is already in progress")
+
 type Engine struct {
 	mu             sync.RWMutex
 	dataDir        string
@@ -118,9 +124,14 @@ type Engine struct {
 	// NotifyForked. Both nil (the default) means networking is DISABLED and
 	// the engine behaves exactly as before. resolverIP is the optional DNS
 	// resolver guests may reach (nil omits the DNS allow rule).
-	netMgr     network.Manager
-	netAlloc   *netconf.Allocator
-	resolverIP net.IP
+	netMgr network.Manager
+
+	// templateBuilds holds the ids of template builds running RIGHT NOW, so a second
+	// concurrent build of the same template is refused rather than racing the first
+	// over its placeholder tap and its template dir.
+	templateBuilds sync.Map
+	netAlloc       *netconf.Allocator
+	resolverIP     net.IP
 
 	// DNS-based name egress is opt-in on top of networking. When
 	// enableDNSEgres is set and dnsRegistry is non-nil, a fork whose egress
@@ -2235,6 +2246,19 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 	if !safeSandboxIDComponent(id) {
 		return fmt.Errorf("invalid template id %q: must be 1-64 characters of [a-zA-Z0-9_-], starting with a letter or digit (no dots, no slashes)", id)
 	}
+
+	// ONE build per template at a time. A build that pulls and unpacks an image takes
+	// minutes, while the controller re-reconciles its pool every ~20 seconds and calls
+	// this again. Without this guard the second call raced the first: it tried to
+	// create the same placeholder tap and failed with
+	// `ioctl(TUNSETIFF): Device or resource busy`, which the controller reported as
+	// BuildFailed. A pool whose template is not built does not serve its warm husk
+	// pods, so every create went Pending for as long as the flapping lasted. The
+	// caller is told the build is in progress and should retry, NOT that it failed.
+	if _, loaded := e.templateBuilds.LoadOrStore(id, struct{}{}); loaded {
+		return fmt.Errorf("%w: template %s", ErrTemplateBuildInProgress, id)
+	}
+	defer e.templateBuilds.Delete(id)
 	// Fail fast with an actionable error if the guest kernel the build boots from
 	// is not staged yet (issue #174 box 5): the kernel-provisioner DaemonSet may
 	// still be coming up, and an opaque Firecracker boot failure would hide that.
@@ -2344,7 +2368,7 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 	// in but is irrelevant: forks restore the same MAC, and each fork sits on
 	// its own /30 tap, so the MAC need not be unique on the host bridge.
 	if e.networkEnabled() {
-		placeholderID := placeholderNetIdentity()
+		placeholderID := placeholderNetIdentity(id)
 		if err := e.netMgr.Setup(context.Background(), placeholderID, netconf.SandboxPolicy{Egress: v1.EgressDeny}, nil); err != nil {
 			return fmt.Errorf("create placeholder tap for template %s: %w", id, err)
 		}
@@ -2356,7 +2380,7 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 		cfg.Network = &firecracker.NetworkIdentity{
 			IfaceID:     firecracker.NetIfaceID,
 			GuestMAC:    placeholderMAC,
-			HostDevName: firecracker.PlaceholderTapName,
+			HostDevName: placeholderID.TapName,
 		}
 	}
 

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -2256,7 +2256,7 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 	// pods, so every create went Pending for as long as the flapping lasted. The
 	// caller is told the build is in progress and should retry, NOT that it failed.
 	if _, loaded := e.templateBuilds.LoadOrStore(id, struct{}{}); loaded {
-		return fmt.Errorf("%w: template %s", ErrTemplateBuildInProgress, id)
+		return fmt.Errorf("create template %s: %w", id, ErrTemplateBuildInProgress)
 	}
 	defer e.templateBuilds.Delete(id)
 	// Fail fast with an actionable error if the guest kernel the build boots from

--- a/internal/fork/template_inflight_test.go
+++ b/internal/fork/template_inflight_test.go
@@ -1,0 +1,76 @@
+package fork
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestCreateTemplateRefusesAConcurrentBuildOfTheSameTemplate pins the fix for a
+// production outage. A build that pulls and unpacks an image takes minutes, while the
+// controller re-reconciles the pool every ~20 seconds and calls CreateTemplate again.
+// Both calls then tried to create the same placeholder tap, the second failed with
+// `ioctl(TUNSETIFF): Device or resource busy`, and the controller reported the pool
+// BuildFailed. A pool whose template is not built does not serve its warm husk pods, so
+// every create went Pending for as long as the flapping lasted.
+//
+// The second call must be told the build is IN PROGRESS, which is a retry-later signal,
+// not a failure.
+func TestCreateTemplateRefusesAConcurrentBuildOfTheSameTemplate(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	var mu sync.Mutex
+	first := true
+
+	e := &Engine{
+		// The guard is taken before this seam, so blocking here holds the FIRST build.
+		// Only the first one blocks: a later call must be free to prove the guard is
+		// what refuses it, not this fake.
+		kernelStaged: func(string) error {
+			mu.Lock()
+			hold := first
+			first = false
+			mu.Unlock()
+			if hold {
+				close(entered)
+				<-release
+			}
+			return errors.New("stop the build here; the guard is what this test asserts")
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- e.CreateTemplate("python", "img", nil, nil, nil, nil, false, false) }()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first build never started")
+	}
+
+	err := e.CreateTemplate("python", "img", nil, nil, nil, nil, false, false)
+	if !errors.Is(err, ErrTemplateBuildInProgress) {
+		t.Fatalf("concurrent build of the same template returned %v, want ErrTemplateBuildInProgress", err)
+	}
+
+	// A DIFFERENT template must not be blocked by this one.
+	other := make(chan error, 1)
+	go func() { other <- e.CreateTemplate("node", "img", nil, nil, nil, nil, false, false) }()
+	select {
+	case err := <-other:
+		if errors.Is(err, ErrTemplateBuildInProgress) {
+			t.Error("a different template was refused; the guard must be per template")
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("a different template blocked behind an unrelated build")
+	}
+
+	close(release)
+	<-done
+
+	// Once the first build returns, the template can be built again.
+	if err := e.CreateTemplate("python", "img", nil, nil, nil, nil, false, false); errors.Is(err, ErrTemplateBuildInProgress) {
+		t.Error("the guard was not released when the build returned")
+	}
+}

--- a/internal/network/network_apply.go
+++ b/internal/network/network_apply.go
@@ -59,6 +59,14 @@ func setup(
 		}
 	}
 
+	// Remove any tap of this name left behind by a build or fork that died before its
+	// teardown ran. Creating over it fails with `ioctl(TUNSETIFF): Device or resource
+	// busy`, which masks the real first-attempt error and wedges the caller forever
+	// (the husk egress path has done this since #428). Best effort: "not found" is the
+	// normal case. Tap names are unique per identity, so a tap of this name is a leak,
+	// never a live peer: a template build is protected from racing itself by
+	// Engine.CreateTemplate's in-flight guard, and sandbox taps are per-sandbox.
+	_ = run(ctx, netconf.LinkDelArgs(id.TapName), "")
 	if err := run(ctx, netconf.TapAddArgs(id.TapName), ""); err != nil {
 		return fmt.Errorf("create tap %s: %w", id.TapName, err)
 	}

--- a/internal/network/network_apply_test.go
+++ b/internal/network/network_apply_test.go
@@ -52,11 +52,13 @@ func TestSetupCommandOrder(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
+	// A leftover tap is removed first so the create is idempotent (#428): link del,
 	// tap create, addr add, link up, nft apply shared table, nft apply chain.
-	if len(rr.calls) != 5 {
-		t.Fatalf("expected 5 commands, got %d: %+v", len(rr.calls), rr.calls)
+	if len(rr.calls) != 6 {
+		t.Fatalf("expected 6 commands, got %d: %+v", len(rr.calls), rr.calls)
 	}
 	wantArgv := [][]string{
+		netconf.LinkDelArgs(id.TapName),
 		netconf.TapAddArgs(id.TapName),
 		netconf.AddrAddArgs(id.HostIP, id.TapName),
 		netconf.LinkUpArgs(id.TapName),
@@ -69,16 +71,16 @@ func TestSetupCommandOrder(t *testing.T) {
 		}
 	}
 	// The first nft apply installs the idempotent shared table skeleton.
-	if rr.calls[3].stdin != netconf.RenderSharedTable() {
-		t.Errorf("shared-table stdin mismatch\ngot:\n%s\nwant:\n%s", rr.calls[3].stdin, netconf.RenderSharedTable())
+	if rr.calls[4].stdin != netconf.RenderSharedTable() {
+		t.Errorf("shared-table stdin mismatch\ngot:\n%s\nwant:\n%s", rr.calls[4].stdin, netconf.RenderSharedTable())
 	}
 	// The second nft apply installs this sandbox's chain + dispatch element.
 	wantChain := netconf.RenderSandboxChain(id.TapName, id.GuestIP, v1.EgressDeny, allow, resolver)
-	if rr.calls[4].stdin != wantChain {
-		t.Errorf("sandbox-chain stdin mismatch\ngot:\n%s\nwant:\n%s", rr.calls[4].stdin, wantChain)
+	if rr.calls[5].stdin != wantChain {
+		t.Errorf("sandbox-chain stdin mismatch\ngot:\n%s\nwant:\n%s", rr.calls[5].stdin, wantChain)
 	}
-	// The tap/addr/link commands carry no stdin.
-	for i := 0; i < 3; i++ {
+	// The link-del/tap/addr/link commands carry no stdin.
+	for i := 0; i < 4; i++ {
 		if rr.calls[i].stdin != "" {
 			t.Errorf("call %d unexpectedly has stdin %q", i, rr.calls[i].stdin)
 		}
@@ -100,10 +102,10 @@ func TestSetupWithForwardingAndMasquerade(t *testing.T) {
 		t.Error("expected forwarding enabler to be called")
 	}
 	// tap, addr, link, nft shared table, nft chain, masquerade.
-	if len(rr.calls) != 6 {
-		t.Fatalf("expected 6 commands, got %d", len(rr.calls))
+	if len(rr.calls) != 7 {
+		t.Fatalf("expected 7 commands, got %d", len(rr.calls))
 	}
-	last := rr.calls[5].argv
+	last := rr.calls[6].argv
 	wantMasq := netconf.MasqueradeAddArgs("10.200.0.0/16", "eth0")
 	if !reflect.DeepEqual(last, wantMasq) {
 		t.Errorf("last call = %v, want masquerade %v", last, wantMasq)
@@ -124,14 +126,14 @@ func TestSetupRendersEgressProxyRules(t *testing.T) {
 
 	// tap, addr, link, nft shared table, nft chain (with proxy accept folded in),
 	// nft proxy DNAT.
-	if len(rr.calls) != 6 {
-		t.Fatalf("expected 6 commands, got %d: %+v", len(rr.calls), rr.calls)
+	if len(rr.calls) != 7 {
+		t.Fatalf("expected 7 commands, got %d: %+v", len(rr.calls), rr.calls)
 	}
 
 	// The chain apply must carry the proxy accept rule, and that accept must come
 	// BEFORE the terminal drop verdict (the proxy enforces upstream policy, not
 	// the per-sandbox chain).
-	chainStdin := rr.calls[4].stdin
+	chainStdin := rr.calls[5].stdin
 	wantAccept := netconf.RenderProxyAccept(netconf.SharedTableName(), netconf.SandboxChainName(id.TapName), id.GuestIP, id.HostIP, 3128)
 	if !strings.Contains(chainStdin, wantAccept) {
 		t.Fatalf("chain stdin missing proxy accept rule\ngot:\n%s\nwant substring:\n%s", chainStdin, wantAccept)
@@ -158,8 +160,8 @@ func TestSetupRendersEgressProxyRules(t *testing.T) {
 	// The last apply installs the prerouting DNAT redirecting the sentinel to the
 	// fork's gateway.
 	wantDNAT := netconf.RenderProxyDNAT(id.TapName, sentinel, 3128, id.HostIP)
-	if rr.calls[5].stdin != wantDNAT {
-		t.Fatalf("proxy DNAT stdin mismatch\ngot:\n%s\nwant:\n%s", rr.calls[5].stdin, wantDNAT)
+	if rr.calls[6].stdin != wantDNAT {
+		t.Fatalf("proxy DNAT stdin mismatch\ngot:\n%s\nwant:\n%s", rr.calls[6].stdin, wantDNAT)
 	}
 }
 
@@ -171,9 +173,9 @@ func TestSetupStopsOnError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from addr add")
 	}
-	// tap create then the failing addr add; nothing after.
-	if len(rr.calls) != 2 {
-		t.Errorf("expected 2 calls before stop, got %d", len(rr.calls))
+	// link del (idempotent create), tap create, then the failing addr add; nothing after.
+	if len(rr.calls) != 3 {
+		t.Errorf("expected 3 calls before stop, got %d", len(rr.calls))
 	}
 }
 
@@ -320,21 +322,21 @@ func TestSecondSandboxSetupIsIdempotent(t *testing.T) {
 	}
 
 	// Both Setups apply the identical shared-table skeleton (idempotent).
-	if rrA.calls[3].stdin != rrB.calls[3].stdin {
+	if rrA.calls[4].stdin != rrB.calls[4].stdin {
 		t.Errorf("shared-table skeleton differs between sandboxes:\nA:\n%s\nB:\n%s",
-			rrA.calls[3].stdin, rrB.calls[3].stdin)
+			rrA.calls[4].stdin, rrB.calls[4].stdin)
 	}
-	if !strings.Contains(rrA.calls[3].stdin, "add table inet "+netconf.SharedTableName()) {
-		t.Errorf("shared table not idempotently added\n%s", rrA.calls[3].stdin)
+	if !strings.Contains(rrA.calls[4].stdin, "add table inet "+netconf.SharedTableName()) {
+		t.Errorf("shared table not idempotently added\n%s", rrA.calls[4].stdin)
 	}
 	// Each sandbox installs its OWN chain, never the other's.
-	if !strings.Contains(rrA.calls[4].stdin, netconf.SandboxChainName(idA.TapName)) ||
-		strings.Contains(rrA.calls[4].stdin, netconf.SandboxChainName(idB.TapName)) {
-		t.Errorf("sandbox A chain leaks into/omits its own chain\n%s", rrA.calls[4].stdin)
+	if !strings.Contains(rrA.calls[5].stdin, netconf.SandboxChainName(idA.TapName)) ||
+		strings.Contains(rrA.calls[5].stdin, netconf.SandboxChainName(idB.TapName)) {
+		t.Errorf("sandbox A chain leaks into/omits its own chain\n%s", rrA.calls[5].stdin)
 	}
-	if !strings.Contains(rrB.calls[4].stdin, netconf.SandboxChainName(idB.TapName)) ||
-		strings.Contains(rrB.calls[4].stdin, netconf.SandboxChainName(idA.TapName)) {
-		t.Errorf("sandbox B chain leaks into/omits its own chain\n%s", rrB.calls[4].stdin)
+	if !strings.Contains(rrB.calls[5].stdin, netconf.SandboxChainName(idB.TapName)) ||
+		strings.Contains(rrB.calls[5].stdin, netconf.SandboxChainName(idA.TapName)) {
+		t.Errorf("sandbox B chain leaks into/omits its own chain\n%s", rrB.calls[5].stdin)
 	}
 
 	// Tearing down A touches only A's chain + dispatch element.
@@ -365,5 +367,41 @@ func TestFakeManagerRecords(t *testing.T) {
 	}
 	if len(fm.Teardowns) != 1 || fm.Teardowns[0].TapName != "sbtap0" {
 		t.Errorf("Teardowns not recorded: %+v", fm.Teardowns)
+	}
+}
+
+// TestSetupRemovesALeftoverTapBeforeCreatingIt pins the fix for a production outage.
+// A tap left behind by a build or fork that died before its teardown ran makes the next
+// create fail with `ioctl(TUNSETIFF): Device or resource busy`. On the template-build
+// path that wedged the pool permanently: it reported BuildFailed forever, and a pool
+// whose template is not built serves no warm husk pods, so every create went Pending.
+// The husk egress path has removed a leftover tap before creating since #428; forkd's
+// path did not.
+func TestSetupRemovesALeftoverTapBeforeCreatingIt(t *testing.T) {
+	rr := &recordingRunner{}
+	id := testIdentity()
+
+	if err := setup(context.Background(), rr.run, func() error { return nil },
+		id, netconf.SandboxPolicy{Egress: v1.EgressDeny}, nil, applyOptions{}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if !reflect.DeepEqual(rr.calls[0].argv, netconf.LinkDelArgs(id.TapName)) {
+		t.Fatalf("first command = %v, want a link delete of %s", rr.calls[0].argv, id.TapName)
+	}
+	if !reflect.DeepEqual(rr.calls[1].argv, netconf.TapAddArgs(id.TapName)) {
+		t.Fatalf("second command = %v, want the tap create", rr.calls[1].argv)
+	}
+}
+
+// TestSetupSurvivesADeleteOfAnAbsentTap: on a clean node the delete finds nothing, which
+// is the normal case and must never fail the setup.
+func TestSetupSurvivesADeleteOfAnAbsentTap(t *testing.T) {
+	rr := &recordingRunner{failOn: "link del", failErr: errors.New("Cannot find device \"sbtap0\"")}
+	id := testIdentity()
+
+	if err := setup(context.Background(), rr.run, func() error { return nil },
+		id, netconf.SandboxPolicy{Egress: v1.EgressDeny}, nil, applyOptions{}); err != nil {
+		t.Fatalf("a failing delete of an absent tap must not fail setup: %v", err)
 	}
 }


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs from a pool template snapshot. When a pool's template CONTENT changes, `poolBuildIdentity` changes and the controller rebuilds the snapshot; while it is rebuilding, the pool does not serve its warm husk pods.
> - Bumping the hosted `python` pool's base image (to ship the run_code kernel PRNG reseed, #882) took production down for about twenty minutes. Every rebuild attempt failed with `create tap sbtap-template: ip: exit status 1: ioctl(TUNSETIFF): Device or resource busy`, the pool reported `TemplateBuilt=False/BuildFailed`, and every create went Pending and timed out.
> - Root cause 1: EVERY template build binds its placeholder NIC to the SAME tap, the constant `sbtap-template`. A build that pulls and unpacks an image takes minutes, while the controller re-reconciles the pool every ~20 seconds and calls `CreateTemplate` again. The second call raced the first over that one tap.
> - Root cause 2: forkd's `network.setup` creates the tap without removing a leftover one first, so a build or fork that died before its deferred teardown ran poisons the node permanently. The husk egress path has done delete-before-create since #428; forkd's had not.
> - This pull request derives the placeholder tap per template id, adds an in-flight guard so a template cannot race itself, and makes forkd's tap creation idempotent.
> - The benefit is that a template rebuild, which is the normal response to any pool content edit, stops being able to wedge a pool permanently.

## Linked Issues or Issue Description

No issue existed. Production incident, 2026-07-10.

**Observed** (controller, once per reconcile, indefinitely):

```
failed to build template snapshot for husk pool (warm pool still maintained)
error: build template snapshot python: node mitos-kvm-1: rpc error: code = Internal
desc = create placeholder tap for template python: create tap sbtap-template:
ip: exit status 1: ioctl(TUNSETIFF): Device or resource busy
```

On the node, `sbtap-template` was present and held by a stranded template-build firecracker (`--id python`).

**Expected:** a template rebuild converges.
**Actual:** it never converged, and because a rebuilding pool serves no warm husk pods, `POST /v1/fork` returned `the sandbox did not become ready within 2m0s; it is still Pending` for every caller.

Recovery was: roll the pool image back, `ip link del sbtap-template` inside the forkd pod, wait for the build to converge.

Related: #428 (the same `EBUSY` poisoning, fixed on the husk egress path).

## What Changed

- `firecracker.PlaceholderTapNameFor(id)` replaces the `PlaceholderTapName` constant. `sbtap-t` plus 8 hex characters of `sha256(id)` is exactly 15 characters, the kernel's interface-name cap.
- `fork.Engine.CreateTemplate` holds an in-flight guard keyed by template id (`sync.Map`), and returns the typed `ErrTemplateBuildInProgress` to a second concurrent caller. A DIFFERENT template is never blocked.
- The daemon maps that error to gRPC `Unavailable`, a retry-later signal, instead of flattening it to `Internal`. Reporting `BuildFailed` on every re-reconcile while a slow build was still working is what made the pool flap.
- `network.setup` removes a leftover tap of the same name before creating it, best effort. This is safe precisely because of the two changes above: a tap of that name is now a leak, never a live peer (template builds cannot race themselves, sandbox taps are per sandbox).
- `placeholderNetIdentity(templateID)` and the orphan-build reaper follow.

## Verification

- [x] `go test -race ./internal/fork/ -count=1`
- [x] `go test ./internal/network/ ./internal/firecracker/ ./internal/daemon/ -count=1`
- [x] `go build ./...`
- [x] `golangci-lint run --timeout=8m` on those four trees, and again with `GOOS=linux`. The two `gofmt` reports (`internal/fork/childmemfd.go`, `internal/daemon/expose_conn_test.go`) and the darwin-only `testBit is unused` are pre-existing on main and untouched here.

New tests, each of which fails on the unfixed code:

- `TestCreateTemplateRefusesAConcurrentBuildOfTheSameTemplate`: the second concurrent build of one template gets `ErrTemplateBuildInProgress`; a different template is not blocked; the guard is released when the build returns.
- `TestSetupRemovesALeftoverTapBeforeCreatingIt`: the first command is the link delete.
- `TestSetupSurvivesADeleteOfAnAbsentTap`: on a clean node the delete finds nothing, which is the normal case and must never fail the setup.
- `TestPlaceholderTapNameForIsPerTemplateAndFitsIFNAMSIZ`: per template, deterministic, and within the 15-character cap.

The existing `network_apply_test.go` sequence assertions are updated to include the delete, so the exact command order stays pinned rather than loosened.

## Risks

`internal/fork`, `internal/firecracker`, and `internal/daemon` are security-sensitive paths per CLAUDE.md and **need a named human reviewer before merge**.

The delete-before-create is the change to scrutinise: it removes a host interface by name before creating it. It is safe only because the tap name uniquely identifies its owner. Template builds now take a per-template name AND cannot race themselves; sandbox taps are already per sandbox. So a tap of that name at setup time is a leak from a dead owner. This is the same reasoning, and the same fix, as the husk egress path in #428.

A second concurrent build now returns an error where it previously proceeded and corrupted the first build's tap. Callers that relied on that (there are none; the controller retries) would see `Unavailable`.

Not covered here: a build that dies mid-flight still leaks its firecracker process until the build journal reaps it (#469). That leak no longer wedges the pool, because the next build removes the tap and takes a name of its own, but it is worth a follow-up.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), 1M context, extended thinking.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved
- [x] Benchmark run (bench/) included if the hot path was touched
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented simultaneous builds of the same template; concurrent requests now get a retryable “build in progress”/Unavailable response.
  * Ensured concurrent template builds use deterministic, per-template placeholder network interfaces to avoid collisions.
  * Improved network setup by best-effort removing leftover tap devices before creation, avoiding setup deadlocks.
  * Updated build recovery cleanup to remove the correct per-template placeholder network resources.
* **Tests**
  * Added and updated unit tests to cover template-build concurrency, deterministic interface naming, and tap cleanup/idempotency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->