### PR TITLE
ci(bench): self-heal a bench box that lost rustup from PATH

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -121,6 +121,23 @@ jobs:
           # The Rust guest agent (guest/agent-rs), built static (musl) so it runs
           # as PID 1 (/init) in the minimal bench rootfs. Same recipe as
           # Dockerfile.forkd.
+          #
+          # Self-heal a bench box that lost rustup (#767): the toolchain went off
+          # PATH (or away entirely) and this step died with "rustup: command not
+          # found" (exit 127), blocking every bare-metal bench. Prefer an existing
+          # install by sourcing its env in case only PATH was lost; install rustup
+          # (minimal stable profile) only when it is genuinely absent. Idempotent.
+          if [ -f "$HOME/.cargo/env" ]; then
+            # shellcheck disable=SC1091
+            . "$HOME/.cargo/env"
+          fi
+          if ! command -v rustup >/dev/null 2>&1; then
+            echo "rustup not found; installing a minimal stable toolchain (#767)"
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --profile minimal --default-toolchain stable
+            # shellcheck disable=SC1091
+            . "$HOME/.cargo/env"
+          fi
           rustup target add x86_64-unknown-linux-musl
           ( cd guest/agent-rs && \
             cargo build --release --target x86_64-unknown-linux-musl --features vsock )


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them; its public performance numbers must be reproducible from bench/ (the no-unverified-claims rule), which the bare-metal Bench workflow produces on a self-hosted [bare-metal, kvm, bench] runner.
> - That workflow builds the Rust guest agent (guest/agent-rs) static-musl as the first real step, using rustup.
> - The bench box lost the Rust toolchain from PATH, so the 'Build guest agent' step died with "rustup: command not found" (exit 127), and every bare-metal bench (fork-exec, exec-rt, metering, and the CoW density sweep #766/#764) stopped producing evidence.
> - It needs addressing now because it blocks the density-sweep evidence for #764 and any refresh of the published bare-metal numbers; the issue itself proposes a guarded install in the build step.
> - This pull request makes the build step self-heal: source the cargo env first (recover a PATH-only loss), then install rustup only when it is genuinely absent.
> - The benefit is that a stripped box repairs itself on the next run instead of hard-failing, and a healthy box is unchanged.

## Linked Issues or Issue Description

Closes #767.

## What Changed

- In .github/workflows/bench.yaml 'Build guest agent': before `rustup target add`, source `$HOME/.cargo/env` if present, and if `rustup` is still not on PATH, install it with the official installer pinned to a minimal stable profile, then source the env. Idempotent.

## Verification

- [x] YAML change is confined to the existing `run: |` shell block at matching indentation; the repo's actionlint and shellcheck-install checks validate it in CI.
- The self-heal path exercises on the next scheduled/dispatched Bench run on the self-hosted box; a healthy box takes the no-op branch (rustup already present).

## Risks

Low risk. The install runs only when rustup is absent, so a healthy runner is untouched. The workflow is not one of the eight required checks and does not gate other PRs; worst case a network hiccup during install fails the same step that already fails today.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow reliability in environments where the Rust toolchain is not already available.
  * Automatically configures the required stable Rust toolchain before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->