### PR TITLE
fix(saas): keepalive the checkout buffer with the inert cell; evict entries that fail it

### DIFF
--- a/docs/superpowers/specs/2026-07-11-preclaimed-checkout-design.md
+++ b/docs/superpowers/specs/2026-07-11-preclaimed-checkout-design.md
@@ -73,6 +73,19 @@ attribution patch.
    while buffered is dropped from the buffer at the next 15 s pass; a pop that
    races a just-died sandbox surfaces to the tenant like any post-create death
    does today. No per-pop health probe (it would re-serialize a round trip).
+9. **Keepalive: the reconcile warms stale entries with the inert run_code cell
+   and evicts any that fail it.** (Added for #903.) Measured on prod
+   (2026-07-14 discriminator on the issue): an idle guest's first run_code
+   decays to 231-350 ms within minutes, a cheap exec touch does NOT restore it,
+   and a 60 s run_code keepalive holds it at 76-110 ms. Each reconcile pass runs
+   `pass` (language python) via RunCodeStream in every cached entry whose last
+   warm is older than 60 s, authenticated with the entry's own token, bounded
+   at 15 s per call. Success refreshes the entry's warmth; failure EVICTS the
+   entry and recycles the CR, so a wedged buffered sandbox is caught at
+   keepalive time rather than at a customer's first exec (the finding-2
+   de-amplifier). The cell is never snapshotted and the guest serves no tenant
+   until checkout, so there is no snapshot-hygiene hazard; the keepalive runs
+   pre-checkout on an org-less sandbox and bills nobody.
 
 ## Data flow
 

--- a/internal/saas/controlplane/checkout.go
+++ b/internal/saas/controlplane/checkout.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -200,11 +201,21 @@ const checkoutKeepAliveTimeout = 15 * time.Second
 const checkoutKeepAliveCell = "pass"
 
 // warmStale runs the keepalive in every cached entry for pool whose lastWarm
-// is older than the interval. Success refreshes lastWarm; failure EVICTS the
-// entry and recycles its CR, because a sandbox that cannot run the inert cell
-// must never be handed to a tenant (this is also the finding-2 de-amplifier:
-// a wedged buffered sandbox is caught here, not at a customer's first exec).
-func (b *checkoutBuffer) warmStale(ctx context.Context, pool string) {
+// is older than the interval, CONCURRENTLY (a wedged guest costs one bounded
+// call, never a serialized reconcile pass). Success refreshes lastWarm;
+// failure EVICTS the entry and recycles its CR, because a sandbox that cannot
+// run the inert cell must never be handed to a tenant (this is also the
+// finding-2 de-amplifier: a wedged buffered sandbox is caught here, not at a
+// customer's first exec). It returns how many entries it evicted so the
+// caller can refill on the SAME pass instead of a cycle later.
+//
+// Eviction is guarded against racing a concurrent checkout (a claim can pop
+// and stamp the entry while the warm is in flight) THREE ways: the entry must
+// still be cached (a pop removes it), the LIVE CR must still carry the
+// buffered label, and the delete carries a resourceVersion precondition from
+// that same fresh read, so a claim landing between the read and the delete
+// conflicts instead of destroying a tenant-owned sandbox.
+func (b *checkoutBuffer) warmStale(ctx context.Context, pool string) int {
 	warm := b.warm
 	if warm == nil {
 		warm = warmBufferedGRPC
@@ -218,26 +229,74 @@ func (b *checkoutBuffer) warmStale(ctx context.Context, pool string) {
 		}
 	}
 	b.mu.Unlock()
+
+	var evicted atomic.Int64
+	var wg sync.WaitGroup
 	for _, e := range stale {
-		wctx, cancel := context.WithTimeout(ctx, checkoutKeepAliveTimeout)
-		err := warm(wctx, e)
-		cancel()
-		if err != nil {
+		wg.Add(1)
+		go func(e bufferedSandbox) {
+			defer wg.Done()
+			wctx, cancel := context.WithTimeout(ctx, checkoutKeepAliveTimeout)
+			err := warm(wctx, e)
+			cancel()
+			if err == nil {
+				b.mu.Lock()
+				for i := range b.entries[pool] {
+					if b.entries[pool][i].name == e.name {
+						b.entries[pool][i].lastWarm = b.k.now()
+					}
+				}
+				b.mu.Unlock()
+				return
+			}
+			// Drop from the cache first; if the entry is ALREADY gone, a
+			// checkout popped it mid-warm and the sandbox belongs to a tenant
+			// now: leave the CR strictly alone.
+			b.mu.Lock()
+			still := false
+			q := b.entries[pool][:0]
+			for _, cur := range b.entries[pool] {
+				if cur.name == e.name {
+					still = true
+					continue
+				}
+				q = append(q, cur)
+			}
+			b.entries[pool] = q
+			b.mu.Unlock()
+			if !still {
+				slog.Info("checkout keepalive lost its entry to a concurrent claim; leaving the sandbox alone",
+					"sandbox", e.name, "pool", pool)
+				return
+			}
 			slog.Warn("checkout keepalive failed; evicting the buffered sandbox so the refill loop replaces it",
 				"sandbox", e.name, "pool", pool, "error", err.Error())
-			b.dropAndDelete(ctx, pool, &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{
-				Name: e.name, Namespace: b.k.singleTenantNamespace,
-			}})
-			continue
-		}
-		b.mu.Lock()
-		for i := range b.entries[pool] {
-			if b.entries[pool][i].name == e.name {
-				b.entries[pool][i].lastWarm = b.k.now()
+			// Fresh read: the CR must STILL be buffered, and the delete is
+			// preconditioned on the resourceVersion of this read (a cached RV
+			// would spuriously conflict on benign status churn). A checkout
+			// stamping the org between the read and the delete bumps the RV,
+			// so the delete conflicts and the tenant keeps the sandbox.
+			var cur v1.Sandbox
+			ns := b.k.singleTenantNamespace
+			if gerr := b.k.c.Get(ctx, client.ObjectKey{Namespace: ns, Name: e.name}, &cur); gerr != nil {
+				evicted.Add(1)
+				return
 			}
-		}
-		b.mu.Unlock()
+			if _, buffered := cur.Labels[BufferedLabelKey]; !buffered {
+				slog.Info("checkout keepalive raced a claim; the sandbox is tenant-owned and stays",
+					"sandbox", e.name, "pool", pool)
+				return
+			}
+			rv := cur.ResourceVersion
+			if derr := b.k.c.Delete(ctx, &cur, client.Preconditions{ResourceVersion: &rv}); derr != nil &&
+				!apierrors.IsNotFound(derr) && !apierrors.IsConflict(derr) {
+				slog.Warn("checkout keepalive recycle failed", "sandbox", e.name, "error", derr.Error())
+			}
+			evicted.Add(1)
+		}(e)
 	}
+	wg.Wait()
+	return int(evicted.Load())
 }
 
 // warmBufferedGRPC is the real keepalive: one RunCodeStream of the inert cell
@@ -331,8 +390,9 @@ func (b *checkoutBuffer) reconcilePool(ctx context.Context, pool string) {
 	}
 	// Keepalive pass (#903): warm every stale cached entry so a checkout never
 	// hands out a guest whose run_code working set has decayed, and evict any
-	// entry that cannot run the cell.
-	b.warmStale(ctx, pool)
+	// entry that cannot run the cell. Evictions come off the Ready count NOW,
+	// so the refill below reacts on this pass instead of a cycle later.
+	count -= b.warmStale(ctx, pool)
 
 	if count >= b.cfg.Floor || count >= b.cfg.Cap {
 		return

--- a/internal/saas/controlplane/checkout.go
+++ b/internal/saas/controlplane/checkout.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"connectrpc.com/connect"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,6 +17,8 @@ import (
 	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/saas"
 	"mitos.run/mitos/internal/tenant"
+	sandboxv1 "mitos.run/mitos/proto/sandbox/v1"
+	"mitos.run/mitos/proto/sandbox/v1/sandboxv1connect"
 )
 
 // BufferedLabelKey marks a pre-created, org-less sandbox held by the gateway
@@ -56,6 +59,10 @@ type bufferedSandbox struct {
 	resourceVersion string
 	podName         string
 	createdAt       time.Time
+	// lastWarm is when the keepalive (or the activation that created the entry)
+	// last ran the inert cell in this guest. The zero value means unknown
+	// warmth (an adopted entry), which warms on the next pass.
+	lastWarm time.Time
 }
 
 // checkoutBuffer serves eligible creates from pre-activated sandboxes. The
@@ -64,6 +71,10 @@ type bufferedSandbox struct {
 type checkoutBuffer struct {
 	k   *K8sControlPlane
 	cfg CheckoutConfig
+
+	// warm runs the keepalive cell in one buffered guest (nil selects the real
+	// Connect RunCodeStream). A seam so tests pin WHEN the buffer warms.
+	warm func(ctx context.Context, e bufferedSandbox) error
 
 	mu      sync.Mutex
 	entries map[string][]bufferedSandbox
@@ -170,6 +181,112 @@ const (
 	refillBackoffCap  = time.Minute
 )
 
+// checkoutKeepAliveInterval paces the per-entry keepalive. Measured on prod
+// (#903, 2026-07-14 discriminator): an idle buffered guest's first run_code
+// decays to 231-350 ms within minutes (and materially within one minute),
+// while a 60 s run_code keepalive holds it at 76-110 ms; a cheap exec touch
+// does NOT help, so the keepalive must be a run_code cell.
+const checkoutKeepAliveInterval = 60 * time.Second
+
+// checkoutKeepAliveTimeout bounds one keepalive call so a wedged guest costs
+// one bounded call and an eviction, never a stuck reconcile loop.
+const checkoutKeepAliveTimeout = 15 * time.Second
+
+// checkoutKeepAliveCell is the inert cell the keepalive runs. Nothing here is
+// ever snapshotted (the buffered guest was already reseeded at its activation
+// handshake and serves no tenant until checkout), so unlike the template
+// build's warm cell there is no snapshot-hygiene hazard; the cell only needs
+// to touch the run_code kernel.
+const checkoutKeepAliveCell = "pass"
+
+// warmStale runs the keepalive in every cached entry for pool whose lastWarm
+// is older than the interval. Success refreshes lastWarm; failure EVICTS the
+// entry and recycles its CR, because a sandbox that cannot run the inert cell
+// must never be handed to a tenant (this is also the finding-2 de-amplifier:
+// a wedged buffered sandbox is caught here, not at a customer's first exec).
+func (b *checkoutBuffer) warmStale(ctx context.Context, pool string) {
+	warm := b.warm
+	if warm == nil {
+		warm = warmBufferedGRPC
+	}
+	now := b.k.now()
+	b.mu.Lock()
+	var stale []bufferedSandbox
+	for _, e := range b.entries[pool] {
+		if now.Sub(e.lastWarm) > checkoutKeepAliveInterval {
+			stale = append(stale, e)
+		}
+	}
+	b.mu.Unlock()
+	for _, e := range stale {
+		wctx, cancel := context.WithTimeout(ctx, checkoutKeepAliveTimeout)
+		err := warm(wctx, e)
+		cancel()
+		if err != nil {
+			slog.Warn("checkout keepalive failed; evicting the buffered sandbox so the refill loop replaces it",
+				"sandbox", e.name, "pool", pool, "error", err.Error())
+			b.dropAndDelete(ctx, pool, &v1.Sandbox{ObjectMeta: metav1.ObjectMeta{
+				Name: e.name, Namespace: b.k.singleTenantNamespace,
+			}})
+			continue
+		}
+		b.mu.Lock()
+		for i := range b.entries[pool] {
+			if b.entries[pool][i].name == e.name {
+				b.entries[pool][i].lastWarm = b.k.now()
+			}
+		}
+		b.mu.Unlock()
+	}
+}
+
+// warmBufferedGRPC is the real keepalive: one RunCodeStream of the inert cell
+// against the buffered sandbox's own runtime endpoint, authenticated with its
+// per-sandbox token (the same custody chain the checkout response hands the
+// tenant). No code output is read beyond the terminal frames; nothing is
+// logged from the stream.
+func warmBufferedGRPC(ctx context.Context, e bufferedSandbox) error {
+	cli := sandboxv1connect.NewSandboxClient(http.DefaultClient, "http://"+e.endpoint)
+	req := connect.NewRequest(&sandboxv1.RunCodeStreamRequest{
+		Code:           checkoutKeepAliveCell,
+		Language:       "python",
+		TimeoutSeconds: int64(checkoutKeepAliveTimeout / time.Second),
+	})
+	req.Header().Set("Authorization", "Bearer "+e.token)
+	req.Header().Set("X-Sandbox-Id", e.name)
+	stream, err := cli.RunCodeStream(ctx, req)
+	if err != nil {
+		return fmt.Errorf("keepalive RunCodeStream open: %w", err)
+	}
+	defer func() { _ = stream.Close() }()
+	var exitCode int32
+	sawExit := false
+	var runErrName string
+	for stream.Receive() {
+		msg := stream.Msg()
+		switch v := msg.Msg.(type) {
+		case *sandboxv1.RunCodeResponse_Error:
+			runErrName = v.Error.GetName()
+		case *sandboxv1.RunCodeResponse_ExitCode:
+			exitCode = v.ExitCode
+			sawExit = true
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return fmt.Errorf("keepalive RunCodeStream recv: %w", err)
+	}
+	if runErrName != "" {
+		return fmt.Errorf("keepalive cell failed: %s", runErrName)
+	}
+	if !sawExit {
+		return fmt.Errorf("keepalive stream ended without an exit_code frame")
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("keepalive cell exited %d", exitCode)
+	}
+	return nil
+}
+
 // reconcilePool is one pass of the buffer loop for one pool: sync the cache
 // against the cluster (the CRs are the truth: adopt unknown Ready entries,
 // prune failed ones, reap over-age ones), then refill toward the floor, at
@@ -212,6 +329,11 @@ func (b *checkoutBuffer) reconcilePool(ctx context.Context, pool string) {
 			}
 		}
 	}
+	// Keepalive pass (#903): warm every stale cached entry so a checkout never
+	// hands out a guest whose run_code working set has decayed, and evict any
+	// entry that cannot run the cell.
+	b.warmStale(ctx, pool)
+
 	if count >= b.cfg.Floor || count >= b.cfg.Cap {
 		return
 	}
@@ -349,6 +471,9 @@ func (b *checkoutBuffer) refillOne(ctx context.Context, pool string) error {
 		resourceVersion: cur.ResourceVersion,
 		podName:         cur.Status.Pod,
 		createdAt:       cur.CreationTimestamp.Time,
+		// The activation that just completed exercised the guest, so the entry
+		// starts warm and the first keepalive lands one interval from now.
+		lastWarm: b.k.now(),
 	})
 	return nil
 }

--- a/internal/saas/controlplane/checkout_keepalive_test.go
+++ b/internal/saas/controlplane/checkout_keepalive_test.go
@@ -1,0 +1,144 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "mitos.run/mitos/api/v1"
+)
+
+// seedTokenSecret creates the controller-owned token Secret an adopt reads.
+func seedTokenSecret(t *testing.T, c client.Client, ns, name, token string) {
+	t.Helper()
+	if err := c.Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       map[string][]byte{"token": []byte(token)},
+	}); err != nil {
+		t.Fatalf("seed token secret: %v", err)
+	}
+}
+
+// recordingWarmer records keepalive invocations per sandbox and can fail
+// selected names, so tests pin WHEN the buffer warms and what an eviction
+// looks like without a live guest.
+type recordingWarmer struct {
+	mu    sync.Mutex
+	calls map[string]int
+	fail  map[string]bool
+}
+
+func newRecordingWarmer() *recordingWarmer {
+	return &recordingWarmer{calls: map[string]int{}, fail: map[string]bool{}}
+}
+
+func (w *recordingWarmer) warm(_ context.Context, e bufferedSandbox) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls[e.name]++
+	if w.fail[e.name] {
+		return errors.New("keepalive cell failed")
+	}
+	return nil
+}
+
+func (w *recordingWarmer) count(name string) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.calls[name]
+}
+
+// TestCheckoutKeepaliveWarmsStaleEntries is the #903 finding-1 mitigation
+// contract: a buffered entry whose last warm is older than the keepalive
+// interval gets ONE inert run_code per reconcile pass, a fresh entry gets
+// none, and a warmed entry is not re-warmed until the interval elapses again.
+// The measured basis (2026-07-14 prod discriminator on #903): an idle guest's
+// first run_code decays to 231-350 ms while a 60 s run_code keepalive holds it
+// at 76-110 ms; a cheap exec touch does NOT help, so the keepalive must be a
+// run_code cell.
+func TestCheckoutKeepaliveWarmsStaleEntries(t *testing.T) {
+	cp := checkoutCP(t)
+	b := cp.checkout
+	w := newRecordingWarmer()
+	b.warm = w.warm
+
+	stale := seedBuffered(t, cp.c, "sb-stale")
+	stale.lastWarm = time.Now().Add(-2 * checkoutKeepAliveInterval)
+	b.add(stale)
+	fresh := seedBuffered(t, cp.c, "sb-fresh")
+	fresh.lastWarm = time.Now()
+	b.add(fresh)
+
+	b.reconcilePool(context.Background(), "python")
+	if got := w.count("sb-stale"); got != 1 {
+		t.Fatalf("stale entry warmed %d times, want exactly 1", got)
+	}
+	if got := w.count("sb-fresh"); got != 0 {
+		t.Fatalf("fresh entry warmed %d times, want 0", got)
+	}
+
+	// A second immediate pass must not re-warm: the successful keepalive
+	// refreshed lastWarm.
+	b.reconcilePool(context.Background(), "python")
+	if got := w.count("sb-stale"); got != 1 {
+		t.Fatalf("stale entry re-warmed within the interval (calls=%d); lastWarm was not refreshed", got)
+	}
+}
+
+// TestCheckoutKeepaliveEvictsOnFailure: a buffered sandbox that cannot run the
+// inert cell must NEVER be handed to a tenant. The failed entry leaves the
+// cache and its CR is deleted (the refill loop replaces it); this also
+// de-amplifies the finding-2 stalls, because a wedged buffered sandbox is
+// detected at keepalive time instead of at a customer's first exec.
+func TestCheckoutKeepaliveEvictsOnFailure(t *testing.T) {
+	cp := checkoutCP(t)
+	b := cp.checkout
+	w := newRecordingWarmer()
+	w.fail["sb-wedged"] = true
+	b.warm = w.warm
+
+	wedged := seedBuffered(t, cp.c, "sb-wedged")
+	wedged.lastWarm = time.Now().Add(-2 * checkoutKeepAliveInterval)
+	b.add(wedged)
+
+	b.reconcilePool(context.Background(), "python")
+
+	if _, ok := b.pop("python"); ok {
+		t.Fatal("a buffered sandbox that failed its keepalive stayed claimable; it must be evicted")
+	}
+	var cur v1.Sandbox
+	err := cp.c.Get(context.Background(), client.ObjectKey{Namespace: "mitos", Name: "sb-wedged"}, &cur)
+	if err == nil {
+		t.Fatal("the wedged buffered CR still exists; eviction must delete it so the refill loop replaces it")
+	}
+}
+
+// TestCheckoutAdoptedEntriesWarmOnFirstPass: an adopted entry (gateway restart
+// or the other replica's refill) has unknown warmth, so it must be warmed on
+// the pass that adopts it rather than trusted for a full interval.
+func TestCheckoutAdoptedEntriesWarmOnFirstPass(t *testing.T) {
+	cp := checkoutCP(t)
+	b := cp.checkout
+	w := newRecordingWarmer()
+	b.warm = w.warm
+
+	// Seed the CR plus its token secret, but do NOT pre-add a cache entry:
+	// reconcilePool must adopt it, then warm it in the same pass.
+	e := seedBuffered(t, cp.c, "sb-adopted")
+	seedTokenSecret(t, cp.c, "mitos", "sb-adopted"+tokenSecretSuffix, e.token)
+
+	b.reconcilePool(context.Background(), "python")
+	if got := w.count("sb-adopted"); got != 1 {
+		t.Fatalf("adopted entry warmed %d times on the adopting pass, want 1 (unknown warmth must not be trusted)", got)
+	}
+}
+
+// noopWarm satisfies the warm seam for tests that exercise the buffer's other
+// behavior and must not dial their fake endpoints.
+func noopWarm(context.Context, bufferedSandbox) error { return nil }

--- a/internal/saas/controlplane/checkout_keepalive_test.go
+++ b/internal/saas/controlplane/checkout_keepalive_test.go
@@ -142,3 +142,42 @@ func TestCheckoutAdoptedEntriesWarmOnFirstPass(t *testing.T) {
 // noopWarm satisfies the warm seam for tests that exercise the buffer's other
 // behavior and must not dial their fake endpoints.
 func noopWarm(context.Context, bufferedSandbox) error { return nil }
+
+// TestCheckoutKeepaliveEvictionNeverDeletesAClaimedSandbox pins the race the
+// review found: a keepalive is in flight (bounded at 15 s) while a tenant
+// checkout pops and claims the same entry. A failed warm that then evicts by
+// bare name would DELETE the tenant's live sandbox. The eviction must instead
+// notice the claim (the entry left the cache, and the live CR no longer
+// carries the buffered label) and leave the CR alone.
+func TestCheckoutKeepaliveEvictionNeverDeletesAClaimedSandbox(t *testing.T) {
+	cp := checkoutCP(t)
+	b := cp.checkout
+
+	e := seedBuffered(t, cp.c, "sb-raced")
+	e.lastWarm = time.Now().Add(-2 * checkoutKeepAliveInterval)
+	b.add(e)
+
+	// The warm seam simulates the race deterministically: while the keepalive
+	// is "in flight", the tenant checkout wins the entry (pop + the org stamp,
+	// exactly what claim does), then the warm comes back failed.
+	b.warm = func(ctx context.Context, we bufferedSandbox) error {
+		popped, ok := b.pop("python")
+		if !ok || popped.name != "sb-raced" {
+			t.Fatalf("test setup: expected to pop sb-raced, got %v ok=%v", popped.name, ok)
+		}
+		if !b.stampOrg(ctx, "mitos", orgA, popped) {
+			t.Fatalf("test setup: org stamp failed")
+		}
+		return errors.New("keepalive lost the race and failed")
+	}
+
+	b.reconcilePool(context.Background(), "python")
+
+	var cur v1.Sandbox
+	if err := cp.c.Get(context.Background(), client.ObjectKey{Namespace: "mitos", Name: "sb-raced"}, &cur); err != nil {
+		t.Fatalf("the claimed sandbox was DELETED by the losing keepalive: %v", err)
+	}
+	if _, buffered := cur.Labels[BufferedLabelKey]; buffered {
+		t.Fatalf("test setup: the CR should be claimed (no buffered label), labels=%v", cur.Labels)
+	}
+}

--- a/internal/saas/controlplane/checkout_test.go
+++ b/internal/saas/controlplane/checkout_test.go
@@ -240,6 +240,9 @@ func TestRefillFillsToFloorAndStopsAtIt(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		stop := flipToReadyWhenCreatedInNs(t, c, "mitos", "10.0.0.5:9091", "tok-refill")
+		// The keepalive is exercised by the checkout_keepalive tests; here it
+		// must not dial the fake endpoints, so warming is a no-op.
+		cp.checkout.warm = noopWarm
 		cp.checkout.reconcilePool(context.Background(), "python")
 		stop()
 	}
@@ -293,6 +296,9 @@ func TestRefillBacksOffAfterFailure(t *testing.T) {
 		WithSingleTenantNamespace("mitos"),
 		WithCheckout(CheckoutConfig{Pools: []string{"python"}, Floor: 1, Cap: 2, MaxAge: 10 * time.Minute}))
 
+	// The keepalive is exercised by the checkout_keepalive tests; here it
+	// must not dial the fake endpoints, so warming is a no-op.
+	cp.checkout.warm = noopWarm
 	cp.checkout.reconcilePool(context.Background(), "python")
 	if n := creates.Load(); n != 1 {
 		t.Fatalf("first pass made %d create attempts, want 1", n)
@@ -323,6 +329,9 @@ func TestReconcileAdoptsExistingBufferedSandboxes(t *testing.T) {
 		t.Fatalf("seed secret: %v", err)
 	}
 
+	// The keepalive is exercised by the checkout_keepalive tests; here it
+	// must not dial the fake endpoints, so warming is a no-op.
+	cp.checkout.warm = noopWarm
 	cp.checkout.reconcilePool(context.Background(), "python")
 
 	got, ok := cp.checkout.pop("python")
@@ -357,6 +366,9 @@ func TestReconcilePrunesFailedBufferedSandboxes(t *testing.T) {
 		t.Fatalf("status: %v", err)
 	}
 
+	// The keepalive is exercised by the checkout_keepalive tests; here it
+	// must not dial the fake endpoints, so warming is a no-op.
+	cp.checkout.warm = noopWarm
 	cp.checkout.reconcilePool(context.Background(), "python")
 
 	var gone v1.Sandbox
@@ -384,6 +396,9 @@ func TestReconcileReapsOverAgeBufferedSandboxes(t *testing.T) {
 	// Age is CreationTimestamp-based; step the control plane clock past MaxAge.
 	cp.now = func() time.Time { return time.Now().Add(11 * time.Minute) }
 
+	// The keepalive is exercised by the checkout_keepalive tests; here it
+	// must not dial the fake endpoints, so warming is a no-op.
+	cp.checkout.warm = noopWarm
 	cp.checkout.reconcilePool(context.Background(), "python")
 
 	var gone v1.Sandbox


### PR DESCRIPTION
## Thinking Path

> - Rung C of the TTI ladder (#902) proved the pre-claimed checkout's create win (32.9 ms median) but was config-reverted for two reasons: a 210 ms first-exec median and 4/20 client read-timeout stalls (#903).
> - The 2026-07-14 discriminating experiment on prod (posted to #903) pinned the first: an idle guest's first run_code decays to 231-350 ms within minutes, a cheap exec touch does NOT restore it, and a 60 s run_code keepalive holds it at 76-110 ms; the buffer pops oldest-first, so it paid the decay on nearly every create.
> - The same experiment reproduced a finding-2-class stall on the classic path after idle, so a buffered sandbox that has quietly wedged is a live hazard the buffer must catch before handing it to a customer.
> - This pull request implements the measured mitigation: the buffer's reconcile pass warms every stale cached entry with the inert cell through the entry's own runtime endpoint and token, and EVICTS (recycles) any entry that fails it.
> - The benefit is the buffered first exec bounded near the ~100 ms band the keepalive arm measured (on top of the proven 33 ms create), plus wedged buffered sandboxes caught at keepalive time; together the prerequisites for re-enabling gateway.checkout and measuring rung D/E.

## Linked Issues or Issue Description

Refs #903 (finding 1 mitigation, finding 2 de-amplifier). Related: #896 (the feature), #902 (the ladder), #905 (stall attribution instrumentation).

## What Changed

- internal/saas/controlplane/checkout.go: per-entry lastWarm; warmStale in the reconcile pass (60 s interval, 15 s per-call bound, sequential); warmBufferedGRPC runs the inert cell via RunCodeStream with the entry's token; a failed keepalive evicts the entry and recycles the CR; refilled entries start warm (their activation just exercised the guest), adopted entries have unknown warmth and warm on the adopting pass.
- internal/saas/controlplane/checkout_keepalive_test.go: four contracts pinned TDD-first (stale warmed once and not re-warmed inside the interval; fresh untouched; failure evicts cache AND CR; adopted entries warm on the adopting pass).
- internal/saas/controlplane/checkout_test.go: the five existing reconcile tests get an explicit no-op warmer so they keep exercising their own behavior without dialing fake endpoints.
- docs/superpowers/specs/2026-07-11-preclaimed-checkout-design.md: decision 9 records the keepalive with the measured basis.

## Verification

- [x] go test ./internal/saas/controlplane/ green; the new tests fail without the checkout.go change (red run confirmed).
- [x] golangci-lint run --timeout=5m AND GOOS=linux golangci-lint run --timeout=5m clean on ./internal/saas/....
- [ ] The end-to-end effect (buffered first exec ~100 ms) is measured on prod as a ladder rung after the roll + checkout re-enable, per the no-unverified-claims rule; numbers land in bench/results, not here.

## Risks

- The keepalive adds one inert run_code per buffered sandbox per minute, pre-checkout, org-less (bills nobody, never snapshotted, the guest serves no tenant until checkout). A wedged guest costs one bounded 15 s call and an eviction; eviction feeds the existing refill loop with its #894-shaped backoff. Off (checkout disabled, the current prod state), this code does not run.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (design doc decision 9)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (it did not: the keepalive uses the existing per-sandbox token custody chain on an org-less pre-checkout sandbox)
- [x] Benchmark run (bench/) included if the hot path was touched (hot path untouched: the keepalive runs in the reconcile loop; the measured rung lands in bench/results after the roll)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added proactive “keepalive” warming for cached buffered sandboxes before they’re used.
  * Stale entries are warmed on a schedule, and entries that fail warming are removed so replacements can be created.
  * Newly adopted sandboxes are warmed/validated on first reconcile before use.
* **Documentation**
  * Updated the buffered sandbox keepalive policy and checkout behavior in the design documentation.
* **Tests**
  * Added end-to-end coverage for warming, eviction on failure, and safety when a sandbox is concurrently claimed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->