### PR TITLE
refactor(fork): consolidate CreateTemplate trailing bools into CreateTemplateOpts

### DIFF
--- a/cmd/crash-reap-smoke/main.go
+++ b/cmd/crash-reap-smoke/main.go
@@ -78,7 +78,7 @@ func run(o opts) error {
 		return setupErr(fmt.Errorf("new engine 1: %w", err))
 	}
 	templateID := "crash-tmpl"
-	if err := engine1.CreateTemplate(templateID, o.image, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine1.CreateTemplate(templateID, o.image, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return setupErr(fmt.Errorf("create template: %w", err))
 	}
 	sandboxID := "crash-fork-1"

--- a/cmd/forkd/main.go
+++ b/cmd/forkd/main.go
@@ -219,7 +219,7 @@ func main() {
 	if mockMode {
 		fmt.Println("forkd: running in mock mode")
 		mock := fork.NewMockEngine()
-		if err := mock.CreateTemplate("default", "python:3.12-slim", nil, nil, nil, nil, false, false); err != nil {
+		if err := mock.CreateTemplate("default", "python:3.12-slim", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 			fmt.Fprintf(os.Stderr, "forkd: mock template: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/live-fork-egress-smoke/main.go
+++ b/cmd/live-fork-egress-smoke/main.go
@@ -157,7 +157,7 @@ func run(image, dataDir, fcBin, kernel, agentBin, sentinel string, proxyPort int
 	}
 
 	templateID := "lfe-tmpl"
-	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return setupErr(fmt.Errorf("create template: %w", err))
 	}
 

--- a/cmd/live-state-fork-smoke/main.go
+++ b/cmd/live-state-fork-smoke/main.go
@@ -91,7 +91,7 @@ func run(image, dataDir, fcBin, kernel, agentBin string) error {
 	}
 
 	const templateID = "lsf-tmpl"
-	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return setupErr(fmt.Errorf("create template: %w", err))
 	}
 

--- a/cmd/mem-smoke/main.go
+++ b/cmd/mem-smoke/main.go
@@ -91,7 +91,7 @@ func run(o opts) error {
 
 	templateID := "mem-tmpl"
 	fmt.Printf("mem-smoke: building template %q from %q\n", templateID, o.image)
-	if err := engine.CreateTemplate(templateID, o.image, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, o.image, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return setupErr(fmt.Errorf("create template: %w", err))
 	}
 

--- a/cmd/net-fork-smoke/main.go
+++ b/cmd/net-fork-smoke/main.go
@@ -69,7 +69,7 @@ func run(image, dataDir, fcBin, kernel, agentBin string) error {
 	}
 
 	templateID := "nf-tmpl"
-	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return setupErr(fmt.Errorf("create template: %w", err))
 	}
 

--- a/cmd/pull-smoke/main.go
+++ b/cmd/pull-smoke/main.go
@@ -189,7 +189,7 @@ func buildHolderTemplate(dataDir, rootfs, fcBin, kernel, agentBin, templateID st
 	if err != nil {
 		return nil, "", fmt.Errorf("node A new engine: %w", err)
 	}
-	if err := engine.CreateTemplate(templateID, rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, rootfs, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return nil, "", fmt.Errorf("node A build template: %w", err)
 	}
 	digest := engine.GetCapacity().TemplateDigests[templateID]

--- a/cmd/sandbox-server/main.go
+++ b/cmd/sandbox-server/main.go
@@ -552,7 +552,7 @@ func (s *server) handleCreateTemplate(w http.ResponseWriter, r *http.Request) {
 		// does not yet expose a force-rebuild knob (issue #584 wires that through
 		// the k8s controller/forkd gRPC path only for now), so it always takes the
 		// reuse-or-rebuild gate's default reuse-if-healthy behavior.
-		if err := s.engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, workloadFromReq(req.Workload), vmResFromReq(req.Resources), false, false); err != nil {
+		if err := s.engine.CreateTemplate(req.ID, s.rootfsPath, nil, nil, workloadFromReq(req.Workload), vmResFromReq(req.Resources), fork.CreateTemplateOpts{}); err != nil {
 			s.releaseIdempotent(idemKey)
 			errResp(w, fmt.Sprintf("create template: %v", err), 500)
 			return

--- a/cmd/tmpl-smoke/main.go
+++ b/cmd/tmpl-smoke/main.go
@@ -110,7 +110,7 @@ func run(o opts) error {
 	}
 	fmt.Printf("tmpl-smoke: building template %q from image %q (init=%v, huge_pages=%q)\n", templateID, o.image, initCommands, o.hugePages)
 	buildStart := time.Now()
-	if err := engine.CreateTemplate(templateID, o.image, initCommands, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, o.image, initCommands, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		return fmt.Errorf("create template from image: %w", err)
 	}
 	fmt.Printf("tmpl-smoke: template built in %s\n", time.Since(buildStart).Round(time.Millisecond))

--- a/cmd/vol-smoke/main.go
+++ b/cmd/vol-smoke/main.go
@@ -121,7 +121,7 @@ func run(o opts) error {
 
 	fmt.Printf("vol-smoke: building template %q from %q with %d volumes\n", templateID, o.image, len(specs))
 	buildStart := time.Now()
-	if err := engine.CreateTemplate(templateID, o.image, nil, specs, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, o.image, nil, specs, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		if isPullFailure(err) {
 			fmt.Println("PULL_FAILED")
 		}

--- a/internal/controller/distribution_test.go
+++ b/internal/controller/distribution_test.go
@@ -59,7 +59,7 @@ func startFakeForkdNodeTLSDist(t *testing.T, registry *NodeRegistry, nodeName, h
 	engine.ForkDelay = 0
 	digests := make(map[string]string)
 	for _, tmpl := range heldTemplates {
-		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, false, false); err != nil {
+		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 			t.Fatal(err)
 		}
 		digests[tmpl] = engine.GetCapacity().TemplateDigests[tmpl]
@@ -98,7 +98,7 @@ func startDistForkdNode(t *testing.T, registry *NodeRegistry, nodeName, httpEndp
 	engine.ForkDelay = 0
 	digests := make(map[string]string)
 	for _, tmpl := range heldTemplates {
-		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, false, false); err != nil {
+		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 			t.Fatal(err)
 		}
 		digests[tmpl] = engine.GetCapacity().TemplateDigests[tmpl]

--- a/internal/controller/forkd_client_test.go
+++ b/internal/controller/forkd_client_test.go
@@ -25,7 +25,7 @@ func startFakeForkd(t *testing.T, templates ...string) (string, *fork.MockEngine
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
 	for _, tmpl := range templates {
-		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, false, false); err != nil {
+		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -50,7 +50,7 @@ func startForkRequestRecordingForkd(t *testing.T, templates ...string) (string, 
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
 	for _, tmpl := range templates {
-		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, false, false); err != nil {
+		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -504,7 +504,7 @@ func startFakeForkdNodeFull(registry *NodeRegistry, nodeName string, serverTLS, 
 	engine = fork.NewMockEngine()
 	engine.ForkDelay = 0
 	for _, tmpl := range templates {
-		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, false, false); err != nil {
+		if err := engine.CreateTemplate(tmpl, tmpl, nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 			return nil, nil, nil, nil, err
 		}
 	}

--- a/internal/daemon/delivery_test.go
+++ b/internal/daemon/delivery_test.go
@@ -47,7 +47,7 @@ func (e *kvmReportingEngine) Terminate(id string) error {
 func TestForkWithSecretsFailsWhenAgentUnreachable(t *testing.T) {
 	engine := &kvmReportingEngine{MockEngine: fork.NewMockEngine()}
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))
@@ -72,7 +72,7 @@ func TestForkWithSecretsFailsWhenAgentUnreachable(t *testing.T) {
 func TestForkFailsWhenAgentUnreachableEvenEnvOnly(t *testing.T) {
 	engine := &kvmReportingEngine{MockEngine: fork.NewMockEngine()}
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))
@@ -90,7 +90,7 @@ func TestForkFailsWhenAgentUnreachableEvenEnvOnly(t *testing.T) {
 func TestForkMockEngineSkipsDelivery(t *testing.T) {
 	engine := fork.NewMockEngine() // KVMAvailable=false
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))
@@ -179,7 +179,7 @@ func kvmEngineWithTemplate(t *testing.T, dir string) *kvmReportingEngine {
 	mock.ForkDelay = 0
 	mock.VsockDir = dir
 	engine := &kvmReportingEngine{MockEngine: mock}
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	return engine
@@ -206,7 +206,7 @@ func TestForkDeliversConfigureToAgent(t *testing.T) {
 	mock.ForkDelay = 0
 	mock.VsockDir = dir
 	engine := &kvmReportingEngine{MockEngine: mock}
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	// The mock will report this exact path for sandbox "sb-ok".
@@ -385,7 +385,7 @@ func TestForkMockEngineSendsNoNotify(t *testing.T) {
 	mock := fork.NewMockEngine() // KVMAvailable=false
 	mock.ForkDelay = 0
 	mock.VsockDir = dir
-	if err := mock.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := mock.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	rec := startFakeVsockAgent(t, filepath.Join(dir, "sandboxes", "sb-mock", "vsock.sock"))

--- a/internal/daemon/enc_key_test.go
+++ b/internal/daemon/enc_key_test.go
@@ -30,7 +30,7 @@ type keyProbeEngine struct {
 	forkKeyErr   error
 }
 
-func (e *keyProbeEngine) CreateTemplate(id, _ string, _ []string, _ []volume.Spec, _ *firecracker.WorkloadSpec, _ *firecracker.VMResources, _ bool, _ bool) error {
+func (e *keyProbeEngine) CreateTemplate(id, _ string, _ []string, _ []volume.Spec, _ *firecracker.WorkloadSpec, _ *firecracker.VMResources, _ fork.CreateTemplateOpts) error {
 	k, err := e.prov.KeyFor(id)
 	if err != nil {
 		e.createKeyErr = err

--- a/internal/daemon/grpc_service.go
+++ b/internal/daemon/grpc_service.go
@@ -156,7 +156,7 @@ func (g *grpcService) CreateTemplate(ctx context.Context, req *forkdpb.CreateTem
 		g.srv.keyProvider.SetWrappedKey(req.TemplateId, req.EncryptionKey, req.KekId)
 		defer g.srv.keyProvider.ForgetKey(req.TemplateId)
 	}
-	if err := g.srv.engine.CreateTemplate(req.TemplateId, req.Image, req.InitCommands, vols, toFirecrackerWorkload(req.Workload), vmResources(req.Resources), req.ForceRebuild, req.WarmKernel); err != nil {
+	if err := g.srv.engine.CreateTemplate(req.TemplateId, req.Image, req.InitCommands, vols, toFirecrackerWorkload(req.Workload), vmResources(req.Resources), fork.CreateTemplateOpts{ForceRebuild: req.ForceRebuild, WarmKernel: req.WarmKernel}); err != nil {
 		return nil, grpcError(err)
 	}
 	// Report the content-addressed digest the engine just recorded so the

--- a/internal/daemon/interface.go
+++ b/internal/daemon/interface.go
@@ -37,13 +37,12 @@ type ForkEngine interface {
 	ReclaimVolume(sandboxID string) error
 	// CreateTemplate builds a template snapshot. volumes are the template's
 	// declared volumes; the engine bakes one placeholder drive per volume into
-	// the snapshot. Nil leaves the template drive-less (only the rootfs).
-	// forceRebuild, when true, skips the reuse-or-rebuild gate (#584) and always
-	// deletes and rebuilds; the controller sets it when the template CONTENT
-	// changed (issue #475). warmKernel, when true, runs one trivial run_code
-	// cell before the snapshot so forks wake with a warm code-interpreter
-	// kernel; warmup failures fail open (the build continues cold).
-	CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec, workload *firecracker.WorkloadSpec, vmRes *firecracker.VMResources, forceRebuild bool, warmKernel bool) error
+	// the snapshot. Nil leaves the template drive-less (only the rootfs). opts
+	// carries ForceRebuild (skip the reuse-or-rebuild gate #584 and always
+	// rebuild; the controller sets it when template CONTENT changed, #475) and
+	// WarmKernel (run one trivial run_code cell before the snapshot so forks wake
+	// with a warm code-interpreter kernel; warmup failures fail open).
+	CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec, workload *firecracker.WorkloadSpec, vmRes *firecracker.VMResources, opts fork.CreateTemplateOpts) error
 	// PullTemplate fetches a template's snapshot from a peer forkd's CAS over
 	// the peer's token-gated TLS surface, materializes it, verifies it, and
 	// records the digest. token is a credential and must never be logged.

--- a/internal/daemon/list_sandboxes_test.go
+++ b/internal/daemon/list_sandboxes_test.go
@@ -16,7 +16,7 @@ import (
 func TestServerListSandboxesMergesActivity(t *testing.T) {
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/daemon/metering_test.go
+++ b/internal/daemon/metering_test.go
@@ -50,7 +50,7 @@ func (f *fakeMeteringEngine) GetCapacity() fork.Capacity {
 func (f *fakeMeteringEngine) ListSandboxes() []fork.SandboxRecord { return nil }
 func (f *fakeMeteringEngine) ListVolumes() []fork.VolumeRecord    { return nil }
 func (f *fakeMeteringEngine) ReclaimVolume(string) error          { panic("not used") }
-func (f *fakeMeteringEngine) CreateTemplate(string, string, []string, []volume.Spec, *firecracker.WorkloadSpec, *firecracker.VMResources, bool, bool) error {
+func (f *fakeMeteringEngine) CreateTemplate(string, string, []string, []volume.Spec, *firecracker.WorkloadSpec, *firecracker.VMResources, fork.CreateTemplateOpts) error {
 	panic("not used")
 }
 func (f *fakeMeteringEngine) PullTemplate(context.Context, string, string, string, string) error {

--- a/internal/daemon/token_auth_test.go
+++ b/internal/daemon/token_auth_test.go
@@ -231,7 +231,7 @@ func TestUnregisterSandboxClearsToken(t *testing.T) {
 func TestForkRegistersTokenOnServer(t *testing.T) {
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	api := NewSandboxAPI(t.TempDir())
@@ -264,7 +264,7 @@ func TestForkRegistersTokenOnServer(t *testing.T) {
 func TestForkWithEmptyTokenFailsClosed(t *testing.T) {
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	api := NewSandboxAPI(t.TempDir())
@@ -288,7 +288,7 @@ func TestForkWithEmptyTokenFailsClosed(t *testing.T) {
 func TestForkRunningRegistersToken(t *testing.T) {
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	api := NewSandboxAPI(t.TempDir())

--- a/internal/daemon/tracing_test.go
+++ b/internal/daemon/tracing_test.go
@@ -20,7 +20,7 @@ func TestForkProducesSpans(t *testing.T) {
 
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))
@@ -100,7 +100,7 @@ func TestTracingOffNoSpans(t *testing.T) {
 	// default no-op provider. The fork path must not panic and must cost nothing.
 	engine := fork.NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 	srv := NewServer(engine, NewSandboxAPI(t.TempDir()))

--- a/internal/daemon/vitals_api_test.go
+++ b/internal/daemon/vitals_api_test.go
@@ -29,7 +29,7 @@ import (
 func TestForkRecordsVitalsLabels(t *testing.T) {
 	engine := fork.NewMockEngine() // KVMAvailable=false
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "py", nil, nil, nil, nil, fork.CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	api := NewSandboxAPI(t.TempDir())

--- a/internal/daemon/warm_kernel_plumbing_test.go
+++ b/internal/daemon/warm_kernel_plumbing_test.go
@@ -28,13 +28,13 @@ type warmKernelProbeEngine struct {
 	calls map[string]bool
 }
 
-func (e *warmKernelProbeEngine) CreateTemplate(id string, _ string, _ []string, _ []volume.Spec, _ *firecracker.WorkloadSpec, _ *firecracker.VMResources, _ bool, warmKernel bool) error {
+func (e *warmKernelProbeEngine) CreateTemplate(id string, _ string, _ []string, _ []volume.Spec, _ *firecracker.WorkloadSpec, _ *firecracker.VMResources, opts fork.CreateTemplateOpts) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.calls == nil {
 		e.calls = make(map[string]bool)
 	}
-	e.calls[id] = warmKernel
+	e.calls[id] = opts.WarmKernel
 	return nil
 }
 

--- a/internal/fork/encryption_test.go
+++ b/internal/fork/encryption_test.go
@@ -140,7 +140,7 @@ func TestCreateTemplateEncryptedCreatesContainerAndWritesInside(t *testing.T) {
 		t.Fatalf("seed rootfs: %v", err)
 	}
 
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -175,7 +175,7 @@ func TestForkEncryptedOpensContainerWhenNotOpen(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -218,7 +218,7 @@ func TestDeleteTemplateShredsContainer(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestEncryptionDisabledCreatesNoContainer(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 	if e.crypt != nil {
@@ -274,7 +274,7 @@ func TestCreateTemplateFailedBuildRollsBackContainer(t *testing.T) {
 	e.runTemplateBuild = func(id string, cfg firecracker.VMConfig, initCommands []string, _ *firecracker.WorkloadSpec, _ bool) error {
 		return fmt.Errorf("boom: build failed")
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err == nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err == nil {
 		t.Fatal("expected CreateTemplate to fail when the build step fails")
 	}
 
@@ -304,7 +304,7 @@ func TestCreateTemplateFailedBuildRollsBackContainer(t *testing.T) {
 		writeFakeSnapshot(t, e.dataDir, id)
 		return nil
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("retry CreateTemplate after rollback: %v", err)
 	}
 	if len(fake.creates) != 2 {
@@ -329,7 +329,7 @@ func TestDeleteTemplateForgetsAndZeroizesKey(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -380,7 +380,7 @@ func TestEnsureTemplateOpenSerializesConcurrentForks(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -433,7 +433,7 @@ func TestTerminateDoesNotShredSharedTemplateContainer(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -485,7 +485,7 @@ func TestCreateTemplateFailsClosedWithoutKey(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err == nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err == nil {
 		t.Fatal("CreateTemplate must fail closed when encryption is on but no key is available")
 	}
 	if len(fake.creates) != 0 {
@@ -522,7 +522,7 @@ func TestCreateTemplateUsesRequestKey(t *testing.T) {
 	if err := os.WriteFile(rootfs, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed rootfs: %v", err)
 	}
-	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("tmpl1", rootfs, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate with request key: %v", err)
 	}
 	if len(fake.creates) != 1 || fake.creates[0] != "tmpl1" {

--- a/internal/fork/engine.go
+++ b/internal/fork/engine.go
@@ -2238,7 +2238,24 @@ func logBuildPlan(image string, initCommands []string, cache templatebuild.Cache
 		image, len(plan), cached, len(plan)-cached)
 }
 
-func (e *Engine) CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec, workload *firecracker.WorkloadSpec, vmRes *firecracker.VMResources, forceRebuild bool, warmKernel bool) (retErr error) {
+// CreateTemplateOpts carries the optional booleans CreateTemplate accepts.
+// They live in a struct rather than as trailing positional parameters so a
+// caller cannot silently transpose them: CreateTemplate already takes a long
+// argument list, and two adjacent bare bools compile fine when swapped (the
+// concern CodeRabbit raised on #736). The zero value is the common case: reuse
+// an on-disk template if it verifies, and build a cold snapshot.
+type CreateTemplateOpts struct {
+	// ForceRebuild skips the reuse-or-rebuild gate (#584) and always deletes and
+	// rebuilds. The controller sets it when the template CONTENT changed (#475),
+	// because digest verification proves integrity, not content identity.
+	ForceRebuild bool
+	// WarmKernel runs one trivial run_code cell before the snapshot so forks wake
+	// with a warm code-interpreter kernel. Warmup failures fail open (the build
+	// continues cold).
+	WarmKernel bool
+}
+
+func (e *Engine) CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec, workload *firecracker.WorkloadSpec, vmRes *firecracker.VMResources, opts CreateTemplateOpts) (retErr error) {
 	// Path-traversal guard (CodeQL go/path-injection): id becomes a host path
 	// component (templates/<id>/...) through recordTemplateDigest and verify. The
 	// gRPC boundary validates it, but the sandbox-server REST handler does not, so
@@ -2277,7 +2294,7 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 	// forceRebuild skips reuse entirely: the controller sets it when the
 	// template CONTENT changed (issue #475), because digest verification proves
 	// integrity, not content identity.
-	if !forceRebuild {
+	if !opts.ForceRebuild {
 		reuse, verr := shouldReuseTemplate(e.dataDir, id, func(string) error {
 			if err := e.VerifyTemplate(id); err != nil {
 				return err
@@ -2437,7 +2454,7 @@ func (e *Engine) CreateTemplate(id string, image string, initCommands []string, 
 		cfg.VolumeDrives = drives
 	}
 
-	if err := e.runTemplateBuild(id, cfg, initCommands, workload, warmKernel); err != nil {
+	if err := e.runTemplateBuild(id, cfg, initCommands, workload, opts.WarmKernel); err != nil {
 		return err
 	}
 	d, err := recordTemplateDigest(e.casStore, e.dataDir, id, e.manifestMetadata(cfg))

--- a/internal/fork/engine_pause_kvm_test.go
+++ b/internal/fork/engine_pause_kvm_test.go
@@ -61,7 +61,7 @@ func TestEnginePauseResumePreservesStateKVM(t *testing.T) {
 	}
 
 	const templateID = "pause-tmpl"
-	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate(templateID, image, nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("create template: %v", err)
 	}
 

--- a/internal/fork/mock.go
+++ b/internal/fork/mock.go
@@ -278,13 +278,13 @@ func mockMountTable(specs []volume.Spec) []vsock.VolumeMountEntry {
 	return volumeMountTable(prepared)
 }
 
-func (e *MockEngine) CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec, _ *firecracker.WorkloadSpec, _ *firecracker.VMResources, _ bool, warmKernel bool) error {
+func (e *MockEngine) CreateTemplate(id string, image string, initCommands []string, volumes []volume.Spec, _ *firecracker.WorkloadSpec, _ *firecracker.VMResources, opts CreateTemplateOpts) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	e.lastInitCommands = initCommands
 	e.lastTemplateVolumes = volumes
-	e.lastWarmKernel = warmKernel
+	e.lastWarmKernel = opts.WarmKernel
 	e.templates[id] = &Template{
 		ID:          id,
 		Image:       image,

--- a/internal/fork/mock_test.go
+++ b/internal/fork/mock_test.go
@@ -10,7 +10,7 @@ import (
 func TestMockEngine_CreateTemplate(t *testing.T) {
 	engine := NewMockEngine()
 
-	if err := engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
@@ -22,7 +22,7 @@ func TestMockEngine_CreateTemplate(t *testing.T) {
 
 func TestMockEngine_CapacityReportsTotalAndEstimate(t *testing.T) {
 	engine := NewMockEngine()
-	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false)
+	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{})
 
 	cap := engine.GetCapacity()
 	if cap.MemoryTotal != 16*1024*1024*1024 {
@@ -51,7 +51,7 @@ func TestMockEngine_CapacityReportsTotalAndEstimate(t *testing.T) {
 
 func TestMockEngine_Fork(t *testing.T) {
 	engine := NewMockEngine()
-	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false)
+	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{})
 
 	result, err := engine.Fork("python", "sandbox-1", ForkOpts{})
 	if err != nil {
@@ -88,7 +88,7 @@ func TestMockEngine_ForkUnknownSnapshot(t *testing.T) {
 
 func TestMockEngine_Terminate(t *testing.T) {
 	engine := NewMockEngine()
-	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false)
+	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{})
 	engine.Fork("python", "sandbox-1", ForkOpts{})
 
 	if err := engine.Terminate("sandbox-1"); err != nil {
@@ -112,7 +112,7 @@ func TestMockEngine_TerminateUnknown(t *testing.T) {
 func TestMockEngine_ConcurrentForks(t *testing.T) {
 	engine := NewMockEngine()
 	engine.ForkDelay = 0
-	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false)
+	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{})
 
 	const n = 100
 	var wg sync.WaitGroup
@@ -146,7 +146,7 @@ func TestMockEngine_ConcurrentForks(t *testing.T) {
 func TestMockEngine_ForkLatency(t *testing.T) {
 	engine := NewMockEngine()
 	engine.ForkDelay = 500 * time.Microsecond
-	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false)
+	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{})
 
 	result, err := engine.Fork("python", "sandbox-1", ForkOpts{})
 	if err != nil {
@@ -161,7 +161,7 @@ func TestMockEngine_ForkLatency(t *testing.T) {
 func TestMockEngine_MemoryAccounting(t *testing.T) {
 	engine := NewMockEngine()
 	engine.ForkDelay = 0
-	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, false, false)
+	engine.CreateTemplate("python", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{})
 
 	for i := 0; i < 10; i++ {
 		engine.Fork("python", "sandbox-"+string(rune('0'+i)), ForkOpts{})
@@ -186,7 +186,7 @@ func TestMockEngine_MemoryAccounting(t *testing.T) {
 func TestMockEngine_ListSandboxes(t *testing.T) {
 	engine := NewMockEngine()
 	engine.ForkDelay = 0
-	if err := engine.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, false, false); err != nil {
+	if err := engine.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,7 +240,7 @@ func TestMockEngine_ListSandboxes(t *testing.T) {
 func TestMockForkRunning(t *testing.T) {
 	e := NewMockEngine()
 	e.ForkDelay = 0
-	if err := e.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("py", "python:3.12-slim", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	parent, err := e.Fork("py", "parent", ForkOpts{})

--- a/internal/fork/pathsafe_entry_test.go
+++ b/internal/fork/pathsafe_entry_test.go
@@ -41,7 +41,7 @@ func TestForkRejectsUnsafeIDs(t *testing.T) {
 func TestCreateTemplateRejectsUnsafeID(t *testing.T) {
 	e := newGateEngine(t, t.TempDir(), false)
 	for _, id := range []string{"../../etc", "a/b", "..", ".", `a\b`} {
-		err := e.CreateTemplate(id, "img", nil, nil, nil, nil, false, false)
+		err := e.CreateTemplate(id, "img", nil, nil, nil, nil, CreateTemplateOpts{})
 		if err == nil {
 			t.Fatalf("CreateTemplate(%q) = nil error, want rejection", id)
 		}

--- a/internal/fork/pause_resume_test.go
+++ b/internal/fork/pause_resume_test.go
@@ -10,7 +10,7 @@ import "testing"
 // KVM acceptance bar in TestEnginePauseResumePreservesStateKVM.
 func TestMockPauseResumeRepeatedCycles(t *testing.T) {
 	e := NewMockEngine()
-	if err := e.CreateTemplate("py", "py", nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("py", "py", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	e.ForkDelay = 0

--- a/internal/fork/template_inflight_test.go
+++ b/internal/fork/template_inflight_test.go
@@ -41,7 +41,7 @@ func TestCreateTemplateRefusesAConcurrentBuildOfTheSameTemplate(t *testing.T) {
 	}
 
 	done := make(chan error, 1)
-	go func() { done <- e.CreateTemplate("python", "img", nil, nil, nil, nil, false, false) }()
+	go func() { done <- e.CreateTemplate("python", "img", nil, nil, nil, nil, CreateTemplateOpts{}) }()
 
 	select {
 	case <-entered:
@@ -49,14 +49,14 @@ func TestCreateTemplateRefusesAConcurrentBuildOfTheSameTemplate(t *testing.T) {
 		t.Fatal("the first build never started")
 	}
 
-	err := e.CreateTemplate("python", "img", nil, nil, nil, nil, false, false)
+	err := e.CreateTemplate("python", "img", nil, nil, nil, nil, CreateTemplateOpts{})
 	if !errors.Is(err, ErrTemplateBuildInProgress) {
 		t.Fatalf("concurrent build of the same template returned %v, want ErrTemplateBuildInProgress", err)
 	}
 
 	// A DIFFERENT template must not be blocked by this one.
 	other := make(chan error, 1)
-	go func() { other <- e.CreateTemplate("node", "img", nil, nil, nil, nil, false, false) }()
+	go func() { other <- e.CreateTemplate("node", "img", nil, nil, nil, nil, CreateTemplateOpts{}) }()
 	select {
 	case err := <-other:
 		if errors.Is(err, ErrTemplateBuildInProgress) {
@@ -70,7 +70,7 @@ func TestCreateTemplateRefusesAConcurrentBuildOfTheSameTemplate(t *testing.T) {
 	<-done
 
 	// Once the first build returns, the template can be built again.
-	if err := e.CreateTemplate("python", "img", nil, nil, nil, nil, false, false); errors.Is(err, ErrTemplateBuildInProgress) {
+	if err := e.CreateTemplate("python", "img", nil, nil, nil, nil, CreateTemplateOpts{}); errors.Is(err, ErrTemplateBuildInProgress) {
 		t.Error("the guard was not released when the build returned")
 	}
 }

--- a/internal/fork/template_init_test.go
+++ b/internal/fork/template_init_test.go
@@ -53,7 +53,7 @@ func TestCreateTemplate_InitFailureAbortsBuild(t *testing.T) {
 		return runInitCommandsForTest(initCommands)
 	}
 
-	err := e.CreateTemplate("py", "/exists/rootfs.ext4", []string{"echo ok", "pip install nope"}, nil, nil, nil, false, false)
+	err := e.CreateTemplate("py", "/exists/rootfs.ext4", []string{"echo ok", "pip install nope"}, nil, nil, nil, CreateTemplateOpts{})
 	if err == nil {
 		t.Fatal("expected CreateTemplate to fail when an init command fails")
 	}
@@ -110,7 +110,7 @@ func TestCreateTemplate_FilePathSkipsImageBuild(t *testing.T) {
 	// recordTemplateDigest will fail (no real snapshot on disk), but the build
 	// seam must have been reached with the file path as the rootfs and the
 	// image build seam must NOT have run (it t.Fatals if it does).
-	_ = e.CreateTemplate("py", rootfs, nil, nil, nil, nil, false, false)
+	_ = e.CreateTemplate("py", rootfs, nil, nil, nil, nil, CreateTemplateOpts{})
 	if gotCfg.RootfsPath != rootfs {
 		t.Errorf("file-path rootfs not passed through: got %q want %q", gotCfg.RootfsPath, rootfs)
 	}

--- a/internal/fork/template_reuse_engine_test.go
+++ b/internal/fork/template_reuse_engine_test.go
@@ -69,7 +69,7 @@ func TestCreateTemplateEngineReusesHealthyTemplate(t *testing.T) {
 		return nil
 	}
 
-	if err := e.CreateTemplate(id, "/fake/reuse-rootfs.ext4", nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate(id, "/fake/reuse-rootfs.ext4", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: unexpected error %v", err)
 	}
 	if built {
@@ -105,7 +105,7 @@ func TestCreateTemplateEngineRebuildsCorruptedTemplate(t *testing.T) {
 		return nil
 	}
 
-	if err := e.CreateTemplate(id, "/fake/rebuild-rootfs.ext4", nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate(id, "/fake/rebuild-rootfs.ext4", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate: unexpected error %v", err)
 	}
 	if !built {
@@ -142,7 +142,7 @@ func TestCreateTemplateEngineForceRebuildAlwaysRebuilds(t *testing.T) {
 		return nil
 	}
 
-	if err := e.CreateTemplate(id, "/fake/force-rebuild-rootfs.ext4", nil, nil, nil, nil, true, false); err != nil {
+	if err := e.CreateTemplate(id, "/fake/force-rebuild-rootfs.ext4", nil, nil, nil, nil, CreateTemplateOpts{ForceRebuild: true}); err != nil {
 		t.Fatalf("CreateTemplate: unexpected error %v", err)
 	}
 	if !built {

--- a/internal/fork/volume_test.go
+++ b/internal/fork/volume_test.go
@@ -295,7 +295,7 @@ func TestCreateTemplateBakesReadOnlyForShare(t *testing.T) {
 		// Fresh writable: must bake writable.
 		{Name: "scratch", SizeMB: 32, MountPath: "/scratch", Policy: volume.ForkPolicyFresh},
 	}
-	_ = e.CreateTemplate("tmpl", rootfs, nil, vols, nil, nil, false, false)
+	_ = e.CreateTemplate("tmpl", rootfs, nil, vols, nil, nil, CreateTemplateOpts{})
 
 	if len(gotDrives) != 2 {
 		t.Fatalf("expected 2 placeholder drives, got %d", len(gotDrives))
@@ -350,7 +350,7 @@ func TestCreateTemplateBakesPlaceholderDrives(t *testing.T) {
 	}
 	// recordTemplateDigest fails (no real snapshot), but the build seam must have
 	// been reached with the placeholder drives in order.
-	_ = e.CreateTemplate("tmpl", rootfs, nil, vols, nil, nil, false, false)
+	_ = e.CreateTemplate("tmpl", rootfs, nil, vols, nil, nil, CreateTemplateOpts{})
 
 	if len(gotDrives) != 2 {
 		t.Fatalf("expected 2 placeholder drives, got %d: %+v", len(gotDrives), gotDrives)

--- a/internal/fork/warm_kernel_engine_test.go
+++ b/internal/fork/warm_kernel_engine_test.go
@@ -20,10 +20,10 @@ func TestCreateTemplate_ThreadsWarmKernelToBuild(t *testing.T) {
 		return nil
 	}
 
-	if err := e.CreateTemplate("warm", "/fake/rootfs.ext4", nil, nil, nil, nil, false, true); err != nil {
+	if err := e.CreateTemplate("warm", "/fake/rootfs.ext4", nil, nil, nil, nil, CreateTemplateOpts{WarmKernel: true}); err != nil {
 		t.Fatalf("CreateTemplate(warm): %v", err)
 	}
-	if err := e.CreateTemplate("cold", "/fake/rootfs.ext4", nil, nil, nil, nil, false, false); err != nil {
+	if err := e.CreateTemplate("cold", "/fake/rootfs.ext4", nil, nil, nil, nil, CreateTemplateOpts{}); err != nil {
 		t.Fatalf("CreateTemplate(cold): %v", err)
 	}
 


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs; templates are built by forkd's engine.
> - The forkd engine (internal/fork) and its ForkEngine interface (internal/daemon) own template creation via CreateTemplate.
> - CreateTemplate had grown two trailing positional booleans, forceRebuild and warmKernel, on an already long parameter list; two adjacent bare bools compile fine when transposed, so a caller could silently swap "force a rebuild" and "warm the kernel".
> - CodeRabbit flagged exactly this on #736; the cleanup was deferred to #741 because it churns 40+ call sites in an otherwise green, behavior-complete PR. It serves the boring-failure and maintainability posture of the fork engine.
> - This pull request replaces the two trailing bools with a CreateTemplateOpts{ForceRebuild, WarmKernel bool} struct threaded through the engine, the mock, the ForkEngine interface, the gRPC handler, and every cmd and test call site.
> - The benefit is that the two flags are now named at every call site and can no longer be transposed, and future optional knobs (for example the #786 rlimit template knob) extend the struct instead of lengthening the positional list.

## Linked Issues or Issue Description

Closes #741

## What Changed

- Added `fork.CreateTemplateOpts{ForceRebuild, WarmKernel bool}` with doc comments carrying the semantics previously attached to the two parameters.
- Changed `Engine.CreateTemplate`, `MockEngine.CreateTemplate`, and the `daemon.ForkEngine` interface method to take `opts CreateTemplateOpts` in place of the trailing `forceRebuild, warmKernel` booleans.
- Updated the gRPC handler to build the struct from `CreateTemplateRequest` (`ForceRebuild`/`WarmKernel`), and swept every cmd smoke tool and test call site (most to the zero value `CreateTemplateOpts{}`).
- Updated the three test doubles that implement the interface (warm-kernel, key-probe, metering fakes) to the new signature.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...` clean
- [x] `go test ./internal/daemon/` (includes `TestCreateTemplatePlumbsWarmKernel`, which now exercises the struct end to end over gRPC)
- [x] `go test ./internal/fork/ -run 'Mock|TemplateInflight|PathSafe'`
- [x] `gofmt -l` clean on all touched files
- The KVM-gated warm-kernel and template-reuse engine tests continue to cover `WarmKernel` and `ForceRebuild` through the new API on the firecracker runners.

## Risks

Low risk. Pure signature refactor with no behavior change: the zero value reproduces the previous `false, false` default, and the gRPC handler maps the same request fields. No wire, CRD, or snapshot format change.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured template-creation options, including controls for forced rebuilding and kernel warming.
  - Template creation now consistently uses these options across supported workflows.

- **Bug Fixes**
  - Preserved existing template reuse, rebuild, and warm-kernel behavior while improving configuration handling.

- **Tests**
  - Updated coverage and test setups to validate the new template-creation options across fork, encryption, volume, and lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->