### PR TITLE
fix(computer-use): re-pin Chromium to 150.0.7871.124, the current trixie build

### DIFF
--- a/images/computer-use/Dockerfile
+++ b/images/computer-use/Dockerfile
@@ -25,14 +25,16 @@ FROM debian:stable-slim
 # independent of --no-sandbox, the seccomp profile, and every headless/gpu flag
 # combination tried. We pinned back to 147.0.7727.137 until Debian shipped a
 # launchable 150+ (issue tracked in the PR that added the pin). That 147 build
-# has since been REMOVED from the archive (apt exit 100 on every build), and
-# the security pocket now ships 150.0.7871.114, sixty-eight point releases past
-# the SIGTRAP build; the docker-build CDP smoke (below in ci.yaml) is the gate
+# has since been REMOVED from the archive (apt exit 100 on every build). The
+# security pocket keeps only its latest build, so the pin has to track it: it
+# shipped 150.0.7871.114, then rotated that out too (apt exit 100 again), and
+# now ships 150.0.7871.124, ten point releases further on and still well past
+# the SIGTRAP build. The docker-build CDP smoke (below in ci.yaml) is the gate
 # that proves it launches and binds the debugging port before this can merge.
 # The isolation boundary here remains the Firecracker microVM, not Chromium's
 # own sandbox (already --no-sandbox; see docs/threat-model.md). apt-mark hold
 # keeps a transitive upgrade from moving the version underneath the pin.
-ARG CHROMIUM_VERSION=150.0.7871.114-1~deb13u1
+ARG CHROMIUM_VERSION=150.0.7871.124-1~deb13u1
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       chromium="${CHROMIUM_VERSION}" \


### PR DESCRIPTION
## Thinking Path

> - Mitos ships a headless Chromium + CDP template (images/computer-use) for browser-automation sandboxes; the microVM is the isolation boundary and Chromium runs with --no-sandbox.
> - The Dockerfile pins Chromium to an exact version because the pin has a launch-crash history (150.0.7871.46 SIGTRAPed), and the required docker-build check runs a CDP smoke that will not merge a non-launching browser.
> - Debian's security pocket keeps only its latest build, so an exact pin is a moving target: it rotated 150.0.7871.114 out of the archive, so apt now fails with "Version '150.0.7871.114-1~deb13u1' ... was not found" (exit 100).
> - That turns the required docker-build check red on main and on every open PR (a docs-only PR fails identically), blocking the whole merge queue, so it needs fixing now.
> - This pull request re-pins to 150.0.7871.124, the version the trixie security pocket currently ships.
> - The benefit is that docker-build goes green again repo-wide, and the CDP smoke gate confirms the new build launches before this merges.

## Linked Issues or Issue Description

No issue filed; this is a live main-breaking regression. The computer-use image pinned Chromium 150.0.7871.114, which Debian rotated out of the trixie security pocket, failing every docker-build at the apt install step. Re-pin to the current build. Related to the computer-use pin history noted in the Dockerfile.

## What Changed

- images/computer-use/Dockerfile: CHROMIUM_VERSION 150.0.7871.114 -> 150.0.7871.124 (the current trixie security build), with the pin-history comment updated to record the rotation.

## Verification

- [x] Confirmed 150.0.7871.124-1~deb13u1 is the version currently published for chromium in Debian trixie (packages.debian.org/trixie/chromium).
- [x] The required docker-build job builds this image and runs the CDP smoke (launch Chromium, assert /json/version returns a webSocketDebuggerUrl); that is the gate that proves the new build launches and binds the debugging port. It must pass before merge.

## Risks

Low risk. A same-line security point bump (150.0.7871.114 -> .124), well past the .46 build that SIGTRAPed; the CDP smoke gate fails the build if it does not launch. The moving-pin treadmill remains (the next rotation will need another bump); a durable fix (a snapshot.debian.org pin) is out of scope for this unblock.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context, extended thinking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled Chromium version to improve runtime installation reliability.
  * Ensured Chromium-related components use the matching updated version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->