### PR TITLE
ci: harden the TTI canary and activation gate (CodeRabbit follow-up to #915)

### DIFF
--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -2575,6 +2575,15 @@ jobs:
                 fail_active "activate $n returned a non-numeric latency_ms='$lat'; the measurement is broken, not fast"
                 ;;
             esac
+            # A lone "." (or any value with no digit) passes the pattern above
+            # but is not a number, so require at least one digit.
+            case "$lat" in
+              *[0-9]*) : ;;
+              *)
+                kill $stub_pid 2>/dev/null || true
+                fail_active "activate $n returned a digitless latency_ms='$lat'; the measurement is broken, not fast"
+                ;;
+            esac
             echo "activate $n: OK latency_ms=$lat vsock=$vsock"
 
             # First run: exec a real command through the guest agent over the

--- a/.github/workflows/kvm-test.yaml
+++ b/.github/workflows/kvm-test.yaml
@@ -2565,6 +2565,16 @@ jobs:
               kill $stub_pid 2>/dev/null || true
               fail_active "activate $n result ok=$ok"
             fi
+            # Reject a non-numeric latency BEFORE it reaches the percentile awk,
+            # which would fold null/empty into 0.000 and could sneak a broken
+            # measurement past the gross-regression ceiling below (a P50 gate is
+            # only as trustworthy as its samples).
+            case "$lat" in
+              ''|null|*[!0-9.]*|*.*.*)
+                kill $stub_pid 2>/dev/null || true
+                fail_active "activate $n returned a non-numeric latency_ms='$lat'; the measurement is broken, not fast"
+                ;;
+            esac
             echo "activate $n: OK latency_ms=$lat vsock=$vsock"
 
             # First run: exec a real command through the guest agent over the

--- a/.github/workflows/tti-canary.yaml
+++ b/.github/workflows/tti-canary.yaml
@@ -11,6 +11,12 @@ name: TTI canary
 #
 # It exercises PROD (creates and terminates real sandboxes on the benchmark org,
 # which holds a headroom tier), so it is scheduled off-peak and paced.
+#
+# The measurement job is READ-ONLY (no issues token, checkout credentials not
+# persisted): it runs the benchmark harness, which is the untrusted-input
+# surface on the self-hosted runner. A SEPARATE dependent job holds the
+# issues:write token and runs only github-script (no harness), so the write
+# token is never present while the benchmark executes.
 
 on:
   schedule:
@@ -18,13 +24,12 @@ on:
   workflow_dispatch:
     inputs:
       iterations:
-        description: iterations to run
+        description: iterations to run (integer)
         default: "40"
         required: false
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: tti-canary
@@ -34,44 +39,83 @@ jobs:
   canary:
     runs-on: [self-hosted, bench, kvm]
     timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      regressed: ${{ steps.gate.outputs.regressed }}
+      verdict: ${{ steps.gate.outputs.verdict }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - name: Run the hosted TTI harness against api.mitos.run
-        id: run
+      - name: Run the harness and compute the verdict
+        id: gate
         env:
           MITOS_API_KEY: ${{ secrets.MITOS_BENCH_API_KEY }}
+          # Passed through env, NOT interpolated into the script body, so a
+          # crafted dispatch input cannot break out of the shell on the runner.
+          ITERATIONS: ${{ github.event.inputs.iterations || '40' }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           if [ -z "${MITOS_API_KEY:-}" ]; then
             echo "MITOS_BENCH_API_KEY secret is not set; cannot run the canary" >&2
             exit 2
           fi
-          N="${{ github.event.inputs.iterations || '40' }}"
+          # Reject a non-integer iteration count before it reaches the harness.
+          case "$ITERATIONS" in
+            ''|*[!0-9]*)
+              echo "iterations must be a positive integer, got '$ITERATIONS'" >&2
+              exit 2
+              ;;
+          esac
+
           python3 -m venv /tmp/tti-canary-venv
           /tmp/tti-canary-venv/bin/pip install --quiet --upgrade pip
           # The harness imports `mitos`; install the SDK from this checkout so
           # the client is pinned to the repo, not to whatever is on the box.
           /tmp/tti-canary-venv/bin/pip install --quiet ./sdk/python
-          # Paced identically to the ladder (13 s) for comparability with
-          # bench/results; the benchmark org's tier removes rate-limit retries.
-          /tmp/tti-canary-venv/bin/python3 -u bench/tti-latency.py "$N" --interval 13 | tee /tmp/tti-canary.out
 
-      - name: Verdict against the baseline
-        id: verdict
-        run: |
+          # Capture the harness status instead of letting it abort the step, so
+          # the verdict still runs (and the tracking issue still opens) on a
+          # harness or parse failure. Paced identically to the ladder (13 s).
           set +e
+          /tmp/tti-canary-venv/bin/python3 -u bench/tti-latency.py "$ITERATIONS" --interval 13 | tee /tmp/tti-canary.out
+          HARNESS_RC=${PIPESTATUS[0]}
           python3 bench/canary-check.py /tmp/tti-canary.out --baseline bench/canary-baseline.json | tee /tmp/tti-verdict.txt
-          echo "code=$?" >> "$GITHUB_OUTPUT"
+          VERDICT_RC=$?
+          set -e
+
+          if [ "$HARNESS_RC" -ne 0 ]; then
+            echo "harness exited $HARNESS_RC; treating as a regression signal" | tee -a /tmp/tti-verdict.txt
+          fi
+
           {
-            echo "verdict<<EOF"
+            if [ "$HARNESS_RC" -ne 0 ] || [ "$VERDICT_RC" -ne 0 ]; then
+              echo "regressed=true"
+            else
+              echo "regressed=false"
+            fi
+            echo "verdict<<VERDICT_EOF"
             cat /tmp/tti-verdict.txt
-            echo "EOF"
+            echo "VERDICT_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Open or update the regression issue
-        if: steps.verdict.outputs.code != '0'
+  # Separate job: holds the issues:write token and runs ONLY github-script (no
+  # benchmark, no checkout of untrusted content), so the write token is never in
+  # scope while the harness executes on the self-hosted runner.
+  report:
+    needs: canary
+    if: always() && needs.canary.outputs.regressed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the regression issue and fail the run
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          VERDICT: ${{ needs.canary.outputs.verdict }}
         with:
           script: |
             const verdict = process.env.VERDICT || 'canary verdict unavailable';
@@ -79,25 +123,21 @@ jobs:
             const marker = '<!-- tti-canary-tracking -->';
             const title = 'TTI canary regression: hosted P50 or success rate breached the baseline';
             const body = [
-              marker,
-              '',
-              `The nightly hosted TTI canary breached its baseline (bench/canary-baseline.json).`,
-              '',
-              '```',
-              verdict,
-              '```',
-              '',
-              `Run: ${runUrl}`,
-              '',
+              marker, '',
+              'The nightly hosted TTI canary breached its baseline (bench/canary-baseline.json).',
+              '', '```', verdict, '```', '',
+              `Run: ${runUrl}`, '',
               'This is the in-region measurement from mitos-bench1 (the ladder harness).',
               'Investigate the regression; do NOT raise the baseline to silence this without a',
               'fresh ladder measurement in bench/results/ that justifies it.',
             ].join('\n');
-            const existing = await github.rest.issues.listForRepo({
+            // Paginate all labeled issues and skip pull requests (listForRepo
+            // returns both), so an older tracker is never missed and duplicated.
+            const items = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner, repo: context.repo.repo,
-              state: 'open', labels: 'tti-canary', per_page: 20,
+              state: 'open', labels: 'tti-canary', per_page: 100,
             });
-            const hit = existing.data.find(i => (i.body || '').includes(marker));
+            const hit = items.find(i => !i.pull_request && (i.body || '').includes(marker));
             if (hit) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner, repo: context.repo.repo,
@@ -109,11 +149,4 @@ jobs:
                 title, body, labels: ['tti-canary', 'performance'],
               });
             }
-        env:
-          VERDICT: ${{ steps.verdict.outputs.verdict }}
-
-      - name: Fail the run on regression
-        if: steps.verdict.outputs.code != '0'
-        run: |
-          echo "canary regression, see the tracking issue" >&2
-          exit 1
+            core.setFailed('TTI canary regression, see the tracking issue');

--- a/.github/workflows/tti-canary.yaml
+++ b/.github/workflows/tti-canary.yaml
@@ -69,6 +69,10 @@ jobs:
               exit 2
               ;;
           esac
+          if [ "$ITERATIONS" -le 0 ]; then
+            echo "iterations must be greater than zero, got '$ITERATIONS'" >&2
+            exit 2
+          fi
 
           python3 -m venv /tmp/tti-canary-venv
           /tmp/tti-canary-venv/bin/pip install --quiet --upgrade pip
@@ -121,10 +125,12 @@ jobs:
             const verdict = process.env.VERDICT || 'canary verdict unavailable';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const marker = '<!-- tti-canary-tracking -->';
-            const title = 'TTI canary regression: hosted P50 or success rate breached the baseline';
+            const title = 'TTI canary: hosted regression or measurement failure';
             const body = [
               marker, '',
-              'The nightly hosted TTI canary breached its baseline (bench/canary-baseline.json).',
+              'The nightly hosted TTI canary did not pass. The verdict below identifies the',
+              'cause: a measured P50 or success-rate breach of bench/canary-baseline.json, OR',
+              'a harness/parse failure (the measurement itself did not complete).',
               '', '```', verdict, '```', '',
               `Run: ${runUrl}`, '',
               'This is the in-region measurement from mitos-bench1 (the ladder harness).',
@@ -149,4 +155,4 @@ jobs:
                 title, body, labels: ['tti-canary', 'performance'],
               });
             }
-            core.setFailed('TTI canary regression, see the tracking issue');
+            core.setFailed('TTI canary regression or measurement failure, see the tracking issue');


### PR DESCRIPTION
## Thinking Path

> - PR #915 added the latency regression guards (CI activation ceiling + nightly in-region TTI canary).
> - It auto-merged on green checks before CodeRabbit posted its review, so five valid findings landed unaddressed. That merge-before-review was a process miss; this follow-up closes them promptly.
> - Two are security-relevant on the self-hosted runner: the dispatch input was shell-interpolated (injection), and the benchmark job held an issues:write token while running the untrusted-input harness.
> - The others harden failure handling and measurement integrity.
> - This pull request applies all five: input hardening, a read-only/write-split job structure, failure preservation, a non-numeric-sample guard, and paginated issue lookup.
> - The benefit is a canary that cannot be turned into runner code execution, cannot leak a write token to the harness, and cannot silently pass on a broken measurement.

## Linked Issues or Issue Description

Refs #915 (the PR these findings are on), #871 (the TTI work these guards protect).

## What Changed

- .github/workflows/tti-canary.yaml: iterations passed via env and integer-validated (no shell interpolation on the self-hosted runner); split into a read-only canary job (persist-credentials false, no issues token) and a separate report job (issues:write, github-script only); harness status captured so the verdict always runs and the report job fires on a harness or parse failure; issue lookup paginates and skips pull requests.
- .github/workflows/kvm-test.yaml: the husk-stub activation step rejects a non-numeric latency_ms fail-fast so a broken measurement cannot fold to 0.000 and pass the ceiling.

## Verification

- [x] actionlint clean on both workflows.
- [x] The iteration and latency validation globs exercised locally: a decimal is accepted; null, empty, alpha, and malformed rejected.
- [ ] The canary end-to-end run was validated on box1 against prod on #915; this changes only input handling, job split, and failure paths, not the measurement.

## Risks

- Low: CI-only. The benchmark job intentionally loses the issues token; the report job has no network beyond the GitHub API.

## Model Used

- Claude Opus 4.8 (claude-opus-4-8, 1M context), extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD) (validation globs verified)
- [x] Docs updated in the same PR (workflow comments explain the split and guards)
- [x] Threat-model delta included if the security surface moved (CI-only hardening)
- [x] Benchmark run (bench/) included if the hot path was touched (not touched)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation of latency measurements to block missing, null, or malformed values from affecting statistical results.
  * Improved benchmark safety by verifying required API credentials and ensuring iteration counts are valid positive integers.
  * Ensured measurement or verdict failures no longer get coerced into successful outcomes.

* **Chores**
  * Refined canary workflow to separate benchmark execution from issue tracking/reporting.
  * The workflow now updates the existing tracking issue with verdict details and fails only after the report step when a regression is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->