### PR TITLE
fix(controller): back off and fail terminally when a claim can never activate

### DIFF
--- a/internal/controller/activate_backoff_test.go
+++ b/internal/controller/activate_backoff_test.go
@@ -1,0 +1,52 @@
+package controller
+
+// Unit coverage for the activation retry backoff (issue #894): a claim that
+// cannot activate must back off from the flat capacityPendingRequeue cadence as
+// the failure persists, capped, so it stops hammering forkd and the apiserver.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestActivateRetryBackoff(t *testing.T) {
+	cases := []struct {
+		name   string
+		waited time.Duration
+		want   time.Duration
+	}{
+		{"fresh failure returns the base cadence", 0, capacityPendingRequeue},
+		{"just under the first double stays at base", 9 * time.Second, capacityPendingRequeue},
+		{"at the first double grows to 10s", 10 * time.Second, 10 * time.Second},
+		{"between doubles holds the lower step", 15 * time.Second, 10 * time.Second},
+		{"at the second double grows to 20s", 20 * time.Second, 20 * time.Second},
+		{"past the cap threshold clamps to the max", 40 * time.Second, activateFailingMaxBackoff},
+		{"far past clamps to the max", 5 * time.Minute, activateFailingMaxBackoff},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := activateRetryBackoff(c.waited); got != c.want {
+				t.Errorf("activateRetryBackoff(%s) = %s, want %s", c.waited, got, c.want)
+			}
+		})
+	}
+}
+
+// The backoff must never decrease as the failure persists and never exceed the
+// cap: a regression either way reintroduces the full-cadence hammering (#894).
+func TestActivateRetryBackoffMonotonicAndCapped(t *testing.T) {
+	var prev time.Duration
+	for w := time.Duration(0); w <= 10*time.Minute; w += time.Second {
+		got := activateRetryBackoff(w)
+		if got < prev {
+			t.Fatalf("backoff decreased at waited=%s: %s < %s", w, got, prev)
+		}
+		if got > activateFailingMaxBackoff {
+			t.Fatalf("backoff exceeded the cap at waited=%s: %s > %s", w, got, activateFailingMaxBackoff)
+		}
+		if got < capacityPendingRequeue {
+			t.Fatalf("backoff below the base cadence at waited=%s: %s < %s", w, got, capacityPendingRequeue)
+		}
+		prev = got
+	}
+}

--- a/internal/controller/sandboxclaim_controller.go
+++ b/internal/controller/sandboxclaim_controller.go
@@ -64,6 +64,35 @@ const capacityPendingRequeue = 5 * time.Second
 // Cleared once the pool exists, so a later pool deletion starts a fresh clock.
 const poolMissingSinceAnnotation = "mitos.run/pool-missing-since"
 
+// activateFailingSinceAnnotation stamps, in RFC3339, the instant a claim first
+// failed to activate its selected husk pod. Like poolMissingSinceAnnotation it
+// is the durable anchor for a bounded-wait deadline: an activation may fail
+// transiently (a husk still coming up) and recover, so the claim retries with
+// backoff for a grace period before failing terminally (issue #894). Cleared on
+// a successful activation so a later re-activation starts a fresh clock.
+const activateFailingSinceAnnotation = "mitos.run/activate-failing-since"
+
+// activateFailingMaxBackoff caps the requeue delay for a persistently failing
+// activation, so a claim that cannot activate stops retrying at full cadence
+// (issue #894) without stalling recovery once a transient fault clears.
+const activateFailingMaxBackoff = 30 * time.Second
+
+// activateRetryBackoff returns the requeue delay for a claim that has been
+// failing to activate for waited: capacityPendingRequeue while the failure is
+// fresh, doubling as it persists, capped at activateFailingMaxBackoff. It is
+// derived from elapsed time rather than a stored attempt count, so it is
+// stateless and monotonic across controller restarts (issue #894).
+func activateRetryBackoff(waited time.Duration) time.Duration {
+	b := capacityPendingRequeue
+	for waited >= 2*b && b < activateFailingMaxBackoff {
+		b *= 2
+	}
+	if b > activateFailingMaxBackoff {
+		b = activateFailingMaxBackoff
+	}
+	return b
+}
+
 // huskHealthRequeue is how often a Ready husk claim re-checks its backing pod's
 // readiness so its Ready condition reflects a node/pod outage (the endpoint is
 // unreachable) instead of falsely staying Ready (#177). A pod watch would detect
@@ -1054,17 +1083,75 @@ func (r *SandboxReconciler) reconcileHuskClaim(ctx context.Context, claim *v1.Sa
 		if uerr := r.unmarkHuskPodClaimed(ctx, pod); uerr != nil {
 			logger.Error(uerr, "release husk pod claim label after activation failure", "pod", pod.Name)
 		}
+		// Bounded retry with backoff, then terminal (#894). An activation that can
+		// NEVER succeed (a missing snapshot artifact, a digest that will never
+		// match) previously re-pended at the flat capacityPendingRequeue cadence
+		// forever, with no backoff and no terminal state, burning forkd RPCs and
+		// apiserver writes (a stuck pair produced ~1750 futile RPCs and ~3500
+		// writes in an hour). Anchor the first-failure instant on a durable
+		// annotation, mirroring poolMissingSinceAnnotation: back off as the
+		// failure persists, and after the same bounded grace as the capacity wait
+		// fail the claim terminally with the engine's own error so the cause is
+		// actionable (#28).
+		now := r.now()
+		failingSince := now
+		if stamp := claim.Annotations[activateFailingSinceAnnotation]; stamp != "" {
+			if parsed, perr := time.Parse(time.RFC3339, stamp); perr == nil {
+				failingSince = parsed
+			}
+		} else {
+			if claim.Annotations == nil {
+				claim.Annotations = map[string]string{}
+			}
+			claim.Annotations[activateFailingSinceAnnotation] = now.Format(time.RFC3339)
+			if uerr := r.Update(ctx, claim); uerr != nil {
+				return ctrl.Result{}, uerr
+			}
+		}
+		waited := now.Sub(failingSince)
+		maxWait := r.maxPendingDuration()
+
+		// Bounded fail: activation never succeeded within the grace period.
+		if waited >= maxWait {
+			finished := metav1.NewTime(now)
+			claim.Status.Phase = v1.SandboxFailed
+			claim.Status.FinishedAt = &finished
+			setCondition(&claim.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: finished,
+				Reason:             "ActivateFailed",
+				Message: fmt.Sprintf(
+					"%s; still failing after %s, past the %s grace period. The husk snapshot on node %q may be missing or corrupt; check the pool's TemplateBuilt condition and forkd's logs on that node, then recreate the sandbox",
+					msg, waited.Round(time.Second), maxWait, pod.Spec.NodeName,
+				),
+			})
+			_ = r.Status().Update(ctx, claim)
+			logger.Info("claim failed: husk activation did not succeed past bounded wait", "claim", claim.Name, "node", pod.Spec.NodeName, "waited", waited.Round(time.Second), "maxWait", maxWait)
+			return ctrl.Result{}, nil
+		}
+
 		beforeStatus := claim.Status.DeepCopy()
 		claim.Status.Phase = v1.SandboxPending
 		setCondition(&claim.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
-			LastTransitionTime: metav1.NewTime(r.now()),
+			LastTransitionTime: metav1.NewTime(now),
 			Reason:             "ActivateFailed",
-			Message:            msg + "; the claim will retry",
+			Message:            msg + "; the claim will retry with backoff",
 		})
 		_ = r.writeClaimStatusIfChanged(ctx, claim, beforeStatus)
-		return ctrl.Result{RequeueAfter: capacityPendingRequeue}, nil
+		return ctrl.Result{RequeueAfter: activateRetryBackoff(waited)}, nil
+	}
+
+	// A previously failing activation just succeeded: clear the grace stamp so a
+	// later re-activation (failover, #177) starts a fresh clock. The guard makes
+	// the common first-try success pay only a map lookup, never a write.
+	if claim.Annotations[activateFailingSinceAnnotation] != "" {
+		delete(claim.Annotations, activateFailingSinceAnnotation)
+		if uerr := r.Update(ctx, claim); uerr != nil {
+			return ctrl.Result{}, uerr
+		}
 	}
 
 	// The pod was already claimed (optimistic-lock label patch) BEFORE activation,


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them; the controller's Sandbox claim reconciler selects a warm husk pod and activates it (restores the snapshot and hands over env, secrets, and the API token).
> - Every provisioning failure the reconciler already classifies (a missing pool, secret resolution, token minting) either retries with a bounded grace or fails terminally; the husk activation failure was the exception.
> - An activation that can never succeed (a missing or corrupt snapshot artifact, a digest that will never match) re-pended at the flat capacityPendingRequeue cadence forever, with no backoff and no terminal state. A stuck pair produced roughly 1750 futile forkd RPCs and 3500 apiserver writes in an hour.
> - This violates the boring-failure principle (a claim that cannot activate must settle, not hammer) and needs fixing before it can amplify under real tenant load.
> - This pull request anchors the first activation failure on a durable annotation, backs the retry off as the failure persists, and fails the claim terminally after the same bounded grace the capacity wait uses, with the engine's own error surfaced.
> - The benefit is that a stuck claim stops hammering forkd and etcd and lands in a terminal Failed state an operator (or the GC) can act on, while a transient activation fault still recovers within the grace period.

## Linked Issues or Issue Description

Closes #894.

## What Changed

- internal/controller/sandboxclaim_controller.go: on husk activation failure, stamp `mitos.run/activate-failing-since` (RFC3339) on the first failure, then either requeue with `activateRetryBackoff(waited)` (capacityPendingRequeue doubling to a 30s cap) or, once past `maxPendingDuration`, transition to terminal Failed with FinishedAt and an actionable ActivateFailed condition carrying the engine error and the node. The stamp is cleared on a successful activation so a later re-activation starts a fresh clock.
- Added `activateRetryBackoff` (pure, elapsed-time-derived, stateless across restarts) plus `activateFailingSinceAnnotation` and `activateFailingMaxBackoff`.
- Added activate_backoff_test.go: a table test of the backoff curve and a monotonic-plus-capped property test.

## Verification

- [x] `go build ./internal/controller/`, `go vet ./internal/controller/` clean; `gofmt -l` clean.
- [x] `go test ./internal/controller/ -run TestActivateRetryBackoff` (the new unit tests) pass.
- [x] `go test ./internal/controller/ -run 'TestHuskClaimActivateFailureNotReady|TestHuskClaimActivateFailureJoinsTheTokenSecretWrite|TestHuskClaimActivatesDormantPod|TestHuskClaimActivateCarriesExpectedDigest|TestClaimFailsTerminallyWhenPoolNeverAppears'` (envtest) all pass: the activation failure path, happy path, token-write join, and pool-missing terminal are unaffected.

## Risks

Low risk. The retry path still releases the husk pod and re-pends within the grace period, so transient faults recover exactly as before, only at a backed-off cadence. The new terminal transition reuses the proven pool-missing grace bound and GC stamping (#630), so a permanently stuck claim is reaped like any other Failed sandbox. One extra metadata write occurs on the first failure and on recovery only.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activation failures now retry with an increasing backoff instead of a fixed interval.
  * Retry attempts are capped by the configured maximum pending duration.
  * Claims that exceed the retry window transition to `SandboxFailed` with actionable failure details.
  * Successful activation clears the failure timer so future retries start fresh.

* **Bug Fixes**
  * Prevented activation retries from exceeding the configured backoff limit.
  * Added safeguards to ensure retry delays never decrease.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->