### PR TITLE
ci: latency regression guards (CI activation ceiling + nightly in-region TTI canary)

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -2612,6 +2612,28 @@ jobs:
           read -r CNT MIN P50 P99 MAX <<< "$STATS"
           echo "husk-stub activation latency: n=$CNT min=${MIN}ms p50=${P50}ms p99=${P99}ms max=${MAX}ms"
 
+          # GROSS activation-latency regression gate. This step's activate is the
+          # full LoadSnapshot + resume + guest-ready for the 256 MiB bench snapshot,
+          # and it is remarkably stable on this shared runner: P50 ~54 ms, max ~58 ms
+          # across recent main runs. The <=10 ms bare-metal target is NOT asserted
+          # here (shared CI is not bare metal, see below); what IS asserted is a
+          # GENEROUS ceiling so a gross regression fails the build instead of only
+          # showing in the summary. 200 ms is ~3.7x the observed P50 with wide margin
+          # against nested-KVM noise on a cold runner, so it catches the class of
+          # break that matters (the restore silently returning to a slow path, a 2-3x
+          # slowdown) without flaking on ordinary variance. The SUBTLE +20 ms class
+          # (which rode a flag-off path in v1.40.0) is caught by the in-region prod
+          # TTI canary (.github/workflows/tti-canary.yaml), not here; and the
+          # prepare-time restore fast path is asserted tightly (vmstate_restore < 10 ms)
+          # by the "Prepare-time restore" step above. Together: mechanism gate +
+          # gross-CI gate + subtle prod gate.
+          ACTIVATE_CEILING_MS=200
+          if awk "BEGIN{exit !(${P50} > ${ACTIVATE_CEILING_MS})}"; then
+            echo "HUSK-STUB-FAILED: activation P50 ${P50}ms exceeds the ${ACTIVATE_CEILING_MS}ms gross-regression ceiling; the warm-claim activate has regressed materially (restore back on the hot path, or a 2-3x slowdown). Investigate before merge; do NOT raise the ceiling to make this green."
+            exit 1
+          fi
+          echo "activation P50 ${P50}ms within the ${ACTIVATE_CEILING_MS}ms gross-regression ceiling"
+
           {
             echo ""
             echo "## Husk-stub in-place activation latency (shared-CI-class, NOT bare metal)"

--- a/.github/workflows/tti-canary.yaml
+++ b/.github/workflows/tti-canary.yaml
@@ -1,0 +1,119 @@
+name: TTI canary
+
+# Nightly hosted TTI regression guard. Runs bench/tti-latency.py against the
+# live hosted API from the IN-REGION self-hosted bench runner (mitos-bench1,
+# same region as prod), so the number is the reproducible ladder number, not an
+# internet-skewed one. If TTI P50 regresses past bench/canary-baseline.json or
+# the success rate drops, the run fails and a single tracking issue is opened or
+# updated. This catches the subtle-drift class (the v1.40.0 +20 ms activate
+# regression that rode a flag-off path and nothing caught) that the CI KVM gate,
+# on a shared runner, cannot resolve.
+#
+# It exercises PROD (creates and terminates real sandboxes on the benchmark org,
+# which holds a headroom tier), so it is scheduled off-peak and paced.
+
+on:
+  schedule:
+    - cron: "0 4 * * *"  # 04:00 UTC nightly
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: iterations to run
+        default: "40"
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: tti-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    runs-on: [self-hosted, bench, kvm]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Run the hosted TTI harness against api.mitos.run
+        id: run
+        env:
+          MITOS_API_KEY: ${{ secrets.MITOS_BENCH_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MITOS_API_KEY:-}" ]; then
+            echo "MITOS_BENCH_API_KEY secret is not set; cannot run the canary" >&2
+            exit 2
+          fi
+          N="${{ github.event.inputs.iterations || '40' }}"
+          python3 -m venv /tmp/tti-canary-venv
+          /tmp/tti-canary-venv/bin/pip install --quiet --upgrade pip
+          # The harness imports `mitos`; install the SDK from this checkout so
+          # the client is pinned to the repo, not to whatever is on the box.
+          /tmp/tti-canary-venv/bin/pip install --quiet ./sdk/python
+          # Paced identically to the ladder (13 s) for comparability with
+          # bench/results; the benchmark org's tier removes rate-limit retries.
+          /tmp/tti-canary-venv/bin/python3 -u bench/tti-latency.py "$N" --interval 13 | tee /tmp/tti-canary.out
+
+      - name: Verdict against the baseline
+        id: verdict
+        run: |
+          set +e
+          python3 bench/canary-check.py /tmp/tti-canary.out --baseline bench/canary-baseline.json | tee /tmp/tti-verdict.txt
+          echo "code=$?" >> "$GITHUB_OUTPUT"
+          {
+            echo "verdict<<EOF"
+            cat /tmp/tti-verdict.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the regression issue
+        if: steps.verdict.outputs.code != '0'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const verdict = process.env.VERDICT || 'canary verdict unavailable';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const marker = '<!-- tti-canary-tracking -->';
+            const title = 'TTI canary regression: hosted P50 or success rate breached the baseline';
+            const body = [
+              marker,
+              '',
+              `The nightly hosted TTI canary breached its baseline (bench/canary-baseline.json).`,
+              '',
+              '```',
+              verdict,
+              '```',
+              '',
+              `Run: ${runUrl}`,
+              '',
+              'This is the in-region measurement from mitos-bench1 (the ladder harness).',
+              'Investigate the regression; do NOT raise the baseline to silence this without a',
+              'fresh ladder measurement in bench/results/ that justifies it.',
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'tti-canary', per_page: 20,
+            });
+            const hit = existing.data.find(i => (i.body || '').includes(marker));
+            if (hit) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: hit.number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['tti-canary', 'performance'],
+              });
+            }
+        env:
+          VERDICT: ${{ steps.verdict.outputs.verdict }}
+
+      - name: Fail the run on regression
+        if: steps.verdict.outputs.code != '0'
+        run: |
+          echo "canary regression, see the tracking issue" >&2
+          exit 1

--- a/bench/canary-baseline.json
+++ b/bench/canary-baseline.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Regression thresholds for the nightly hosted TTI canary (.github/workflows/tti-canary.yaml). The canary runs bench/tti-latency.py against api.mitos.run from the in-region self-hosted bench runner (mitos-bench1) and fails, opening a tracking issue, when a threshold is breached. Raise a threshold ONLY with a fresh ladder measurement that justifies it (bench/results/), never to make a red canary green.",
+  "tti_p50_ceiling_ms": 125,
+  "min_success_rate_pct": 95,
+  "provenance": "Baseline: rung E measured TTI P50 96.8 ms, 100/100 success (bench/results/2026-07-12-tti-create-path-ladder.md, v1.42.1, 2026-07-14). The 125 ms ceiling catches a ~29 percent regression (still under Daytona 136.2) with margin for the harness's observed ~6 percent run-to-run drift; it is deliberately tighter than a shared-CI gate because this runs on stable in-region bare metal. The success gate guards the read-timeout stall class that #903/#908 fixed."
+}

--- a/bench/canary-check.py
+++ b/bench/canary-check.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Verdict for the nightly hosted TTI canary.
+
+Reads a `bench/tti-latency.py` summary (from a file or stdin) and the threshold
+file `bench/canary-baseline.json`, then decides pass or regression:
+
+  - TTI P50 must be <= tti_p50_ceiling_ms
+  - success rate must be >= min_success_rate_pct
+
+Exit 0 = within thresholds, exit 1 = regression (the workflow then opens the
+tracking issue and fails). A parse failure is exit 2 (a canary that cannot read
+its own input must be loud, not silently green).
+
+Pure and offline: it does not touch the network. The workflow owns the GitHub
+issue side effect so this stays unit-checkable via --self-test.
+"""
+import argparse
+import json
+import re
+import sys
+
+
+def parse_summary(text):
+    """Extract (tti_p50_ms, success_pct) from a tti-latency.py summary block.
+
+    The harness prints, among other lines:
+        P50      96.8
+        success rate: 100/100 (100.0%), rate-limited retries: 0
+    We match the FIRST 'P50' line (TTI section) and the success percentage.
+    """
+    p50 = None
+    m = re.search(r"^\s*P50\s+([0-9]+\.?[0-9]*)\s*$", text, re.MULTILINE)
+    if m:
+        p50 = float(m.group(1))
+    success = None
+    m = re.search(r"success rate:\s*\d+/\d+\s*\(([0-9]+\.?[0-9]*)%\)", text)
+    if m:
+        success = float(m.group(1))
+    return p50, success
+
+
+def verdict(text, baseline):
+    p50, success = parse_summary(text)
+    if p50 is None or success is None:
+        return 2, f"could not parse TTI P50 (got {p50}) or success rate (got {success}) from the harness output"
+    ceiling = baseline["tti_p50_ceiling_ms"]
+    min_success = baseline["min_success_rate_pct"]
+    problems = []
+    if p50 > ceiling:
+        problems.append(f"TTI P50 {p50:.1f} ms exceeds the {ceiling} ms ceiling")
+    if success < min_success:
+        problems.append(f"success rate {success:.1f}% is under the {min_success}% floor")
+    if problems:
+        return 1, f"REGRESSION: {'; '.join(problems)} (P50={p50:.1f} ms, success={success:.1f}%)"
+    return 0, f"OK: TTI P50 {p50:.1f} ms <= {ceiling} ms, success {success:.1f}% >= {min_success}%"
+
+
+SELF_TEST_CASES = [
+    # (summary, baseline, want_code)
+    ("  P50      96.8\n  success rate: 100/100 (100.0%), rate-limited retries: 0",
+     {"tti_p50_ceiling_ms": 125, "min_success_rate_pct": 95}, 0),
+    ("  P50     140.0\n  success rate: 100/100 (100.0%), rate-limited retries: 0",
+     {"tti_p50_ceiling_ms": 125, "min_success_rate_pct": 95}, 1),
+    ("  P50      96.8\n  success rate: 88/100 (88.0%), rate-limited retries: 0",
+     {"tti_p50_ceiling_ms": 125, "min_success_rate_pct": 95}, 1),
+    ("no summary here", {"tti_p50_ceiling_ms": 125, "min_success_rate_pct": 95}, 2),
+]
+
+
+def self_test():
+    ok = True
+    for i, (text, base, want) in enumerate(SELF_TEST_CASES):
+        code, msg = verdict(text, base)
+        status = "ok" if code == want else "FAIL"
+        if code != want:
+            ok = False
+        print(f"  case {i}: want {want} got {code} [{status}] {msg}")
+    print("SELF-TEST PASS" if ok else "SELF-TEST FAIL")
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("summary", nargs="?", help="path to the harness summary (default stdin)")
+    ap.add_argument("--baseline", default="bench/canary-baseline.json")
+    ap.add_argument("--self-test", action="store_true", help="validate the parser on known cases and exit")
+    args = ap.parse_args()
+    if args.self_test:
+        sys.exit(self_test())
+    text = open(args.summary).read() if args.summary else sys.stdin.read()
+    with open(args.baseline) as f:
+        baseline = json.load(f)
+    code, msg = verdict(text, baseline)
+    print(msg)
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Thinking Path

> - This session drove hosted TTI to a measured P50 96.8 ms (rung E, below Daytona, at Northflank), but the number is a point-in-time manual measurement.
> - CI has NO latency-regression gate: the ladder and TTI harness are manual-only, and the husk-stub KVM step measures activation but explicitly does not assert a target.
> - That gap already bit us: the v1.40.0 +20 ms activate regression rode a flag-off path and nothing caught it.
> - The fix is layered: a tight structural mechanism gate already exists (#904 asserts vmstate_restore < 10 ms on the prepare-restore fast path); this adds a gross-regression CI ceiling and a subtle-drift prod canary.
> - This pull request adds both: the husk-stub activation step now fails past a generous 200 ms ceiling, and a nightly scheduled workflow runs the ladder harness from the in-region self-hosted bench runner and opens a tracking issue if TTI P50 or success rate breaches bench/canary-baseline.json.
> - The benefit is that the measured win cannot silently regress: gross breaks fail a PR, subtle drift fails a nightly run and files an issue.

## Linked Issues or Issue Description

Related: #871 (the TTI gap this protects), #15 (the benchmark program). The canary guards the numbers recorded in bench/results/2026-07-12-tti-create-path-ladder.md.

## What Changed

- .github/workflows/kvm-test.yaml: the husk-stub activation step asserts P50 under a 200 ms gross-regression ceiling (observed ~54 ms, stable across main runs) so a 2-3x activate regression fails firecracker-test. Comment explains why shared CI cannot gate the subtle class.
- .github/workflows/tti-canary.yaml: a scheduled (nightly) + dispatchable workflow that runs bench/tti-latency.py against api.mitos.run from the in-region self-hosted bench runner (real ladder numbers), checks the verdict, and opens or updates ONE tracking issue (label tti-canary) on breach, then fails the run.
- bench/canary-baseline.json: the thresholds (TTI P50 125 ms, success 95 percent) with provenance and a do-not-raise-to-silence note.
- bench/canary-check.py: the pure parse-and-verdict (exit 0/1/2), validated by its own --self-test.

## Verification

- [x] actionlint clean on both workflows.
- [x] bench/canary-check.py --self-test passes (4 cases: within, P50 breach, success breach, unparseable).
- [x] The MITOS_BENCH_API_KEY repo secret is set (a limited pro-tier bench-org key) and the tti-canary label exists.
- [ ] A workflow_dispatch of the canary against prod is triggered to validate the end-to-end run on the self-hosted runner; result noted on the PR.

## Risks

- The canary creates and terminates real sandboxes on the benchmark org each night (headroom tier, off-peak, paced). It is read-only to the rest of prod. The ceiling and thresholds are set generously to avoid flaking; a genuine breach is the intended signal. No production code changes.

## Model Used

- Claude Opus 4.8 (claude-opus-4-8, 1M context), extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD) (canary-check.py --self-test)
- [x] Docs updated in the same PR (baseline provenance + workflow comments are the surface)
- [x] Threat-model delta included if the security surface moved (it did not: a bench-org key in an encrypted repo secret, already on the bench box; no new tenant-facing surface)
- [x] Benchmark run (bench/) included if the hot path was touched (this IS benchmark tooling; no hot-path code)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a nightly performance canary to monitor hosted time-to-interactive (TTI), compare results with established thresholds, and report regressions.
  * Regression failures now automatically update a tracked issue with the latest diagnostic results.

* **Bug Fixes**
  * Builds now fail when in-place activation latency exceeds the defined performance ceiling.

* **Tests**
  * Added offline validation for parsing performance summaries and evaluating canary results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->