### PR TITLE
ci: measure the control-plane throughput ceiling on kind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -694,6 +694,61 @@ jobs:
           echo "created sandbox: $ID"
           mitos sandbox ls | grep -q "$ID"
           mitos sandbox terminate "$ID"
+      - name: Control-plane throughput ceiling (mock engine, single node)
+        # Issue #15 item 2: exercise the sustained-throughput harness against a
+        # LIVE control plane on every run and record a real, reproducible
+        # claims/sec number, instead of leaving the harness only unit-tested.
+        #
+        # What this measures, honestly: the CONTROL-PLANE path only. Each claim
+        # is a Sandbox CR create -> reconcile -> NodeRegistry node select ->
+        # mock forkd Fork -> status Ready, observed by a watch. This is the
+        # etcd/apiserver/reconciler ceiling (the exact coupling external
+        # scaling critiques target), on ONE kind node with the MOCK engine (no
+        # KVM, no guest VM). It is therefore NOT hardware density and NOT the
+        # warm-husk activation path; both of those are the KVM tail proven in
+        # kvm-test.yaml. The single-config number here is a control-plane
+        # datapoint, not a saturation ceiling: sweep --rate to trace the curve.
+        #
+        # The gate is CORRECTNESS, not an absolute rate. Shared GitHub runners
+        # vary too much to assert a claims/sec threshold without flaking, so we
+        # keep arrival concurrency low and assert only that the run completed,
+        # some claims reached Ready, and the achieved rate is positive. The
+        # achieved rate and per-node density are uploaded as an artifact for the
+        # density curve, per CLAUDE.md operating principle 1 (no unverified
+        # claims): the number is produced on a live cluster, never hardcoded.
+        run: |
+          set -euo pipefail
+          go build -o /tmp/claim-bench ./bench/claim/
+          mkdir -p "$GITHUB_WORKSPACE/control-plane-artifacts"
+          OUT="$GITHUB_WORKSPACE/control-plane-artifacts/control-plane-throughput.json"
+          /tmp/claim-bench \
+            --mode sustained \
+            --kubeconfig "${KUBECONFIG:-$HOME/.kube/config}" \
+            --namespace default \
+            --pool dev-default \
+            --rate 5 \
+            --duration 20s \
+            --max-concurrent 8 \
+            --json "$OUT"
+          echo "=== recorded control-plane throughput JSON ==="
+          cat "$OUT"
+          # Correctness gate (jq ships on ubuntu-latest). completed>0 proves the
+          # end-to-end control-plane path drove claims to Ready under load;
+          # achieved_per_sec>0 proves the aggregation produced a real rate.
+          completed=$(jq -r '.completed' "$OUT")
+          rate=$(jq -r '.achieved_per_sec' "$OUT")
+          echo "completed=$completed achieved_per_sec=$rate"
+          if [ "$completed" -le 0 ]; then
+            echo "FAIL: no claims reached Ready under sustained load; control-plane path is broken"
+            kubectl -n default get sandboxes -o wide || true
+            kubectl -n mitos logs deployment/mitos-controller --tail=100 || true
+            exit 1
+          fi
+          if ! awk "BEGIN { exit !($rate > 0) }"; then
+            echo "FAIL: achieved_per_sec was not positive ($rate)"
+            exit 1
+          fi
+          echo "PASS: control-plane throughput ceiling recorded ($completed claims, ${rate}/s on mock engine, single node)"
       - name: kubectl mitos ls/ps/tree render the objects (object-level smoke)
         # Build a claim and a fork on the mock control plane, then assert the
         # kubectl-mitos plugin renders them at the OBJECT level: ls shows the
@@ -713,6 +768,13 @@ jobs:
           kubectl mitos tree | grep -q "$ID"
           echo "kubectl mitos ls/ps/tree rendered the objects"
           mitos sandbox terminate "$ID"
+      - name: Upload control-plane throughput artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: control-plane-throughput-mock
+          path: control-plane-artifacts/*.json
+          if-no-files-found: warn
       - name: mitos dev down (cleanup)
         if: always()
         run: |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -369,7 +369,15 @@ construction with a clear message and prints no number.
   records achieved claims/sec, peak concurrency, and per-node density (sweep the
   rate to trace the density curve and find where achieved/sec stops tracking the
   target). Aggregation is the unit-tested `internal/benchstat.AggregateThroughput`.
-  **Status: harness runnable on a cluster; numbers OPEN.**
+  **Status: harness runnable on a cluster; hardware density curve OPEN (pending
+  the #16 reference node). A CONTROL-PLANE datapoint is now produced on every
+  `kind-e2e` run**: the job runs `sustained` mode against the mock `dev-default`
+  pool on one kind node and records achieved control-plane claims/sec plus
+  per-node density as the `control-plane-throughput-mock` artifact. That number
+  is the etcd/apiserver/reconciler ceiling on that fixed config (mock engine, no
+  KVM, single node); it is NOT hardware density and NOT the warm-husk activation
+  path. See `bench/results/control-plane-throughput-method.md` for the method and
+  what the number does and does not mean.**
 - **Pool-rebuild propagation** (#15 item 3):
   `bench/pool-rebuild-propagation.sh <kubeconfig> <pool> [ns]`, the `pool-rebuild`
   mode. It triggers a pool rebuild and times from the spec change to all-nodes

--- a/bench/results/control-plane-throughput-method.md
+++ b/bench/results/control-plane-throughput-method.md
@@ -1,0 +1,67 @@
+# Control-plane throughput ceiling: method
+
+This file records the METHOD for the control-plane throughput datapoint that the
+`kind-e2e` CI job now produces on every run (issue #15 item 2). It deliberately
+contains NO hardcoded numbers. Per CLAUDE.md operating principle 1 (no unverified
+claims), the number is produced on a live cluster and published as a CI artifact,
+never pasted here; when a reference hardware run traces the full density curve,
+its distribution and host go in a dated result file next to this one (mirroring
+`2026-06-13-bare-metal-husk.md`).
+
+## What CI measures
+
+The `kind-e2e` job stands up the MOCK control plane (`mitos dev up`: forkd
+`--mock`, controller `--mock --disable-pki-bootstrap`) on ONE kind node, waits
+for the `dev-default` `SandboxPool` to report a ready snapshot, then runs:
+
+```
+bench/claim --mode sustained --namespace default --pool dev-default \
+  --rate 5 --duration 20s --max-concurrent 8 --json <artifact>
+```
+
+Each arrived claim is a `Sandbox` CR create, and the harness records its offset
+to `status.phase=Ready`, the concurrency at that instant, and the node it landed
+on. The aggregation is the unit-tested `internal/benchstat.AggregateThroughput`.
+The JSON (`completed`, `window_ms`, `achieved_per_sec`, `peak_concurrent`,
+`per_node_density`) is uploaded as the `control-plane-throughput-mock` artifact.
+
+## What the number IS
+
+The achieved claims/sec is the CONTROL-PLANE ceiling of this path, on this fixed
+config: `Sandbox` CR create -> reconcile -> `NodeRegistry` node select -> mock
+forkd `Fork` -> `status.phase=Ready`, observed by a watch. This is the
+etcd / apiserver / reconciler throughput, the coupling that external scaling
+critiques (running one Kubernetes control-plane transaction per sandbox) target.
+It is a real, reproducible number produced by a live control plane.
+
+## What the number is NOT
+
+- NOT hardware density. The mock engine forks no real VM and holds no real
+  guest memory, so nothing here reflects per-node fork memory (that is the CoW
+  density datapoint in `BENCHMARKS.md`) or how many live sandboxes a real node
+  packs.
+- NOT the warm-husk activation path. On the mock/dev overlay claims fork on the
+  raw-forkd mock engine; the pre-warmed husk-pod claim + in-place mTLS activation
+  is the KVM tail proven in `kvm-test.yaml`, not this job.
+- NOT a saturation ceiling. CI runs ONE operating point (rate 5/s, 8 concurrent)
+  chosen to stay well inside a single kind node so the run is a stable
+  correctness gate on shared runners. The knee (where achieved/sec stops tracking
+  the arrival rate) is only visible by sweeping `--rate` upward.
+
+## The CI gate
+
+The gate is CORRECTNESS, not an absolute rate: shared GitHub runners vary too
+much to assert a claims/sec threshold without flaking. CI asserts only that the
+run completed, `completed > 0` (the end-to-end control-plane path drove claims to
+Ready under load), and `achieved_per_sec > 0`. The rate itself is recorded, not
+gated.
+
+## Tracing the real density curve
+
+On the reference KVM node (#16), against a warm pool sized for the target
+concurrency, run `bench/sustained-claims-throughput.sh` several times sweeping
+`--rate` (and `--max-concurrent`), and record each
+`(rate -> achieved/sec, peak density, per-node density)` point plus the host
+(CPU, kernel, Firecracker version, node count, pool size) in a new dated result
+file. The p99 degradation point is where achieved/sec stops tracking the target
+arrival rate. Do not publish a number this harness did not produce.


### PR DESCRIPTION
## Thinking Path

> - Mitos boots Firecracker microVMs and forks them via copy-on-write snapshots, exposed through CRDs on Kubernetes; the claim path writes a Sandbox CR per create.
> - The controller + pool path is the subsystem: a claim is a Sandbox CR create, reconciled to Ready via node select and a fork, observed by a watch.
> - The gap: issue #15 item 2 asks for sustained claims/sec and a density curve. The harness (bench/claim --mode sustained) shipped and is unit-tested, but no number was ever produced, so the control-plane throughput was an unmeasured assertion.
> - It needs addressing now because whether the Kubernetes control plane scales per-sandbox is the open question behind ADR 0009; a measured ceiling replaces the assertion. This serves ROADMAP issue #15.
> - This pull request runs the harness in the kind-e2e job on every CI run and records the achieved control-plane claims/sec plus per-node density as an artifact.
> - The benefit is a real, reproducible control-plane ceiling produced by a live control plane, per the no-unverified-claims rule, instead of a hardcoded or hand-waved figure.

## Linked Issues or Issue Description

Related: #15

## What Changed

- `.github/workflows/ci.yaml`: after the mock control plane is Ready and the dev-default pool has a snapshot, run `bench/claim --mode sustained` (rate 5/s, 20s, max-concurrent 8) against it; assert only correctness (completed > 0, achieved/sec > 0) so shared-runner variance cannot flake it; upload the result JSON as the `control-plane-throughput-mock` artifact.
- `bench/results/control-plane-throughput-method.md`: the method and, explicitly, what the number is (the etcd/apiserver/reconciler ceiling on one kind node, mock engine) and is not (hardware density; the warm-husk activation path).
- `BENCHMARKS.md`: update the #15 item 2 status to point at the CI datapoint and the method note.

## Verification

- [x] `actionlint .github/workflows/ci.yaml`: clean for the added steps (the only two warnings it reports are pre-existing, at lines far from this change).
- [x] `go build ./bench/claim/`: the harness the step invokes builds.
- [x] YAML parses (actionlint loads the whole workflow; step indentation confirmed).
- [x] No em or en dashes in the diff.
- [x] The number is produced on a live cluster in-job, never hardcoded; the density curve is swept with `bench/sustained-claims-throughput.sh` per the method note.

## Risks

Low risk. The step runs after the existing "sandbox create reaches Ready" step on the same mock control plane and gates on correctness only, so it adds no new flake surface. Worst case is a genuine control-plane regression (claims stop reaching Ready under load), which is exactly what it should catch; on failure it dumps sandbox state and controller logs.

## Model Used

Claude Opus 4.8 (1M context), model id `claude-opus-4-8`, high reasoning effort.

## Checklist

- [x] PR title is a conventional commit (ci)
- [x] Thinking Path traces from project context to this change
- [x] Model Used is filled in (with version and capability details)
- [ ] Tests added for behavior changes, in the same commit (TDD) (n/a: the harness aggregation is already unit-tested in internal/benchstat; this wires it into CI)
- [x] Docs updated in the same PR (BENCHMARKS.md, method note)
- [ ] Threat-model delta included if the security surface moved (n/a: no surface change)
- [x] Benchmark run included if the hot path was touched (this IS the benchmark wiring; it produces the number in CI)
- [x] No em or en dashes introduced anywhere
- [x] Secret values never logged, in errors, in condition messages, or on host paths
- [x] No internal/instance-local references (only public #NNN)
- [x] Every commit carries a Signed-off-by trailer
