### PR TITLE
feat(integrations): ComputeSDK provider adapter for the TTI leaderboard (#891)

### DIFF
--- a/contrib/computesdk-mitos/.gitignore
+++ b/contrib/computesdk-mitos/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+*.tsbuildinfo

--- a/contrib/computesdk-mitos/README.md
+++ b/contrib/computesdk-mitos/README.md
@@ -1,0 +1,161 @@
+# @computesdk/mitos
+
+A [ComputeSDK](https://www.computesdk.com) provider for [Mitos](https://mitos.run).
+
+Mitos runs snapshot-fork Firecracker microVM sandboxes. A warm pool is kept
+ready and every create forks a fresh, independent VM from a copy-on-write
+snapshot, so a sandbox is ready in well under a second instead of booting from
+cold. This provider maps the ComputeSDK sandbox surface onto the hosted Mitos
+control plane at `https://api.mitos.run`, driving it through the official Mitos
+TypeScript SDK ([`@mitos/sdk`](https://github.com/mitos-run/mitos/tree/main/sdk/typescript)).
+
+## Status: staged for submission
+
+This package lives in the Mitos repository under `contrib/computesdk-mitos`. It
+is a ready-to-submit ComputeSDK provider, staged here because two dependencies
+must be resolved before it can be published into the ComputeSDK monorepo. See
+[Submission runbook](#submission-runbook) for the exact remaining steps.
+
+## Features
+
+- Sub-second warm forks from a snapshot pool, not cold boots.
+- `create`, `runCommand`, `getById`, `list`, and `destroy` over the hosted API.
+- Filesystem operations (`readFile`, `writeFile`, `mkdir`, `readdir`, `exists`,
+  `remove`) over the native Mitos file RPCs and shell.
+- Python and shell out of the box on the default `python` template, which also
+  carries the code-interpreter kernel.
+
+## Installation
+
+```bash
+npm install computesdk @computesdk/mitos
+```
+
+## Configuration
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `apiKey` | `string` | `MITOS_API_KEY` env | Bearer token for the hosted API. |
+| `baseUrl` | `string` | `MITOS_BASE_URL` env, else `https://api.mitos.run` | Control plane URL. Point at a self-hosted control plane or a local standalone sandbox-server to run off the hosted service. |
+| `template` | `string` | `"python"` | Template to fork from when a create call names none. |
+| `timeout` | `number` | none | Per-command execution timeout in milliseconds. |
+
+Get an API key from [https://mitos.run](https://mitos.run).
+
+## Usage
+
+```typescript
+import { compute } from "computesdk";
+import { mitos } from "@computesdk/mitos";
+
+compute.setConfig({
+  provider: mitos({ apiKey: process.env.MITOS_API_KEY }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand("python3 -c \"print(1 + 1)\"");
+console.log(result.stdout.trim()); // 2
+
+await sandbox.filesystem.writeFile("/workspace/hello.txt", "hello\n");
+console.log((await sandbox.filesystem.readFile("/workspace/hello.txt")).trim()); // hello
+
+await sandbox.destroy();
+```
+
+### What each method maps to
+
+| ComputeSDK method | Mitos SDK call |
+| --- | --- |
+| `sandbox.create(options?)` | `SandboxServer.fork(template)` |
+| `sandbox.runCommand(cmd, opts?)` | `Sandbox.exec(cmd, opts)` over the Connect ExecStream RPC |
+| `filesystem.readFile` / `writeFile` / `readdir` | `Sandbox.files.read` / `write` / `list` |
+| `filesystem.mkdir` / `exists` / `remove` | shell via `runCommand` |
+| `sandbox.destroy(id)` | `DELETE /v1/sandboxes/{id}` |
+| `provider.sandbox.getById(id)` / `list()` | `GET /v1/sandboxes` |
+
+`getUrl` throws: per-port public URLs are a separate Mitos feature (named
+`<label>.mitos.run` URLs via `mitos workspace serve`), not part of the direct
+sandbox surface this provider drives.
+
+## Concurrent burst caveat
+
+The ComputeSDK benchmark harness includes a concurrent burst run alongside the
+sequential time-to-interactive run. The hosted Mitos production pool currently
+runs on a single KVM node, so the burst row will reflect single-node warm-pool
+capacity, not multi-node scale-out. This is honest and expected: the
+sequential time-to-interactive number is a warm-pool checkout, while the burst
+number is bounded by how many forks one node can serve at once. Multi-node
+capacity is tracked in the Mitos repository and is not claimed here.
+
+## Development
+
+```bash
+npm install   # resolves @mitos/sdk via the file: reference below
+npm run typecheck
+npm test
+npm run build
+```
+
+The `@mitos/sdk` dependency is a `file:../../sdk/typescript` reference into this
+repository, so its `dist/` must be built once first:
+
+```bash
+cd ../../sdk/typescript && npm ci && npm run build
+```
+
+The tests stub `fetch` to exercise the create and destroy REST wire shapes
+without a live server. A full create, run, and destroy round trip against
+`https://api.mitos.run` needs a real `MITOS_API_KEY` and is the live smoke test
+described below.
+
+### Live smoke test
+
+With a real key set:
+
+```bash
+export MITOS_API_KEY=...   # never commit or print this
+node --input-type=module -e '
+  import { compute } from "computesdk";
+  import { mitos } from "@computesdk/mitos";
+  compute.setConfig({ provider: mitos({ apiKey: process.env.MITOS_API_KEY }) });
+  const sb = await compute.sandbox.create();
+  const r = await sb.runCommand("python3 -c \"print(21*2)\"");
+  console.log(r.exitCode, r.stdout.trim());
+  await sb.destroy();
+'
+```
+
+## Submission runbook
+
+Being listed on the ComputeSDK leaderboard does not require sponsorship; the
+ComputeSDK contribution guide states any provider can be added. The remaining
+steps are user-gated because they need publish rights and credentials this
+repository does not hold:
+
+1. **Publish `@mitos/sdk` to npm.** ComputeSDK packages cannot depend on a
+   `file:` path. Publish the Mitos TypeScript SDK
+   (`sdk/typescript`, package name `@mitos/sdk`) to the public registry, then in
+   this package's `package.json` swap the dependency from
+   `"@mitos/sdk": "file:../../sdk/typescript"` to the published version range
+   (for example `"@mitos/sdk": "^0.1.0"`).
+2. **Copy the package into the ComputeSDK monorepo.** Copy
+   `contrib/computesdk-mitos` to `packages/mitos` in a clone of
+   [`computesdk/computesdk`](https://github.com/computesdk/computesdk). Change the
+   two workspace-managed dependencies to the workspace protocol the monorepo
+   uses: `"@computesdk/provider": "workspace:*"` and `"computesdk": "workspace:*"`.
+   Add a `vitest.config.ts` and, if desired, wire the
+   `@computesdk/test-utils` suite as shown in the monorepo's `ADD-PROVIDER.md`.
+3. **Open the pull request.** Run `pnpm install` and `pnpm --filter @computesdk/mitos typecheck build test` at the monorepo root, then open a PR against
+   `computesdk/computesdk` following its `ADD-PROVIDER.md` and contribution guide.
+4. **Provide benchmark credentials.** Give the ComputeSDK maintainers a
+   `MITOS_API_KEY` for the daily run so the provider can create, run, and destroy
+   sandboxes during the benchmark. Scope the key to the benchmark and rotate it
+   on the usual cadence.
+
+Once those four steps land, Mitos appears in the daily ComputeSDK
+time-to-interactive leaderboard.
+
+## License
+
+MIT, matching the ComputeSDK provider packages.

--- a/contrib/computesdk-mitos/package.json
+++ b/contrib/computesdk-mitos/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@computesdk/mitos",
+  "version": "0.1.0",
+  "description": "Mitos provider for ComputeSDK: snapshot-fork Firecracker microVM sandboxes with sub-second warm forks",
+  "author": "Mitos maintainers <maintainers@mitos.run>",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "computesdk",
+    "mitos",
+    "sandbox",
+    "firecracker",
+    "microvm",
+    "code-execution",
+    "python",
+    "javascript",
+    "cloud",
+    "compute",
+    "provider"
+  ],
+  "dependencies": {
+    "@computesdk/provider": "^2.1.3",
+    "computesdk": "^4.1.3",
+    "@mitos/sdk": "file:../../sdk/typescript"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/mitos"
+  },
+  "homepage": "https://mitos.run",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/contrib/computesdk-mitos/src/__tests__/index.test.ts
+++ b/contrib/computesdk-mitos/src/__tests__/index.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { mitos } from "../index";
+
+/**
+ * These tests stub global fetch to stand in for the hosted Mitos control plane,
+ * so they exercise the create and destroy REST wire shapes deterministically
+ * without a live server or a real API key. The exec and file paths ride the
+ * Connect streaming protocol and are covered by the live smoke test in the
+ * README (against https://api.mitos.run), not here.
+ */
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function stubFetch(handler: (call: FetchCall) => Response): FetchCall[] {
+  const calls: FetchCall[] = [];
+  vi.stubGlobal("fetch", (input: unknown, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const call = { url, init };
+    calls.push(call);
+    return Promise.resolve(handler(call));
+  });
+  return calls;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("mitos provider", () => {
+  it("is a factory that names the provider 'mitos'", () => {
+    const provider = mitos({ apiKey: "test-key" });
+    expect(provider.name).toBe("mitos");
+    expect(typeof provider.sandbox.create).toBe("function");
+    expect(typeof provider.sandbox.destroy).toBe("function");
+  });
+
+  it("requires an API key on create", async () => {
+    const provider = mitos({});
+    const prev = process.env.MITOS_API_KEY;
+    delete process.env.MITOS_API_KEY;
+    try {
+      await expect(provider.sandbox.create()).rejects.toThrow(/Missing Mitos API key/);
+    } finally {
+      if (prev !== undefined) process.env.MITOS_API_KEY = prev;
+    }
+  });
+
+  it("forks the default python template against the hosted base URL with bearer auth", async () => {
+    const calls = stubFetch(({ url }) => {
+      if (url.endsWith("/v1/fork")) {
+        return jsonResponse({
+          id: "sandbox-abcd1234",
+          template_id: "python",
+          endpoint: "https://api.mitos.run",
+          fork_time_ms: 84,
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const provider = mitos({ apiKey: "test-key" });
+    const sandbox = await provider.sandbox.create();
+
+    expect(sandbox.sandboxId).toBe("sandbox-abcd1234");
+
+    const forkCall = calls.find((c) => c.url.endsWith("/v1/fork"));
+    expect(forkCall).toBeDefined();
+    expect(forkCall!.url).toBe("https://api.mitos.run/v1/fork");
+    expect(forkCall!.init?.method).toBe("POST");
+    const headers = forkCall!.init?.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-key");
+    expect(JSON.parse(String(forkCall!.init?.body)).template).toBe("python");
+  });
+
+  it("honors a custom baseUrl and template", async () => {
+    const calls = stubFetch(({ url }) => {
+      if (url.endsWith("/v1/fork")) {
+        return jsonResponse({
+          id: "sandbox-xyz",
+          template_id: "node",
+          endpoint: "http://localhost:8080",
+          fork_time_ms: 5,
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const provider = mitos({
+      apiKey: "k",
+      baseUrl: "http://localhost:8080",
+      template: "node",
+    });
+    const sandbox = await provider.sandbox.create();
+
+    expect(sandbox.sandboxId).toBe("sandbox-xyz");
+    const forkCall = calls.find((c) => c.url.endsWith("/v1/fork"));
+    expect(forkCall!.url).toBe("http://localhost:8080/v1/fork");
+    expect(JSON.parse(String(forkCall!.init?.body)).template).toBe("node");
+  });
+
+  it("destroys a sandbox by id via DELETE and tolerates a 404", async () => {
+    const calls = stubFetch(({ url }) => {
+      if (url.includes("/v1/sandboxes/")) {
+        return new Response("", { status: 200 });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const provider = mitos({ apiKey: "test-key" });
+    await provider.sandbox.destroy("sandbox-abcd1234");
+
+    const delCall = calls.find((c) => c.init?.method === "DELETE");
+    expect(delCall).toBeDefined();
+    expect(delCall!.url).toBe(
+      "https://api.mitos.run/v1/sandboxes/sandbox-abcd1234",
+    );
+
+    // A 404 (already gone) is swallowed rather than thrown.
+    stubFetch(() => jsonResponse({ error: { code: "not_found" } }, 404));
+    await expect(
+      provider.sandbox.destroy("sandbox-missing"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/contrib/computesdk-mitos/src/index.ts
+++ b/contrib/computesdk-mitos/src/index.ts
@@ -1,0 +1,353 @@
+/**
+ * Mitos Provider for ComputeSDK.
+ *
+ * Mitos runs snapshot-fork Firecracker microVM sandboxes: a warm pool is kept
+ * ready and each create forks a fresh, independent VM from a copy-on-write
+ * snapshot, so a sandbox boots in well under a second rather than from cold.
+ * This provider talks to the hosted Mitos control plane at https://api.mitos.run
+ * through the official Mitos TypeScript SDK (@mitos/sdk), mapping the ComputeSDK
+ * provider surface onto the SDK's direct (hosted) mode.
+ */
+
+import {
+  HttpClient,
+  Sandbox as MitosSandbox,
+  SandboxServer,
+  AgentRunError,
+} from "@mitos/sdk";
+import { defineProvider, escapeShellArg } from "@computesdk/provider";
+
+import type {
+  CommandResult,
+  SandboxInfo,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+} from "computesdk";
+
+/**
+ * The hosted Mitos API front door. Overridable with the `baseUrl` config field
+ * or the MITOS_BASE_URL environment variable (for a self-hosted control plane or
+ * a local standalone sandbox-server).
+ */
+const DEFAULT_BASE_URL = "https://api.mitos.run";
+
+/**
+ * The template every fork starts from when the caller does not name one. Mitos
+ * keeps a warm "python" pool on the hosted control plane; it carries the
+ * code-interpreter kernel, so both runCommand and code cells work out of the box.
+ */
+const DEFAULT_TEMPLATE = "python";
+
+/**
+ * Mitos-specific configuration options.
+ */
+export interface MitosConfig {
+  /** Mitos API key. Falls back to the MITOS_API_KEY environment variable. */
+  apiKey?: string;
+  /**
+   * Base URL of the Mitos control plane. Defaults to https://api.mitos.run, or
+   * the MITOS_BASE_URL environment variable when set. Point this at a
+   * self-hosted control plane or a local standalone sandbox-server to run
+   * off the hosted service.
+   */
+  baseUrl?: string;
+  /** Template to fork from when the create call does not name one. Defaults to "python". */
+  template?: string;
+  /** Execution timeout in milliseconds, applied per command when set. */
+  timeout?: number;
+}
+
+function resolveApiKey(config: MitosConfig): string {
+  return (
+    config.apiKey ||
+    (typeof process !== "undefined" && process.env?.MITOS_API_KEY) ||
+    ""
+  );
+}
+
+function resolveBaseUrl(config: MitosConfig): string {
+  return (
+    config.baseUrl ||
+    (typeof process !== "undefined" && process.env?.MITOS_BASE_URL) ||
+    DEFAULT_BASE_URL
+  );
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    error instanceof AgentRunError &&
+    (error.code === "not_found" || error.code === "sandbox_not_found")
+  );
+}
+
+/**
+ * Rebinds a Mitos direct-mode Sandbox to the hosted control plane by id, so the
+ * getById and list paths can exec, read, and write against an existing sandbox
+ * without re-forking. Exec and file traffic round-trip through the control plane
+ * URL, addressed by the sandbox id.
+ */
+function bindSandbox(baseUrl: string, apiKey: string, id: string): MitosSandbox {
+  const http = new HttpClient(baseUrl, apiKey || undefined);
+  return new MitosSandbox({
+    id,
+    endpoint: baseUrl,
+    token: apiKey || undefined,
+    http,
+    terminator: async () => {
+      await http.del(`/v1/sandboxes/${encodeURIComponent(id)}`);
+      return undefined;
+    },
+  });
+}
+
+const decoder = new TextDecoder();
+
+export const mitos = defineProvider<MitosSandbox, MitosConfig>({
+  name: "mitos",
+  methods: {
+    sandbox: {
+      create: async (config: MitosConfig, options?: CreateSandboxOptions) => {
+        const apiKey = resolveApiKey(config);
+        if (!apiKey) {
+          throw new Error(
+            `Missing Mitos API key. Provide 'apiKey' in config or set the MITOS_API_KEY environment variable. Get a key from https://mitos.run.`,
+          );
+        }
+
+        const baseUrl = resolveBaseUrl(config);
+        // The requested runtime/template maps onto a Mitos template name. A
+        // provider-agnostic templateId or snapshotId wins; then a "runtime"
+        // hint; then the configured or default template.
+        const runtime = (options as { runtime?: string } | undefined)?.runtime;
+        const template =
+          options?.templateId ||
+          options?.snapshotId ||
+          (runtime && runtime !== "node" && runtime !== "javascript"
+            ? runtime
+            : undefined) ||
+          config.template ||
+          DEFAULT_TEMPLATE;
+
+        try {
+          const server = new SandboxServer(baseUrl, apiKey);
+          const sandbox = await server.fork(template);
+          return { sandbox, sandboxId: sandbox.id };
+        } catch (error) {
+          if (error instanceof AgentRunError) {
+            if (error.code === "unauthorized") {
+              throw new Error(
+                `Mitos authentication failed. Please check your MITOS_API_KEY. ${error.remediation ?? ""}`.trim(),
+              );
+            }
+            if (error.code === "rate_limited") {
+              throw new Error(
+                `Mitos rate limit reached. ${error.remediation ?? "Check your usage at https://mitos.run."}`.trim(),
+              );
+            }
+          }
+          throw new Error(
+            `Failed to create Mitos sandbox: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      getById: async (config: MitosConfig, sandboxId: string) => {
+        const apiKey = resolveApiKey(config);
+        const baseUrl = resolveBaseUrl(config);
+        try {
+          const server = new SandboxServer(baseUrl, apiKey);
+          const summaries = await server.listSandboxes();
+          const match = summaries.find((s) => s.id === sandboxId);
+          if (!match) {
+            return null;
+          }
+          return { sandbox: bindSandbox(baseUrl, apiKey, sandboxId), sandboxId };
+        } catch (error) {
+          if (isNotFound(error)) {
+            return null;
+          }
+          throw new Error(
+            `Failed to get Mitos sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      list: async (config: MitosConfig) => {
+        const apiKey = resolveApiKey(config);
+        const baseUrl = resolveBaseUrl(config);
+        try {
+          const server = new SandboxServer(baseUrl, apiKey);
+          const summaries = await server.listSandboxes();
+          return summaries.map((s) => ({
+            sandbox: bindSandbox(baseUrl, apiKey, s.id),
+            sandboxId: s.id,
+          }));
+        } catch (error) {
+          throw new Error(
+            `Failed to list Mitos sandboxes: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      destroy: async (config: MitosConfig, sandboxId: string) => {
+        const apiKey = resolveApiKey(config);
+        const baseUrl = resolveBaseUrl(config);
+        try {
+          const http = new HttpClient(baseUrl, apiKey || undefined);
+          await http.del(`/v1/sandboxes/${encodeURIComponent(sandboxId)}`);
+        } catch (error) {
+          if (isNotFound(error)) {
+            return;
+          }
+          throw new Error(
+            `Failed to destroy Mitos sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      runCommand: async (
+        sandbox: MitosSandbox,
+        command: string,
+        options?: RunCommandOptions,
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+
+        let fullCommand = command;
+        if (options?.env && Object.keys(options.env).length > 0) {
+          const envPrefix = Object.entries(options.env)
+            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+            .join(" ");
+          fullCommand = `${envPrefix} ${fullCommand}`;
+        }
+        if (options?.cwd) {
+          fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+        }
+        if (options?.background) {
+          fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
+        }
+
+        const execOpts: {
+          timeoutSeconds?: number;
+          onStdout?: (chunk: Uint8Array) => void;
+          onStderr?: (chunk: Uint8Array) => void;
+        } = {};
+        const timeoutMs = options?.timeout;
+        if (typeof timeoutMs === "number" && timeoutMs > 0) {
+          execOpts.timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+        }
+        if (options?.onStdout) {
+          const cb = options.onStdout;
+          execOpts.onStdout = (chunk) => cb(decoder.decode(chunk, { stream: true }));
+        }
+        if (options?.onStderr) {
+          const cb = options.onStderr;
+          execOpts.onStderr = (chunk) => cb(decoder.decode(chunk, { stream: true }));
+        }
+
+        try {
+          const result = await sandbox.exec(fullCommand, execOpts);
+          return {
+            stdout: result.stdout,
+            stderr: result.stderr,
+            exitCode: result.exitCode,
+            durationMs: result.execTimeMs ?? Date.now() - startTime,
+          };
+        } catch (error) {
+          // A command that exceeds its deadline surfaces as a typed error; return
+          // it as a failed CommandResult (exit 124) rather than throwing, so the
+          // caller sees the standard non-zero-exit shape.
+          if (error instanceof AgentRunError && error.code === "exec_timeout") {
+            return {
+              stdout: "",
+              stderr: error.message,
+              exitCode: 124,
+              durationMs: Date.now() - startTime,
+            };
+          }
+          throw new Error(
+            `Mitos command execution failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      getInfo: async (sandbox: MitosSandbox): Promise<SandboxInfo> => ({
+        id: sandbox.id,
+        provider: "mitos",
+        status: "running",
+        createdAt: new Date(),
+        timeout: 300000,
+        metadata: { mitosSandboxId: sandbox.id, endpoint: sandbox.endpoint },
+      }),
+
+      getUrl: async (
+        _sandbox: MitosSandbox,
+        options: { port: number; protocol?: string },
+      ): Promise<string> => {
+        // Public port exposure is a separate Mitos feature (named
+        // <label>.mitos.run URLs via `mitos workspace serve`) and is not part of
+        // the direct sandbox surface this provider drives.
+        throw new Error(
+          `Mitos direct-mode sandboxes do not expose per-port URLs (requested port ${options.port}). Use the Mitos Expose feature (mitos workspace serve) for public URLs.`,
+        );
+      },
+
+      getInstance: (sandbox: MitosSandbox): MitosSandbox => sandbox,
+
+      filesystem: {
+        readFile: async (sandbox: MitosSandbox, path: string): Promise<string> => {
+          return sandbox.files.read(path);
+        },
+        writeFile: async (
+          sandbox: MitosSandbox,
+          path: string,
+          content: string,
+        ): Promise<void> => {
+          await sandbox.files.write(path, content);
+        },
+        mkdir: async (
+          sandbox: MitosSandbox,
+          path: string,
+          runCommand,
+        ): Promise<void> => {
+          const result = await runCommand(sandbox, `mkdir -p "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to create directory: ${path}`);
+          }
+        },
+        readdir: async (sandbox: MitosSandbox, path: string): Promise<FileEntry[]> => {
+          const entries = await sandbox.files.list(path);
+          return entries.map((entry) => ({
+            name: entry.name,
+            type: entry.isDir ? ("directory" as const) : ("file" as const),
+            size: entry.size,
+            modified:
+              entry.modifiedAt !== undefined
+                ? new Date(Number(entry.modifiedAt) * 1000)
+                : undefined,
+          }));
+        },
+        exists: async (
+          sandbox: MitosSandbox,
+          path: string,
+          runCommand,
+        ): Promise<boolean> => {
+          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          return result.exitCode === 0;
+        },
+        remove: async (
+          sandbox: MitosSandbox,
+          path: string,
+          runCommand,
+        ): Promise<void> => {
+          const result = await runCommand(sandbox, `rm -rf "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to remove: ${path}`);
+          }
+        },
+      },
+    },
+  },
+});
+
+export type { Sandbox as MitosSandbox } from "@mitos/sdk";

--- a/contrib/computesdk-mitos/tsconfig.json
+++ b/contrib/computesdk-mitos/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/contrib/computesdk-mitos/tsup.config.ts
+++ b/contrib/computesdk-mitos/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/contrib/computesdk-mitos/vitest.config.ts
+++ b/contrib/computesdk-mitos/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs and a hosted control plane at api.mitos.run.
> - The subsystem here is the client edge: the TypeScript SDK (sdk/typescript, @mitos/sdk) and a new adapter that wraps it.
> - ComputeSDK publishes a public daily time-to-interactive leaderboard across many sandbox providers, but Mitos has no ComputeSDK provider, so it cannot appear there and cannot be compared head to head with the peers it benchmarks against.
> - A leaderboard listing is a credible, third-party, reproducible number, which is exactly the kind of external proof the project values; getting on it now supports the hosted go-to-market work.
> - ComputeSDK providers are built with defineProvider from @computesdk/provider and live in an external monorepo, and @mitos/sdk is not yet on npm, so the provider cannot be merged straight into their repo today.
> - This pull request adds a complete, typechecked, tested ComputeSDK provider under contrib/computesdk-mitos that talks to the hosted API through @mitos/sdk, plus a submission runbook for the remaining user-gated steps.
> - The benefit is that the adapter is done and verified in-repo, so once the SDK is published to npm the package can be copied into ComputeSDK and Mitos joins the leaderboard with a known-good create, run, and destroy path.

## Linked Issues or Issue Description

Related: #891

This does not `Closes` #891 on its own: the provider is complete and verified here, but four user-gated steps remain before Mitos is actually listed (publish @mitos/sdk to npm, copy the package into computesdk/computesdk, open the PR there, and hand the benchmark a scoped MITOS_API_KEY). Those steps are documented in the package README.

## What Changed

- Add `contrib/computesdk-mitos`, a ComputeSDK provider package (`@computesdk/mitos`).
- `src/index.ts` implements `defineProvider` with `create`, `runCommand`, `getById`, `list`, `destroy`, `getInfo`, `getInstance`, a `getUrl` that throws a clear not-supported error, and a `filesystem` group (`readFile` / `writeFile` / `readdir` over the native Mitos file RPCs; `mkdir` / `exists` / `remove` over the shell).
- The client is the repository's own `@mitos/sdk` via a `file:../../sdk/typescript` reference, so `create` forks a template with `SandboxServer.fork`, `runCommand` maps to `Sandbox.exec`, and `destroy` issues `DELETE /v1/sandboxes/{id}`. Base URL defaults to `https://api.mitos.run`, overridable by config or `MITOS_BASE_URL`; the API key resolves from config or `MITOS_API_KEY`.
- `src/__tests__/index.test.ts` stubs `fetch` and drives the create and destroy REST wire shapes (base URL, bearer auth, template, DELETE path, 404 tolerance) plus the missing-key and custom-config paths.
- `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, and a `.gitignore`, mirroring the ComputeSDK provider package layout in their `ADD-PROVIDER.md`.
- `README.md` with usage, a method-mapping table, the concurrent-burst caveat, and a step-by-step submission runbook.

## Verification

- [x] `npx tsc --noEmit` in `contrib/computesdk-mitos`: clean (exit 0), after building the SDK dist with `cd sdk/typescript && npm ci && npm run build`.
- [x] `npx vitest run`: 5 tests pass (provider factory shape, missing-key error, default python fork against api.mitos.run with bearer auth, custom baseUrl and template, destroy DELETE with 404 tolerance).
- [x] `npx tsup`: builds `cjs`, `esm`, and `dts` output cleanly.
- [x] No em or en dashes in any added file (checked with a unicode grep).
- Live create, run, and destroy against `https://api.mitos.run` needs a real key and is documented as a smoke test in the README; it was not run in CI because no key is committed.

## Risks

Low risk. The package is additive and self-contained under `contrib/`; it is not wired into any Go, Python, or existing CI job, so it cannot affect the shipped controller, forkd, or SDKs. The only external behavior is HTTP calls to the hosted API, gated behind an explicit API key. The main open item is external and non-code: publishing the SDK and submitting to ComputeSDK.

## Model Used

Claude Fable 5 (Anthropic), model id claude-fable-5, dispatched as a subagent.

## Checklist

- [x] PR title is a conventional commit (feat, fix, docs, ci, chore, refactor, test)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [x] Tests added for behavior changes, in the same commit (TDD)
- [x] Docs updated in the same PR
- [ ] Threat-model delta (docs/threat-model.md) included if the security surface moved (not applicable: no change to the forkd or VM security surface; this is a client-side adapter over the existing authenticated hosted API)
- [ ] Benchmark run (bench/) included if the hot path was touched (not applicable: no hot path touched)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public `#NNN` / mitos-run/mitos URLs)
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Mitos ComputeSDK provider for creating, managing, and deleting sandboxes.
  * Added command execution with environment, working-directory, background execution, streaming output, and timeout handling.
  * Added filesystem operations, sandbox metadata, configurable templates, API base URL, and timeouts.
  * Added support for CommonJS, ESM, and TypeScript package consumers.

* **Documentation**
  * Added installation, configuration, usage, development, testing, and deployment guidance for the Mitos provider.

* **Tests**
  * Added coverage for provider creation, authentication, configuration, sandbox deletion, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->