### PR TITLE
feat(chart): gateway.orgTiers renders the operator tier grants

### DIFF
--- a/deploy/charts/charttest/gateway_orgtiers_test.go
+++ b/deploy/charts/charttest/gateway_orgtiers_test.go
@@ -1,0 +1,43 @@
+package charttest
+
+import (
+	"strings"
+	"testing"
+)
+
+// Operator tier grants (mitos-run/mitos #881): the gateway grew the repeatable
+// --org-tier flag, but the chart never rendered it, so neither the hosted
+// operator nor a self-hoster could grant an org a tier above the fail-closed
+// free default through values. These tests pin the wiring: off by default,
+// one flag per granted org when set, and the schema rejecting unknown tiers.
+
+// TestGatewayOrgTiersOffByDefault: a default render carries no tier grants;
+// every org stays on the fail-closed free default.
+func TestGatewayOrgTiersOffByDefault(t *testing.T) {
+	if strings.Contains(render(t), "--org-tier") {
+		t.Fatal("--org-tier rendered by default; tier grants must be operator opt-in")
+	}
+}
+
+// TestGatewayOrgTiersRenderPerOrg: each granted org renders its own
+// --org-tier=<org>=<tier> flag on the gateway container.
+func TestGatewayOrgTiersRenderPerOrg(t *testing.T) {
+	out := render(t,
+		"gateway.orgTiers.org-bench=pro",
+		"gateway.orgTiers.org-partner=starter",
+	)
+	for _, needle := range []string{
+		"- --org-tier=org-bench=pro",
+		"- --org-tier=org-partner=starter",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("rendered manifests missing %q", needle)
+		}
+	}
+}
+
+// TestGatewayOrgTiersSchemaRejectsUnknownTier: a typo'd tier fails the render
+// instead of deploying a gateway that exits on flag parsing.
+func TestGatewayOrgTiersSchemaRejectsUnknownTier(t *testing.T) {
+	renderExpectSchemaError(t, "gateway.orgTiers.org-bench=platinum")
+}

--- a/deploy/charts/mitos/templates/gateway.yaml
+++ b/deploy/charts/mitos/templates/gateway.yaml
@@ -46,6 +46,9 @@ spec:
             - --checkout-cap={{ int .Values.gateway.checkout.cap }}
             - --checkout-max-age={{ .Values.gateway.checkout.maxAge }}
             {{- end }}
+            {{- range $org, $tier := .Values.gateway.orgTiers }}
+            - --org-tier={{ $org }}={{ $tier }}
+            {{- end }}
           {{- if or .Values.database.dsnSecretRef.name (and .Values.telemetry.enabled .Values.telemetry.endpoint) .Values.gateway.singleTenantNamespace .Values.saas.apiKeyPepperSecret.name }}
           env:
             {{- include "mitos.database.env" . | nindent 12 }}

--- a/deploy/charts/mitos/values.schema.json
+++ b/deploy/charts/mitos/values.schema.json
@@ -914,6 +914,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "orgTiers": {
+          "description": "Operator tier grants (issue #881): map of orgID to tier name. Each entry renders one --org-tier=<org>=<tier> gateway flag; unlisted orgs stay on the fail-closed free default. The pro tier also opens the sandbox egress posture.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["free", "starter", "pro"]
+          }
+        },
         "enabled": {
           "description": "Render the gateway Deployment, Service, and RBAC.",
           "type": "boolean"

--- a/deploy/charts/mitos/values.yaml
+++ b/deploy/charts/mitos/values.yaml
@@ -731,6 +731,12 @@ console:
 # programmatic counterpart to the console.
 gateway:
   enabled: true
+  # Operator tier grants (issue #881 wiring): map of orgID to tier name (free,
+  # starter, pro). Each entry renders one repeatable --org-tier flag; an org
+  # not named here stays on the fail-closed free default. Note the pro tier
+  # also opens the sandbox egress posture. Org ids and tier names are not
+  # secrets.
+  orgTiers: {}
   image:
     repository: mitos-gateway
     tag: ""


### PR DESCRIPTION
## Thinking Path

> - The gateway grew the repeatable --org-tier flag (#881) so an operator can grant one org a tier above the fail-closed free default (concurrency, creation rate, egress posture).
> - The chart never rendered it, so the grant was unreachable through gitops for the hosted operator and through values for a self-hoster (self-host is first-class, principle 7).
> - The immediate operator need is granting the benchmark org a wider tier for the TTI ladder work; the general need is any paying org before the Paddle plan wiring (#618) lands.
> - A typo'd tier name would make the gateway exit on flag parsing at rollout, so the schema must reject unknown tiers at template time (boring failure).
> - This pull request adds gateway.orgTiers (map of orgID to free/starter/pro), one rendered --org-tier flag per grant, schema enforcement, and charttest coverage.
> - The benefit is tier grants become one values entry, validated before deploy.

## Linked Issues or Issue Description

Related: #881 (the gateway flag this exposes), #618 (the eventual plan-driven replacement).

## What Changed

- deploy/charts/mitos/values.yaml + values.schema.json: gateway.orgTiers map, default empty; schema restricts tier values to free/starter/pro.
- deploy/charts/mitos/templates/gateway.yaml: one --org-tier=<org>=<tier> arg per entry.
- deploy/charts/charttest/gateway_orgtiers_test.go: off by default, per-org rendering, schema rejection of unknown tiers (TDD, red before the chart change).

## Verification

- [x] go test ./deploy/charts/charttest/ green; the new tests fail against the unchanged chart.

## Risks

- Low risk: default-empty map renders nothing. A grant is deliberate operator configuration; the pro tier's open-egress implication is stated in the value docs and the flag help.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (values.yaml + schema descriptions are the chart's user surface)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (it did not: #881 documented the grant surface; this only exposes the existing flag as a value)
- [x] Benchmark run (bench/) included if the hot path was touched (not touched)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gateway configuration for assigning organizations to `free`, `starter`, or `pro` tiers.
  * Configured tier mappings are applied automatically during deployment.
  * Organizations without a mapping remain on the default `free` tier.

* **Bug Fixes**
  * Invalid tier values are now rejected during configuration validation instead of generating deployable manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->