### PR TITLE
fix(controller): treat an in-progress template build as retry-later, not BuildFailed

### DIFF
--- a/internal/controller/forkd_client.go
+++ b/internal/controller/forkd_client.go
@@ -29,6 +29,19 @@ func isRetryableCapacity(err error) bool {
 	return hasGRPCCode(err, codes.ResourceExhausted) || hasGRPCCode(err, codes.Unavailable)
 }
 
+// isTemplateBuildInProgress reports whether err (possibly wrapped) is forkd's
+// "a build of this template is already running" signal rather than a build
+// failure. Engine.CreateTemplate's in-flight guard (#884) returns
+// fork.ErrTemplateBuildInProgress when a second concurrent build of the same
+// template races the first, and the daemon maps it to gRPC Unavailable. The
+// controller must treat this as retry-later, not a failure: while a slow or
+// stuck build holds the guard, flapping the TemplateBuilt condition to
+// BuildFailed on every ~20s reconcile makes a build IN PROGRESS look like a
+// build FAILURE (#888), which is misleading during an incident (#887).
+func isTemplateBuildInProgress(err error) bool {
+	return hasGRPCCode(err, codes.Unavailable)
+}
+
 // hasGRPCCode reports whether err (possibly wrapped) carries the given gRPC
 // status code anywhere in its unwrap chain.
 func hasGRPCCode(err error, code codes.Code) bool {

--- a/internal/controller/pool_healing_conditions_test.go
+++ b/internal/controller/pool_healing_conditions_test.go
@@ -6,9 +6,12 @@ package controller_test
 // operator recovery lever that bypasses rebuildBackoff on demand.
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "mitos.run/mitos/api/v1"
 	"mitos.run/mitos/internal/controller"
@@ -95,6 +98,43 @@ func TestTemplateBuiltConditionSurfacesBuildError(t *testing.T) {
 		t.Fatalf("ensureTemplateBuilt (plaintext, healthy node): %v", err)
 	}
 	okCond := controller.TemplateBuiltConditionForTest(nil, now)
+	if okCond.Status != metav1.ConditionTrue || okCond.Reason != "Built" {
+		t.Fatalf("TemplateBuilt = %s/%s, want True/Built", okCond.Status, okCond.Reason)
+	}
+}
+
+// A build still IN PROGRESS on the node (#884's in-flight guard, surfaced as
+// gRPC Unavailable and wrapped by ensureTemplateBuilt) must NOT flap the
+// TemplateBuilt condition to False/BuildFailed (#888): templateBuiltConditionUpdate
+// returns ok=false so the reconcile leaves the prior condition untouched, while a
+// genuine build failure still sets False/BuildFailed and a success sets True/Built.
+func TestTemplateBuiltConditionSkipsWhileBuildInProgress(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+
+	// Mirror ensureTemplateBuilt's wrapping of the gRPC error the daemon returns
+	// for fork.ErrTemplateBuildInProgress (codes.Unavailable).
+	inProgress := fmt.Errorf("build template snapshot py: %w",
+		status.Error(codes.Unavailable, "create template py: a build of this template is already in progress"))
+	if _, ok := controller.TemplateBuiltConditionUpdateForTest(inProgress, now); ok {
+		t.Fatal("a build-in-progress (Unavailable) error must NOT set a TemplateBuilt condition; want ok=false")
+	}
+
+	// A genuine build failure (not Unavailable) still surfaces as BuildFailed.
+	failed := fmt.Errorf("build template snapshot py: %w",
+		status.Error(codes.Internal, "boot failed: kernel not staged"))
+	cond, ok := controller.TemplateBuiltConditionUpdateForTest(failed, now)
+	if !ok {
+		t.Fatal("a genuine build failure must set the TemplateBuilt condition; want ok=true")
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != "BuildFailed" {
+		t.Fatalf("TemplateBuilt = %s/%s, want False/BuildFailed", cond.Status, cond.Reason)
+	}
+
+	// A successful build still surfaces as True/Built.
+	okCond, ok := controller.TemplateBuiltConditionUpdateForTest(nil, now)
+	if !ok {
+		t.Fatal("a successful build must set the TemplateBuilt condition; want ok=true")
+	}
 	if okCond.Status != metav1.ConditionTrue || okCond.Reason != "Built" {
 		t.Fatalf("TemplateBuilt = %s/%s, want True/Built", okCond.Status, okCond.Reason)
 	}

--- a/internal/controller/pool_rebuild.go
+++ b/internal/controller/pool_rebuild.go
@@ -311,6 +311,21 @@ func templateBuiltCondition(buildErr error, now metav1.Time) metav1.Condition {
 	}
 }
 
+// templateBuiltConditionUpdate returns the TemplateBuilt condition to set for
+// buildErr and whether it should be set at all. It is the controller-side
+// complement of the #884 daemon mapping: a build still IN PROGRESS on the node
+// (the in-flight guard, surfaced as gRPC Unavailable) is a retry-later signal,
+// not a failure, so ok is false and the caller leaves the prior TemplateBuilt
+// condition untouched instead of flapping it to False/BuildFailed on every
+// reconcile while the build runs (#888). Every other outcome (success, or a
+// genuine build failure) sets the condition as before.
+func templateBuiltConditionUpdate(buildErr error, now metav1.Time) (metav1.Condition, bool) {
+	if buildErr != nil && isTemplateBuildInProgress(buildErr) {
+		return metav1.Condition{}, false
+	}
+	return templateBuiltCondition(buildErr, now), true
+}
+
 // truncateMessage bounds s to at most n bytes so a long error never produces
 // an oversized condition message. It is a byte-level cut (not rune-aware):
 // the callers here are ASCII forkd/Kubernetes error text, and a Kubernetes

--- a/internal/controller/sandboxpool_controller.go
+++ b/internal/controller/sandboxpool_controller.go
@@ -328,7 +328,14 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// in place here even when the holder count is already satisfied.
 		buildErr := r.ensureTemplateBuilt(ctx, &pool, template, nodeFilter)
 		if buildErr != nil {
-			logger.Error(buildErr, "failed to build template snapshot for husk pool (warm pool still maintained)")
+			if isTemplateBuildInProgress(buildErr) {
+				// A concurrent build holds the node's in-flight guard (#884). This
+				// is retry-later, not a failure: log quietly and let the requeue
+				// below try again, without flapping BuildFailed (#888).
+				logger.Info("template snapshot build in progress on the node; will retry", "pool", pool.Name)
+			} else {
+				logger.Error(buildErr, "failed to build template snapshot for husk pool (warm pool still maintained)")
+			}
 		}
 
 		// Bound voluntary disruption of the warm pool: a PodDisruptionBudget so a
@@ -365,8 +372,12 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		// TemplateBuilt (#578): surfaces ensureTemplateBuilt's result (already
 		// captured in buildErr above) as a condition, so a build failure is
-		// visible on the pool object and not just in the reconcile log.
-		setCondition(&pool.Status.Conditions, templateBuiltCondition(buildErr, now))
+		// visible on the pool object and not just in the reconcile log. A build
+		// still in progress (#888) leaves the prior condition untouched rather
+		// than transitioning it to False/BuildFailed.
+		if cond, ok := templateBuiltConditionUpdate(buildErr, now); ok {
+			setCondition(&pool.Status.Conditions, cond)
+		}
 
 		// Force-rebuild annotation (#584, #578): an operator setting
 		// mitos.run/force-rebuild is an explicit override that bypasses
@@ -420,7 +431,13 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// just in the reconcile log.
 	buildErr := r.ensureTemplateBuilt(ctx, &pool, template, nodeFilter)
 	if buildErr != nil {
-		logger.Error(buildErr, "failed to create snapshots")
+		if isTemplateBuildInProgress(buildErr) {
+			// Retry-later, not a failure (#888): a concurrent build holds the
+			// node's in-flight guard (#884).
+			logger.Info("template snapshot build in progress on the node; will retry", "pool", pool.Name)
+		} else {
+			logger.Error(buildErr, "failed to create snapshots")
+		}
 	}
 	readySnapshots := r.readySnapshotCountOn(templateID, nodeFilter)
 
@@ -434,7 +451,9 @@ func (r *SandboxPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	now := metav1.Now()
-	setCondition(&pool.Status.Conditions, templateBuiltCondition(buildErr, now))
+	if cond, ok := templateBuiltConditionUpdate(buildErr, now); ok {
+		setCondition(&pool.Status.Conditions, cond)
+	}
 	setCondition(&pool.Status.Conditions, metav1.Condition{
 		Type:               "Ready",
 		Status:             conditionStatus(readySnapshots >= desired),

--- a/internal/controller/testsupport_test.go
+++ b/internal/controller/testsupport_test.go
@@ -336,6 +336,14 @@ func TemplateBuiltConditionForTest(buildErr error, now metav1.Time) metav1.Condi
 	return templateBuiltCondition(buildErr, now)
 }
 
+// TemplateBuiltConditionUpdateForTest exposes templateBuiltConditionUpdate so
+// the external controller_test package can assert that a build-in-progress
+// signal (gRPC Unavailable, #888) is not surfaced as a BuildFailed condition
+// transition but leaves the prior TemplateBuilt condition untouched.
+func TemplateBuiltConditionUpdateForTest(buildErr error, now metav1.Time) (metav1.Condition, bool) {
+	return templateBuiltConditionUpdate(buildErr, now)
+}
+
 // ForceRebuildAnnotationForTest exposes the forceRebuildAnnotation key to the
 // external controller_test package.
 const ForceRebuildAnnotationForTest = forceRebuildAnnotation


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots; the controller drives forkd to build the per-pool template snapshot that husk pods and raw-forkd claims fork from.
> - forkd's Engine.CreateTemplate carries an in-flight guard (#884): a second concurrent build of the same template returns fork.ErrTemplateBuildInProgress, which the daemon maps to gRPC Unavailable, so two builds never race the placeholder tap.
> - The controller side never distinguished that retry-later signal from a genuine failure: templateBuiltCondition stamped ANY build error as TemplateBuilt=False/BuildFailed, and both reconcile paths logged it at error level.
> - So while a slow or stuck build held the guard, the pool re-called CreateTemplate every ~20s, hit the guard, and flapped BuildFailed on every reconcile. Found deploying to prod 2026-07-10; it made the #887 build hang look like a build FAILURE during the incident and hammered the guard with wasted work. This serves the boring-failure principle for the capacity/build path.
> - This pull request classifies the Unavailable signal at the controller and treats it as a quiet requeue-later that leaves the prior TemplateBuilt condition untouched, rather than a BuildFailed transition.
> - The benefit is that a build in progress reads as in progress, a genuine failure still reads as BuildFailed, and the tight error-log-and-requeue loop against the guard is gone.

## Linked Issues or Issue Description

Closes #888. Controller-side complement of #884 (the daemon mapping); relates to #887 (the build hang this obscured) and #785 (build progress conditions).

## What Changed

- Added `isTemplateBuildInProgress(err)` in forkd_client.go: unwrap-aware detection of gRPC Unavailable, the code the daemon maps `fork.ErrTemplateBuildInProgress` to.
- Added `templateBuiltConditionUpdate(buildErr, now) (Condition, bool)` in pool_rebuild.go: returns ok=false for the in-progress signal so the caller leaves the prior TemplateBuilt condition untouched; every other outcome (success or genuine failure) sets the condition as before. `templateBuiltCondition` itself is unchanged.
- Both the husk-mode and raw-forkd reconcile paths now gate the condition set on that helper and log the in-progress case at info level instead of error.
- Added a decision test asserting Unavailable -> no condition change, a non-Unavailable failure -> False/BuildFailed, and success -> True/Built.

## Verification

- [x] `go build ./internal/controller/`, `go vet ./internal/controller/` clean
- [x] `go test ./internal/controller/ -run 'TemplateBuiltCondition|TestTemplateBuiltConditionSkipsWhileBuildInProgress'` (envtest) passes, including the pre-existing `TestTemplateBuiltConditionSurfacesBuildError`
- [x] `go test ./internal/controller/ -run 'Pool|HuskPoolBuilds|TemplateBuilt|Healing|Rebuild|Snapshot'` (envtest) green: no regression on either reconcile path
- [x] `gofmt -l` clean on all touched files

## Risks

Low risk. The only behavior change is that a gRPC-Unavailable build error no longer transitions TemplateBuilt to False/BuildFailed and is logged at info rather than error; the requeue cadence is unchanged (the same ~10s retry drives the build to completion). A genuine build failure (any other code) is unaffected, preserving the #578 "failure visible on the pool object" invariant.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template build status handling while a build is still in progress.
  * Preserved the existing `TemplateBuilt` status instead of reporting a premature failure.
  * Reduced unnecessary error-level logging during expected build progress.
  * Continued reporting genuine build failures and successful builds accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->