### PR TITLE
fix(controller): prepare-restore pods on a pre-digest pool get --snapshot-dir, ending the silent no-op

### DIFF
--- a/internal/controller/huskpod.go
+++ b/internal/controller/huskpod.go
@@ -651,6 +651,16 @@ func (r *SandboxPoolReconciler) buildHuskPod(pool *v1.SandboxPool, template *v1.
 		args = append(args, "--snapshot-dir", huskSnapshotMountPath, "--expected-digest", opts.ExpectedDigest)
 	} else {
 		args = append(args, "--allow-unverified-snapshots")
+		// Prepare-time restore needs the snapshot dir at STARTUP, digest or no
+		// digest: without it the dormant restore silently no-ops and every claim
+		// keeps paying the full restore while the flags claim otherwise (found
+		// live at the first prod canary). The verify posture is unchanged; this
+		// branch stays --allow-unverified-snapshots, only the dir is threaded.
+		// A fork child restores its own node-local fork snapshot at spawn and is
+		// never pre-restored, so it keeps no --snapshot-dir.
+		if opts.PrepareRestore && opts.ForkSnapshotID == "" {
+			args = append(args, "--snapshot-dir", huskSnapshotMountPath)
+		}
 	}
 
 	// Volumes + mounts: the mTLS Secret, the node's template snapshot subdir

--- a/internal/controller/huskpod_test.go
+++ b/internal/controller/huskpod_test.go
@@ -1617,3 +1617,49 @@ func TestBuildHuskPodThreadsPrepareKernelPrefault(t *testing.T) {
 		t.Errorf("husk args must omit --prepare-kernel-prefault by default: %v", off.Spec.Containers[0].Args)
 	}
 }
+
+// TestPrepareRestorePodGetsSnapshotDirWithoutDigest pins the prod gap found at
+// the rung D canary (2026-07-14): on a pre-digest pool (no recorded template
+// digest, the hosted python pool's shape), the builder emitted --snapshot-dir
+// only together with --expected-digest, so a --prepare-restore stub had no
+// PrepareSnapshotDir and the dormant restore SILENTLY no-opped; every claim
+// kept paying the full restore while the flags claimed otherwise. A
+// prepare-restore pod must always know its snapshot dir; the verify posture
+// (digest verify vs --allow-unverified-snapshots) is unchanged and separate.
+func TestPrepareRestorePodGetsSnapshotDirWithoutDigest(t *testing.T) {
+	r := &controller.SandboxPoolReconciler{}
+	pool := &v1.SandboxPool{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	tmpl := &v1.PoolTemplateSpec{}
+
+	// Pre-digest pool + prepare-restore: the snapshot dir must be threaded.
+	on := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{
+		StubImage: "img", MultiVM: true, PrepareEgressLink: true, PrepareRestore: true,
+	})
+	args := on.Spec.Containers[0].Args
+	if !argsContain(args, "--snapshot-dir") {
+		t.Errorf("prepare-restore pod on a pre-digest pool missing --snapshot-dir; the dormant restore silently no-ops without it: %v", args)
+	}
+	if !argsContain(args, "--allow-unverified-snapshots") {
+		t.Errorf("pre-digest pool must keep the unverified escape hatch (verify posture unchanged): %v", args)
+	}
+	if argsContain(args, "--expected-digest") {
+		t.Errorf("no digest exists; --expected-digest must not be invented: %v", args)
+	}
+
+	// A fork child is never pre-restored; it must not gain the flag.
+	child := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{
+		StubImage: "img", MultiVM: true, PrepareEgressLink: true, PrepareRestore: true,
+		ForkSnapshotID: "fk-1",
+	})
+	if argsContain(child.Spec.Containers[0].Args, "--snapshot-dir") {
+		t.Errorf("fork-child pod must not carry --snapshot-dir: %v", child.Spec.Containers[0].Args)
+	}
+
+	// Without prepare-restore, the pre-digest render is byte-for-byte unchanged.
+	off := r.BuildHuskPodForTest(pool, tmpl, controller.HuskPodOptions{
+		StubImage: "img", MultiVM: true, PrepareEgressLink: true,
+	})
+	if argsContain(off.Spec.Containers[0].Args, "--snapshot-dir") {
+		t.Errorf("--snapshot-dir leaked into the flags-off pre-digest render: %v", off.Spec.Containers[0].Args)
+	}
+}


### PR DESCRIPTION
## Thinking Path

> - The prepare-time restore chain (v1.42.0, flags on in the hosted deployment) moved the microVM restore off the warm-claim hot path; the rollout plan's first gate is a one-pod prod canary.
> - The canary (2026-07-14) found the replacement pod Ready with all three prepare flags and restartCount=0, but NO dormant-restore marker: the restore silently no-opped.
> - Root cause: buildHuskPod emits --snapshot-dir only inside the recorded-digest verify branch, and the hosted python pool is pre-digest, so the stub started with an empty PrepareSnapshotDir, which is a designed no-op precondition of prepareRestoreDefaultVM.
> - The KVM gate could not catch this: it drives cmd/husk-stub directly and passes --snapshot-dir itself; the controller-side arg threading was only pinned for the flags, not the dir.
> - This pull request threads --snapshot-dir in the pre-digest branch whenever PrepareRestore is on (never for a fork child), with the verify posture byte-for-byte unchanged.
> - The benefit is the flags now do what they say on the pools prod actually runs, and the canary can proceed to prove the fast path.

## Linked Issues or Issue Description

Related: #889 (prepare-time restore), #871. Found by the rollout canary the plan (docs/superpowers/plans/2026-07-10-prepare-time-restore.md) mandates.

## What Changed

- internal/controller/huskpod.go: the pre-digest else-branch adds --snapshot-dir when opts.PrepareRestore is on and the pod is not a fork child; --allow-unverified-snapshots stays and no digest is invented.
- internal/controller/huskpod_test.go: TestPrepareRestorePodGetsSnapshotDirWithoutDigest (red before the fix) pins the dir on a pre-digest prepare-restore pod, its absence on a fork child, and the byte-for-byte flags-off render.

## Verification

- [x] eval $(setup-envtest use 1.31 -p env) && go test ./internal/controller/ green (full suite, 238s).
- [x] go test ./internal/husk/ ./cmd/husk-stub/ green.
- [x] golangci-lint run --timeout=5m AND GOOS=linux golangci-lint run --timeout=5m clean on ./internal/controller/....
- [ ] Prod canary re-run after the roll proves the dormant markers + fast-path activate (the rung D gate).

## Risks

- Low risk: the added arg only appears when the operator opted into --husk-prepare-restore; a stub without the flag ignores --snapshot-dir for restore purposes (it only skips the verify, exactly as before, since no digest accompanies it). Fork-child pods are untouched.

## Model Used

- Claude Fable 5 (Anthropic), model id claude-fable-5, extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR (no doc claims change; the plan's canary step found and now covers this)
- [x] Threat-model delta (docs/threat-model.md) included if the security surface moved (it did not: same dir the activate request already names, same verify posture)
- [x] Benchmark run (bench/) included if the hot path was touched (the rung D prod measurement follows the roll per the ladder method)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot restoration for warm pods when no expected template digest is configured.
  * Warm pods now receive the snapshot directory needed to perform prepare-time restores.
  * Preserved existing behavior for fork-child pods and when prepare-time restore is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->