### PR TITLE
docs(platforms): supported-host matrix and air-gapped install runbook

### DIFF
--- a/docs/platforms/air-gapped.md
+++ b/docs/platforms/air-gapped.md
@@ -1,0 +1,103 @@
+# Air-gapped and offline install
+
+mitos self-hosts fully offline. Nothing in the runtime dials a third-party SaaS:
+billing, self-serve signup, and abuse checks are hosted-only surfaces that are
+capability-gated off by default, so an air-gapped install is a clean, complete
+product, not a degraded one. What an offline install needs is exactly three
+things staged inside the boundary: the container images, the Helm chart, and the
+per-node microVM assets (guest kernel and Firecracker). This runbook stages each
+one and installs against them.
+
+Do the staging from a connected mirror host, then move the artifacts across the
+boundary by whatever mechanism your environment allows (internal registry,
+tarballs on removable media).
+
+## 1. Mirror the container images
+
+Every mitos image lives under `ghcr.io/mitos-run`. Copy each to your internal
+registry at the release tag you intend to run (`vX.Y.Z`). Use any registry
+copier; `skopeo` and `crane` both work without a local Docker daemon.
+
+```bash
+SRC=ghcr.io/mitos-run
+DST=registry.internal/mitos      # your internal registry
+TAG=vX.Y.Z                       # the mitos release to run
+
+for img in mitos-controller mitos-forkd mitos-husk-stub \
+           mitos-kvm-device-plugin mitos-facade mitos-canary \
+           mitos-gateway mitos-console; do
+  skopeo copy "docker://$SRC/$img:$TAG" "docker://$DST/$img:$TAG"
+done
+```
+
+The list above is the runtime set. `mitos-ci-runner` is a CI-only image and is
+not needed to run mitos.
+
+## 2. Mirror the Helm chart
+
+The chart is published as an OCI artifact. Pull it on the connected host and
+carry the `.tgz` across, or push it to your internal OCI registry.
+
+```bash
+# Pull to a local .tgz (carry this across the boundary):
+helm pull oci://ghcr.io/mitos-run/charts/mitos --version X.Y.Z
+
+# Or re-push to an internal OCI registry:
+helm push mitos-X.Y.Z.tgz oci://registry.internal/mitos/charts
+```
+
+## 3. Stage the per-node microVM assets
+
+KVM workers boot microVMs from a pinned guest kernel and a Firecracker binary.
+These are node-level assets, provisioned outside the chart, so they must be
+pre-staged on (or reachable from) each KVM worker:
+
+- **Guest kernel**: the pinned `vmlinux` (see the version referenced by the
+  build and bench workflows). Place it where the node's kernel provisioning
+  expects it; see `host-prerequisites.md`.
+- **Firecracker**: mitos runs a patched Firecracker (lazy-restore) built from
+  `hack/install-firecracker-patched.sh`, which downloads a single release
+  binary. Mirror that binary internally and run the script pointed at your
+  mirror, or stage the binary onto each node directly. Stock Firecracker
+  v1.15.0 also works, without the lazy-restore latency win.
+
+Neither asset changes a snapshot's portable identity, so staging the same
+kernel and Firecracker version across the fleet is all that is required.
+
+## 4. Install against the mirror
+
+Point the chart at your internal registry. `image.registry` is the single global
+lever every component appends its repository to, and `global.imageTag` overrides
+all component tags at once:
+
+```bash
+helm install mitos oci://registry.internal/mitos/charts/mitos \
+  --version X.Y.Z -n mitos --create-namespace \
+  --set image.registry=registry.internal/mitos \
+  --set global.imageTag=vX.Y.Z
+```
+
+If the internal registry requires authentication, create a pull secret in the
+install namespace and reference it via the chart's `imagePullSecrets` values;
+`image.pullPolicy` defaults to `IfNotPresent`, which is correct offline.
+
+## 5. Preflight and verify
+
+`mitos doctor` is offline-safe: every check reads the local host, none dial out.
+Run it on each KVM worker before and after install:
+
+```bash
+mitos doctor
+```
+
+Once the pods are up, the sandboxes themselves need no outbound internet: the
+per-sandbox egress default is deny, so a workload only reaches the destinations
+you allow. The platform requires no egress at all once the images, chart, and
+microVM assets are local.
+
+## What is deliberately absent offline
+
+Per the self-host capability model, the hosted-only surfaces (self-serve signup,
+billing and credits, Paddle, allowlist gating, abuse email checks) are gated off
+and never appear: no dead links, no empty billing panels. The console, CLI, and
+SDK point at a real first success against your own cluster.

--- a/docs/platforms/prerequisites.md
+++ b/docs/platforms/prerequisites.md
@@ -130,3 +130,7 @@ an in-cluster Job; it exits non-zero if any check fails. See
 
 Once the install is healthy, `lifecycle.md` is the day-2 guide: upgrading, CRD
 schema changes, rolling back, backing up state, and uninstalling.
+
+See also: `supported-hosts.md` for the host-support matrix (which machines can be
+KVM workers versus control-plane only), and `air-gapped.md` for the offline
+install runbook.

--- a/docs/platforms/supported-hosts.md
+++ b/docs/platforms/supported-hosts.md
@@ -1,0 +1,80 @@
+# Supported hosts
+
+This page is the host-support matrix: which machines can run mitos sandboxes,
+which can only run the control plane, and which cannot run mitos at all. It is
+the decision companion to `host-prerequisites.md` (the authoritative per-node
+kernel checklist) and to the concrete realizations in `talos-hetzner.md` and
+`k3s-quickstart.md`.
+
+The rule is simple and mechanical: a machine is a supported **KVM worker** if it
+passes `mitos doctor`. That command is the per-requirement hard gate; it exits
+non-zero and prints an actionable remediation for every requirement it finds
+unmet, so you never have to guess why a node was rejected.
+
+## Two kinds of node
+
+mitos splits cleanly into a control plane and KVM workers, and they have
+different requirements.
+
+| Node role | Runs | KVM required | Requirement source |
+| --- | --- | --- | --- |
+| Control plane | controller, gateway, facade, console (Deployments) | No | ordinary Kubernetes node |
+| KVM worker | forkd (DaemonSet) and the husk pods that boot microVMs | Yes | `host-prerequisites.md` + `mitos doctor` |
+
+You can run the control plane on any Kubernetes node (including a managed cloud
+control plane). Only the KVM workers, the nodes that actually boot and fork
+microVMs, carry the kernel and device requirements below.
+
+## What a KVM worker must provide
+
+These are summarized from `host-prerequisites.md`, which remains the source of
+truth. Each row names the `mitos doctor` check that gates it.
+
+| Requirement | `mitos doctor` check | Needed for |
+| --- | --- | --- |
+| `/dev/kvm` present and usable | `kvm-device` | booting every microVM |
+| `kvm_intel` / `kvm_amd` loaded | `kernel-module-*` | KVM acceleration |
+| `vhost_vsock` module | `kernel-module-vhost_vsock` | guest agent exec/files/env over vsock |
+| `tun` module | `kernel-module-tun` | per-sandbox tap networking |
+| `nf_tables` support | (see prerequisites) | husk egress isolation and kube-proxy |
+| containerd on a real filesystem | (see prerequisites) | the overlay snapshotter cannot stack on overlay/tmpfs |
+| adequate free space on `--data-dir` | `data-dir-space` | template rootfs images, snapshots, jailer chroots |
+| `CONFIG_USERFAULTFD=y` (perf path) | `userfaultfd` | hugepage-backed restore and snapshot-resume prefetch |
+
+The userfaultfd row is required only for the snapshot-resume performance path; a
+node without it still serves sandboxes on the slower 4 KiB file-backed restore.
+
+## The matrix
+
+"Supported" below means "can be a KVM worker". Anything can host the control
+plane.
+
+| Host | KVM worker | Notes |
+| --- | --- | --- |
+| Bare metal with VT-x/AMD-V exposed (for example Hetzner AX) | Yes | The first-class target. See `talos-hetzner.md` and `k3s-quickstart.md`. |
+| Cloud instances that expose `/dev/kvm` (GCP nested virtualization, `*.metal` instance types on AWS/Azure) | Yes, if `mitos doctor` passes | Bare-metal or nested-virt-enabled node pools only; the managed control plane is unaffected. |
+| Standard cloud VMs without nested virtualization (for example Hetzner Cloud) | No | No `/dev/kvm`. Use them for the control plane and attach a bare-metal KVM node pool for workers. |
+| `kind` / CI with the mock engine | No | The mock engine (`KVMAvailable=false`) proves object-level behavior only; it never boots or forks a real microVM. Not a runtime host. |
+| Rescue / minimal / ramdisk-root kernel | No | Typically fails `nf_tables` and the real-filesystem requirement; a minimal kernel also often ships `# CONFIG_USERFAULTFD is not set`. Install a real OS. See `host-prerequisites.md`. |
+
+## Distro and kernel notes
+
+- Stock Debian and Ubuntu kernels enable `CONFIG_USERFAULTFD=y`; the Hetzner
+  rescue kernel and many minimal kernels do not, so the hugepage and prefetch
+  path cannot run there (fall back to 4 KiB templates).
+- A rescue/recovery environment fails two requirements at once (`nf_tables` and
+  a real root filesystem), each with a symptom far from its cause. Boot a real
+  installed OS before running mitos.
+
+## The one gate to run
+
+On every prospective KVM worker:
+
+```bash
+mitos doctor
+```
+
+It runs all of the checks in the table above against the live host and exits
+non-zero if any fails, with a remediation line per failing check. Passing
+`mitos doctor` on a node is the definition of that node being supported; there
+is no separate approval list to maintain.


### PR DESCRIPTION
## Thinking Path

> - Mitos self-hosts on Kubernetes with a control plane (controller, gateway, facade, console) and KVM workers (forkd plus husk pods that boot Firecracker microVMs); self-host is a first-class, Apache-2.0 peer of the hosted product.
> - The host requirements live in host-prerequisites.md and are enforced by mitos doctor, but there was no single page mapping requirements to host TYPES, so an operator learned a node was unsuitable only by running doctor on it and reading a rejection.
> - Separately, the offline story was advertised (the E2B migration doc names air-gapped as a headline) with no runbook behind it, a journey-rule dead end for a regulated or disconnected self-hoster.
> - These need fixing now because the self-hosted first-run must have no dead ends (Experience is DNA) and self-host is a peer surface, not an afterthought.
> - This pull request adds a host-support matrix and an air-gapped install runbook, both grounded in the real chart values and doctor checks, and cross-links them so neither is a dead end.
> - The benefit is that an operator can decide up front which machines to buy or pool and can install fully offline without reverse-engineering the chart.

## Linked Issues or Issue Description

Closes #777. Closes #788.

## What Changed

- docs/platforms/supported-hosts.md: a matrix of host types against KVM-worker supportability, each requirement tied to its mitos doctor check, splitting control-plane from KVM-worker requirements. Explicit that bare metal is supported, nested-virt cloud instances are supported if doctor passes, and plain cloud VMs / rescue kernels are not workers.
- docs/platforms/air-gapped.md: an offline runbook that stages the container images (the real ghcr.io/mitos-run list), the OCI Helm chart, and the per-node guest kernel plus Firecracker binary, then installs against them via image.registry and global.imageTag. Notes the runtime dials no third-party SaaS and that hosted-only surfaces are capability-gated off.
- prerequisites.md: a See also linking both new pages.

## Verification

- [x] Content is grounded in verified facts: the chart image keys (image.registry, global.imageTag, per-component repository) from deploy/charts/mitos/values.yaml; the mitos doctor checks from internal/agentcli/doctor.go; the host requirements from host-prerequisites.md; the Firecracker patched-binary path from hack/install-firecracker-patched.sh.
- [x] No em or en dashes; all internal links point to sibling docs/platforms pages.
- Docs-only change: no code paths touched.

## Risks

Low risk. Documentation only. The pages describe existing, shipped behavior (the chart levers and doctor checks already exist); they add no claims that are not reproducible from the chart and the doctor command.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an offline installation runbook covering image and Helm chart mirroring, node preparation, installation, and readiness checks.
  * Documented offline deployment limitations, including unavailable hosted-only capabilities.
  * Added a host-support matrix covering control-plane and KVM worker requirements.
  * Documented supported and unsupported host environments, kernel requirements, and acceptance checks.
  * Added cross-references between platform prerequisites, supported hosts, and air-gapped installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->