### PR TITLE
docs(readme): publish the reproducible benchmark set and multi-cloud install matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Homebrew, deb/rpm, scoop/winget, checksums) is in
 kubectl apply -k deploy/
 ```
 
-The self-contained kustomize base installs the CRDs, the controller (husk mode), the forkd DaemonSet, the `/dev/kvm` device plugin, and the PKI bootstrap, and applies on a real KVM node with no manual patches. Nodes need `/dev/kvm` and the label `mitos.run/kvm=true`. The Helm chart is published to the OCI registry on GHCR: `helm install mitos oci://ghcr.io/mitos-run/charts/mitos --version 1.25.0`; see [deploy/charts/mitos](deploy/charts/mitos/README.md). Then declare a warm pool, and fork from it with a `Sandbox` whose `source.fromSandbox` points at a live session ([templates](docs/templates.md)):
+The self-contained kustomize base installs the CRDs, the controller (husk mode), the forkd DaemonSet, the `/dev/kvm` device plugin, and the PKI bootstrap, and applies on a real KVM node with no manual patches. The Helm chart is published to the OCI registry on GHCR: `helm install mitos oci://ghcr.io/mitos-run/charts/mitos --version 1.42.1`; see [deploy/charts/mitos](deploy/charts/mitos/README.md). Then declare a warm pool, and fork from it with a `Sandbox` whose `source.fromSandbox` points at a live session ([templates](docs/templates.md)):
 
 ```yaml
 apiVersion: mitos.run/v1
@@ -171,6 +171,17 @@ spec:
       - { name: workspace, size: 5Gi, forkPolicy: Snapshot }
   warm: { min: 10 }
 ```
+
+**Where it runs.** The only node requirement is `/dev/kvm` plus the label `mitos.run/kvm=true`, so mitos installs on any Kubernetes cluster with bare-metal or nested-virtualization KVM nodes:
+
+| platform | KVM node | guide |
+|---|---|---|
+| Bare metal (Talos, Hetzner) | native `/dev/kvm` | [docs/platforms/talos-hetzner.md](docs/platforms/talos-hetzner.md) (first-class reference) |
+| AWS / EKS | `*.metal` or nested-virt node groups | generic chart today; per-cloud guide is issue [#919](https://github.com/mitos-run/mitos/issues/919) |
+| GKE | nested-virtualization node pools | generic chart today; per-cloud guide is [#919](https://github.com/mitos-run/mitos/issues/919) |
+| Azure / AKS | nested-virt-capable VM sizes | generic chart today; per-cloud guide is [#919](https://github.com/mitos-run/mitos/issues/919) |
+
+The chart and CRDs are identical across all of them; only the node pool that supplies `/dev/kvm` differs.
 
 ## Why Mitos
 
@@ -188,6 +199,53 @@ Two ways to run it:
 > Two engine paths exist. The **husk pod-native path is the default**: each VM runs in its own unprivileged pod, and the source husk pod snapshots its running VM so N child pods restore it via CoW. The **raw-forkd path** runs forks in forkd's in-process engine. Everything here runs on the husk default unless explicitly marked `engine path`.
 
 Sandboxes are not pods. Pod-scoped Kubernetes mechanisms (NetworkPolicy, ResourceQuota, PSA) govern the husk pod, not the workload inside the microVM; the sandbox is the VM, not the husk pod, and where we provide an equivalent it is documented as ours. The full claim and exec data paths and the component diagram are at [mitos.run/docs/architecture](https://mitos.run/docs/architecture).
+
+## Benchmarks
+
+Every number here is reproducible from [`bench/`](bench/) on real KVM hardware; nothing is published that a reader cannot regenerate (the project's no-unverified-claims rule). Each row names what it measures and the exact command that reproduces it. Full per-run data and hardware context live in [`bench/results/`](bench/results/).
+
+### Hosted time-to-interactive, against the ComputeSDK peer set
+
+Time to interactive (TTI) is the only figure that is apples-to-apples with the public [ComputeSDK benchmark](https://github.com/computesdk/benchmarks) every hosted sandbox vendor is measured against: the clock starts at `create()` and stops when a command has actually RUN inside the sandbox and returned.
+
+| provider | TTI P50 | measures |
+|---|---|---|
+| northflank | 95.9 ms | ComputeSDK published |
+| **mitos** | **96.8 ms** | our harness, `api.mitos.run` |
+| daytona | 136.2 ms | ComputeSDK published |
+| e2b | 365.6 ms | ComputeSDK published |
+
+Reproduce our number and the peer table (peer numbers are read from the immutable commit ComputeSDK published, not re-run by us):
+
+```sh
+MITOS_API_KEY=... python3 bench/tti-latency.py 100        # our TTI, N=100
+python3 bench/peer-tti.py --date 2026-07-09 \
+  --ref 3eddee1a972bd49aea56fd6c16d238ca0a45dece            # the peer table
+```
+
+Read it with the caveats the [full record](bench/results/2026-07-12-tti-create-path-ladder.md) states and does not hide: this is **our harness beside their published numbers, not a measured position in their leaderboard**; it is the sequential run (a concurrent burst would drain today's single-node warm pool, issue #586); and claiming an actual leaderboard rank requires shipping the `computesdk/computesdk` adapter (issue #891). Within those bounds, hosted mitos sits below Daytona and level with Northflank, 100/100 successful iterations.
+
+### Forking inside your cluster (one agent spawning subagents)
+
+When an agent runs in your cluster and branches itself into parallel attempts, the cost that matters is fork-to-first-exec: the wall clock from a live-VM fork to a command returning in the child. Measured with the same in-process engine `forkd` drives:
+
+| metric | number | measures |
+|---|---|---|
+| fork -> first exec | P50 ~104 ms (reference node), ~67 ms on reflink + NVMe | one live fork to a ready, exec-serving child |
+| fork(n) fan-out | ~56 ms P50 per child at n=4 and n=16 | one warm base fanned into N independent siblings |
+| CoW memory density | 8 forks cost ~35 MiB resident, not ~209 MiB | unique pages paid for, shared pages counted once |
+
+```sh
+go build -o /tmp/bench ./cmd/bench/
+/tmp/bench --mode fork-exec   --template <id> --data-dir <dir> --iterations 100   # fork -> first exec
+/tmp/bench --mode fork-fanout --template <id> --data-dir <dir> --fanout-n 1,4,16   # 1-to-N fan-out
+```
+
+Full method and hardware in [bench/README.md](bench/README.md); results in [2026-06-19-bare-metal-fork-exec.md](bench/results/2026-06-19-bare-metal-fork-exec.md) and [2026-06-21-kvm-perf-correctness.md](bench/results/2026-06-21-kvm-perf-correctness.md).
+
+### Warm-claim activate (the engine, not the round trip)
+
+The engine's own warm-sandbox activate (snapshot load + fork-correctness handshake + guest-ready) is P50 ~27 ms on the bare-metal reference node, reproducible from [`bench/husk-activate-latency.sh`](bench/husk-activate-latency.sh). This is a smaller, different number than the end-to-end hosted TTI above; quoting the engine figure against a competitor's create-API number would be a category error, so we keep them separate.
 
 ## Features
 


### PR DESCRIPTION
## Thinking Path

> - The README had a Speed table but not the headline benchmark: the hosted TTI number and the ComputeSDK peer comparison the whole market is measured against were absent.
> - The project rule is no unverified claims: every number on the README must be reproducible from bench/ or carry an explicit issue reference, so the section is built from the numbers already recorded in bench/results with the exact repro command beside each.
> - The user asked for four things on the README: the ComputeSDK comparison, forking inside the cluster (an agent spawning subagents), easy migration, and multi-cloud self-install.
> - Migration is already present (the change-one-import E2B/Daytona shims); the gaps were the benchmarks and a cloud-explicit install matrix.
> - This pull request adds a Benchmarks section (TTI vs peers, in-cluster fork-exec and fan-out, CoW density, engine activate), each with its repro command and the honesty caveats the bench records carry, and makes the self-install section map bare-metal and EKS/GKE/AKS to their KVM node type.
> - The benefit is a public, reproducible benchmark story a reader can regenerate, and a clear where-it-runs answer, without a single unbacked number.

## Linked Issues or Issue Description

Related: #871 (the TTI work), #15 (the benchmark program), #919 (the per-cloud install guides this references as a target). Numbers are drawn from bench/results/2026-07-12-tti-create-path-ladder.md, 2026-07-10-tti-hosted.md, 2026-06-19-bare-metal-fork-exec.md, 2026-06-21-kvm-perf-correctness.md.

## What Changed

- README.md: a Benchmarks section (hosted TTI vs ComputeSDK peers = 96.8 ms P50 vs Daytona 136.2 / Northflank 95.9 / E2B 365.6; in-cluster fork-to-first-exec ~104 ms and fork(n) fan-out ~56 ms/child; CoW density 8 forks ~35 MiB; engine activate ~27 ms), each with the exact reproduce command and links to bench/results. A multi-cloud install matrix (KVM node requirement; bare-metal reference + EKS/GKE/AKS node types; per-cloud guides tracked as #919). Chart-version example bumped to a current release.

## Verification

- [x] Every number cross-checked against its bench/results source (96.8, the three peer figures, 103.88 fork-exec P50, 56.31/55.96 fan-out, the CoW density line) and matches.
- [x] Every internal link resolves on main (bench scripts, cmd/bench, bench/README.md, the Hetzner platform doc).
- [x] No em or en dashes in the added lines.
- [x] The peer comparison carries the bench record's caveats verbatim (our harness beside their published numbers, sequential, single node, leaderboard rank needs #891).

## Risks

- Documentation only. No number is published that is not already reproducible from bench/; the one forward-looking item (per-cloud guides) is marked as target issue #919 rather than claimed as done.

## Model Used

- Claude Opus 4.8 (claude-opus-4-8, 1M context), extended thinking enabled.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD) (docs only)
- [x] Docs updated in the same PR (this IS the doc)
- [x] Threat-model delta included if the security surface moved (it did not)
- [x] Benchmark run (bench/) included if the hot path was touched (this publishes existing bench records; no hot-path change)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN / mitos-run/mitos URLs)
- [x] Every commit carries a Signed-off-by trailer (git commit -s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes installation instructions to use Helm chart version 1.42.1.
  * Added platform and node requirements with links to platform-specific guidance.
  * Added reproducible benchmark results covering hosted time-to-interactive, in-cluster forking, and engine warm-claim activation latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->